### PR TITLE
Disable aggressive ARC optimizations

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1488,12 +1488,13 @@ export class Module {
         passes.push("rse");
         passes.push("vacuum");
       }
-      if (usesARC) {
-        if (optimizeLevel < 3) {
-          passes.push("flatten");
-        }
-        passes.push("post-assemblyscript");
-      }
+      // FIXME: see issue #1288
+      // if (usesARC) {
+      //   if (optimizeLevel < 3) {
+      //     passes.push("flatten");
+      //   }
+      //   passes.push("post-assemblyscript");
+      // }
       passes.push("optimize-instructions");
       passes.push("inlining");
       passes.push("dce");

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
@@ -1580,6 +1580,17 @@
    end
   end
  )
+ (func $~lib/rt/pure/__release (param $0 i32)
+  local.get $0
+  i32.const 1564
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
+ )
  (func $~lib/array/Array<extends-baseaggregate/A2>#push (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1587,13 +1598,16 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $1
   i32.const 1116
   i32.load
   local.tee $6
   i32.const 1
   i32.add
   local.tee $2
-  local.set $1
+  local.set $0
   local.get $2
   i32.const 1112
   i32.load
@@ -1602,7 +1616,7 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $1
+   local.get $0
    i32.const 268435452
    i32.gt_u
    if
@@ -1620,28 +1634,28 @@
    call $~lib/rt/tlsf/maybeInitialize
    local.get $4
    call $~lib/rt/tlsf/checkUsedBlock
-   local.get $1
+   local.get $0
    i32.const 2
    i32.shl
    local.tee $5
    call $~lib/rt/tlsf/reallocateBlock
    i32.const 16
    i32.add
-   local.tee $1
+   local.tee $0
    i32.add
    local.get $5
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $1
+   local.get $0
    local.get $4
    i32.ne
    if
     i32.const 1104
-    local.get $1
+    local.get $0
     i32.store
     i32.const 1108
-    local.get $1
+    local.get $0
     i32.store
    end
    i32.const 1112
@@ -1654,12 +1668,14 @@
   i32.const 2
   i32.shl
   i32.add
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__retain
   i32.store
   i32.const 1116
   local.get $2
   i32.store
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $~start
   (local $0 i32)
@@ -1688,14 +1704,7 @@
   local.get $0
   call $~lib/array/Array<extends-baseaggregate/A2>#push
   local.get $0
-  i32.const 1564
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/pure/decrement
-  end
+  call $~lib/rt/pure/__release
  )
  (func $~lib/rt/pure/markGray (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -958,18 +958,22 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   call $~lib/rt/tlsf/maybeInitialize
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $3
   i32.const 1200
   i32.store
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  local.set $2
   local.get $1
-  local.tee $0
   i32.load
-  local.tee $2
+  local.tee $0
   i32.eqz
   if
    i32.const 0
@@ -979,22 +983,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $0
+  local.get $2
   i32.load
-  local.tee $1
+  local.tee $2
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $1
+   local.set $0
+   local.get $2
    call $~lib/rt/pure/__release
   end
+  local.get $1
   local.get $0
-  local.get $2
   i32.store
-  local.get $0
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
   call $~lib/rt/pure/__release
  )
  (func $~lib/rt/pure/decrement (param $0 i32)

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $i32_=>_none (func (param i32)))
- (type $i32_i32_=>_none (func (param i32 i32)))
- (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -891,22 +891,17 @@
   call $~lib/rt/rtrace/onalloc
   local.get $1
  )
- (func $logical/Obj#constructor (result i32)
-  (local $0 i32)
+ (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  call $~lib/rt/tlsf/maybeInitialize
-  call $~lib/rt/tlsf/allocateBlock
-  i32.const 16
-  i32.add
-  local.tee $1
+  local.get $0
   i32.const 1232
   i32.gt_u
   if
-   local.get $1
+   local.get $0
    i32.const 16
    i32.sub
-   local.tee $0
+   local.tee $1
    i32.load offset=4
    local.tee $2
    i32.const -268435456
@@ -925,14 +920,14 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
+   local.get $1
    local.get $2
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $0
+   local.get $1
    call $~lib/rt/rtrace/onincrement
-   local.get $0
+   local.get $1
    i32.load
    i32.const 1
    i32.and
@@ -945,7 +940,14 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
+ )
+ (func $logical/Obj#constructor (result i32)
+  call $~lib/rt/tlsf/maybeInitialize
+  call $~lib/rt/tlsf/allocateBlock
+  i32.const 16
+  i32.add
+  call $~lib/rt/pure/__retain
  )
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
@@ -958,16 +960,24 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start
-  (local $0 i32)
+ (func $start:logical
+  (local $0 f64)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
   call $logical/Obj#constructor
-  local.tee $0
-  if (result i32)
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  if
    i32.const 1
-  else
-   i32.const 0
+   local.set $1
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.eqz
   if
    i32.const 0
@@ -978,12 +988,16 @@
    unreachable
   end
   call $logical/Obj#constructor
-  local.tee $1
+  local.tee $2
+  call $~lib/rt/pure/__retain
+  local.tee $5
   if (result i32)
    i32.const 1
   else
    i32.const 0
   end
+  local.get $5
+  call $~lib/rt/pure/__release
   i32.eqz
   if
    i32.const 0
@@ -993,10 +1007,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $4
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
+ )
+ (func $~start
+  call $start:logical
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -977,6 +977,16 @@
    call $~lib/rt/pure/decrement
   end
  )
+ (func $managed-cast/testDowncastToNullable (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/rt/pure/__retain
+  local.get $0
+  call $~lib/rt/pure/__release
+  call $~lib/rt/pure/__release
+ )
  (func $~lib/rt/__instanceof (param $0 i32) (result i32)
   local.get $0
   i32.const 16
@@ -1016,9 +1026,13 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   call $managed-cast/Cat#constructor
   call $managed-cast/Cat#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.eqz
   if
    i32.const 0
@@ -1028,12 +1042,18 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/rt/pure/__release
   call $managed-cast/Cat#constructor
-  local.set $4
+  local.tee $4
+  call $managed-cast/testDowncastToNullable
   call $managed-cast/Cat#constructor
-  local.set $5
+  local.tee $5
+  call $managed-cast/testDowncastToNullable
   call $managed-cast/Cat#constructor
   local.tee $6
+  call $~lib/rt/pure/__retain
+  local.tee $0
   call $~lib/rt/__instanceof
   i32.eqz
   if
@@ -1044,18 +1064,24 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/rt/pure/__release
   call $managed-cast/Cat#constructor
-  local.tee $1
-  local.set $0
+  local.tee $7
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  local.set $1
   block $__inlined_func$managed-cast/testUpcastFromNullable
    block $folding-inner0
-    local.get $1
+    local.get $0
     i32.eqz
     br_if $folding-inner0
-    local.get $0
+    local.get $1
     call $~lib/rt/__instanceof
     i32.eqz
     br_if $folding-inner0
+    local.get $0
+    call $~lib/rt/pure/__release
     br $__inlined_func$managed-cast/testUpcastFromNullable
    end
    i32.const 0
@@ -1066,7 +1092,10 @@
    unreachable
   end
   call $managed-cast/Cat#constructor
-  local.tee $0
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  local.get $1
   call $~lib/rt/__instanceof
   i32.eqz
   if
@@ -1077,8 +1106,15 @@
    call $~lib/builtins/abort
    unreachable
   end
+  call $~lib/rt/pure/__retain
+  local.get $1
+  call $~lib/rt/pure/__release
+  call $~lib/rt/pure/__release
   call $managed-cast/Cat#constructor
-  local.tee $7
+  local.tee $9
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  local.get $1
   call $~lib/rt/__instanceof
   i32.eqz
   if
@@ -1089,6 +1125,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  call $~lib/rt/pure/__retain
+  local.get $1
+  call $~lib/rt/pure/__release
+  call $~lib/rt/pure/__release
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
@@ -1098,11 +1138,11 @@
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $9
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -1116,10 +1116,18 @@
  (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  local.tee $3
   i32.const 7
   i32.and
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  local.tee $1
   i32.const 7
   i32.and
   i32.or
@@ -1131,16 +1139,16 @@
   select
   if
    loop $do-continue|0
-    local.get $0
+    local.get $3
     i64.load
     local.get $1
     i64.load
     i64.eq
     if
-     local.get $0
+     local.get $3
      i32.const 8
      i32.add
-     local.set $0
+     local.set $3
      local.get $1
      i32.const 8
      i32.add
@@ -1157,29 +1165,33 @@
   end
   loop $while-continue|1
    local.get $2
-   local.tee $3
+   local.tee $0
    i32.const 1
    i32.sub
    local.set $2
-   local.get $3
+   local.get $0
    if
-    local.get $0
+    local.get $3
     i32.load16_u
-    local.tee $3
+    local.tee $0
     local.get $1
     i32.load16_u
-    local.tee $4
+    local.tee $6
     i32.ne
     if
-     local.get $3
      local.get $4
+     call $~lib/rt/pure/__release
+     local.get $5
+     call $~lib/rt/pure/__release
+     local.get $0
+     local.get $6
      i32.sub
      return
     end
-    local.get $0
+    local.get $3
     i32.const 2
     i32.add
-    local.set $0
+    local.set $3
     local.get $1
     i32.const 2
     i32.add
@@ -1187,14 +1199,26 @@
     br $while-continue|1
    end
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.eq
   if
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    return
   end
@@ -1217,8 +1241,16 @@
    local.get $2
    call $~lib/util/string/compareImpl
    i32.eqz
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
@@ -1482,6 +1514,8 @@
  )
  (func $object-literal/testOmittedTypes (param $0 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load
   if
    i32.const 0
@@ -1631,9 +1665,13 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $object-literal/testOmittedFoo (param $0 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load
   i32.const 1392
   call $~lib/string/String.__eq
@@ -1759,6 +1797,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $start:object-literal
   (local $0 i32)
@@ -1771,19 +1811,22 @@
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $1
   i32.const 0
   i32.store
-  local.get $3
+  local.get $1
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $1
+  local.tee $0
   i32.const 123
   i32.store
-  local.get $3
+  local.get $1
   i32.const 1040
   i32.store offset=4
-  local.get $3
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load
   i32.const 123
   i32.ne
@@ -1795,7 +1838,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $1
   i32.load offset=4
   i32.const 1040
   call $~lib/string/String.__eq
@@ -1808,197 +1851,201 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.store
-  local.get $2
+  local.get $1
   i32.const 0
   i32.store offset=4
-  local.get $2
+  local.get $1
   i32.const 123
   i32.store
-  local.get $2
+  local.get $1
   block $__inlined_func$~lib/string/String#substring (result i32)
    i32.const 1312
    i32.const 0
    i32.const 1040
    call $~lib/string/String#get:length
-   local.tee $5
+   local.tee $2
    i32.const 0
-   local.get $5
+   local.get $2
    i32.lt_s
    select
-   local.tee $4
+   local.tee $3
    i32.const 5
-   local.get $5
+   local.get $2
    i32.const 5
-   local.get $5
+   local.get $2
    i32.lt_s
    select
-   local.tee $1
-   local.get $4
-   local.get $1
+   local.tee $5
+   local.get $3
+   local.get $5
    i32.gt_s
    select
    i32.const 1
    i32.shl
-   local.tee $0
-   local.get $4
-   local.get $1
-   local.get $4
-   local.get $1
+   local.tee $4
+   local.get $3
+   local.get $5
+   local.get $3
+   local.get $5
    i32.lt_s
    select
    i32.const 1
    i32.shl
-   local.tee $4
+   local.tee $3
    i32.sub
-   local.tee $1
+   local.tee $5
    i32.eqz
    br_if $__inlined_func$~lib/string/String#substring
    drop
    i32.const 1040
    i32.const 0
-   local.get $0
-   local.get $5
+   local.get $4
+   local.get $2
    i32.const 1
    i32.shl
    i32.eq
-   local.get $4
+   local.get $3
    select
    br_if $__inlined_func$~lib/string/String#substring
    drop
-   local.get $1
+   local.get $5
    i32.const 1
    call $~lib/rt/tlsf/__alloc
-   local.tee $0
-   local.get $4
+   local.tee $4
+   local.get $3
    i32.const 1040
    i32.add
-   local.get $1
+   local.get $5
    call $~lib/memory/memory.copy
-   local.get $0
+   local.get $4
    call $~lib/rt/pure/__retain
   end
   i32.store offset=4
-  local.get $2
+  local.get $1
   call $object-literal/testUnmanaged
   i32.const 65
   i32.const 4
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.store
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store offset=4
-  local.get $0
+  local.get $1
   i64.const 0
   i64.store offset=8
-  local.get $0
+  local.get $1
   i64.const 0
   i64.store offset=16
-  local.get $0
+  local.get $1
   f32.const 0
   f32.store offset=24
-  local.get $0
+  local.get $1
   f64.const 0
   f64.store offset=32
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store8 offset=40
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store8 offset=41
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store16 offset=42
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store16 offset=44
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store offset=48
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store offset=52
-  local.get $0
+  local.get $1
   f64.const 0
   f64.store offset=56
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store8 offset=64
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store offset=4
-  local.get $0
+  local.get $1
   i64.const 0
   i64.store offset=8
-  local.get $0
+  local.get $1
   i64.const 0
   i64.store offset=16
-  local.get $0
+  local.get $1
   f32.const 0
   f32.store offset=24
-  local.get $0
+  local.get $1
   f64.const 0
   f64.store offset=32
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store8 offset=40
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store8 offset=41
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store16 offset=42
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store16 offset=44
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store offset=48
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store offset=52
-  local.get $0
+  local.get $1
   f64.const 0
   f64.store offset=56
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store8 offset=64
-  local.get $0
+  local.get $1
   call $object-literal/testOmittedTypes
   i32.const 16
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $4
   i32.const 0
   i32.store
-  local.get $2
+  local.get $4
   i32.const 0
   i32.store offset=4
-  local.get $2
+  local.get $4
   f64.const 0
   f64.store offset=8
-  local.get $2
+  local.get $4
   i32.const 0
   i32.store
-  local.get $2
+  local.get $4
   i32.const 1360
   i32.store offset=4
-  local.get $2
+  local.get $4
   f64.const 0
   f64.store offset=8
-  local.get $2
+  local.get $4
+  call $~lib/rt/pure/__retain
+  local.tee $5
   i32.load
   if
    i32.const 0
@@ -2008,7 +2055,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $5
   i32.load offset=4
   i32.const 1360
   call $~lib/string/String.__eq
@@ -2021,7 +2068,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $5
   f64.load offset=8
   f64.const 0
   f64.ne
@@ -2033,70 +2080,72 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $5
+  call $~lib/rt/pure/__release
   i32.const 40
   i32.const 6
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $5
   i32.const 1392
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1424
   i32.store offset=4
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=8
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=12
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=16
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=20
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=24
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=28
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=32
-  local.get $1
+  local.get $5
   i32.const -1
   i32.store offset=36
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=8
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=12
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=16
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=20
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=24
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=28
-  local.get $1
+  local.get $5
   i32.const 0
   i32.store offset=32
-  local.get $1
+  local.get $5
   call $object-literal/testOmittedFoo
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $2
-  call $~lib/rt/pure/__release
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/rc/optimize.optimized.wat
+++ b/tests/compiler/rc/optimize.optimized.wat
@@ -28,15 +28,15 @@
  (export "getRef" (func $rc/optimize/getRef))
  (export "OptimizeARC.eliminates.linearArgument" (func $rc/optimize/eliminated_vi))
  (export "OptimizeARC.eliminates.linearLocal" (func $rc/optimize/eliminated_vi))
- (export "OptimizeARC.eliminates.linearChain" (func $rc/optimize/eliminated_vi))
+ (export "OptimizeARC.eliminates.linearChain" (func $rc/optimize/OptimizeARC.eliminates.linearChain))
  (export "OptimizeARC.eliminates.balancedReleases" (func $rc/optimize/eliminated_vii))
- (export "OptimizeARC.eliminates.partialReleases" (func $rc/optimize/eliminated_vii))
+ (export "OptimizeARC.eliminates.partialReleases" (func $rc/optimize/OptimizeARC.eliminates.partialReleases))
  (export "OptimizeARC.eliminates.balancedRetains" (func $rc/optimize/eliminated_viii))
- (export "OptimizeARC.eliminates.balancedInsideLoop" (func $rc/optimize/eliminated_vii))
+ (export "OptimizeARC.eliminates.balancedInsideLoop" (func $rc/optimize/OptimizeARC.eliminates.balancedInsideLoop))
  (export "OptimizeARC.eliminates.balancedOutsideLoop" (func $rc/optimize/eliminated_vii))
- (export "OptimizeARC.eliminates.balancedInsideOutsideLoop" (func $rc/optimize/eliminated_vii))
+ (export "OptimizeARC.eliminates.balancedInsideOutsideLoop" (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoop))
  (export "OptimizeARC.eliminates.balancedInsideOutsideLoopWithBranch" (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoopWithBranch))
- (export "OptimizeARC.eliminates.replace" (func $rc/optimize/eliminated_vii))
+ (export "OptimizeARC.eliminates.replace" (func $rc/optimize/OptimizeARC.eliminates.replace))
  (export "OptimizeARC.eliminates.replaceAlreadyRetained" (func $rc/optimize/eliminated_rr))
  (export "OptimizeARC.keeps.partialRetains" (func $rc/optimize/OptimizeARC.keeps.partialRetains))
  (export "OptimizeARC.keeps.reachesReturn" (func $rc/optimize/OptimizeARC.keeps.reachesReturn))
@@ -1000,23 +1000,113 @@
   end
  )
  (func $rc/optimize/eliminated_rr (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
   call $~lib/rt/tlsf/maybeInitialize
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
   call $~lib/rt/pure/__retain
+  local.set $1
+  call $~lib/rt/pure/__release
+  local.get $1
+ )
+ (func $rc/optimize/OptimizeARC.eliminates.linearChain (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/rt/pure/__retain
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+ )
+ (func $rc/optimize/OptimizeARC.eliminates.partialReleases (param $0 i32) (param $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  if
+   local.get $0
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $rc/optimize/OptimizeARC.eliminates.balancedInsideLoop (param $0 i32) (param $1 i32)
+  loop $while-continue|0
+   local.get $1
+   if
+    local.get $0
+    call $~lib/rt/pure/__retain
+    local.tee $0
+    call $~lib/rt/pure/__release
+    br $while-continue|0
+   end
+  end
+ )
+ (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoop (param $0 i32) (param $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  loop $while-continue|0
+   local.get $1
+   if
+    local.get $0
+    call $~lib/rt/pure/__release
+    local.get $0
+    call $~lib/rt/pure/__retain
+    local.set $0
+    br $while-continue|0
+   end
+  end
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $rc/optimize/OptimizeARC.eliminates.balancedInsideOutsideLoopWithBranch (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
   loop $while-continue|0
    local.get $1
    if
     local.get $2
     if
+     local.get $0
+     call $~lib/rt/pure/__release
      return
     end
+    local.get $0
+    call $~lib/rt/pure/__release
+    local.get $0
+    call $~lib/rt/pure/__retain
+    local.set $0
     br $while-continue|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+ )
+ (func $rc/optimize/OptimizeARC.eliminates.replace (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  local.tee $1
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $0
+   call $~lib/rt/pure/__release
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $rc/optimize/OptimizeARC.keeps.partialRetains (param $0 i32) (param $1 i32)
   local.get $1

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -1195,10 +1195,18 @@
  (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  local.tee $3
   i32.const 7
   i32.and
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  local.tee $1
   i32.const 7
   i32.and
   i32.or
@@ -1210,16 +1218,16 @@
   select
   if
    loop $do-continue|0
-    local.get $0
+    local.get $3
     i64.load
     local.get $1
     i64.load
     i64.eq
     if
-     local.get $0
+     local.get $3
      i32.const 8
      i32.add
-     local.set $0
+     local.set $3
      local.get $1
      i32.const 8
      i32.add
@@ -1236,29 +1244,33 @@
   end
   loop $while-continue|1
    local.get $2
-   local.tee $3
+   local.tee $0
    i32.const 1
    i32.sub
    local.set $2
-   local.get $3
+   local.get $0
    if
-    local.get $0
+    local.get $3
     i32.load16_u
-    local.tee $3
+    local.tee $0
     local.get $1
     i32.load16_u
-    local.tee $4
+    local.tee $6
     i32.ne
     if
-     local.get $3
      local.get $4
+     call $~lib/rt/pure/__release
+     local.get $5
+     call $~lib/rt/pure/__release
+     local.get $0
+     local.get $6
      i32.sub
      return
     end
-    local.get $0
+    local.get $3
     i32.const 2
     i32.add
-    local.set $0
+    local.set $3
     local.get $1
     i32.const 2
     i32.add
@@ -1266,14 +1278,26 @@
     br $while-continue|1
    end
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.eq
   if
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    return
   end
@@ -1296,8 +1320,16 @@
    local.get $2
    call $~lib/util/string/compareImpl
    i32.eqz
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -1700,13 +1700,19 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   block $__inlined_func$~lib/string/String#concat (result i32)
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $2
    i32.const 1424
-   local.get $0
+   local.get $2
    select
-   local.set $2
+   local.set $3
    local.get $1
+   call $~lib/rt/pure/__retain
+   local.tee $5
    call $~lib/rt/pure/__retain
    local.tee $0
    i32.eqz
@@ -1721,16 +1727,16 @@
     i32.const 1424
     local.set $0
    end
-   local.get $2
-   call $~lib/string/String#get:length
-   i32.const 1
-   i32.shl
-   local.tee $3
-   local.get $0
+   local.get $3
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    local.tee $4
+   local.get $0
+   call $~lib/string/String#get:length
+   i32.const 1
+   i32.shl
+   local.tee $6
    i32.add
    local.tee $1
    i32.eqz
@@ -1745,19 +1751,23 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.tee $1
-   local.get $2
    local.get $3
+   local.get $4
    call $~lib/memory/memory.copy
    local.get $1
-   local.get $3
+   local.get $4
    i32.add
    local.get $0
-   local.get $4
+   local.get $6
    call $~lib/memory/memory.copy
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
  )
  (func $start:retain-release-sanity
   (local $0 i32)
@@ -1956,22 +1966,25 @@
       local.get $3
       local.get $3
       i32.load offset=12
-      local.tee $5
+      local.tee $2
       i32.const 1
       i32.add
-      local.tee $2
+      local.tee $5
       call $~lib/array/ensureSize
       local.get $3
       i32.load offset=4
-      local.get $5
+      local.get $2
       i32.const 2
       i32.shl
       i32.add
       i32.const 1344
+      call $~lib/rt/pure/__retain
       i32.store
       local.get $3
-      local.get $2
+      local.get $5
       i32.store offset=12
+      i32.const 1344
+      call $~lib/rt/pure/__release
       local.get $0
       i32.const 1
       i32.add
@@ -1993,9 +2006,13 @@
   i32.const 1392
   call $~lib/string/String.__concat
   local.tee $1
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 1456
   call $~lib/string/String.__concat
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__release
   i32.const 4

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -1579,6 +1579,15 @@
   i32.store offset=12
   local.get $3
  )
+ (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (param $0 i32) (result i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.const 0
+  i32.ne
+ )
  (func $std/array/Ref#constructor (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 4
@@ -1890,45 +1899,59 @@
  (func $std/array/isArraysEqual<u8> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  block $folding-inner0
-   local.get $0
-   i32.load offset=12
-   local.tee $3
-   local.get $1
-   i32.load offset=12
-   i32.ne
-   br_if $folding-inner0
-   local.get $0
-   local.get $1
-   i32.eq
-   if
-    i32.const 1
-    return
-   end
-   loop $for-loop|0
-    local.get $2
-    local.get $3
-    i32.lt_s
-    if
-     local.get $0
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
+  block $folding-inner1
+   block $folding-inner0
+    local.get $0
+    i32.load offset=12
+    local.tee $3
+    local.get $1
+    i32.load offset=12
+    i32.ne
+    br_if $folding-inner0
+    local.get $0
+    local.get $1
+    i32.eq
+    br_if $folding-inner1
+    loop $for-loop|0
      local.get $2
-     call $~lib/array/Array<u8>#__get
-     local.get $1
-     local.get $2
-     call $~lib/array/Array<u8>#__get
-     i32.ne
-     br_if $folding-inner0
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-     br $for-loop|0
+     local.get $3
+     i32.lt_s
+     if
+      local.get $0
+      local.get $2
+      call $~lib/array/Array<u8>#__get
+      local.get $1
+      local.get $2
+      call $~lib/array/Array<u8>#__get
+      i32.ne
+      br_if $folding-inner0
+      local.get $2
+      i32.const 1
+      i32.add
+      local.set $2
+      br $for-loop|0
+     end
     end
+    br $folding-inner1
    end
-   i32.const 1
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 0
    return
   end
-  i32.const 0
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  i32.const 1
  )
  (func $~lib/array/Array<u32>#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
@@ -2028,58 +2051,82 @@
  )
  (func $std/array/isArraysEqual<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
-  block $folding-inner0
-   local.get $2
-   i32.eqz
-   if
-    local.get $0
-    i32.load offset=12
-    local.tee $2
-    local.get $1
-    i32.load offset=12
-    i32.ne
-    br_if $folding-inner0
-    local.get $0
-    local.get $1
-    i32.eq
-    if
-     i32.const 1
-     return
-    end
-   end
-   loop $for-loop|0
-    local.get $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
+  block $folding-inner1
+   block $folding-inner0
     local.get $2
-    i32.lt_s
+    i32.eqz
     if
      local.get $0
-     local.get $3
-     call $~lib/array/Array<u32>#__get
+     i32.load offset=12
+     local.tee $2
      local.get $1
-     local.get $3
-     call $~lib/array/Array<u32>#__get
+     i32.load offset=12
      i32.ne
      br_if $folding-inner0
-     local.get $3
-     i32.const 1
-     i32.add
-     local.set $3
-     br $for-loop|0
+     local.get $0
+     local.get $1
+     i32.eq
+     br_if $folding-inner1
     end
+    loop $for-loop|0
+     local.get $3
+     local.get $2
+     i32.lt_s
+     if
+      local.get $0
+      local.get $3
+      call $~lib/array/Array<u32>#__get
+      local.get $1
+      local.get $3
+      call $~lib/array/Array<u32>#__get
+      i32.ne
+      br_if $folding-inner0
+      local.get $3
+      i32.const 1
+      i32.add
+      local.set $3
+      br $for-loop|0
+     end
+    end
+    br $folding-inner1
    end
-   i32.const 1
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 0
    return
   end
-  i32.const 0
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  i32.const 1
  )
  (func $std/array/internalCapacity<i32> (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 16
   i32.sub
   i32.load offset=12
   i32.const 2
   i32.shr_s
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
@@ -2357,6 +2404,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=12
   local.tee $3
@@ -2403,6 +2453,8 @@
   i32.const 2
   i32.shl
   call $~lib/memory/memory.copy
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $2
  )
  (func $~lib/array/Array<i32>#copyWithin (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
@@ -3017,16 +3069,24 @@
  )
  (func $start:std/array~anonymous|3 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 100
   call $~lib/array/Array<i32>#push
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
   i32.const 100
   i32.eq
  )
  (func $start:std/array~anonymous|5 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/array/Array<i32>#pop
   drop
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
   i32.const 100
   i32.eq
@@ -3088,8 +3148,12 @@
  )
  (func $start:std/array~anonymous|8 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 100
   call $~lib/array/Array<i32>#push
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
   i32.const 10
   i32.lt_s
@@ -3101,8 +3165,12 @@
  )
  (func $start:std/array~anonymous|10 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/array/Array<i32>#pop
   drop
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
   i32.const 3
   i32.lt_s
@@ -3163,8 +3231,12 @@
  )
  (func $start:std/array~anonymous|13 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 100
   call $~lib/array/Array<i32>#push
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
   i32.const 10
   i32.gt_s
@@ -3176,17 +3248,24 @@
  )
  (func $start:std/array~anonymous|15 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/array/Array<i32>#pop
   drop
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
   i32.const 3
   i32.gt_s
  )
  (func $start:std/array~anonymous|16 (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<i32>#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -3229,24 +3308,35 @@
  )
  (func $start:std/array~anonymous|17 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 100
   call $~lib/array/Array<i32>#push
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $start:std/array~anonymous|19 (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/array/Array<i32>#pop
   drop
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $start:std/array~anonymous|20 (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.eqz
   if
@@ -3337,6 +3427,8 @@
     unreachable
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $start:std/array~anonymous|21 (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
@@ -3365,12 +3457,16 @@
  )
  (func $start:std/array~anonymous|22 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 100
   call $~lib/array/Array<i32>#push
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
  )
  (func $~lib/array/Array<i32>#map<i32> (param $0 i32) (param $1 i32) (result i32)
@@ -3431,20 +3527,27 @@
   local.get $5
  )
  (func $start:std/array~anonymous|23 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
+  call $~lib/rt/pure/__release
   local.get $0
  )
  (func $start:std/array~anonymous|24 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/array/Array<i32>#pop
   drop
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
  )
  (func $start:std/array~anonymous|25 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -3507,33 +3610,44 @@
  )
  (func $start:std/array~anonymous|26 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 100
   call $~lib/array/Array<i32>#push
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
   i32.const 2
   i32.ge_s
  )
  (func $start:std/array~anonymous|27 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
+  call $~lib/rt/pure/__release
   local.get $0
   i32.const 2
   i32.ge_s
  )
  (func $start:std/array~anonymous|28 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/array/Array<i32>#pop
   drop
   local.get $0
   global.get $std/array/i
   i32.add
   global.set $std/array/i
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $0
   i32.const 2
   i32.ge_s
@@ -3603,16 +3717,24 @@
  )
  (func $start:std/array~anonymous|33 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $2
   i32.const 1
   call $~lib/array/Array<i32>#push
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   local.get $1
   i32.add
  )
  (func $start:std/array~anonymous|35 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $2
   call $~lib/array/Array<i32>#pop
   drop
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   local.get $1
   i32.add
@@ -4030,6 +4152,83 @@
   i32.lt_s
   i32.sub
  )
+ (func $std/array/isArraysEqual<f32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
+  block $folding-inner1
+   block $folding-inner0
+    local.get $0
+    i32.load offset=12
+    local.tee $4
+    local.get $1
+    i32.load offset=12
+    i32.ne
+    br_if $folding-inner0
+    local.get $0
+    local.get $1
+    i32.eq
+    br_if $folding-inner1
+    loop $for-loop|0
+     local.get $2
+     local.get $4
+     i32.lt_s
+     if
+      local.get $0
+      local.get $2
+      call $~lib/array/Array<f32>#__get
+      local.tee $3
+      local.get $3
+      f32.ne
+      if (result i32)
+       local.get $1
+       local.get $2
+       call $~lib/array/Array<f32>#__get
+       local.tee $3
+       local.get $3
+       f32.ne
+      else
+       i32.const 0
+      end
+      i32.eqz
+      if
+       local.get $0
+       local.get $2
+       call $~lib/array/Array<f32>#__get
+       local.get $1
+       local.get $2
+       call $~lib/array/Array<f32>#__get
+       f32.ne
+       br_if $folding-inner0
+      end
+      local.get $2
+      i32.const 1
+      i32.add
+      local.set $2
+      br $for-loop|0
+     end
+    end
+    br $folding-inner1
+   end
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 0
+   return
+  end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  i32.const 1
+ )
  (func $~lib/util/sort/weakHeapSort<f64> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4330,6 +4529,83 @@
   i32.shl
   i32.add
   f64.load
+ )
+ (func $std/array/isArraysEqual<f64> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
+  block $folding-inner1
+   block $folding-inner0
+    local.get $0
+    i32.load offset=12
+    local.tee $4
+    local.get $1
+    i32.load offset=12
+    i32.ne
+    br_if $folding-inner0
+    local.get $0
+    local.get $1
+    i32.eq
+    br_if $folding-inner1
+    loop $for-loop|0
+     local.get $2
+     local.get $4
+     i32.lt_s
+     if
+      local.get $0
+      local.get $2
+      call $~lib/array/Array<f64>#__get
+      local.tee $3
+      local.get $3
+      f64.ne
+      if (result i32)
+       local.get $1
+       local.get $2
+       call $~lib/array/Array<f64>#__get
+       local.tee $3
+       local.get $3
+       f64.ne
+      else
+       i32.const 0
+      end
+      i32.eqz
+      if
+       local.get $0
+       local.get $2
+       call $~lib/array/Array<f64>#__get
+       local.get $1
+       local.get $2
+       call $~lib/array/Array<f64>#__get
+       f64.ne
+       br_if $folding-inner0
+      end
+      local.get $2
+      i32.const 1
+      i32.add
+      local.set $2
+      br $for-loop|0
+     end
+    end
+    br $folding-inner1
+   end
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 0
+   return
+  end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  i32.const 1
  )
  (func $~lib/util/sort/weakHeapSort<i32> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -4833,22 +5109,25 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   block $__inlined_func$std/array/isSorted<i32> (result i32)
    i32.const 1
    local.set $2
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $3
    local.get $1
    call $~lib/array/Array<i32>#sort
-   local.tee $3
+   local.tee $4
+   call $~lib/rt/pure/__retain
    local.tee $0
    i32.load offset=12
-   local.set $4
+   local.set $5
    loop $for-loop|0
     local.get $2
-    local.get $4
+    local.get $5
     i32.lt_s
     if
-     i32.const 0
      local.get $0
      local.get $2
      i32.const 1
@@ -4861,8 +5140,12 @@
      call_indirect (type $i32_i32_=>_i32)
      i32.const 0
      i32.gt_s
-     br_if $__inlined_func$std/array/isSorted<i32>
-     drop
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      i32.const 0
+      br $__inlined_func$std/array/isSorted<i32>
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -4870,6 +5153,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
   end
   i32.eqz
@@ -4881,7 +5166,18 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $std/array/assertSortedDefault<i32> (param $0 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 48
+  call $std/array/assertSorted<i32>
+  local.get $0
   call $~lib/rt/pure/__release
  )
  (func $start:std/array~anonymous|44 (param $0 i32) (param $1 i32) (result i32)
@@ -4891,6 +5187,9 @@
  )
  (func $~lib/array/Array<~lib/array/Array<i32>>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   local.get $0
   i32.load offset=12
@@ -4918,6 +5217,7 @@
    i32.store offset=12
   end
   local.get $2
+  call $~lib/rt/pure/__retain
   local.tee $3
   local.get $0
   i32.load offset=4
@@ -4937,6 +5237,10 @@
    local.get $1
    call $~lib/rt/pure/__release
   end
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $std/array/createReverseOrderedNestedArray (result i32)
   (local $0 i32)
@@ -5022,6 +5326,13 @@
   local.get $2
  )
  (func $start:std/array~anonymous|47 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.const 0
   call $~lib/array/Array<u32>#__get
@@ -5029,18 +5340,103 @@
   i32.const 0
   call $~lib/array/Array<u32>#__get
   i32.sub
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  loop $for-loop|0
+   local.get $4
+   local.get $1
+   i32.lt_s
+   if
+    local.get $0
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    call $~lib/rt/pure/__retain
+    local.set $6
+    local.get $4
+    i32.const 1
+    i32.sub
+    local.set $3
+    loop $while-continue|1
+     local.get $3
+     i32.const 0
+     i32.ge_s
+     if
+      block $while-break|1
+       local.get $6
+       local.get $0
+       local.get $3
+       i32.const 2
+       i32.shl
+       i32.add
+       i32.load
+       call $~lib/rt/pure/__retain
+       local.tee $5
+       local.get $2
+       call_indirect (type $i32_i32_=>_i32)
+       i32.const 0
+       i32.lt_s
+       if (result i32)
+        local.get $0
+        local.get $3
+        i32.const 1
+        i32.add
+        i32.const 2
+        i32.shl
+        i32.add
+        local.get $5
+        i32.store
+        local.get $3
+        i32.const 1
+        i32.sub
+       else
+        local.get $5
+        call $~lib/rt/pure/__release
+        br $while-break|1
+       end
+       local.set $3
+       local.get $5
+       call $~lib/rt/pure/__release
+       br $while-continue|1
+      end
+     end
+    end
+    local.get $0
+    local.get $3
+    i32.const 1
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $6
+    i32.store
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
+    br $for-loop|0
+   end
+  end
  )
  (func $~lib/array/Array<~lib/array/Array<i32>>#sort (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $0
   i32.load offset=12
-  local.tee $5
+  local.tee $2
   i32.const 1
   i32.le_s
   if
@@ -5050,105 +5446,43 @@
   end
   local.get $0
   i32.load offset=4
-  local.set $2
-  local.get $5
+  local.set $3
+  local.get $2
   i32.const 2
   i32.eq
   if
-   local.get $2
+   local.get $3
    i32.load offset=4
-   local.tee $3
-   local.get $2
+   call $~lib/rt/pure/__retain
+   local.tee $2
+   local.get $3
    i32.load
-   local.tee $5
+   call $~lib/rt/pure/__retain
+   local.tee $4
    local.get $1
    call_indirect (type $i32_i32_=>_i32)
    i32.const 0
    i32.lt_s
    if
-    local.get $2
-    local.get $5
-    i32.store offset=4
-    local.get $2
     local.get $3
+    local.get $4
+    i32.store offset=4
+    local.get $3
+    local.get $2
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
+   local.get $2
+   call $~lib/rt/pure/__release
+   local.get $4
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $3
   local.get $2
-  local.set $3
   local.get $1
-  local.set $7
-  loop $for-loop|0
-   local.get $4
-   local.get $5
-   i32.lt_s
-   if
-    local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    local.set $6
-    local.get $4
-    i32.const 1
-    i32.sub
-    local.set $1
-    loop $while-continue|1
-     local.get $1
-     i32.const 0
-     i32.ge_s
-     if
-      local.get $6
-      local.get $3
-      local.get $1
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.tee $8
-      local.get $7
-      call_indirect (type $i32_i32_=>_i32)
-      i32.const 0
-      i32.lt_s
-      if
-       local.get $1
-       local.tee $2
-       i32.const 1
-       i32.sub
-       local.set $1
-       local.get $3
-       local.get $2
-       i32.const 1
-       i32.add
-       i32.const 2
-       i32.shl
-       i32.add
-       local.get $8
-       i32.store
-       br $while-continue|1
-      end
-     end
-    end
-    local.get $3
-    local.get $1
-    i32.const 1
-    i32.add
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $6
-    i32.store
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
+  call $~lib/util/sort/insertionSort<~lib/array/Array<i32>>
   local.get $0
   call $~lib/rt/pure/__retain
  )
@@ -5158,31 +5492,35 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>> (result i32)
    i32.const 1
    local.set $2
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $5
    local.get $1
    call $~lib/array/Array<~lib/array/Array<i32>>#sort
-   local.tee $5
-   local.tee $4
+   local.tee $6
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=12
-   local.set $6
+   local.set $7
    loop $for-loop|0
     local.get $2
-    local.get $6
+    local.get $7
     i32.lt_s
     if
-     local.get $4
+     local.get $0
      local.get $2
      i32.const 1
      i32.sub
      call $~lib/array/Array<std/array/Ref>#__get
-     local.tee $0
-     local.get $4
+     local.tee $3
+     local.get $0
      local.get $2
      call $~lib/array/Array<std/array/Ref>#__get
-     local.tee $3
+     local.tee $4
      local.get $1
      call_indirect (type $i32_i32_=>_i32)
      i32.const 0
@@ -5192,12 +5530,14 @@
       call $~lib/rt/pure/__release
       local.get $3
       call $~lib/rt/pure/__release
+      local.get $4
+      call $~lib/rt/pure/__release
       i32.const 0
       br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>
      end
-     local.get $0
-     call $~lib/rt/pure/__release
      local.get $3
+     call $~lib/rt/pure/__release
+     local.get $4
      call $~lib/rt/pure/__release
      local.get $2
      i32.const 1
@@ -5206,6 +5546,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
   end
   i32.eqz
@@ -5217,6 +5559,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
  )
@@ -5305,11 +5649,22 @@
   local.get $2
  )
  (func $start:std/array~anonymous|48 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load
   local.get $1
   i32.load
   i32.sub
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
@@ -5322,10 +5677,18 @@
  (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  local.tee $3
   i32.const 7
   i32.and
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  local.tee $1
   i32.const 7
   i32.and
   i32.or
@@ -5337,16 +5700,16 @@
   select
   if
    loop $do-continue|0
-    local.get $0
+    local.get $3
     i64.load
     local.get $1
     i64.load
     i64.eq
     if
-     local.get $0
+     local.get $3
      i32.const 8
      i32.add
-     local.set $0
+     local.set $3
      local.get $1
      i32.const 8
      i32.add
@@ -5363,29 +5726,33 @@
   end
   loop $while-continue|1
    local.get $2
-   local.tee $3
+   local.tee $0
    i32.const 1
    i32.sub
    local.set $2
-   local.get $3
+   local.get $0
    if
-    local.get $0
+    local.get $3
     i32.load16_u
-    local.tee $3
+    local.tee $0
     local.get $1
     i32.load16_u
-    local.tee $4
+    local.tee $6
     i32.ne
     if
-     local.get $3
      local.get $4
+     call $~lib/rt/pure/__release
+     local.get $5
+     call $~lib/rt/pure/__release
+     local.get $0
+     local.get $6
      i32.sub
      return
     end
-    local.get $0
+    local.get $3
     i32.const 2
     i32.add
-    local.set $0
+    local.set $3
     local.get $1
     i32.const 2
     i32.add
@@ -5393,23 +5760,35 @@
     br $while-continue|1
    end
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $folding-inner0
-   i32.const 1
-   local.get $1
-   i32.eqz
-   i32.const 1
    local.get $0
-   i32.eqz
-   local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    local.get $1
+   call $~lib/rt/pure/__retain
+   local.tee $1
    i32.eq
-   select
-   select
+   if (result i32)
+    i32.const 1
+   else
+    local.get $0
+    i32.eqz
+   end
+   if (result i32)
+    i32.const 1
+   else
+    local.get $1
+    i32.eqz
+   end
    br_if $folding-inner0
    local.get $0
    call $~lib/string/String#get:length
@@ -5425,12 +5804,20 @@
    local.get $2
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
+    local.get $1
+    call $~lib/rt/pure/__release
     i32.const -1
     return
    end
    local.get $3
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
+    local.get $1
+    call $~lib/rt/pure/__release
     i32.const 1
     return
    end
@@ -5443,16 +5830,32 @@
    i32.lt_s
    select
    call $~lib/util/string/compareImpl
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.eq
   if
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    return
   end
@@ -5475,21 +5878,128 @@
    local.get $2
    call $~lib/util/string/compareImpl
    i32.eqz
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
+ )
+ (func $std/array/isArraysEqual<~lib/string/String | null> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.tee $5
+  local.get $1
+  i32.load offset=12
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 0
+   return
+  end
+  local.get $0
+  local.get $1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 1
+   return
+  end
+  loop $for-loop|0
+   local.get $2
+   local.get $5
+   i32.lt_s
+   if
+    local.get $0
+    local.get $2
+    call $~lib/array/Array<std/array/Ref | null>#__get
+    local.set $3
+    local.get $1
+    local.get $2
+    call $~lib/array/Array<std/array/Ref | null>#__get
+    local.set $4
+    local.get $3
+    call $~lib/rt/pure/__retain
+    local.tee $6
+    local.get $4
+    call $~lib/rt/pure/__retain
+    local.tee $7
+    call $~lib/string/String.__eq
+    i32.eqz
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $7
+    call $~lib/rt/pure/__release
+    if
+     local.get $0
+     call $~lib/rt/pure/__release
+     local.get $1
+     call $~lib/rt/pure/__release
+     local.get $3
+     call $~lib/rt/pure/__release
+     local.get $4
+     call $~lib/rt/pure/__release
+     i32.const 0
+     return
+    end
+    local.get $3
+    call $~lib/rt/pure/__release
+    local.get $4
+    call $~lib/rt/pure/__release
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  i32.const 1
  )
  (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   block $__inlined_func$~lib/string/String#concat (result i32)
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $2
    i32.const 6176
-   local.get $0
+   local.get $2
    select
-   local.set $2
+   local.set $3
    local.get $1
+   call $~lib/rt/pure/__retain
+   local.tee $5
    call $~lib/rt/pure/__retain
    local.tee $0
    i32.eqz
@@ -5504,16 +6014,16 @@
     i32.const 6176
     local.set $0
    end
-   local.get $2
-   call $~lib/string/String#get:length
-   i32.const 1
-   i32.shl
-   local.tee $3
-   local.get $0
+   local.get $3
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    local.tee $4
+   local.get $0
+   call $~lib/string/String#get:length
+   i32.const 1
+   i32.shl
+   local.tee $6
    i32.add
    local.tee $1
    i32.eqz
@@ -5528,19 +6038,23 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.tee $1
-   local.get $2
    local.get $3
+   local.get $4
    call $~lib/memory/memory.copy
    local.get $1
-   local.get $3
+   local.get $4
    i32.add
    local.get $0
-   local.get $4
+   local.get $6
    call $~lib/memory/memory.copy
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -5624,17 +6138,23 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  i32.const 6304
+  call $~lib/rt/pure/__retain
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $3
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    i32.const 6240
@@ -5643,18 +6163,20 @@
    i32.load8_u
    select
    call $~lib/rt/pure/__retain
+   local.get $3
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $4
   local.get $3
-  i32.const 6304
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 5
   i32.add
   i32.mul
   i32.const 5
   i32.add
-  local.tee $7
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
@@ -5662,19 +6184,19 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|1
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $0
-    local.get $5
+    local.get $6
     i32.add
     i32.load8_u
-    local.tee $8
+    local.tee $9
     i32.eqz
     i32.const 4
     i32.add
-    local.set $6
+    local.set $7
     local.get $1
     local.get $2
     i32.const 1
@@ -5682,45 +6204,45 @@
     i32.add
     i32.const 6240
     i32.const 6272
-    local.get $8
+    local.get $9
     select
-    local.get $6
+    local.get $7
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
     local.get $2
-    local.get $6
+    local.get $7
     i32.add
     local.set $2
-    local.get $4
+    local.get $5
     if
      local.get $1
      local.get $2
      i32.const 1
      i32.shl
      i32.add
-     i32.const 6304
-     local.get $4
+     local.get $3
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
      local.get $2
-     local.get $4
+     local.get $5
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|1
    end
   end
   local.get $0
-  local.get $3
+  local.get $4
   i32.add
   i32.load8_u
-  local.tee $3
+  local.tee $4
   i32.eqz
   i32.const 4
   i32.add
@@ -5732,13 +6254,13 @@
   i32.add
   i32.const 6240
   i32.const 6272
-  local.get $3
+  local.get $4
   select
   local.get $0
   i32.const 1
   i32.shl
   call $~lib/memory/memory.copy
-  local.get $7
+  local.get $8
   local.get $0
   local.get $2
   i32.add
@@ -5748,10 +6270,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $3
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
@@ -5919,6 +6445,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
@@ -5926,6 +6455,8 @@
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
@@ -5935,6 +6466,8 @@
    local.get $0
    i32.load
    call $~lib/util/number/itoa32
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
   local.get $4
@@ -6012,19 +6545,28 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/array/Array<i32>#join (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=12
   local.get $1
   call $~lib/util/string/joinIntegerArray<i32>
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
   (local $1 i32)
@@ -6082,6 +6624,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
@@ -6089,6 +6634,8 @@
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
@@ -6098,6 +6645,8 @@
    local.get $0
    i32.load
    call $~lib/util/number/utoa32
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
   local.get $4
@@ -6175,19 +6724,28 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/array/Array<u32>#join (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=12
   local.get $1
   call $~lib/util/string/joinIntegerArray<u32>
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
@@ -7193,28 +7751,34 @@
  )
  (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (local $3 f64)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 f64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  i32.const 7024
+  call $~lib/rt/pure/__retain
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
+   local.get $3
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $4
+  local.get $5
   i32.eqz
   if
    block $__inlined_func$~lib/util/number/dtoa
     local.get $0
     f64.load
-    local.tee $3
+    local.tee $4
     f64.const 0
     f64.eq
     if
@@ -7222,14 +7786,14 @@
      local.set $0
      br $__inlined_func$~lib/util/number/dtoa
     end
-    local.get $3
-    local.get $3
+    local.get $4
+    local.get $4
     f64.sub
     f64.const 0
     f64.ne
     if
-     local.get $3
-     local.get $3
+     local.get $4
+     local.get $4
      f64.ne
      if
       i32.const 7088
@@ -7238,7 +7802,7 @@
      end
      i32.const 7120
      i32.const 7168
-     local.get $3
+     local.get $4
      f64.const 0
      f64.lt
      select
@@ -7250,7 +7814,7 @@
     i32.const 1
     call $~lib/rt/tlsf/__alloc
     local.tee $1
-    local.get $3
+    local.get $4
     call $~lib/util/number/dtoa_core
     local.tee $0
     i32.const 28
@@ -7270,19 +7834,21 @@
     call $~lib/rt/tlsf/checkUsedBlock
     call $~lib/rt/tlsf/freeBlock
    end
+   local.get $3
+   call $~lib/rt/pure/__release
    local.get $0
    return
   end
-  local.get $4
-  i32.const 7024
+  local.get $5
+  local.get $3
   call $~lib/string/String#get:length
-  local.tee $5
+  local.tee $6
   i32.const 28
   i32.add
   i32.mul
   i32.const 28
   i32.add
-  local.tee $7
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
@@ -7290,14 +7856,14 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.lt_s
    if
     local.get $1
     local.get $2
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
@@ -7306,35 +7872,35 @@
     local.get $2
     i32.add
     local.set $2
-    local.get $5
+    local.get $6
     if
      local.get $1
      local.get $2
      i32.const 1
      i32.shl
      i32.add
-     i32.const 7024
-     local.get $5
+     local.get $3
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
      local.get $2
-     local.get $5
+     local.get $6
      i32.add
      local.set $2
     end
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $7
+  local.get $8
   local.get $1
   local.get $2
   local.get $0
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.add
@@ -7348,10 +7914,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $3
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -7362,6 +7932,9 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $5
   local.get $1
   i32.const 1
   i32.sub
@@ -7369,6 +7942,8 @@
   i32.const 0
   i32.lt_s
   if
+   local.get $5
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
@@ -7377,38 +7952,39 @@
   if
    local.get $0
    i32.load
-   local.tee $5
+   local.tee $4
    if
-    local.get $5
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $5
+    local.set $4
    end
-   local.get $5
+   local.get $4
    if (result i32)
-    local.get $5
+    local.get $4
     call $~lib/rt/pure/__retain
    else
     i32.const 6064
    end
    local.get $5
    call $~lib/rt/pure/__release
+   local.get $4
+   call $~lib/rt/pure/__release
    return
   end
   i32.const 6064
   local.set $1
-  local.get $2
-  local.tee $4
+  local.get $5
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $5
+   local.get $4
    local.get $6
    i32.lt_s
    if
     local.get $3
     local.tee $2
     local.get $0
-    local.get $5
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
@@ -7451,7 +8027,7 @@
     if
      local.get $1
      local.tee $2
-     local.get $4
+     local.get $5
      call $~lib/string/String.__concat
      local.tee $7
      local.tee $1
@@ -7467,10 +8043,10 @@
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $5
+    local.get $4
     i32.const 1
     i32.add
-    local.set $5
+    local.set $4
     br $for-loop|0
    end
   end
@@ -7515,36 +8091,48 @@
    local.get $3
    local.set $1
   end
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/array/Array<~lib/string/String | null>#join (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=4
   local.get $0
   i32.load offset=12
   local.get $1
   call $~lib/util/string/joinReferenceArray<~lib/string/String | null>
+  local.get $1
+  call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $6
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $7
   i32.const 0
   i32.lt_s
   if
+   local.get $6
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $7
   i32.eqz
   if
    local.get $0
@@ -7555,6 +8143,8 @@
     call $~lib/rt/pure/__retain
     local.set $4
    end
+   local.get $6
+   call $~lib/rt/pure/__release
    local.get $4
    call $~lib/rt/pure/__release
    i32.const 8272
@@ -7565,12 +8155,12 @@
   end
   i32.const 6064
   local.set $1
-  i32.const 6304
+  local.get $6
   call $~lib/string/String#get:length
-  local.set $7
+  local.set $8
   loop $for-loop|0
    local.get $4
-   local.get $5
+   local.get $7
    i32.lt_s
    if
     local.get $3
@@ -7593,31 +8183,32 @@
     local.get $3
     if
      local.get $1
-     local.get $1
+     local.tee $5
      i32.const 8272
      call $~lib/string/String.__concat
-     local.tee $6
+     local.tee $1
      local.tee $2
+     local.get $5
      i32.ne
      if
       local.get $2
       call $~lib/rt/pure/__retain
       local.set $2
-      local.get $1
+      local.get $5
       call $~lib/rt/pure/__release
      end
-     local.get $6
+     local.get $1
      call $~lib/rt/pure/__release
      local.get $2
      local.set $1
     end
-    local.get $7
+    local.get $8
     if
      local.get $1
      local.tee $2
-     i32.const 6304
+     local.get $6
      call $~lib/string/String.__concat
-     local.tee $6
+     local.tee $5
      local.tee $1
      local.get $2
      i32.ne
@@ -7628,7 +8219,7 @@
       local.get $2
       call $~lib/rt/pure/__release
      end
-     local.get $6
+     local.get $5
      call $~lib/rt/pure/__release
     end
     local.get $4
@@ -7639,8 +8230,9 @@
    end
   end
   local.get $3
+  local.tee $4
   local.get $0
-  local.get $5
+  local.get $7
   i32.const 2
   i32.shl
   i32.add
@@ -7651,31 +8243,35 @@
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $2
+  local.tee $0
   if
    local.get $1
-   local.get $1
+   local.tee $2
    i32.const 8272
    call $~lib/string/String.__concat
-   local.tee $0
+   local.tee $4
    local.tee $3
+   local.get $2
    i32.ne
    if
     local.get $3
     call $~lib/rt/pure/__retain
     local.set $3
-    local.get $1
+    local.get $2
     call $~lib/rt/pure/__release
    end
-   local.get $0
+   local.get $4
    call $~lib/rt/pure/__release
    local.get $3
    local.set $1
   end
-  local.get $2
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -7684,7 +8280,10 @@
   i32.load offset=4
   local.get $0
   i32.load offset=12
+  i32.const 6304
   call $~lib/util/string/joinReferenceArray<std/array/Ref | null>
+  i32.const 6304
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/itoa_stream<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -7758,34 +8357,42 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  i32.const 6304
+  call $~lib/rt/pure/__retain
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $3
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load8_s
    call $~lib/util/number/itoa32
+   local.get $3
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $4
   local.get $3
-  i32.const 6304
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 11
   i32.add
   i32.mul
   i32.const 11
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -7793,49 +8400,49 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
     local.get $2
     local.get $0
-    local.get $5
+    local.get $6
     i32.add
     i32.load8_s
     call $~lib/util/number/itoa_stream<i8>
     local.get $2
     i32.add
     local.set $2
-    local.get $4
+    local.get $5
     if
      local.get $1
      local.get $2
      i32.const 1
      i32.shl
      i32.add
-     i32.const 6304
-     local.get $4
+     local.get $3
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
      local.get $2
-     local.get $4
+     local.get $5
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
   local.get $2
   local.get $0
-  local.get $3
+  local.get $4
   i32.add
   i32.load8_s
   call $~lib/util/number/itoa_stream<i8>
@@ -7847,10 +8454,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $3
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -7894,34 +8505,42 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  i32.const 6304
+  call $~lib/rt/pure/__retain
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $3
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load16_u
    call $~lib/util/number/utoa32
+   local.get $3
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $4
   local.get $3
-  i32.const 6304
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 10
   i32.add
   i32.mul
   i32.const 10
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -7929,14 +8548,14 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
     local.get $2
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 1
     i32.shl
     i32.add
@@ -7945,35 +8564,35 @@
     local.get $2
     i32.add
     local.set $2
-    local.get $4
+    local.get $5
     if
      local.get $1
      local.get $2
      i32.const 1
      i32.shl
      i32.add
-     i32.const 6304
-     local.get $4
+     local.get $3
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
      local.get $2
-     local.get $4
+     local.get $5
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
   local.get $2
   local.get $0
-  local.get $3
+  local.get $4
   i32.const 1
   i32.shl
   i32.add
@@ -7987,10 +8606,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $3
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
@@ -8115,36 +8738,42 @@
  (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i64)
-  (local $5 i32)
+  (local $4 i32)
+  (local $5 i64)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  i32.const 6304
+  call $~lib/rt/pure/__retain
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $3
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    block $__inlined_func$~lib/util/number/utoa64 (result i32)
     i32.const 6608
     local.get $0
     i64.load
-    local.tee $4
+    local.tee $5
     i64.eqz
     br_if $__inlined_func$~lib/util/number/utoa64
     drop
-    local.get $4
+    local.get $5
     i64.const 4294967295
     i64.le_u
     if
-     local.get $4
+     local.get $5
      i32.wrap_i64
      local.tee $1
      call $~lib/util/number/decimalCount32
@@ -8158,7 +8787,7 @@
      local.get $2
      call $~lib/util/number/utoa_dec_simple<u32>
     else
-     local.get $4
+     local.get $5
      call $~lib/util/number/decimalCount64High
      local.tee $1
      i32.const 1
@@ -8166,25 +8795,27 @@
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $0
-     local.get $4
+     local.get $5
      local.get $1
      call $~lib/util/number/utoa_dec_simple<u64>
     end
     local.get $0
     call $~lib/rt/pure/__retain
    end
+   local.get $3
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $4
   local.get $3
-  i32.const 6304
   call $~lib/string/String#get:length
-  local.tee $5
+  local.tee $6
   i32.const 20
   i32.add
   i32.mul
   i32.const 20
   i32.add
-  local.tee $7
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
@@ -8192,14 +8823,14 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $6
-   local.get $3
+   local.get $7
+   local.get $4
    i32.lt_s
    if
     local.get $1
     local.get $2
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
@@ -8208,35 +8839,35 @@
     local.get $2
     i32.add
     local.set $2
-    local.get $5
+    local.get $6
     if
      local.get $1
      local.get $2
      i32.const 1
      i32.shl
      i32.add
-     i32.const 6304
-     local.get $5
+     local.get $3
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
      local.get $2
-     local.get $5
+     local.get $6
      i32.add
      local.set $2
     end
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $7
+  local.get $8
   local.get $1
   local.get $2
   local.get $0
-  local.get $3
+  local.get $4
   i32.const 3
   i32.shl
   i32.add
@@ -8250,10 +8881,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $3
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/util/number/itoa_stream<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
@@ -8329,17 +8964,23 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  i32.const 6304
+  call $~lib/rt/pure/__retain
+  local.set $4
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
+   local.get $4
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $4
+  local.get $5
   i32.eqz
   if
    block $__inlined_func$~lib/util/number/itoa64 (result i32)
@@ -8373,14 +9014,14 @@
      call $~lib/util/number/decimalCount32
      local.get $0
      i32.add
-     local.tee $4
+     local.tee $5
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $1
      local.get $2
-     local.get $4
+     local.get $5
      call $~lib/util/number/utoa_dec_simple<u32>
     else
      local.get $3
@@ -8406,18 +9047,20 @@
     local.get $1
     call $~lib/rt/pure/__retain
    end
+   local.get $4
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $5
   local.get $4
-  i32.const 6304
   call $~lib/string/String#get:length
-  local.tee $5
+  local.tee $6
   i32.const 21
   i32.add
   i32.mul
   i32.const 21
   i32.add
-  local.tee $7
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
@@ -8425,14 +9068,14 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.lt_s
    if
     local.get $1
     local.get $2
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
@@ -8441,35 +9084,35 @@
     local.get $2
     i32.add
     local.set $2
-    local.get $5
+    local.get $6
     if
      local.get $1
      local.get $2
      i32.const 1
      i32.shl
      i32.add
-     i32.const 6304
-     local.get $5
+     local.get $4
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
      local.get $2
-     local.get $5
+     local.get $6
      i32.add
      local.set $2
     end
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $7
+  local.get $8
   local.get $1
   local.get $2
   local.get $0
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.add
@@ -8483,10 +9126,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $4
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
@@ -8497,17 +9144,23 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  i32.const 6304
+  call $~lib/rt/pure/__retain
+  local.set $5
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $6
   i32.const 0
   i32.lt_s
   if
+   local.get $5
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $6
   i32.eqz
   if
    local.get $0
@@ -8526,18 +9179,20 @@
    else
     i32.const 6064
    end
+   local.get $5
+   call $~lib/rt/pure/__release
    local.get $4
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6064
   local.set $1
-  i32.const 6304
+  local.get $5
   call $~lib/string/String#get:length
-  local.set $7
+  local.set $8
   loop $for-loop|0
    local.get $4
-   local.get $5
+   local.get $6
    i32.lt_s
    if
     local.get $3
@@ -8567,7 +9222,7 @@
      local.get $1
      local.get $2
      call $~lib/string/String.__concat
-     local.tee $8
+     local.tee $9
      local.tee $2
      i32.ne
      if
@@ -8578,18 +9233,18 @@
       call $~lib/rt/pure/__release
      end
      call $~lib/rt/pure/__release
-     local.get $8
+     local.get $9
      call $~lib/rt/pure/__release
      local.get $2
      local.set $1
     end
-    local.get $7
+    local.get $8
     if
      local.get $1
      local.tee $2
-     i32.const 6304
+     local.get $5
      call $~lib/string/String.__concat
-     local.tee $6
+     local.tee $7
      local.tee $1
      local.get $2
      i32.ne
@@ -8600,7 +9255,7 @@
       local.get $2
       call $~lib/rt/pure/__release
      end
-     local.get $6
+     local.get $7
      call $~lib/rt/pure/__release
     end
     local.get $4
@@ -8610,14 +9265,14 @@
     br $for-loop|0
    end
   end
+  local.get $3
   local.get $0
-  local.get $5
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load
   local.tee $2
-  local.get $3
   i32.ne
   if
    local.get $2
@@ -8652,6 +9307,8 @@
    local.get $3
    local.set $1
   end
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
   local.get $1
@@ -8691,40 +9348,47 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load8_u
    call $~lib/util/number/utoa32
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 6304
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 10
   i32.add
   i32.mul
   i32.const 10
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -8732,53 +9396,53 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $5
+    local.get $6
     i32.add
     i32.load8_u
     call $~lib/util/number/itoa_stream<u8>
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $4
+    local.set $3
+    local.get $5
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 6304
-     local.get $4
+     local.get $2
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.add
   i32.load8_u
   call $~lib/util/number/itoa_stream<u8>
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -8786,10 +9450,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/array/Array<u8>#toString (param $0 i32) (result i32)
@@ -8797,7 +9465,10 @@
   i32.load offset=4
   local.get $0
   i32.load offset=12
+  i32.const 6304
   call $~lib/util/string/joinIntegerArray<u8>
+  i32.const 6304
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -8807,17 +9478,23 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  i32.const 6304
+  call $~lib/rt/pure/__retain
+  local.set $5
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $6
   i32.const 0
   i32.lt_s
   if
+   local.get $5
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $6
   i32.eqz
   if
    local.get $0
@@ -8835,18 +9512,20 @@
    else
     i32.const 6064
    end
+   local.get $5
+   call $~lib/rt/pure/__release
    local.get $4
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6064
   local.set $1
-  i32.const 6304
+  local.get $5
   call $~lib/string/String#get:length
-  local.set $7
+  local.set $8
   loop $for-loop|0
    local.get $4
-   local.get $5
+   local.get $6
    i32.lt_s
    if
     local.get $3
@@ -8872,9 +9551,9 @@
      local.get $1
      local.get $3
      call $~lib/array/Array<u8>#toString
-     local.tee $6
+     local.tee $7
      call $~lib/string/String.__concat
-     local.tee $8
+     local.tee $9
      local.tee $2
      i32.ne
      if
@@ -8884,20 +9563,20 @@
       local.get $1
       call $~lib/rt/pure/__release
      end
-     local.get $6
+     local.get $7
      call $~lib/rt/pure/__release
-     local.get $8
+     local.get $9
      call $~lib/rt/pure/__release
      local.get $2
      local.set $1
     end
-    local.get $7
+    local.get $8
     if
      local.get $1
      local.tee $2
-     i32.const 6304
+     local.get $5
      call $~lib/string/String.__concat
-     local.tee $6
+     local.tee $7
      local.tee $1
      local.get $2
      i32.ne
@@ -8908,7 +9587,7 @@
       local.get $2
       call $~lib/rt/pure/__release
      end
-     local.get $6
+     local.get $7
      call $~lib/rt/pure/__release
     end
     local.get $4
@@ -8920,7 +9599,7 @@
   end
   local.get $3
   local.get $0
-  local.get $5
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -8959,29 +9638,36 @@
    local.get $3
    local.set $1
   end
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $5
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $6
   i32.const 0
   i32.lt_s
   if
+   local.get $5
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $6
   i32.eqz
   if
    local.get $0
@@ -9000,18 +9686,20 @@
    else
     i32.const 6064
    end
+   local.get $5
+   call $~lib/rt/pure/__release
    local.get $4
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6064
   local.set $1
-  i32.const 6304
+  local.get $5
   call $~lib/string/String#get:length
-  local.set $7
+  local.set $8
   loop $for-loop|0
    local.get $4
-   local.get $5
+   local.get $6
    i32.lt_s
    if
     local.get $3
@@ -9038,11 +9726,11 @@
      call $~lib/array/Array<u32>#join
      local.tee $2
      local.get $1
-     local.get $1
      local.get $2
      call $~lib/string/String.__concat
-     local.tee $8
+     local.tee $9
      local.tee $2
+     local.get $1
      i32.ne
      if
       local.get $2
@@ -9052,18 +9740,18 @@
       call $~lib/rt/pure/__release
      end
      call $~lib/rt/pure/__release
-     local.get $8
+     local.get $9
      call $~lib/rt/pure/__release
      local.get $2
      local.set $1
     end
-    local.get $7
+    local.get $8
     if
      local.get $1
      local.tee $2
-     i32.const 6304
+     local.get $5
      call $~lib/string/String.__concat
-     local.tee $6
+     local.tee $7
      local.tee $1
      local.get $2
      i32.ne
@@ -9074,7 +9762,7 @@
       local.get $2
       call $~lib/rt/pure/__release
      end
-     local.get $6
+     local.get $7
      call $~lib/rt/pure/__release
     end
     local.get $4
@@ -9085,7 +9773,7 @@
    end
   end
   local.get $0
-  local.get $5
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -9107,11 +9795,11 @@
    call $~lib/array/Array<u32>#join
    local.tee $0
    local.get $1
-   local.get $1
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
    local.tee $3
+   local.get $1
    i32.ne
    if
     local.get $3
@@ -9126,6 +9814,8 @@
    local.get $3
    local.set $1
   end
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
   local.get $1
@@ -9135,7 +9825,10 @@
   i32.load offset=4
   local.get $0
   i32.load offset=12
+  i32.const 6304
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>
+  i32.const 6304
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -9145,17 +9838,23 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  i32.const 6304
+  call $~lib/rt/pure/__retain
+  local.set $5
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $6
   i32.const 0
   i32.lt_s
   if
+   local.get $5
+   call $~lib/rt/pure/__release
    i32.const 6064
    return
   end
-  local.get $5
+  local.get $6
   i32.eqz
   if
    local.get $0
@@ -9173,18 +9872,20 @@
    else
     i32.const 6064
    end
+   local.get $5
+   call $~lib/rt/pure/__release
    local.get $4
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6064
   local.set $1
-  i32.const 6304
+  local.get $5
   call $~lib/string/String#get:length
-  local.set $7
+  local.set $8
   loop $for-loop|0
    local.get $4
-   local.get $5
+   local.get $6
    i32.lt_s
    if
     local.get $3
@@ -9210,9 +9911,9 @@
      local.get $1
      local.get $3
      call $~lib/array/Array<~lib/array/Array<u32>>#toString
-     local.tee $6
+     local.tee $7
      call $~lib/string/String.__concat
-     local.tee $8
+     local.tee $9
      local.tee $2
      i32.ne
      if
@@ -9222,20 +9923,20 @@
       local.get $1
       call $~lib/rt/pure/__release
      end
-     local.get $6
+     local.get $7
      call $~lib/rt/pure/__release
-     local.get $8
+     local.get $9
      call $~lib/rt/pure/__release
      local.get $2
      local.set $1
     end
-    local.get $7
+    local.get $8
     if
      local.get $1
      local.tee $2
-     i32.const 6304
+     local.get $5
      call $~lib/string/String.__concat
-     local.tee $6
+     local.tee $7
      local.tee $1
      local.get $2
      i32.ne
@@ -9246,7 +9947,7 @@
       local.get $2
       call $~lib/rt/pure/__release
      end
-     local.get $6
+     local.get $7
      call $~lib/rt/pure/__release
     end
     local.get $4
@@ -9258,7 +9959,7 @@
   end
   local.get $3
   local.get $0
-  local.get $5
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -9297,6 +9998,8 @@
    local.get $3
    local.set $1
   end
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
   local.get $1
@@ -9545,17 +10248,17 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local $14 f32)
-  (local $15 f64)
+  (local $14 i32)
+  (local $15 i32)
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
   (local $19 i32)
-  (local $20 i32)
+  (local $20 f32)
   (local $21 i32)
   (local $22 i32)
   (local $23 i32)
-  (local $24 i32)
+  (local $24 f64)
   (local $25 i32)
   (local $26 i32)
   (local $27 i32)
@@ -9597,39 +10300,49 @@
   call $~lib/array/Array<i32>#constructor
   global.set $std/array/arr
   i32.const 0
+  call $~lib/array/Array.isArray<~lib/array/Array<i32> | null>
+  if
+   i32.const 0
+   i32.const 1296
+   i32.const 46
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
   call $std/array/Ref#constructor
   i32.const 12
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $2
   i32.eqz
   if
    i32.const 12
    i32.const 2
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $2
   end
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store offset=4
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store offset=8
   i32.const 1
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 1
   call $~lib/memory/memory.fill
-  local.get $2
-  local.tee $0
   local.get $1
+  local.tee $0
+  local.get $2
   i32.load
   local.tee $4
   i32.ne
@@ -9640,16 +10353,17 @@
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $2
   local.get $0
   i32.store
-  local.get $1
   local.get $2
-  i32.store offset=4
   local.get $1
+  i32.store offset=4
+  local.get $2
   i32.const 1
   i32.store offset=8
   global.get $std/array/arr
+  call $~lib/array/Array.isArray<~lib/array/Array<i32> | null>
   i32.eqz
   if
    i32.const 0
@@ -9660,7 +10374,7 @@
    unreachable
   end
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 0
@@ -9777,7 +10491,7 @@
   i32.const 1664
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $9
   call $std/array/isArraysEqual<u8>
   i32.eqz
   if
@@ -9798,7 +10512,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $9
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -9919,7 +10633,7 @@
   i32.const 1936
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $9
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -9941,7 +10655,7 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $9
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.load offset=12
@@ -10214,27 +10928,27 @@
   i32.store offset=4
   local.get $0
   i32.load offset=12
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.gt_s
   if
    local.get $0
    i32.load offset=4
-   local.tee $1
-   local.get $2
+   local.tee $2
+   local.get $1
    i32.const 2
    i32.shl
    i32.add
-   local.set $2
+   local.set $1
    loop $do-continue|0
-    local.get $1
+    local.get $2
     i32.load
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $2
     i32.const 4
     i32.add
-    local.tee $1
-    local.get $2
+    local.tee $2
+    local.get $1
     i32.lt_u
     br_if $do-continue|0
    end
@@ -10593,7 +11307,7 @@
   i32.const 2208
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $9
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10619,14 +11333,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $16
+  local.tee $13
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2304
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $25
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10651,14 +11365,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $25
+  local.tee $6
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2400
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $8
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10683,14 +11397,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $8
+  local.tee $7
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2496
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10715,14 +11429,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $11
+  local.tee $28
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2592
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $14
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10747,14 +11461,14 @@
   i32.const 2
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $30
+  local.tee $15
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2688
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10779,14 +11493,14 @@
   i32.const -2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $18
+  local.tee $17
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $18
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10836,22 +11550,21 @@
   i32.const 2928
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $0
+  local.tee $1
   i32.const -4
   i32.const -3
   i32.const -2
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $22
+  local.tee $19
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2976
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -10869,15 +11582,15 @@
   i32.const 3024
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $24
+  local.tee $23
   i32.const 5
   i32.const 2
   i32.const 3
@@ -10902,15 +11615,15 @@
   i32.const 3120
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.const -4
   i32.const -3
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $1
+  local.tee $0
   i32.const 5
   i32.const 2
   i32.const 3
@@ -10929,7 +11642,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -10937,11 +11650,9 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $9
   call $~lib/rt/pure/__release
-  local.get $16
-  call $~lib/rt/pure/__release
-  local.get $20
+  local.get $13
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
@@ -10949,33 +11660,35 @@
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $28
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
   local.get $12
   call $~lib/rt/pure/__release
   local.get $21
+  call $~lib/rt/pure/__release
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $22
   call $~lib/rt/pure/__release
   local.get $23
   call $~lib/rt/pure/__release
-  local.get $24
-  call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $27
   call $~lib/rt/pure/__release
@@ -11369,30 +12082,30 @@
    i32.const 2
    i32.shl
    i32.add
-   local.set $1
+   local.set $2
    loop $while-continue|0
     local.get $0
-    local.get $1
+    local.get $2
     i32.lt_u
     if
      local.get $0
      i32.load
-     local.set $2
+     local.set $1
      local.get $0
-     local.get $1
+     local.get $2
      i32.load
      i32.store
-     local.get $1
      local.get $2
+     local.get $1
      i32.store
      local.get $0
      i32.const 4
      i32.add
      local.set $0
-     local.get $1
+     local.get $2
      i32.const 4
      i32.sub
-     local.set $1
+     local.set $2
      br $while-continue|0
     end
    end
@@ -11653,7 +12366,7 @@
    local.get $4
    i32.load offset=4
    local.set $3
-   loop $while-continue|022
+   loop $while-continue|019
     local.get $0
     local.get $2
     i32.lt_s
@@ -11671,7 +12384,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $while-continue|022
+     br $while-continue|019
     end
    end
    i32.const -1
@@ -11695,7 +12408,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $2
-  local.set $5
+  local.set $9
   i32.const 0
   local.set $0
   block $__inlined_func$~lib/array/Array<f64>#indexOf
@@ -11714,10 +12427,10 @@
     local.set $0
     br $__inlined_func$~lib/array/Array<f64>#indexOf
    end
-   local.get $5
+   local.get $9
    i32.load offset=4
    local.set $4
-   loop $while-continue|023
+   loop $while-continue|020
     local.get $0
     local.get $3
     i32.lt_s
@@ -11735,7 +12448,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $while-continue|023
+     br $while-continue|020
     end
    end
    i32.const -1
@@ -11902,41 +12615,41 @@
    i32.const 3280
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $2
-   i32.load offset=12
    local.tee $3
+   i32.load offset=12
+   local.tee $2
    if (result i32)
     i32.const 0
-    local.get $3
+    local.get $2
     i32.ge_s
    else
     i32.const 1
    end
    br_if $__inlined_func$~lib/array/Array<f32>#includes
    drop
-   local.get $2
+   local.get $3
    i32.load offset=4
-   local.set $5
-   loop $while-continue|024
+   local.set $9
+   loop $while-continue|021
     local.get $0
-    local.get $3
+    local.get $2
     i32.lt_s
     if
      i32.const 1
-     local.get $5
+     local.get $9
      local.get $0
      i32.const 2
      i32.shl
      i32.add
      f32.load
-     local.tee $14
+     local.tee $20
      f32.const nan:0x400000
      f32.eq
      if (result i32)
       i32.const 1
      else
-      local.get $14
-      local.get $14
+      local.get $20
+      local.get $20
       f32.ne
      end
      br_if $__inlined_func$~lib/array/Array<f32>#includes
@@ -11945,7 +12658,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $while-continue|024
+     br $while-continue|021
     end
    end
    i32.const 0
@@ -11961,7 +12674,7 @@
   end
   block $__inlined_func$~lib/array/Array<f64>#includes (result i32)
    i32.const 0
-   local.set $1
+   local.set $2
    i32.const 0
    i32.const 1
    i32.const 3
@@ -11969,7 +12682,7 @@
    i32.const 3312
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $3
+   local.tee $1
    i32.load offset=12
    local.tee $4
    if (result i32)
@@ -11981,38 +12694,38 @@
    end
    br_if $__inlined_func$~lib/array/Array<f64>#includes
    drop
-   local.get $3
+   local.get $1
    i32.load offset=4
-   local.set $16
-   loop $while-continue|025
-    local.get $1
+   local.set $13
+   loop $while-continue|022
+    local.get $2
     local.get $4
     i32.lt_s
     if
      i32.const 1
-     local.get $16
-     local.get $1
+     local.get $13
+     local.get $2
      i32.const 3
      i32.shl
      i32.add
      f64.load
-     local.tee $15
+     local.tee $24
      f64.const nan:0x8000000000000
      f64.eq
      if (result i32)
       i32.const 1
      else
-      local.get $15
-      local.get $15
+      local.get $24
+      local.get $24
       f64.ne
      end
      br_if $__inlined_func$~lib/array/Array<f64>#includes
      drop
-     local.get $1
+     local.get $2
      i32.const 1
      i32.add
-     local.set $1
-     br $while-continue|025
+     local.set $2
+     br $while-continue|022
     end
    end
    i32.const 0
@@ -12081,9 +12794,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  call $~lib/rt/pure/__release
   local.get $3
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -12121,7 +12834,7 @@
   i32.const 3440
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12146,14 +12859,14 @@
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $6
+  local.tee $8
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 3504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $7
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12172,7 +12885,7 @@
   i32.const 3520
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12197,14 +12910,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $11
+  local.tee $14
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 3616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $15
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12223,7 +12936,7 @@
   i32.const 3648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12241,21 +12954,21 @@
   i32.const 3680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $0
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#splice
-  local.tee $18
+  local.tee $17
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 3728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $18
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12267,7 +12980,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $0
   i32.const 3
   i32.const 2
   i32.const 3
@@ -12292,10 +13005,9 @@
   i32.const 3792
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $2
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/array/Array<i32>#splice
@@ -12306,7 +13018,7 @@
   i32.const 3840
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12325,7 +13037,7 @@
   i32.const 3872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12349,7 +13061,7 @@
   i32.const -1
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $24
+  local.tee $23
   i32.const 1
   i32.const 2
   i32.const 3
@@ -12399,14 +13111,14 @@
   i32.const -2
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $31
+  local.tee $29
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 4064
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $32
+  local.tee $30
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12425,7 +13137,7 @@
   i32.const 4096
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $33
+  local.tee $31
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12449,14 +13161,14 @@
   i32.const -2
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $28
+  local.tee $32
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 4176
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $33
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12799,7 +13511,7 @@
   local.tee $2
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#splice
-  local.tee $20
+  local.tee $13
   i32.load offset=12
   if
    i32.const 0
@@ -12825,7 +13537,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $9
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -12849,11 +13561,11 @@
   i32.store offset=16
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $9
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#splice
   local.set $25
-  local.get $20
+  local.get $13
   call $~lib/rt/pure/__release
   local.get $25
   i32.load offset=12
@@ -12897,7 +13609,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $9
   i32.load offset=12
   i32.const 3
   i32.ne
@@ -12909,7 +13621,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $9
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $57
@@ -12924,7 +13636,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $9
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $58
@@ -12939,7 +13651,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $16
+  local.get $9
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $59
@@ -12960,7 +13672,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $13
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -12973,9 +13685,9 @@
   i32.const 2
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $20
+  local.get $13
   call $~lib/array/Array<std/array/Ref | null>#splice
-  local.tee $30
+  local.tee $28
   i32.load offset=12
   i32.const 1
   i32.ne
@@ -12987,7 +13699,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $28
   i32.const 0
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $0
@@ -13012,7 +13724,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $13
   i32.load offset=12
   i32.const 2
   i32.ne
@@ -13024,7 +13736,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $13
   i32.const 0
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $60
@@ -13036,7 +13748,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $13
   i32.const 1
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $2
@@ -13067,47 +13779,47 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $5
-  call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
   local.get $12
   call $~lib/rt/pure/__release
   local.get $21
+  call $~lib/rt/pure/__release
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $22
   call $~lib/rt/pure/__release
   local.get $23
   call $~lib/rt/pure/__release
-  local.get $24
-  call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
   local.get $27
+  call $~lib/rt/pure/__release
+  local.get $29
+  call $~lib/rt/pure/__release
+  local.get $30
   call $~lib/rt/pure/__release
   local.get $31
   call $~lib/rt/pure/__release
   local.get $32
   call $~lib/rt/pure/__release
   local.get $33
-  call $~lib/rt/pure/__release
-  local.get $28
-  call $~lib/rt/pure/__release
-  local.get $29
   call $~lib/rt/pure/__release
   local.get $36
   call $~lib/rt/pure/__release
@@ -13635,17 +14347,17 @@
    unreachable
   end
   loop $for-loop|0
-   local.get $7
+   local.get $5
    i32.const 100
    i32.lt_s
    if
     global.get $std/array/arr
     call $~lib/array/Array<i32>#pop
     drop
-    local.get $7
+    local.get $5
     i32.const 1
     i32.add
-    local.set $7
+    local.set $5
     br $for-loop|0
    end
   end
@@ -13662,7 +14374,7 @@
   i32.const 3
   call $~lib/array/Array<i32>#push
   i32.const 0
-  local.set $1
+  local.set $0
   global.get $std/array/arr
   local.tee $2
   i32.load offset=12
@@ -13672,11 +14384,11 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $0
+  local.tee $1
   i32.load offset=4
   local.set $4
-  loop $for-loop|043
-   local.get $1
+  loop $for-loop|040
+   local.get $0
    local.get $3
    local.get $2
    i32.load offset=12
@@ -13687,7 +14399,7 @@
    select
    i32.lt_s
    if
-    local.get $1
+    local.get $0
     i32.const 2
     i32.shl
     local.tee $5
@@ -13695,21 +14407,21 @@
     i32.load offset=4
     i32.add
     i32.load
-    local.set $7
+    f32.convert_i32_s
+    local.set $20
     local.get $4
     local.get $5
     i32.add
-    local.get $7
-    f32.convert_i32_s
+    local.get $20
     f32.store
-    local.get $1
+    local.get $0
     i32.const 1
     i32.add
-    local.set $1
-    br $for-loop|043
+    local.set $0
+    br $for-loop|040
    end
   end
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 4
   i32.ne
@@ -13721,7 +14433,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/array/Array<f32>#__get
   global.get $std/array/arr
@@ -13830,7 +14542,7 @@
   global.get $std/array/arr
   i32.const 3
   call $~lib/array/Array<i32>#push
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.const 26
@@ -14256,41 +14968,41 @@
    i32.const 5280
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $3
+   local.tee $4
    i32.load offset=12
    local.tee $5
    i32.const 1
    i32.le_s
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
     br $__inlined_func$~lib/array/Array<f32>#sort
    end
-   local.get $3
+   local.get $4
    i32.load offset=4
-   local.set $4
+   local.set $3
    local.get $5
    i32.const 2
    i32.eq
    if
-    local.get $4
+    local.get $3
     f32.load offset=4
-    local.tee $14
-    local.get $4
+    local.tee $20
+    local.get $3
     f32.load
     local.tee $34
     call $~lib/util/sort/COMPARATOR<f32>~anonymous|0
     i32.const 0
     i32.lt_s
     if
-     local.get $4
+     local.get $3
      local.get $34
      f32.store offset=4
-     local.get $4
-     local.get $14
+     local.get $3
+     local.get $20
      f32.store
     end
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
     br $__inlined_func$~lib/array/Array<f32>#sort
    end
@@ -14300,18 +15012,18 @@
    if
     i32.const 0
     local.set $2
-    loop $for-loop|00
+    loop $for-loop|02
      local.get $2
      local.get $5
      i32.lt_s
      if
-      local.get $4
+      local.get $3
       local.get $2
       i32.const 2
       i32.shl
       i32.add
       f32.load
-      local.set $14
+      local.set $20
       local.get $2
       i32.const 1
       i32.sub
@@ -14321,8 +15033,8 @@
        i32.const 0
        i32.ge_s
        if
-        local.get $14
-        local.get $4
+        local.get $20
+        local.get $3
         local.get $0
         i32.const 2
         i32.shl
@@ -14338,7 +15050,7 @@
          i32.const 1
          i32.sub
          local.set $0
-         local.get $4
+         local.get $3
          local.get $1
          i32.const 1
          i32.add
@@ -14351,99 +15063,40 @@
         end
        end
       end
-      local.get $4
+      local.get $3
       local.get $0
       i32.const 1
       i32.add
       i32.const 2
       i32.shl
       i32.add
-      local.get $14
+      local.get $20
       f32.store
       local.get $2
       i32.const 1
       i32.add
       local.set $2
-      br $for-loop|00
+      br $for-loop|02
      end
     end
    else
-    local.get $4
+    local.get $3
     local.get $5
     call $~lib/util/sort/weakHeapSort<f32>
    end
-   local.get $3
+   local.get $4
    call $~lib/rt/pure/__retain
   end
   call $~lib/rt/pure/__release
-  block $__inlined_func$std/array/isArraysEqual<f32> (result i32)
-   i32.const 8
-   i32.const 2
-   i32.const 9
-   i32.const 5328
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.set $7
-   i32.const 0
-   local.set $1
-   block $folding-inner0
-    local.get $3
-    i32.load offset=12
-    local.tee $2
-    local.get $7
-    i32.load offset=12
-    i32.ne
-    br_if $folding-inner0
-    i32.const 1
-    local.get $3
-    local.get $7
-    i32.eq
-    br_if $__inlined_func$std/array/isArraysEqual<f32>
-    drop
-    loop $for-loop|001
-     local.get $1
-     local.get $2
-     i32.lt_s
-     if
-      local.get $3
-      local.get $1
-      call $~lib/array/Array<f32>#__get
-      local.tee $14
-      local.get $14
-      f32.ne
-      if (result i32)
-       local.get $7
-       local.get $1
-       call $~lib/array/Array<f32>#__get
-       local.tee $14
-       local.get $14
-       f32.ne
-      else
-       i32.const 0
-      end
-      i32.eqz
-      if
-       local.get $3
-       local.get $1
-       call $~lib/array/Array<f32>#__get
-       local.get $7
-       local.get $1
-       call $~lib/array/Array<f32>#__get
-       f32.ne
-       br_if $folding-inner0
-      end
-      local.get $1
-      i32.const 1
-      i32.add
-      local.set $1
-      br $for-loop|001
-     end
-    end
-    i32.const 1
-    br $__inlined_func$std/array/isArraysEqual<f32>
-   end
-   i32.const 0
-  end
+  local.get $4
+  i32.const 8
+  i32.const 2
+  i32.const 9
+  i32.const 5328
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $18
+  call $std/array/isArraysEqual<f32>
   i32.eqz
   if
    i32.const 0
@@ -14460,41 +15113,41 @@
    i32.const 5376
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $4
+   local.tee $5
    i32.load offset=12
    local.tee $6
    i32.const 1
    i32.le_s
    if
-    local.get $4
+    local.get $5
     call $~lib/rt/pure/__retain
     br $__inlined_func$~lib/array/Array<f64>#sort
    end
-   local.get $4
+   local.get $5
    i32.load offset=4
-   local.set $5
+   local.set $3
    local.get $6
    i32.const 2
    i32.eq
    if
-    local.get $5
+    local.get $3
     f64.load offset=8
-    local.tee $15
-    local.get $5
+    local.tee $24
+    local.get $3
     f64.load
     local.tee $35
     call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
     i32.const 0
     i32.lt_s
     if
-     local.get $5
+     local.get $3
      local.get $35
      f64.store offset=8
-     local.get $5
-     local.get $15
+     local.get $3
+     local.get $24
      f64.store
     end
-    local.get $4
+    local.get $5
     call $~lib/rt/pure/__retain
     br $__inlined_func$~lib/array/Array<f64>#sort
    end
@@ -14504,29 +15157,29 @@
    if
     i32.const 0
     local.set $2
-    loop $for-loop|02
+    loop $for-loop|03
      local.get $2
      local.get $6
      i32.lt_s
      if
-      local.get $5
+      local.get $3
       local.get $2
       i32.const 3
       i32.shl
       i32.add
       f64.load
-      local.set $15
+      local.set $24
       local.get $2
       i32.const 1
       i32.sub
       local.set $0
-      loop $while-continue|13
+      loop $while-continue|14
        local.get $0
        i32.const 0
        i32.ge_s
        if
-        local.get $15
-        local.get $5
+        local.get $24
+        local.get $3
         local.get $0
         i32.const 3
         i32.shl
@@ -14542,7 +15195,7 @@
          i32.const 1
          i32.sub
          local.set $0
-         local.get $5
+         local.get $3
          local.get $1
          i32.const 1
          i32.add
@@ -14551,103 +15204,44 @@
          i32.add
          local.get $35
          f64.store
-         br $while-continue|13
+         br $while-continue|14
         end
        end
       end
-      local.get $5
+      local.get $3
       local.get $0
       i32.const 1
       i32.add
       i32.const 3
       i32.shl
       i32.add
-      local.get $15
+      local.get $24
       f64.store
       local.get $2
       i32.const 1
       i32.add
       local.set $2
-      br $for-loop|02
+      br $for-loop|03
      end
     end
    else
-    local.get $5
+    local.get $3
     local.get $6
     call $~lib/util/sort/weakHeapSort<f64>
    end
-   local.get $4
+   local.get $5
    call $~lib/rt/pure/__retain
   end
   call $~lib/rt/pure/__release
-  block $__inlined_func$std/array/isArraysEqual<f64> (result i32)
-   i32.const 8
-   i32.const 3
-   i32.const 10
-   i32.const 5456
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.set $2
-   i32.const 0
-   local.set $1
-   block $folding-inner01
-    local.get $4
-    i32.load offset=12
-    local.tee $5
-    local.get $2
-    i32.load offset=12
-    i32.ne
-    br_if $folding-inner01
-    i32.const 1
-    local.get $2
-    local.get $4
-    i32.eq
-    br_if $__inlined_func$std/array/isArraysEqual<f64>
-    drop
-    loop $for-loop|025
-     local.get $1
-     local.get $5
-     i32.lt_s
-     if
-      local.get $4
-      local.get $1
-      call $~lib/array/Array<f64>#__get
-      local.tee $15
-      local.get $15
-      f64.ne
-      if (result i32)
-       local.get $2
-       local.get $1
-       call $~lib/array/Array<f64>#__get
-       local.tee $15
-       local.get $15
-       f64.ne
-      else
-       i32.const 0
-      end
-      i32.eqz
-      if
-       local.get $4
-       local.get $1
-       call $~lib/array/Array<f64>#__get
-       local.get $2
-       local.get $1
-       call $~lib/array/Array<f64>#__get
-       f64.ne
-       br_if $folding-inner01
-      end
-      local.get $1
-      i32.const 1
-      i32.add
-      local.set $1
-      br $for-loop|025
-     end
-    end
-    i32.const 1
-    br $__inlined_func$std/array/isArraysEqual<f64>
-   end
-   i32.const 0
-  end
+  local.get $5
+  i32.const 8
+  i32.const 3
+  i32.const 10
+  i32.const 5456
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $12
+  call $std/array/isArraysEqual<f64>
   i32.eqz
   if
    i32.const 0
@@ -14663,11 +15257,11 @@
   i32.const 5536
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $14
   i32.const 46
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $14
   i32.const 5
   i32.const 2
   i32.const 3
@@ -14692,18 +15286,18 @@
   i32.const 5632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $15
   i32.const 47
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $15
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 5680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14721,7 +15315,7 @@
   i32.const 5728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $19
+  local.set $16
   i32.const 1
   i32.const 2
   i32.const 3
@@ -14735,14 +15329,14 @@
   i32.const 5776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $2
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 5808
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
+  local.set $3
   i32.const 4
   i32.const 2
   i32.const 3
@@ -14752,25 +15346,23 @@
   local.set $0
   i32.const 64
   call $std/array/createReverseOrderedArray
-  local.set $8
+  local.set $6
   i32.const 128
   call $std/array/createReverseOrderedArray
-  local.set $9
+  local.set $8
   i32.const 1024
   call $std/array/createReverseOrderedArray
-  local.set $11
+  local.set $7
   i32.const 10000
   call $std/array/createReverseOrderedArray
-  local.set $13
+  local.set $10
   i32.const 512
   call $std/array/createRandomOrderedArray
-  local.set $12
-  local.get $19
-  i32.const 48
-  call $std/array/assertSorted<i32>
+  local.set $17
+  local.get $16
+  call $std/array/assertSortedDefault<i32>
   local.get $1
-  i32.const 48
-  call $std/array/assertSorted<i32>
+  call $std/array/assertSortedDefault<i32>
   local.get $1
   i32.const 1
   i32.const 2
@@ -14778,7 +15370,7 @@
   i32.const 5872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14790,17 +15382,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
-  i32.const 48
-  call $std/array/assertSorted<i32>
-  local.get $5
+  local.get $2
+  call $std/array/assertSortedDefault<i32>
+  local.get $2
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 5904
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $23
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14812,10 +15403,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
-  i32.const 48
-  call $std/array/assertSorted<i32>
-  local.get $6
+  local.get $3
+  call $std/array/assertSortedDefault<i32>
+  local.get $3
   local.get $0
   i32.const 0
   call $std/array/isArraysEqual<u32>
@@ -14828,10 +15418,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
-  i32.const 48
-  call $std/array/assertSorted<i32>
-  local.get $8
+  local.get $6
+  call $std/array/assertSortedDefault<i32>
+  local.get $6
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14844,10 +15433,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
-  i32.const 48
-  call $std/array/assertSorted<i32>
-  local.get $9
+  local.get $8
+  call $std/array/assertSortedDefault<i32>
+  local.get $8
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14860,10 +15448,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $11
-  i32.const 48
-  call $std/array/assertSorted<i32>
-  local.get $11
+  local.get $7
+  call $std/array/assertSortedDefault<i32>
+  local.get $7
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14876,10 +15463,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $13
-  i32.const 48
-  call $std/array/assertSorted<i32>
-  local.get $13
+  local.get $10
+  call $std/array/assertSortedDefault<i32>
+  local.get $10
   local.get $0
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -14892,48 +15478,47 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $12
-  i32.const 48
-  call $std/array/assertSorted<i32>
-  local.get $3
-  call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $2
-  call $~lib/rt/pure/__release
   local.get $17
-  call $~lib/rt/pure/__release
-  local.get $21
+  call $std/array/assertSortedDefault<i32>
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $22
-  call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $5
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $11
-  call $~lib/rt/pure/__release
-  local.get $13
   call $~lib/rt/pure/__release
   local.get $12
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $14
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $19
+  call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $17
+  call $~lib/rt/pure/__release
+  local.get $22
+  call $~lib/rt/pure/__release
+  local.get $23
   call $~lib/rt/pure/__release
   i32.const 64
   call $std/array/createRandomOrderedArray
@@ -14982,55 +15567,61 @@
   i32.const 6128
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $7
+  local.set $8
   block $__inlined_func$std/array/isSorted<~lib/string/String | null> (result i32)
    i32.const 1
-   local.set $1
+   local.set $2
    local.get $5
+   call $~lib/rt/pure/__retain
+   local.tee $4
    i32.const 55
    call $~lib/array/Array<~lib/array/Array<i32>>#sort
+   local.tee $6
+   call $~lib/rt/pure/__retain
    local.tee $0
-   local.set $2
-   local.get $0
    i32.load offset=12
-   local.set $6
-   loop $for-loop|03
-    local.get $1
-    local.get $6
+   local.set $7
+   loop $for-loop|00
+    local.get $2
+    local.get $7
     i32.lt_s
     if
+     local.get $0
      local.get $2
-     local.get $1
      i32.const 1
      i32.sub
      call $~lib/array/Array<std/array/Ref | null>#__get
-     local.tee $3
+     local.tee $1
+     local.get $0
      local.get $2
-     local.get $1
      call $~lib/array/Array<std/array/Ref | null>#__get
-     local.tee $4
+     local.tee $3
      call $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0
      i32.const 0
      i32.gt_s
      if
-      local.get $3
+      local.get $0
       call $~lib/rt/pure/__release
-      local.get $4
+      local.get $1
+      call $~lib/rt/pure/__release
+      local.get $3
       call $~lib/rt/pure/__release
       i32.const 0
       br $__inlined_func$std/array/isSorted<~lib/string/String | null>
      end
+     local.get $1
+     call $~lib/rt/pure/__release
      local.get $3
      call $~lib/rt/pure/__release
-     local.get $4
-     call $~lib/rt/pure/__release
-     local.get $1
+     local.get $2
      i32.const 1
      i32.add
-     local.set $1
-     br $for-loop|03
+     local.set $2
+     br $for-loop|00
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
   end
   i32.eqz
@@ -15042,62 +15633,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $6
   call $~lib/rt/pure/__release
-  block $__inlined_func$std/array/isArraysEqual<~lib/string/String | null> (result i32)
-   i32.const 0
-   local.set $1
-   i32.const 0
-   local.get $5
-   i32.load offset=12
-   local.tee $3
-   local.get $7
-   i32.load offset=12
-   i32.ne
-   br_if $__inlined_func$std/array/isArraysEqual<~lib/string/String | null>
-   drop
-   i32.const 1
-   local.get $5
-   local.get $7
-   i32.eq
-   br_if $__inlined_func$std/array/isArraysEqual<~lib/string/String | null>
-   drop
-   loop $for-loop|04
-    local.get $1
-    local.get $3
-    i32.lt_s
-    if
-     local.get $5
-     local.get $1
-     call $~lib/array/Array<std/array/Ref | null>#__get
-     local.tee $0
-     local.get $7
-     local.get $1
-     call $~lib/array/Array<std/array/Ref | null>#__get
-     local.tee $2
-     call $~lib/string/String.__eq
-     i32.eqz
-     if
-      local.get $0
-      call $~lib/rt/pure/__release
-      local.get $2
-      call $~lib/rt/pure/__release
-      i32.const 0
-      br $__inlined_func$std/array/isArraysEqual<~lib/string/String | null>
-     end
-     local.get $0
-     call $~lib/rt/pure/__release
-     local.get $2
-     call $~lib/rt/pure/__release
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|04
-    end
-   end
-   i32.const 1
-  end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  local.get $8
+  call $std/array/isArraysEqual<~lib/string/String | null>
   i32.eqz
   if
    i32.const 0
@@ -15108,34 +15650,34 @@
    unreachable
   end
   i32.const 0
-  local.set $1
+  local.set $0
   i32.const 16
   i32.const 16
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.store
-  local.get $2
+  local.get $1
   i32.const 0
   i32.store offset=4
-  local.get $2
+  local.get $1
   i32.const 0
   i32.store offset=8
-  local.get $2
+  local.get $1
   i32.const 0
   i32.store offset=12
   i32.const 1600
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $0
+  local.tee $2
   i32.const 0
   i32.const 1600
   call $~lib/memory/memory.fill
-  local.get $0
-  local.set $3
-  local.get $0
   local.get $2
+  local.set $3
+  local.get $2
+  local.get $1
   i32.load
   local.tee $4
   i32.ne
@@ -15146,37 +15688,37 @@
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
   i32.store
+  local.get $1
   local.get $2
-  local.get $0
   i32.store offset=4
-  local.get $2
+  local.get $1
   i32.const 1600
   i32.store offset=8
-  local.get $2
+  local.get $1
   i32.const 400
   i32.store offset=12
   loop $for-loop|09
-   local.get $1
+   local.get $0
    i32.const 400
    i32.lt_s
    if
-    local.get $1
+    local.get $0
     local.set $3
     call $~lib/math/NativeMath.random
     f64.const 32
     f64.mul
     i32.trunc_f64_s
-    local.set $8
+    local.set $7
     i32.const 0
     local.set $6
     i32.const 6064
     local.set $0
     loop $for-loop|01
      local.get $6
-     local.get $8
+     local.get $7
      i32.lt_s
      if
       block $__inlined_func$~lib/string/String#charAt (result i32)
@@ -15188,7 +15730,7 @@
        f64.mul
        f64.floor
        i32.trunc_f64_s
-       local.tee $1
+       local.tee $2
        i32.const 5088
        call $~lib/string/String#get:length
        i32.ge_u
@@ -15198,7 +15740,7 @@
        i32.const 1
        call $~lib/rt/tlsf/__alloc
        local.tee $4
-       local.get $1
+       local.get $2
        i32.const 1
        i32.shl
        i32.const 5088
@@ -15208,13 +15750,13 @@
        local.get $4
        call $~lib/rt/pure/__retain
       end
-      local.set $1
+      local.set $2
       local.get $0
       local.tee $4
       local.get $0
-      local.get $1
+      local.get $2
       call $~lib/string/String.__concat
-      local.tee $9
+      local.tee $10
       local.tee $0
       i32.ne
       if
@@ -15224,9 +15766,9 @@
        local.get $4
        call $~lib/rt/pure/__release
       end
-      local.get $1
+      local.get $2
       call $~lib/rt/pure/__release
-      local.get $9
+      local.get $10
       call $~lib/rt/pure/__release
       local.get $6
       i32.const 1
@@ -15235,7 +15777,7 @@
       br $for-loop|01
      end
     end
-    local.get $2
+    local.get $1
     local.get $3
     local.get $0
     call $~lib/array/Array<~lib/array/Array<i32>>#__set
@@ -15244,18 +15786,18 @@
     local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|09
    end
   end
-  local.get $2
+  local.get $1
   i32.const 56
   call $std/array/assertSorted<~lib/array/Array<i32>>
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $8
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 2
   i32.const 0
@@ -15268,7 +15810,10 @@
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinBooleanArray
-  local.tee $4
+  local.set $1
+  i32.const 6304
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.const 6336
   call $~lib/string/String.__eq
   i32.eqz
@@ -15286,10 +15831,10 @@
   i32.const 6384
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $6
   i32.const 6064
   call $~lib/array/Array<i32>#join
-  local.tee $7
+  local.tee $8
   i32.const 6736
   call $~lib/string/String.__eq
   i32.eqz
@@ -15307,10 +15852,10 @@
   i32.const 6768
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $7
   i32.const 6800
   call $~lib/array/Array<u32>#join
-  local.tee $8
+  local.tee $10
   i32.const 6736
   call $~lib/string/String.__eq
   i32.eqz
@@ -15328,10 +15873,10 @@
   i32.const 6832
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $14
   i32.const 6864
   call $~lib/array/Array<i32>#join
-  local.tee $11
+  local.tee $15
   i32.const 6896
   call $~lib/string/String.__eq
   i32.eqz
@@ -15349,12 +15894,15 @@
   i32.const 6960
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $2
   i32.load offset=4
-  local.get $1
+  local.get $2
   i32.load offset=12
   call $~lib/util/string/joinFloatArray<f64>
-  local.tee $13
+  local.set $3
+  i32.const 7024
+  call $~lib/rt/pure/__release
+  local.get $3
   i32.const 8112
   call $~lib/string/String.__eq
   i32.eqz
@@ -15372,10 +15920,10 @@
   i32.const 8240
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 6064
   call $~lib/array/Array<~lib/string/String | null>#join
-  local.tee $18
+  local.tee $17
   i32.const 8208
   call $~lib/string/String.__eq
   i32.eqz
@@ -15393,22 +15941,22 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $4
   i32.load offset=4
-  local.tee $3
+  local.tee $5
   i32.const 0
   call $std/array/Ref#constructor
   i32.store
-  local.get $3
+  local.get $5
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $2
+  local.get $4
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $19
+  local.tee $18
   i32.const 8320
   call $~lib/string/String.__eq
   i32.eqz
@@ -15426,7 +15974,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $5
   i32.load offset=4
   local.tee $12
   i32.const 0
@@ -15436,7 +15984,7 @@
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=4
-  local.get $3
+  local.get $5
   call $~lib/array/Array<std/array/Ref | null>#join
   local.tee $12
   i32.const 8400
@@ -15452,33 +16000,33 @@
   end
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $5
-  call $~lib/rt/pure/__release
-  local.get $7
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $14
   call $~lib/rt/pure/__release
-  local.get $13
-  call $~lib/rt/pure/__release
-  local.get $17
-  call $~lib/rt/pure/__release
-  local.get $18
+  local.get $15
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
   local.get $3
+  call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $17
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $18
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $12
   call $~lib/rt/pure/__release
@@ -15509,7 +16057,7 @@
   i32.const 8560
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $7
+  local.set $6
   local.get $3
   i32.const 6304
   call $~lib/array/Array<i32>#join
@@ -15530,7 +16078,7 @@
   i32.const 6304
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $17
+  local.set $23
   local.get $0
   i32.const 8208
   call $~lib/string/String.__eq
@@ -15547,7 +16095,7 @@
   i32.const 6304
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $18
+  local.set $26
   local.get $0
   i32.const 8592
   call $~lib/string/String.__eq
@@ -15560,11 +16108,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $6
   i32.const 6304
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $19
+  local.set $27
   local.get $0
   i32.const 8624
   call $~lib/string/String.__eq
@@ -15583,14 +16131,15 @@
   i32.const 8656
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $8
   i32.load offset=4
-  local.get $6
+  local.get $8
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i8>
-  local.tee $0
-  local.set $12
-  local.get $0
+  local.set $7
+  i32.const 6304
+  call $~lib/rt/pure/__release
+  local.get $7
   i32.const 8688
   call $~lib/string/String.__eq
   i32.eqz
@@ -15608,14 +16157,15 @@
   i32.const 8720
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $10
   i32.load offset=4
-  local.get $8
+  local.get $10
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u16>
-  local.tee $0
-  local.set $21
-  local.get $0
+  local.set $14
+  i32.const 6304
+  call $~lib/rt/pure/__release
+  local.get $14
   i32.const 8752
   call $~lib/string/String.__eq
   i32.eqz
@@ -15633,14 +16183,15 @@
   i32.const 8800
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $15
   i32.load offset=4
-  local.get $9
+  local.get $15
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u64>
-  local.tee $0
-  local.set $22
-  local.get $0
+  local.set $16
+  i32.const 6304
+  call $~lib/rt/pure/__release
+  local.get $16
   i32.const 8848
   call $~lib/string/String.__eq
   i32.eqz
@@ -15658,14 +16209,15 @@
   i32.const 8912
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $17
   i32.load offset=4
-  local.get $11
+  local.get $17
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i64>
-  local.tee $0
-  local.set $23
-  local.get $0
+  local.set $18
+  i32.const 6304
+  call $~lib/rt/pure/__release
+  local.get $18
   i32.const 8960
   call $~lib/string/String.__eq
   i32.eqz
@@ -15683,11 +16235,11 @@
   i32.const 9072
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $29
   i32.const 6304
   call $~lib/array/Array<~lib/string/String | null>#join
   local.tee $0
-  local.set $26
+  local.set $30
   local.get $0
   i32.const 9120
   call $~lib/string/String.__eq
@@ -15706,11 +16258,11 @@
   i32.const 9232
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $31
   i32.const 6304
   call $~lib/array/Array<~lib/string/String | null>#join
   local.tee $0
-  local.set $31
+  local.set $32
   local.get $0
   i32.const 9264
   call $~lib/string/String.__eq
@@ -15752,9 +16304,10 @@
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>
-  local.tee $1
-  local.set $32
-  local.get $1
+  local.set $12
+  i32.const 6304
+  call $~lib/rt/pure/__release
+  local.get $12
   i32.const 9360
   call $~lib/string/String.__eq
   i32.eqz
@@ -15795,9 +16348,10 @@
   local.get $1
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>
-  local.tee $2
-  local.set $33
-  local.get $2
+  local.set $21
+  i32.const 6304
+  call $~lib/rt/pure/__release
+  local.get $21
   i32.const 9360
   call $~lib/string/String.__eq
   i32.eqz
@@ -15823,7 +16377,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $33
   i32.load offset=4
   i32.const 1
   i32.const 2
@@ -15832,16 +16386,17 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $29
+  local.get $33
   i32.store
   local.get $2
   i32.load offset=4
   local.get $2
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>
-  local.tee $28
-  local.set $29
-  local.get $28
+  local.set $19
+  i32.const 6304
+  call $~lib/rt/pure/__release
+  local.get $19
   i32.const 8208
   call $~lib/string/String.__eq
   i32.eqz
@@ -15859,44 +16414,44 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  call $~lib/rt/pure/__release
-  local.get $17
-  call $~lib/rt/pure/__release
-  local.get $18
-  call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $21
-  call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $22
-  call $~lib/rt/pure/__release
-  local.get $11
   call $~lib/rt/pure/__release
   local.get $23
-  call $~lib/rt/pure/__release
-  local.get $24
   call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
   local.get $27
   call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $17
+  call $~lib/rt/pure/__release
+  local.get $18
+  call $~lib/rt/pure/__release
+  local.get $29
+  call $~lib/rt/pure/__release
+  local.get $30
+  call $~lib/rt/pure/__release
   local.get $31
   call $~lib/rt/pure/__release
   local.get $32
   call $~lib/rt/pure/__release
-  local.get $33
+  local.get $12
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $19
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   call $~lib/rt/pure/__release
@@ -15942,7 +16497,7 @@
   i32.store offset=12
   local.get $5
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $7
+  local.tee $6
   i32.load offset=12
   i32.const 10
   i32.ne
@@ -15955,14 +16510,14 @@
    unreachable
   end
   loop $for-loop|1
-   local.get $10
+   local.get $11
    i32.const 10
    i32.lt_s
    if
-    local.get $7
-    local.get $10
+    local.get $6
+    local.get $11
     call $~lib/array/Array<u32>#__get
-    local.get $10
+    local.get $11
     i32.ne
     if
      i32.const 0
@@ -15972,10 +16527,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $10
+    local.get $11
     i32.const 1
     i32.add
-    local.set $10
+    local.set $11
     br $for-loop|1
    end
   end
@@ -15985,7 +16540,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $8
   i32.load offset=4
   local.tee $3
   i32.const 1
@@ -16019,7 +16574,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=12
-  local.get $6
+  local.get $8
   call $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#flat
   local.set $3
   i32.const 8
@@ -16042,21 +16597,21 @@
    unreachable
   end
   i32.const 0
-  local.set $10
+  local.set $11
   loop $for-loop|2
-   local.get $10
+   local.get $11
    local.get $4
    i32.load offset=12
    i32.lt_s
    if
     local.get $3
-    local.get $10
+    local.get $11
     call $~lib/array/Array<std/array/Ref | null>#__get
-    local.tee $8
+    local.tee $7
     local.get $4
-    local.get $10
+    local.get $11
     call $~lib/array/Array<std/array/Ref | null>#__get
-    local.tee $9
+    local.tee $10
     call $~lib/string/String.__eq
     i32.eqz
     if
@@ -16067,14 +16622,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $8
-    call $~lib/rt/pure/__release
-    local.get $9
+    local.get $7
     call $~lib/rt/pure/__release
     local.get $10
+    call $~lib/rt/pure/__release
+    local.get $11
     i32.const 1
     i32.add
-    local.set $10
+    local.set $11
     br $for-loop|2
    end
   end
@@ -16084,9 +16639,9 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $11
   i32.load offset=4
-  local.tee $8
+  local.tee $7
   i32.const 0
   i32.const 2
   i32.const 3
@@ -16094,7 +16649,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $8
+  local.get $7
   i32.const 0
   i32.const 2
   i32.const 3
@@ -16102,9 +16657,9 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $10
+  local.get $11
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $8
+  local.tee $7
   i32.load offset=12
   if
    i32.const 0
@@ -16114,17 +16669,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $10
+  local.get $11
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $9
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $13
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $28
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -16134,9 +16689,9 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
   local.get $6
+  call $~lib/rt/pure/__release
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1784,6 +1784,42 @@
    call $~lib/builtins/abort
    unreachable
   end
+  block $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null> (result i32)
+   i32.const 0
+   call $~lib/rt/pure/__release
+   i32.const 0
+   br $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null>
+  end
+  if
+   i32.const 0
+   i32.const 1312
+   i32.const 43
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  call $~lib/rt/pure/__release
+  i32.const 0
+  if
+   i32.const 0
+   i32.const 1312
+   i32.const 44
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  call $~lib/rt/pure/__release
+  i32.const 0
+  if
+   i32.const 0
+   i32.const 1312
+   i32.const 45
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
   i32.const 12
   i32.const 5
   call $~lib/rt/tlsf/__alloc
@@ -1826,11 +1862,11 @@
   local.set $4
   local.get $6
   i32.load
-  local.tee $1
+  local.tee $0
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $0
+  local.tee $1
   local.set $3
   i32.const 12
   i32.const 15
@@ -1845,11 +1881,13 @@
   local.get $8
   i32.const 0
   i32.store offset=8
-  local.get $0
+  local.get $1
   i32.const 1073741808
   i32.gt_u
-  local.get $0
   local.get $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1886,6 +1924,8 @@
   local.get $8
   local.get $3
   i32.store offset=8
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
   local.get $7

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -1229,6 +1229,8 @@
   local.get $2
   i32.add
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1267,6 +1269,8 @@
   local.get $4
   local.get $2
   i32.store offset=8
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $4
  )
  (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (param $0 i32) (result i32)

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1515,7 +1515,7 @@
   i32.const 24
   i32.shr_s
   call $~lib/util/hash/hash8
-  local.tee $4
+  local.tee $5
   call $~lib/map/Map<i8,i32>#find
   local.tee $3
   if
@@ -1554,14 +1554,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $5
+   local.get $4
+   local.get $3
    i32.const 12
    i32.mul
    i32.add
@@ -1580,7 +1583,7 @@
    local.get $3
    local.get $0
    i32.load
-   local.get $4
+   local.get $5
    local.get $0
    i32.load offset=4
    i32.and
@@ -1593,6 +1596,8 @@
    local.get $1
    local.get $3
    i32.store
+   local.get $4
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2615,14 +2620,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $5
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $1
    i32.const 1
    i32.add
    i32.store offset=16
    local.get $5
+   local.get $1
    i32.const 3
    i32.shl
    i32.add
@@ -2654,6 +2662,8 @@
    local.get $2
    local.get $1
    i32.store
+   local.get $5
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -2873,7 +2883,7 @@
   local.get $1
   local.get $1
   call $~lib/util/hash/hash32
-  local.tee $4
+  local.tee $5
   call $~lib/map/Map<i32,i32>#find
   local.tee $3
   if
@@ -2912,14 +2922,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $5
+   local.get $4
+   local.get $3
    i32.const 12
    i32.mul
    i32.add
@@ -2938,7 +2951,7 @@
    local.get $3
    local.get $0
    i32.load
-   local.get $4
+   local.get $5
    local.get $0
    i32.load offset=4
    i32.and
@@ -2951,6 +2964,8 @@
    local.get $1
    local.get $3
    i32.store
+   local.get $4
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -3730,7 +3745,7 @@
   i32.const 255
   i32.and
   call $~lib/util/hash/hash8
-  local.tee $4
+  local.tee $5
   call $~lib/map/Map<i8,i32>#find
   local.tee $3
   if
@@ -3769,14 +3784,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $5
+   local.get $4
+   local.get $3
    i32.const 12
    i32.mul
    i32.add
@@ -3795,7 +3813,7 @@
    local.get $3
    local.get $0
    i32.load
-   local.get $4
+   local.get $5
    local.get $0
    i32.load offset=4
    i32.and
@@ -3808,6 +3826,8 @@
    local.get $1
    local.get $3
    i32.store
+   local.get $4
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -4169,14 +4189,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $5
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $1
    i32.const 1
    i32.add
    i32.store offset=16
    local.get $5
+   local.get $1
    i32.const 3
    i32.shl
    i32.add
@@ -4208,6 +4231,8 @@
    local.get $2
    local.get $1
    i32.store
+   local.get $5
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -4992,7 +5017,7 @@
   i32.const 16
   i32.shr_s
   call $~lib/util/hash/hash16
-  local.tee $4
+  local.tee $5
   call $~lib/map/Map<i16,i32>#find
   local.tee $3
   if
@@ -5031,14 +5056,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $5
+   local.get $4
+   local.get $3
    i32.const 12
    i32.mul
    i32.add
@@ -5057,7 +5085,7 @@
    local.get $3
    local.get $0
    i32.load
-   local.get $4
+   local.get $5
    local.get $0
    i32.load offset=4
    i32.and
@@ -5070,6 +5098,8 @@
    local.get $1
    local.get $3
    i32.store
+   local.get $4
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -5489,14 +5519,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $5
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $1
    i32.const 1
    i32.add
    i32.store offset=16
    local.get $5
+   local.get $1
    i32.const 3
    i32.shl
    i32.add
@@ -5528,6 +5561,8 @@
    local.get $2
    local.get $1
    i32.store
+   local.get $5
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6277,7 +6312,7 @@
   i32.const 65535
   i32.and
   call $~lib/util/hash/hash16
-  local.tee $4
+  local.tee $5
   call $~lib/map/Map<i16,i32>#find
   local.tee $3
   if
@@ -6316,14 +6351,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $5
+   local.get $4
+   local.get $3
    i32.const 12
    i32.mul
    i32.add
@@ -6342,7 +6380,7 @@
    local.get $3
    local.get $0
    i32.load
-   local.get $4
+   local.get $5
    local.get $0
    i32.load offset=4
    i32.and
@@ -6355,6 +6393,8 @@
    local.get $1
    local.get $3
    i32.store
+   local.get $4
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6720,14 +6760,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $5
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $1
    i32.const 1
    i32.add
    i32.store offset=16
    local.get $5
+   local.get $1
    i32.const 3
    i32.shl
    i32.add
@@ -6759,6 +6802,8 @@
    local.get $2
    local.get $1
    i32.store
+   local.get $5
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -8718,7 +8763,7 @@
   local.get $1
   local.get $1
   call $~lib/util/hash/hash64
-  local.tee $4
+  local.tee $5
   call $~lib/map/Map<i64,i32>#find
   local.tee $3
   if
@@ -8757,14 +8802,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $5
+   local.get $4
+   local.get $3
    i32.const 4
    i32.shl
    i32.add
@@ -8783,7 +8831,7 @@
    local.get $3
    local.get $0
    i32.load
-   local.get $4
+   local.get $5
    local.get $0
    i32.load offset=4
    i32.and
@@ -8796,6 +8844,8 @@
    local.get $2
    local.get $3
    i32.store
+   local.get $4
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9277,14 +9327,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $5
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
    local.get $5
+   local.get $3
    i32.const 24
    i32.mul
    i32.add
@@ -9316,6 +9369,8 @@
    local.get $4
    local.get $3
    i32.store
+   local.get $5
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10672,7 +10727,7 @@
   local.get $1
   i32.reinterpret_f32
   call $~lib/util/hash/hash32
-  local.tee $4
+  local.tee $5
   call $~lib/map/Map<f32,i32>#find
   local.tee $3
   if
@@ -10711,14 +10766,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $5
+   local.get $4
+   local.get $3
    i32.const 12
    i32.mul
    i32.add
@@ -10737,7 +10795,7 @@
    local.get $3
    local.get $0
    i32.load
-   local.get $4
+   local.get $5
    local.get $0
    i32.load offset=4
    i32.and
@@ -10750,6 +10808,8 @@
    local.get $2
    local.get $3
    i32.store
+   local.get $4
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11070,7 +11130,7 @@
   local.get $1
   i32.reinterpret_f32
   call $~lib/util/hash/hash32
-  local.tee $5
+  local.tee $4
   call $~lib/map/Map<f32,i32>#find
   local.tee $3
   if
@@ -11109,14 +11169,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $5
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $4
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $4
+   local.get $5
+   local.get $3
    i32.const 12
    i32.mul
    i32.add
@@ -11135,7 +11198,7 @@
    local.get $3
    local.get $0
    i32.load
-   local.get $5
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
@@ -11148,6 +11211,8 @@
    local.get $4
    local.get $3
    i32.store
+   local.get $5
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11898,7 +11963,7 @@
   local.get $1
   i64.reinterpret_f64
   call $~lib/util/hash/hash64
-  local.tee $4
+  local.tee $5
   call $~lib/map/Map<f64,i32>#find
   local.tee $3
   if
@@ -11937,14 +12002,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
-   local.get $5
+   local.get $4
+   local.get $3
    i32.const 4
    i32.shl
    i32.add
@@ -11963,7 +12031,7 @@
    local.get $3
    local.get $0
    i32.load
-   local.get $4
+   local.get $5
    local.get $0
    i32.load offset=4
    i32.and
@@ -11976,6 +12044,8 @@
    local.get $2
    local.get $3
    i32.store
+   local.get $4
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain
@@ -12371,14 +12441,17 @@
    end
    local.get $0
    i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $5
    local.get $0
    local.get $0
    i32.load offset=16
-   local.tee $5
+   local.tee $3
    i32.const 1
    i32.add
    i32.store offset=16
    local.get $5
+   local.get $3
    i32.const 24
    i32.mul
    i32.add
@@ -12410,6 +12483,8 @@
    local.get $4
    local.get $3
    i32.store
+   local.get $5
+   call $~lib/rt/pure/__release
   end
   local.get $0
   call $~lib/rt/pure/__retain

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -2192,10 +2192,18 @@
  (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  local.tee $3
   i32.const 7
   i32.and
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  local.tee $1
   i32.const 7
   i32.and
   i32.or
@@ -2207,16 +2215,16 @@
   select
   if
    loop $do-continue|0
-    local.get $0
+    local.get $3
     i64.load
     local.get $1
     i64.load
     i64.eq
     if
-     local.get $0
+     local.get $3
      i32.const 8
      i32.add
-     local.set $0
+     local.set $3
      local.get $1
      i32.const 8
      i32.add
@@ -2233,29 +2241,33 @@
   end
   loop $while-continue|1
    local.get $2
-   local.tee $3
+   local.tee $0
    i32.const 1
    i32.sub
    local.set $2
-   local.get $3
+   local.get $0
    if
-    local.get $0
+    local.get $3
     i32.load16_u
-    local.tee $3
+    local.tee $0
     local.get $1
     i32.load16_u
-    local.tee $4
+    local.tee $6
     i32.ne
     if
-     local.get $3
      local.get $4
+     call $~lib/rt/pure/__release
+     local.get $5
+     call $~lib/rt/pure/__release
+     local.get $0
+     local.get $6
      i32.sub
      return
     end
-    local.get $0
+    local.get $3
     i32.const 2
     i32.add
-    local.set $0
+    local.set $3
     local.get $1
     i32.const 2
     i32.add
@@ -2263,14 +2275,26 @@
     br $while-continue|1
    end
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.eq
   if
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    return
   end
@@ -2293,8 +2317,16 @@
    local.get $2
    call $~lib/util/string/compareImpl
    i32.eqz
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/util/string/stagedBinaryLookup (param $0 i32) (param $1 i32) (result i32)
@@ -3083,13 +3115,19 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   block $__inlined_func$~lib/string/String#concat (result i32)
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $2
    i32.const 18624
-   local.get $0
+   local.get $2
    select
-   local.set $2
+   local.set $3
    local.get $1
+   call $~lib/rt/pure/__retain
+   local.tee $5
    call $~lib/rt/pure/__retain
    local.tee $0
    i32.eqz
@@ -3104,16 +3142,16 @@
     i32.const 18624
     local.set $0
    end
-   local.get $2
-   call $~lib/string/String#get:length
-   i32.const 1
-   i32.shl
-   local.tee $3
-   local.get $0
+   local.get $3
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    local.tee $4
+   local.get $0
+   call $~lib/string/String#get:length
+   i32.const 1
+   i32.shl
+   local.tee $6
    i32.add
    local.tee $1
    i32.eqz
@@ -3127,19 +3165,23 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.tee $1
-   local.get $2
    local.get $3
+   local.get $4
    call $~lib/memory/memory.copy
    local.get $1
-   local.get $3
+   local.get $4
    i32.add
    local.get $0
-   local.get $4
+   local.get $6
    call $~lib/memory/memory.copy
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
  )
  (func $start:std/string-casemapping
   (local $0 i64)

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -97,6 +97,17 @@
    call $~lib/rt/pure/decrement
   end
  )
+ (func $~lib/string/String.UTF16.byteLength (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 16
+  i32.sub
+  i32.load offset=12
+  local.get $0
+  call $~lib/rt/pure/__release
+ )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1299,9 +1310,9 @@
  (func $~lib/string/String.UTF16.encode (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
-  i32.const 16
-  i32.sub
-  i32.load offset=12
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/string/String.UTF16.byteLength
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.tee $1
@@ -1313,6 +1324,8 @@
   call $~lib/memory/memory.copy
   local.get $1
   call $~lib/rt/pure/__retain
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $std/string-encoding/testUTF16Encode
   (local $0 i32)
@@ -1493,20 +1506,35 @@
   call $~lib/rt/pure/__retain
  )
  (func $~lib/string/String.UTF16.decode (param $0 i32) (result i32)
+  (local $1 i32)
   local.get $0
-  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 16
   i32.sub
   i32.load offset=12
+  local.set $1
+  local.get $0
+  local.get $1
   call $~lib/string/String.UTF16.decodeUnsafe
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  local.tee $3
   i32.const 7
   i32.and
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  local.tee $1
   i32.const 7
   i32.and
   i32.or
@@ -1518,16 +1546,16 @@
   select
   if
    loop $do-continue|0
-    local.get $0
+    local.get $3
     i64.load
     local.get $1
     i64.load
     i64.eq
     if
-     local.get $0
+     local.get $3
      i32.const 8
      i32.add
-     local.set $0
+     local.set $3
      local.get $1
      i32.const 8
      i32.add
@@ -1544,29 +1572,33 @@
   end
   loop $while-continue|1
    local.get $2
-   local.tee $3
+   local.tee $0
    i32.const 1
    i32.sub
    local.set $2
-   local.get $3
+   local.get $0
    if
-    local.get $0
+    local.get $3
     i32.load16_u
-    local.tee $3
+    local.tee $0
     local.get $1
     i32.load16_u
-    local.tee $4
+    local.tee $6
     i32.ne
     if
-     local.get $3
      local.get $4
+     call $~lib/rt/pure/__release
+     local.get $5
+     call $~lib/rt/pure/__release
+     local.get $0
+     local.get $6
      i32.sub
      return
     end
-    local.get $0
+    local.get $3
     i32.const 2
     i32.add
-    local.set $0
+    local.set $3
     local.get $1
     i32.const 2
     i32.add
@@ -1574,14 +1606,26 @@
     br $while-continue|1
    end
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.eq
   if
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    return
   end
@@ -1604,8 +1648,16 @@
    local.get $2
    call $~lib/util/string/compareImpl
    i32.eqz
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $std/string-encoding/testUTF16DecodeUnsafe
@@ -1620,13 +1672,14 @@
   i32.const 1040
   call $~lib/string/String.UTF16.encode
   local.set $0
-  i32.const 1036
-  i32.load
-  local.set $1
+  i32.const 1040
+  call $~lib/string/String.UTF16.byteLength
+  local.set $7
   local.get $0
+  local.tee $1
   i32.const 0
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $2
+  local.tee $6
   i32.const 1296
   call $~lib/string/String.__eq
   i32.eqz
@@ -1638,10 +1691,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
   local.get $1
+  local.get $7
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $3
+  local.tee $5
   i32.const 1040
   call $~lib/string/String.__eq
   i32.eqz
@@ -1653,7 +1706,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   call $~lib/string/String.UTF16.decodeUnsafe
   local.tee $4
@@ -1668,12 +1721,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.add
   i32.const 2
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $5
+  local.tee $3
   i32.const 1344
   call $~lib/string/String.__eq
   i32.eqz
@@ -1685,12 +1738,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.add
   i32.const 4
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $6
+  local.tee $2
   i32.const 1376
   call $~lib/string/String.__eq
   i32.eqz
@@ -1702,7 +1755,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 8
   i32.add
   i32.const 4
@@ -1719,7 +1772,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 12
   i32.add
   i32.const 0
@@ -1736,15 +1789,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
-  local.get $4
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $2
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
@@ -1757,7 +1810,11 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  local.tee $0
   local.get $0
   i32.const 16
   i32.sub
@@ -1842,6 +1899,8 @@
     end
    end
   end
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $2
  )
  (func $~lib/string/String.UTF8.encodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
@@ -2021,6 +2080,8 @@
  (func $~lib/string/String.UTF8.encode (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   local.get $1
   call $~lib/string/String.UTF8.byteLength
   i32.const 0
@@ -2034,6 +2095,8 @@
   call $~lib/string/String.UTF8.encodeUnsafe
   local.get $2
   call $~lib/rt/pure/__retain
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $std/string-encoding/testUTF8Encode
   (local $0 i32)
@@ -2681,13 +2744,20 @@
   call $~lib/rt/pure/__retain
  )
  (func $~lib/string/String.UTF8.decode (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $0
-  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 16
   i32.sub
   i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $2
   local.get $1
   call $~lib/string/String.UTF8.decodeUnsafe
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $std/string-encoding/testUTF8DecodeNullTerminated
   (local $0 i32)
@@ -3006,6 +3076,8 @@
   (local $3 i32)
   (local $4 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 0
   call $~lib/string/String.UTF8.encode
   local.tee $1
@@ -3043,6 +3115,8 @@
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
   local.get $3
@@ -3051,8 +3125,8 @@
  (func $start:std/string-encoding
   (local $0 i32)
   (local $1 i32)
-  i32.const 1036
-  i32.load
+  i32.const 1040
+  call $~lib/string/String.UTF16.byteLength
   i32.const 12
   i32.ne
   if

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5,19 +5,19 @@
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
- (type $none_=>_i32 (func (result i32)))
+ (type $i32_=>_f64 (func (param i32) (result f64)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
- (type $i32_=>_f64 (func (param i32) (result f64)))
+ (type $none_=>_i32 (func (result i32)))
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
- (type $none_=>_i64 (func (result i64)))
+ (type $i32_=>_i64 (func (param i32) (result i64)))
  (type $f64_i32_=>_f64 (func (param f64 i32) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
@@ -524,7 +524,11 @@
  )
  (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
   local.get $1
   i32.const 1
   i32.shl
@@ -533,6 +537,9 @@
   i32.const 7
   i32.and
   local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  local.tee $2
   i32.const 7
   i32.and
   i32.or
@@ -581,11 +588,15 @@
     local.tee $0
     local.get $2
     i32.load16_u
-    local.tee $4
+    local.tee $6
     i32.ne
     if
-     local.get $0
      local.get $4
+     call $~lib/rt/pure/__release
+     local.get $5
+     call $~lib/rt/pure/__release
+     local.get $0
+     local.get $6
      i32.sub
      return
     end
@@ -600,14 +611,26 @@
     br $while-continue|1
    end
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.eq
   if
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    return
   end
@@ -631,12 +654,23 @@
    local.get $2
    call $~lib/util/string/compareImpl
    i32.eqz
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/string/String.__not (param $0 i32) (result i32)
+  (local $1 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   if (result i32)
    local.get $0
    call $~lib/string/String#get:length
@@ -644,6 +678,8 @@
   else
    i32.const 1
   end
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -1760,10 +1796,14 @@
   (local $3 i32)
   (local $4 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/string/String#get:length
   local.tee $4
   i32.eqz
   if
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 0
    return
   end
@@ -1772,6 +1812,8 @@
   local.tee $3
   i32.eqz
   if
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const -1
    return
   end
@@ -1804,6 +1846,8 @@
     call $~lib/util/string/compareImpl
     i32.eqz
     if
+     local.get $1
+     call $~lib/rt/pure/__release
      local.get $2
      return
     end
@@ -1814,6 +1858,8 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const -1
  )
  (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
@@ -2019,6 +2065,9 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $0
   call $~lib/string/String#get:length
   i32.const 1
@@ -2044,6 +2093,8 @@
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
   local.get $4
@@ -2092,11 +2143,16 @@
   call $~lib/memory/memory.copy
   local.get $1
   call $~lib/rt/pure/__retain
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String#padEnd (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $0
   call $~lib/string/String#get:length
   i32.const 1
@@ -2122,6 +2178,8 @@
   if
    local.get $0
    call $~lib/rt/pure/__retain
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
   local.get $5
@@ -2172,17 +2230,23 @@
   end
   local.get $1
   call $~lib/rt/pure/__retain
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/string/String#get:length
   local.tee $4
   i32.eqz
   if
    local.get $0
    call $~lib/string/String#get:length
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
   local.get $0
@@ -2190,6 +2254,8 @@
   local.tee $3
   i32.eqz
   if
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const -1
    return
   end
@@ -2221,6 +2287,8 @@
     call $~lib/util/string/compareImpl
     i32.eqz
     if
+     local.get $1
+     call $~lib/rt/pure/__release
      local.get $2
      return
     end
@@ -2231,6 +2299,8 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const -1
  )
  (func $~lib/string/String#localeCompare (param $0 i32) (param $1 i32) (result i32)
@@ -2238,8 +2308,12 @@
   (local $3 i32)
   local.get $0
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.eq
   if
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 0
    return
   end
@@ -2251,6 +2325,8 @@
   local.tee $2
   i32.ne
   if
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    i32.const -1
    local.get $3
@@ -2262,6 +2338,8 @@
   local.get $2
   i32.eqz
   if
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 0
    return
   end
@@ -2270,6 +2348,8 @@
   local.get $1
   local.get $2
   call $~lib/util/string/compareImpl
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/string/isSpace (param $0 i32) (result i32)
   local.get $0
@@ -2537,79 +2617,83 @@
  (func $~lib/util/string/strtol<f64> (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 i32)
-  (local $3 f64)
-  (local $4 i32)
-  (local $5 f64)
+  (local $3 i32)
+  (local $4 f64)
+  (local $5 i32)
+  (local $6 f64)
   block $folding-inner0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $3
    call $~lib/string/String#get:length
-   local.tee $1
+   local.tee $0
    i32.eqz
    br_if $folding-inner0
-   local.get $0
+   local.get $3
+   local.tee $2
    i32.load16_u
-   local.set $2
+   local.set $1
    f64.const 1
-   local.set $5
+   local.set $4
    loop $while-continue|0
-    local.get $2
+    local.get $1
     call $~lib/util/string/isSpace
     if
-     local.get $0
+     local.get $2
      i32.const 2
      i32.add
-     local.tee $0
+     local.tee $2
      i32.load16_u
-     local.set $2
-     local.get $1
+     local.set $1
+     local.get $0
      i32.const 1
      i32.sub
-     local.set $1
+     local.set $0
      br $while-continue|0
     end
    end
-   local.get $2
+   local.get $1
    i32.const 45
    i32.eq
    if
-    local.get $1
+    local.get $0
     i32.const 1
     i32.sub
-    local.tee $1
+    local.tee $0
     i32.eqz
     br_if $folding-inner0
     f64.const -1
-    local.set $5
-    local.get $0
+    local.set $4
+    local.get $2
     i32.const 2
     i32.add
-    local.tee $0
+    local.tee $2
     i32.load16_u
-    local.set $2
+    local.set $1
    else
-    local.get $2
+    local.get $1
     i32.const 43
     i32.eq
     if
-     local.get $1
+     local.get $0
      i32.const 1
      i32.sub
-     local.tee $1
+     local.tee $0
      i32.eqz
      br_if $folding-inner0
-     local.get $0
+     local.get $2
      i32.const 2
      i32.add
-     local.tee $0
+     local.tee $2
      i32.load16_u
-     local.set $2
+     local.set $1
     end
    end
-   local.get $1
+   local.get $0
    i32.const 2
    i32.gt_s
    i32.const 0
-   local.get $2
+   local.get $1
    i32.const 48
    i32.eq
    select
@@ -2618,54 +2702,54 @@
      block $case3|1
       block $case2|1
        block $case1|1
-        local.get $0
+        local.get $2
         i32.load16_u offset=2
         i32.const 32
         i32.or
-        local.tee $2
+        local.tee $1
         i32.const 98
         i32.ne
         if
-         local.get $2
+         local.get $1
          i32.const 111
          i32.eq
          br_if $case1|1
-         local.get $2
+         local.get $1
          i32.const 120
          i32.eq
          br_if $case2|1
          br $case3|1
         end
-        local.get $0
+        local.get $2
         i32.const 4
         i32.add
-        local.set $0
-        local.get $1
+        local.set $2
+        local.get $0
         i32.const 2
         i32.sub
-        local.set $1
+        local.set $0
         i32.const 2
         br $break|1
        end
-       local.get $0
+       local.get $2
        i32.const 4
        i32.add
-       local.set $0
-       local.get $1
+       local.set $2
+       local.get $0
        i32.const 2
        i32.sub
-       local.set $1
+       local.set $0
        i32.const 8
        br $break|1
       end
-      local.get $0
+      local.get $2
       i32.const 4
       i32.add
-      local.set $0
-      local.get $1
+      local.set $2
+      local.get $0
       i32.const 2
       i32.sub
-      local.set $1
+      local.set $0
       i32.const 16
       br $break|1
      end
@@ -2674,92 +2758,106 @@
    else
     i32.const 10
    end
-   local.set $4
+   local.set $5
    loop $while-continue|2
     block $while-break|2
-     local.get $1
-     local.tee $2
+     local.get $0
+     local.tee $1
      i32.const 1
      i32.sub
-     local.set $1
-     local.get $2
+     local.set $0
+     local.get $1
      if
-      local.get $0
+      local.get $2
       i32.load16_u
-      local.tee $2
+      local.tee $1
       i32.const 48
       i32.sub
       i32.const 10
       i32.lt_u
       if (result i32)
-       local.get $2
+       local.get $1
        i32.const 48
        i32.sub
       else
-       local.get $2
+       local.get $1
        i32.const 65
        i32.sub
        i32.const 25
        i32.le_u
        if (result i32)
-        local.get $2
+        local.get $1
         i32.const 55
         i32.sub
        else
-        local.get $2
+        local.get $1
         i32.const 97
         i32.sub
         i32.const 25
         i32.gt_u
         br_if $while-break|2
-        local.get $2
+        local.get $1
         i32.const 87
         i32.sub
        end
       end
-      local.tee $2
-      local.get $4
+      local.tee $1
+      local.get $5
       i32.ge_u
       br_if $while-break|2
-      local.get $3
-      local.get $4
+      local.get $6
+      local.get $5
       f64.convert_i32_s
       f64.mul
-      local.get $2
+      local.get $1
       f64.convert_i32_u
       f64.add
-      local.set $3
-      local.get $0
+      local.set $6
+      local.get $2
       i32.const 2
       i32.add
-      local.set $0
+      local.set $2
       br $while-continue|2
      end
     end
    end
-   local.get $5
    local.get $3
+   call $~lib/rt/pure/__release
+   local.get $4
+   local.get $6
    f64.mul
    return
   end
+  local.get $3
+  call $~lib/rt/pure/__release
   f64.const nan:0x8000000000000
  )
- (func $~lib/util/string/strtol<i32> (result i32)
-  (local $0 i32)
+ (func $~lib/string/parseInt (param $0 i32) (result f64)
+  (local $1 f64)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/util/string/strtol<f64>
+  local.get $0
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/util/string/strtol<i32> (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 2912
-  local.set $5
+  (local $6 i32)
   block $folding-inner0
-   i32.const 2912
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $3
    call $~lib/string/String#get:length
    local.tee $0
    i32.eqz
    br_if $folding-inner0
-   i32.const 2912
+   local.get $3
+   local.tee $2
    i32.load16_u
    local.set $1
    i32.const 1
@@ -2768,10 +2866,10 @@
     local.get $1
     call $~lib/util/string/isSpace
     if
-     local.get $5
+     local.get $2
      i32.const 2
      i32.add
-     local.tee $5
+     local.tee $2
      i32.load16_u
      local.set $1
      local.get $0
@@ -2793,10 +2891,10 @@
     br_if $folding-inner0
     i32.const -1
     local.set $4
-    local.get $5
+    local.get $2
     i32.const 2
     i32.add
-    local.tee $5
+    local.tee $2
     i32.load16_u
     local.set $1
    else
@@ -2810,10 +2908,10 @@
      local.tee $0
      i32.eqz
      br_if $folding-inner0
-     local.get $5
+     local.get $2
      i32.const 2
      i32.add
-     local.tee $5
+     local.tee $2
      i32.load16_u
      local.set $1
     end
@@ -2831,7 +2929,7 @@
      block $case3|1
       block $case2|1
        block $case1|1
-        local.get $5
+        local.get $2
         i32.load16_u offset=2
         i32.const 32
         i32.or
@@ -2849,10 +2947,10 @@
          br_if $case2|1
          br $case3|1
         end
-        local.get $5
+        local.get $2
         i32.const 4
         i32.add
-        local.set $5
+        local.set $2
         local.get $0
         i32.const 2
         i32.sub
@@ -2860,10 +2958,10 @@
         i32.const 2
         br $break|1
        end
-       local.get $5
+       local.get $2
        i32.const 4
        i32.add
-       local.set $5
+       local.set $2
        local.get $0
        i32.const 2
        i32.sub
@@ -2871,10 +2969,10 @@
        i32.const 8
        br $break|1
       end
-      local.get $5
+      local.get $2
       i32.const 4
       i32.add
-      local.set $5
+      local.set $2
       local.get $0
       i32.const 2
       i32.sub
@@ -2887,7 +2985,7 @@
    else
     i32.const 10
    end
-   local.set $3
+   local.set $5
    loop $while-continue|2
     block $while-break|2
      local.get $0
@@ -2897,7 +2995,7 @@
      local.set $0
      local.get $1
      if
-      local.get $5
+      local.get $2
       i32.load16_u
       local.tee $1
       i32.const 48
@@ -2931,46 +3029,51 @@
        end
       end
       local.tee $1
-      local.get $3
+      local.get $5
       i32.ge_u
       br_if $while-break|2
       local.get $1
-      local.get $2
-      local.get $3
+      local.get $5
+      local.get $6
       i32.mul
       i32.add
-      local.set $2
-      local.get $5
+      local.set $6
+      local.get $2
       i32.const 2
       i32.add
-      local.set $5
+      local.set $2
       br $while-continue|2
      end
     end
    end
-   local.get $2
+   local.get $3
+   call $~lib/rt/pure/__release
    local.get $4
+   local.get $6
    i32.mul
    return
   end
+  local.get $3
+  call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $~lib/util/string/strtol<i64> (result i64)
-  (local $0 i32)
+ (func $~lib/util/string/strtol<i64> (param $0 i32) (result i64)
   (local $1 i32)
-  (local $2 i64)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
-  i32.const 2960
-  local.set $5
+  (local $6 i64)
   block $folding-inner0
-   i32.const 2960
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $3
    call $~lib/string/String#get:length
    local.tee $0
    i32.eqz
    br_if $folding-inner0
-   i32.const 2960
+   local.get $3
+   local.tee $2
    i32.load16_u
    local.set $1
    i64.const 1
@@ -2979,10 +3082,10 @@
     local.get $1
     call $~lib/util/string/isSpace
     if
-     local.get $5
+     local.get $2
      i32.const 2
      i32.add
-     local.tee $5
+     local.tee $2
      i32.load16_u
      local.set $1
      local.get $0
@@ -3004,10 +3107,10 @@
     br_if $folding-inner0
     i64.const -1
     local.set $4
-    local.get $5
+    local.get $2
     i32.const 2
     i32.add
-    local.tee $5
+    local.tee $2
     i32.load16_u
     local.set $1
    else
@@ -3021,10 +3124,10 @@
      local.tee $0
      i32.eqz
      br_if $folding-inner0
-     local.get $5
+     local.get $2
      i32.const 2
      i32.add
-     local.tee $5
+     local.tee $2
      i32.load16_u
      local.set $1
     end
@@ -3042,7 +3145,7 @@
      block $case3|1
       block $case2|1
        block $case1|1
-        local.get $5
+        local.get $2
         i32.load16_u offset=2
         i32.const 32
         i32.or
@@ -3060,10 +3163,10 @@
          br_if $case2|1
          br $case3|1
         end
-        local.get $5
+        local.get $2
         i32.const 4
         i32.add
-        local.set $5
+        local.set $2
         local.get $0
         i32.const 2
         i32.sub
@@ -3071,10 +3174,10 @@
         i32.const 2
         br $break|1
        end
-       local.get $5
+       local.get $2
        i32.const 4
        i32.add
-       local.set $5
+       local.set $2
        local.get $0
        i32.const 2
        i32.sub
@@ -3082,10 +3185,10 @@
        i32.const 8
        br $break|1
       end
-      local.get $5
+      local.get $2
       i32.const 4
       i32.add
-      local.set $5
+      local.set $2
       local.get $0
       i32.const 2
       i32.sub
@@ -3098,7 +3201,7 @@
    else
     i32.const 10
    end
-   local.set $3
+   local.set $5
    loop $while-continue|2
     block $while-break|2
      local.get $0
@@ -3108,7 +3211,7 @@
      local.set $0
      local.get $1
      if
-      local.get $5
+      local.get $2
       i32.load16_u
       local.tee $1
       i32.const 48
@@ -3142,30 +3245,34 @@
        end
       end
       local.tee $1
-      local.get $3
+      local.get $5
       i32.ge_u
       br_if $while-break|2
       local.get $1
       i64.extend_i32_u
-      local.get $2
-      local.get $3
+      local.get $6
+      local.get $5
       i64.extend_i32_s
       i64.mul
       i64.add
-      local.set $2
-      local.get $5
+      local.set $6
+      local.get $2
       i32.const 2
       i32.add
-      local.set $5
+      local.set $2
       br $while-continue|2
      end
     end
    end
-   local.get $2
+   local.get $3
+   call $~lib/rt/pure/__release
    local.get $4
+   local.get $6
    i64.mul
    return
   end
+  local.get $3
+  call $~lib/rt/pure/__release
   i64.const 0
  )
  (func $~lib/math/ipow32 (param $0 i32) (result i32)
@@ -3285,32 +3392,36 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i64)
-  (local $7 i32)
+  (local $6 i32)
+  (local $7 i64)
   (local $8 i32)
-  (local $9 i64)
+  (local $9 i32)
   (local $10 i64)
-  (local $11 f64)
-  (local $12 i64)
-  (local $13 f64)
-  (local $14 i32)
+  (local $11 i64)
+  (local $12 f64)
+  (local $13 i64)
+  (local $14 f64)
   (local $15 i32)
-  (local $16 i64)
+  (local $16 i32)
+  (local $17 i64)
   block $folding-inner0
    local.get $0
-   call $~lib/string/String#get:length
+   call $~lib/rt/pure/__retain
    local.tee $5
+   call $~lib/string/String#get:length
+   local.tee $6
    i32.eqz
    br_if $folding-inner0
-   local.get $0
+   local.get $5
+   local.tee $0
    i32.load16_u
-   local.set $7
+   local.set $8
    f64.const 1
-   local.set $13
+   local.set $14
    loop $while-continue|0
-    local.get $5
+    local.get $6
     if (result i32)
-     local.get $7
+     local.get $8
      call $~lib/util/string/isSpace
     else
      i32.const 0
@@ -3321,43 +3432,43 @@
      i32.add
      local.tee $0
      i32.load16_u
-     local.set $7
-     local.get $5
+     local.set $8
+     local.get $6
      i32.const 1
      i32.sub
-     local.set $5
+     local.set $6
      br $while-continue|0
     end
    end
-   local.get $5
+   local.get $6
    i32.eqz
    br_if $folding-inner0
-   local.get $7
+   local.get $8
    i32.const 45
    i32.eq
    if (result i32)
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.tee $5
+    local.tee $6
     i32.eqz
     br_if $folding-inner0
     f64.const -1
-    local.set $13
+    local.set $14
     local.get $0
     i32.const 2
     i32.add
     local.tee $0
     i32.load16_u
    else
-    local.get $7
+    local.get $8
     i32.const 43
     i32.eq
     if (result i32)
-     local.get $5
+     local.get $6
      i32.const 1
      i32.sub
-     local.tee $5
+     local.tee $6
      i32.eqz
      br_if $folding-inner0
      local.get $0
@@ -3366,14 +3477,14 @@
      local.tee $0
      i32.load16_u
     else
-     local.get $7
+     local.get $8
     end
    end
-   local.tee $7
+   local.tee $8
    i32.const 73
    i32.eq
    i32.const 0
-   local.get $5
+   local.get $6
    i32.const 8
    i32.ge_s
    select
@@ -3391,20 +3502,22 @@
      i32.const 0
     end
     if
+     local.get $5
+     call $~lib/rt/pure/__release
      f64.const inf
-     local.get $13
+     local.get $14
      f64.copysign
      return
     end
     br $folding-inner0
    end
-   local.get $7
+   local.get $8
    i32.const 48
    i32.sub
    i32.const 10
    i32.ge_u
    i32.const 0
-   local.get $7
+   local.get $8
    i32.const 46
    i32.ne
    select
@@ -3412,7 +3525,7 @@
    local.get $0
    local.set $4
    loop $while-continue|1
-    local.get $7
+    local.get $8
     i32.const 48
     i32.eq
     if
@@ -3421,22 +3534,24 @@
      i32.add
      local.tee $0
      i32.load16_u
-     local.set $7
-     local.get $5
+     local.set $8
+     local.get $6
      i32.const 1
      i32.sub
-     local.set $5
+     local.set $6
      br $while-continue|1
     end
    end
-   local.get $5
+   local.get $6
    i32.const 0
    i32.le_s
    if
+    local.get $5
+    call $~lib/rt/pure/__release
     f64.const 0
     return
    end
-   local.get $7
+   local.get $8
    i32.const 46
    i32.eq
    if
@@ -3449,10 +3564,10 @@
     i32.const 2
     i32.add
     local.set $0
-    local.get $5
+    local.get $6
     i32.const 1
     i32.sub
-    local.tee $5
+    local.tee $6
     if (result i32)
      i32.const 0
     else
@@ -3460,18 +3575,18 @@
     end
     br_if $folding-inner0
     i32.const 1
-    local.set $14
+    local.set $15
     loop $for-loop|2
      local.get $0
      i32.load16_u
-     local.tee $7
+     local.tee $8
      i32.const 48
      i32.eq
      if
-      local.get $5
+      local.get $6
       i32.const 1
       i32.sub
-      local.set $5
+      local.set $6
       local.get $2
       i32.const 1
       i32.sub
@@ -3483,14 +3598,16 @@
       br $for-loop|2
      end
     end
-    local.get $5
+    local.get $6
     i32.const 0
     i32.le_s
     if
+     local.get $5
+     call $~lib/rt/pure/__release
      f64.const 0
      return
     end
-    local.get $7
+    local.get $8
     i32.const 48
     i32.sub
     i32.const 10
@@ -3503,37 +3620,37 @@
     select
     br_if $folding-inner0
    end
-   local.get $7
+   local.get $8
    i32.const 48
    i32.sub
-   local.set $8
+   local.set $9
    loop $for-loop|3
     i32.const 1
-    local.get $14
+    local.get $15
     i32.eqz
     i32.const 0
-    local.get $7
+    local.get $8
     i32.const 46
     i32.eq
     select
-    local.get $8
+    local.get $9
     i32.const 10
     i32.lt_u
     select
     if
      block $for-break3
-      local.get $8
+      local.get $9
       i32.const 10
       i32.lt_u
       if
-       local.get $8
+       local.get $9
        i64.extend_i32_u
-       local.get $6
+       local.get $7
        i64.const 10
        i64.mul
        i64.add
-       local.get $6
-       local.get $8
+       local.get $7
+       local.get $9
        i32.eqz
        i32.eqz
        i64.extend_i32_u
@@ -3542,7 +3659,7 @@
        i32.const 19
        i32.lt_s
        select
-       local.set $6
+       local.set $7
        local.get $1
        i32.const 1
        i32.add
@@ -3551,12 +3668,12 @@
        local.get $1
        local.set $2
        i32.const 1
-       local.set $14
+       local.set $15
       end
-      local.get $5
+      local.get $6
       i32.const 1
       i32.sub
-      local.tee $5
+      local.tee $6
       i32.eqz
       br_if $for-break3
       local.get $0
@@ -3564,17 +3681,17 @@
       i32.add
       local.tee $0
       i32.load16_u
-      local.tee $7
+      local.tee $8
       i32.const 48
       i32.sub
-      local.set $8
+      local.set $9
       br $for-loop|3
      end
     end
    end
    local.get $2
    local.get $1
-   local.get $14
+   local.get $15
    select
    i32.const 19
    local.get $1
@@ -3598,40 +3715,40 @@
     local.get $2
     i32.const 2
     i32.add
-    local.tee $8
+    local.tee $9
     i32.load16_u
     local.tee $0
     i32.const 45
     i32.eq
     if (result i32)
-     local.get $5
+     local.get $6
      i32.const 1
      i32.sub
-     local.tee $5
+     local.tee $6
      i32.eqz
      br_if $~lib/util/string/parseExp|inlined.0
      i32.const -1
      local.set $1
-     local.get $8
+     local.get $9
      i32.const 2
      i32.add
-     local.tee $8
+     local.tee $9
      i32.load16_u
     else
      local.get $0
      i32.const 43
      i32.eq
      if (result i32)
-      local.get $5
+      local.get $6
       i32.const 1
       i32.sub
-      local.tee $5
+      local.tee $6
       i32.eqz
       br_if $~lib/util/string/parseExp|inlined.0
-      local.get $8
+      local.get $9
       i32.const 2
       i32.add
-      local.tee $8
+      local.tee $9
       i32.load16_u
      else
       local.get $0
@@ -3643,16 +3760,16 @@
      i32.const 48
      i32.eq
      if
-      local.get $5
+      local.get $6
       i32.const 1
       i32.sub
-      local.tee $5
+      local.tee $6
       i32.eqz
       br_if $~lib/util/string/parseExp|inlined.0
-      local.get $8
+      local.get $9
       i32.const 2
       i32.add
-      local.tee $8
+      local.tee $9
       i32.load16_u
       local.set $0
       br $while-continue|4
@@ -3667,7 +3784,7 @@
      i32.const 10
      i32.lt_u
      i32.const 0
-     local.get $5
+     local.get $6
      select
      if
       local.get $3
@@ -3677,7 +3794,7 @@
        local.get $1
        i32.const 3200
        i32.mul
-       local.set $15
+       local.set $16
        br $~lib/util/string/parseExp|inlined.0
       end
       local.get $0
@@ -3686,14 +3803,14 @@
       i32.mul
       i32.add
       local.set $3
-      local.get $5
+      local.get $6
       i32.const 1
       i32.sub
-      local.set $5
-      local.get $8
+      local.set $6
+      local.get $9
       i32.const 2
       i32.add
-      local.tee $8
+      local.tee $9
       i32.load16_u
       i32.const 48
       i32.sub
@@ -3704,17 +3821,17 @@
     local.get $1
     local.get $3
     i32.mul
-    local.set $15
+    local.set $16
    end
    block $~lib/util/string/scientific|inlined.0
     i32.const 1
     local.get $4
-    local.get $15
+    local.get $16
     i32.add
     local.tee $0
     i32.const -342
     i32.lt_s
-    local.get $6
+    local.get $7
     i64.eqz
     select
     br_if $~lib/util/string/scientific|inlined.0
@@ -3723,12 +3840,12 @@
     i32.gt_s
     if
      f64.const inf
-     local.set $11
+     local.set $12
      br $~lib/util/string/scientific|inlined.0
     end
-    local.get $6
+    local.get $7
     f64.convert_i64_u
-    local.set $11
+    local.set $12
     local.get $0
     i32.eqz
     br_if $~lib/util/string/scientific|inlined.0
@@ -3741,7 +3858,7 @@
     i32.gt_s
     select
     if
-     local.get $11
+     local.get $12
      local.get $0
      i32.const 3
      i32.shl
@@ -3749,11 +3866,11 @@
      i32.add
      f64.load
      f64.mul
-     local.set $11
+     local.set $12
      i32.const 22
      local.set $0
     end
-    local.get $6
+    local.get $7
     i64.const 9007199254740991
     i64.le_u
     if (result i32)
@@ -3775,7 +3892,7 @@
      i32.const 0
      i32.gt_s
      if
-      local.get $11
+      local.get $12
       local.get $0
       i32.const 3
       i32.shl
@@ -3783,10 +3900,10 @@
       i32.add
       f64.load
       f64.mul
-      local.set $11
+      local.set $12
       br $~lib/util/string/scientific|inlined.0
      end
-     local.get $11
+     local.get $12
      i32.const 0
      local.get $0
      i32.sub
@@ -3801,33 +3918,33 @@
      i32.const 0
      i32.lt_s
      if (result f64)
-      local.get $6
-      local.get $6
+      local.get $7
+      local.get $7
       i64.clz
-      local.tee $9
+      local.tee $10
       i64.shl
-      local.set $6
+      local.set $7
       local.get $0
       local.tee $1
       i64.extend_i32_s
-      local.get $9
+      local.get $10
       i64.sub
-      local.set $9
+      local.set $10
       loop $for-loop|6
        local.get $1
        i32.const -14
        i32.le_s
        if
         f64.const 0.00004294967296
-        local.get $6
+        local.get $7
         i64.const 6103515625
         i64.rem_u
-        local.get $6
+        local.get $7
         i64.const 6103515625
         i64.div_u
-        local.tee $12
+        local.tee $13
         i64.clz
-        local.tee $10
+        local.tee $11
         i64.const 18
         i64.sub
         i64.shl
@@ -3835,15 +3952,15 @@
         f64.mul
         f64.nearest
         i64.trunc_f64_u
-        local.get $12
-        local.get $10
+        local.get $13
+        local.get $11
         i64.shl
         i64.add
-        local.set $6
-        local.get $9
+        local.set $7
         local.get $10
+        local.get $11
         i64.sub
-        local.set $9
+        local.set $10
         local.get $1
         i32.const 14
         i32.add
@@ -3851,49 +3968,49 @@
         br $for-loop|6
        end
       end
-      local.get $6
+      local.get $7
       i32.const 0
       local.get $1
       i32.sub
       call $~lib/math/ipow32
       i64.extend_i32_s
-      local.tee $12
+      local.tee $13
       i64.div_u
-      local.tee $16
+      local.tee $17
       i64.clz
-      local.set $10
-      local.get $6
-      local.get $12
+      local.set $11
+      local.get $7
+      local.get $13
       i64.rem_u
       f64.convert_i64_u
       i64.reinterpret_f64
-      local.get $10
+      local.get $11
       i64.const 52
       i64.shl
       i64.add
       f64.reinterpret_i64
-      local.get $12
+      local.get $13
       f64.convert_i64_u
       f64.div
       i64.trunc_f64_u
-      local.get $16
-      local.get $10
+      local.get $17
+      local.get $11
       i64.shl
       i64.add
       f64.convert_i64_u
-      local.get $9
       local.get $10
+      local.get $11
       i64.sub
       i32.wrap_i64
       call $~lib/math/NativeMath.scalbn
      else
-      local.get $6
-      local.get $6
+      local.get $7
+      local.get $7
       i64.ctz
-      local.tee $9
+      local.tee $10
       i64.shr_u
-      local.set $6
-      local.get $9
+      local.set $7
+      local.get $10
       local.get $0
       local.tee $3
       i64.extend_i32_s
@@ -3905,21 +4022,21 @@
        i32.ge_s
        if
         i64.const 32
-        local.get $6
+        local.get $7
         i64.const 32
         i64.shr_u
         i64.const 1220703125
         i64.mul
-        local.get $6
+        local.get $7
         i64.const 4294967295
         i64.and
         i64.const 1220703125
         i64.mul
-        local.tee $6
+        local.tee $7
         i64.const 32
         i64.shr_u
         i64.add
-        local.tee $9
+        local.tee $10
         i64.const 32
         i64.shr_u
         i32.wrap_i64
@@ -3927,11 +4044,11 @@
         local.tee $0
         i64.extend_i32_u
         i64.sub
-        local.tee $10
+        local.tee $11
         global.get $~lib/util/string/__fixmulShift
         i64.add
         global.set $~lib/util/string/__fixmulShift
-        local.get $6
+        local.get $7
         local.get $0
         i64.extend_i32_u
         i64.shl
@@ -3939,18 +4056,18 @@
         i64.shr_u
         i64.const 1
         i64.and
-        local.get $9
+        local.get $10
         local.get $0
         i64.extend_i32_u
         i64.shl
-        local.get $6
+        local.get $7
         i64.const 4294967295
         i64.and
-        local.get $10
+        local.get $11
         i64.shr_u
         i64.or
         i64.add
-        local.set $6
+        local.set $7
         local.get $3
         i32.const 13
         i32.sub
@@ -3962,23 +4079,23 @@
       call $~lib/math/ipow32
       local.tee $0
       i64.extend_i32_u
-      local.get $6
+      local.get $7
       i64.const 4294967295
       i64.and
       i64.mul
-      local.set $9
+      local.set $10
       i64.const 32
       local.get $0
       i64.extend_i32_u
-      local.get $6
+      local.get $7
       i64.const 32
       i64.shr_u
       i64.mul
-      local.get $9
+      local.get $10
       i64.const 32
       i64.shr_u
       i64.add
-      local.tee $6
+      local.tee $7
       i64.const 32
       i64.shr_u
       i32.wrap_i64
@@ -3986,11 +4103,11 @@
       local.tee $0
       i64.extend_i32_u
       i64.sub
-      local.tee $10
+      local.tee $11
       global.get $~lib/util/string/__fixmulShift
       i64.add
       global.set $~lib/util/string/__fixmulShift
-      local.get $9
+      local.get $10
       local.get $0
       i64.extend_i32_u
       i64.shl
@@ -3998,14 +4115,14 @@
       i64.shr_u
       i64.const 1
       i64.and
-      local.get $6
+      local.get $7
       local.get $0
       i64.extend_i32_u
       i64.shl
-      local.get $9
+      local.get $10
       i64.const 4294967295
       i64.and
-      local.get $10
+      local.get $11
       i64.shr_u
       i64.or
       i64.add
@@ -4015,26 +4132,45 @@
       call $~lib/math/NativeMath.scalbn
      end
     end
-    local.set $11
+    local.set $12
    end
-   local.get $11
-   local.get $13
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $12
+   local.get $14
    f64.copysign
    return
   end
+  local.get $5
+  call $~lib/rt/pure/__release
   f64.const nan:0x8000000000000
+ )
+ (func $~lib/string/parseFloat (param $0 i32) (result f64)
+  (local $1 f64)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/util/string/strtod
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   block $__inlined_func$~lib/string/String#concat (result i32)
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $2
    i32.const 1648
-   local.get $0
+   local.get $2
    select
-   local.set $2
+   local.set $3
    local.get $1
+   call $~lib/rt/pure/__retain
+   local.tee $5
    call $~lib/rt/pure/__retain
    local.tee $0
    i32.eqz
@@ -4049,16 +4185,16 @@
     i32.const 1648
     local.set $0
    end
-   local.get $2
-   call $~lib/string/String#get:length
-   i32.const 1
-   i32.shl
-   local.tee $3
-   local.get $0
+   local.get $3
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    local.tee $4
+   local.get $0
+   call $~lib/string/String#get:length
+   i32.const 1
+   i32.shl
+   local.tee $6
    i32.add
    local.tee $1
    i32.eqz
@@ -4073,35 +4209,62 @@
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.tee $1
-   local.get $2
    local.get $3
+   local.get $4
    call $~lib/memory/memory.copy
    local.get $1
-   local.get $3
+   local.get $4
    i32.add
    local.get $0
-   local.get $4
+   local.get $6
    call $~lib/memory/memory.copy
    local.get $0
    call $~lib/rt/pure/__release
    local.get $1
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/string/String.__ne (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  call $~lib/string/String.__eq
+  i32.eqz
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String.__gt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $folding-inner0
-   i32.const 1
-   local.get $1
-   i32.eqz
-   i32.const 1
    local.get $0
-   i32.eqz
-   local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    local.get $1
+   call $~lib/rt/pure/__retain
+   local.tee $1
    i32.eq
-   select
-   select
+   if (result i32)
+    i32.const 1
+   else
+    local.get $0
+    i32.eqz
+   end
+   if (result i32)
+    i32.const 1
+   else
+    local.get $1
+    i32.eqz
+   end
    br_if $folding-inner0
    local.get $0
    call $~lib/string/String#get:length
@@ -4113,6 +4276,10 @@
    local.tee $3
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
+    local.get $1
+    call $~lib/rt/pure/__release
     i32.const 1
     return
    end
@@ -4128,25 +4295,41 @@
    call $~lib/util/string/compareImpl
    i32.const 0
    i32.gt_s
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/string/String.__lt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $folding-inner0
-   i32.const 1
-   local.get $1
-   i32.eqz
-   i32.const 1
    local.get $0
-   i32.eqz
-   local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    local.get $1
+   call $~lib/rt/pure/__retain
+   local.tee $1
    i32.eq
-   select
-   select
+   if (result i32)
+    i32.const 1
+   else
+    local.get $0
+    i32.eqz
+   end
+   if (result i32)
+    i32.const 1
+   else
+    local.get $1
+    i32.eqz
+   end
    br_if $folding-inner0
    local.get $1
    call $~lib/string/String#get:length
@@ -4158,6 +4341,10 @@
    local.tee $3
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
+    local.get $1
+    call $~lib/rt/pure/__release
     i32.const 1
     return
    end
@@ -4173,9 +4360,45 @@
    call $~lib/util/string/compareImpl
    i32.const 0
    i32.lt_s
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
+ )
+ (func $~lib/string/String.__gte (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  call $~lib/string/String.__lt
+  i32.eqz
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/string/String.__lte (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 1280
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/string/String.__gt
+  i32.eqz
+  i32.const 1280
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String#repeat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -4242,96 +4465,117 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $0
-  call $~lib/string/String#get:length
-  local.tee $3
+  (local $8 i32)
   local.get $1
-  call $~lib/string/String#get:length
-  local.tee $4
-  i32.le_u
-  if
-   local.get $3
-   local.get $4
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    call $~lib/rt/pure/__retain
-   else
-    local.get $2
-    local.get $0
-    local.get $1
-    local.get $0
-    call $~lib/string/String.__eq
-    select
-    call $~lib/rt/pure/__retain
-   end
-   return
-  end
-  local.get $0
-  local.get $1
-  i32.const 0
-  call $~lib/string/String#indexOf
-  local.tee $1
-  i32.const -1
-  i32.xor
-  if
-   local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $1
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
+  block $folding-inner0
+   local.get $0
+   call $~lib/string/String#get:length
+   local.tee $3
+   local.get $1
    call $~lib/string/String#get:length
    local.tee $5
-   local.get $3
-   local.get $4
-   i32.sub
-   local.tee $6
-   i32.add
-   local.tee $3
+   i32.le_u
    if
     local.get $3
-    i32.const 1
-    i32.shl
-    i32.const 1
-    call $~lib/rt/tlsf/__alloc
-    local.tee $3
-    local.get $0
-    local.get $1
-    i32.const 1
-    i32.shl
-    local.tee $7
-    call $~lib/memory/memory.copy
-    local.get $3
-    local.get $7
-    i32.add
-    local.get $2
     local.get $5
-    i32.const 1
-    i32.shl
-    call $~lib/memory/memory.copy
-    local.get $3
-    local.get $1
-    local.get $5
-    i32.add
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $0
-    local.get $1
-    local.get $4
-    i32.add
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $6
-    local.get $1
-    i32.sub
-    i32.const 1
-    i32.shl
-    call $~lib/memory/memory.copy
-    local.get $3
-    call $~lib/rt/pure/__retain
-    return
+    i32.lt_u
+    if (result i32)
+     local.get $0
+     call $~lib/rt/pure/__retain
+    else
+     local.get $2
+     local.get $0
+     local.get $1
+     local.get $0
+     call $~lib/string/String.__eq
+     select
+     call $~lib/rt/pure/__retain
+    end
+    local.set $0
+    br $folding-inner0
    end
+   local.get $0
+   local.get $1
+   i32.const 0
+   call $~lib/string/String#indexOf
+   local.tee $4
+   i32.const -1
+   i32.xor
+   if
+    local.get $2
+    call $~lib/string/String#get:length
+    local.tee $6
+    local.get $3
+    local.get $5
+    i32.sub
+    local.tee $7
+    i32.add
+    local.tee $3
+    if
+     local.get $3
+     i32.const 1
+     i32.shl
+     i32.const 1
+     call $~lib/rt/tlsf/__alloc
+     local.tee $3
+     local.get $0
+     local.get $4
+     i32.const 1
+     i32.shl
+     local.tee $8
+     call $~lib/memory/memory.copy
+     local.get $3
+     local.get $8
+     i32.add
+     local.get $2
+     local.get $6
+     i32.const 1
+     i32.shl
+     call $~lib/memory/memory.copy
+     local.get $3
+     local.get $4
+     local.get $6
+     i32.add
+     i32.const 1
+     i32.shl
+     i32.add
+     local.get $0
+     local.get $4
+     local.get $5
+     i32.add
+     i32.const 1
+     i32.shl
+     i32.add
+     local.get $7
+     local.get $4
+     i32.sub
+     i32.const 1
+     i32.shl
+     call $~lib/memory/memory.copy
+     local.get $3
+     call $~lib/rt/pure/__retain
+     local.set $0
+     br $folding-inner0
+    end
+   end
+   local.get $0
+   call $~lib/rt/pure/__retain
+   local.get $1
+   call $~lib/rt/pure/__release
+   local.get $2
+   call $~lib/rt/pure/__release
+   return
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__retain
  )
  (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
   (local $1 i32)
@@ -4509,88 +4753,220 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  local.get $2
-  local.set $5
-  local.get $0
-  call $~lib/string/String#get:length
-  local.tee $3
   local.get $1
-  local.tee $4
-  call $~lib/string/String#get:length
-  local.tee $10
-  i32.le_u
-  if
-   local.get $3
-   local.get $10
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    call $~lib/rt/pure/__retain
-   else
-    local.get $5
-    local.get $0
-    local.get $4
-    local.get $0
-    call $~lib/string/String.__eq
-    select
-    call $~lib/rt/pure/__retain
+  call $~lib/rt/pure/__retain
+  local.set $7
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $5
+  block $folding-inner0
+   local.get $0
+   call $~lib/string/String#get:length
+   local.tee $3
+   local.get $7
+   call $~lib/string/String#get:length
+   local.tee $10
+   i32.le_u
+   if
+    local.get $3
+    local.get $10
+    i32.lt_u
+    if (result i32)
+     local.get $0
+     call $~lib/rt/pure/__retain
+    else
+     local.get $5
+     local.get $0
+     local.get $7
+     local.get $0
+     call $~lib/string/String.__eq
+     select
+     call $~lib/rt/pure/__retain
+    end
+    local.set $0
+    br $folding-inner0
    end
-   return
-  end
-  local.get $5
-  call $~lib/string/String#get:length
-  local.set $2
-  local.get $10
-  i32.eqz
-  if
-   local.get $2
+   local.get $5
+   call $~lib/string/String#get:length
+   local.set $2
+   local.get $10
    i32.eqz
    if
-    local.get $0
+    local.get $2
+    i32.eqz
+    if
+     local.get $0
+     call $~lib/rt/pure/__retain
+     local.set $0
+     br $folding-inner0
+    end
+    local.get $3
+    local.get $2
+    local.get $3
+    i32.const 1
+    i32.add
+    i32.mul
+    i32.add
+    i32.const 1
+    i32.shl
+    i32.const 1
+    call $~lib/rt/tlsf/__alloc
+    local.tee $4
+    local.get $5
+    local.get $2
+    i32.const 1
+    i32.shl
+    call $~lib/memory/memory.copy
+    local.get $2
+    local.set $1
+    loop $for-loop|0
+     local.get $9
+     local.get $3
+     i32.lt_u
+     if
+      local.get $4
+      local.get $1
+      i32.const 1
+      i32.shl
+      i32.add
+      local.get $0
+      local.get $9
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      i32.store16
+      local.get $4
+      local.get $1
+      i32.const 1
+      i32.add
+      local.tee $1
+      i32.const 1
+      i32.shl
+      i32.add
+      local.get $5
+      local.get $2
+      i32.const 1
+      i32.shl
+      call $~lib/memory/memory.copy
+      local.get $1
+      local.get $2
+      i32.add
+      local.set $1
+      local.get $9
+      i32.const 1
+      i32.add
+      local.set $9
+      br $for-loop|0
+     end
+    end
+    local.get $4
     call $~lib/rt/pure/__retain
-    return
+    local.set $0
+    br $folding-inner0
+   end
+   local.get $2
+   local.get $10
+   i32.eq
+   if
+    local.get $3
+    i32.const 1
+    i32.shl
+    local.tee $3
+    i32.const 1
+    call $~lib/rt/tlsf/__alloc
+    local.tee $1
+    local.get $0
+    local.get $3
+    call $~lib/memory/memory.copy
+    loop $while-continue|1
+     local.get $0
+     local.get $7
+     local.get $6
+     call $~lib/string/String#indexOf
+     local.tee $3
+     i32.const -1
+     i32.xor
+     if
+      local.get $1
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      local.get $5
+      local.get $2
+      i32.const 1
+      i32.shl
+      call $~lib/memory/memory.copy
+      local.get $3
+      local.get $10
+      i32.add
+      local.set $6
+      br $while-continue|1
+     end
+    end
+    local.get $1
+    call $~lib/rt/pure/__retain
+    local.set $0
+    br $folding-inner0
    end
    local.get $3
-   local.get $2
-   local.get $3
-   i32.const 1
-   i32.add
-   i32.mul
-   i32.add
-   i32.const 1
-   i32.shl
-   i32.const 1
-   call $~lib/rt/tlsf/__alloc
-   local.tee $4
-   local.get $5
-   local.get $2
-   i32.const 1
-   i32.shl
-   call $~lib/memory/memory.copy
-   local.get $2
    local.set $1
-   loop $for-loop|0
-    local.get $9
-    local.get $3
-    i32.lt_u
+   loop $while-continue|2
+    local.get $0
+    local.get $7
+    local.get $6
+    call $~lib/string/String#indexOf
+    local.tee $9
+    i32.const -1
+    i32.xor
     if
      local.get $4
+     i32.eqz
+     if
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.const 1
+      call $~lib/rt/tlsf/__alloc
+      local.set $4
+     end
+     local.get $8
      local.get $1
+     i32.gt_u
+     if
+      local.get $4
+      local.get $1
+      i32.const 1
+      i32.shl
+      local.tee $1
+      i32.const 1
+      i32.shl
+      call $~lib/rt/tlsf/__realloc
+      local.set $4
+     end
+     local.get $4
+     local.get $8
      i32.const 1
      i32.shl
      i32.add
      local.get $0
-     local.get $9
+     local.get $6
      i32.const 1
      i32.shl
      i32.add
-     i32.load16_u
-     i32.store16
+     local.get $9
+     local.get $6
+     i32.sub
+     local.tee $6
+     i32.const 1
+     i32.shl
+     call $~lib/memory/memory.copy
      local.get $4
-     local.get $1
-     i32.const 1
+     local.get $6
+     local.get $8
      i32.add
-     local.tee $1
+     local.tee $6
      i32.const 1
      i32.shl
      i32.add
@@ -4599,91 +4975,24 @@
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $1
      local.get $2
+     local.get $6
      i32.add
-     local.set $1
+     local.set $8
      local.get $9
-     i32.const 1
-     i32.add
-     local.set $9
-     br $for-loop|0
-    end
-   end
-   local.get $4
-   call $~lib/rt/pure/__retain
-   return
-  end
-  local.get $2
-  local.get $10
-  i32.eq
-  if
-   local.get $3
-   i32.const 1
-   i32.shl
-   local.tee $3
-   i32.const 1
-   call $~lib/rt/tlsf/__alloc
-   local.tee $1
-   local.get $0
-   local.get $3
-   call $~lib/memory/memory.copy
-   loop $while-continue|1
-    local.get $0
-    local.get $4
-    local.get $7
-    call $~lib/string/String#indexOf
-    local.tee $3
-    i32.const -1
-    i32.xor
-    if
-     local.get $1
-     local.get $3
-     i32.const 1
-     i32.shl
-     i32.add
-     local.get $5
-     local.get $2
-     i32.const 1
-     i32.shl
-     call $~lib/memory/memory.copy
-     local.get $3
      local.get $10
      i32.add
-     local.set $7
-     br $while-continue|1
+     local.set $6
+     br $while-continue|2
     end
    end
-   local.get $1
-   call $~lib/rt/pure/__retain
-   return
-  end
-  local.get $3
-  local.set $1
-  loop $while-continue|2
-   local.get $0
-   local.get $4
-   local.get $7
-   call $~lib/string/String#indexOf
-   local.tee $9
-   i32.const -1
-   i32.xor
+   local.get $8
    if
-    local.get $6
-    i32.eqz
-    if
-     local.get $3
-     i32.const 1
-     i32.shl
-     i32.const 1
-     call $~lib/rt/tlsf/__alloc
-     local.set $6
-    end
     local.get $8
     local.get $1
     i32.gt_u
     if
-     local.get $6
+     local.get $4
      local.get $1
      i32.const 1
      i32.shl
@@ -4691,105 +5000,60 @@
      i32.const 1
      i32.shl
      call $~lib/rt/tlsf/__realloc
-     local.set $6
+     local.set $4
     end
+    local.get $3
     local.get $6
-    local.get $8
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $0
-    local.get $7
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $9
-    local.get $7
     i32.sub
-    local.tee $7
-    i32.const 1
-    i32.shl
-    call $~lib/memory/memory.copy
-    local.get $6
-    local.get $7
-    local.get $8
-    i32.add
-    local.tee $7
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $5
-    local.get $2
-    i32.const 1
-    i32.shl
-    call $~lib/memory/memory.copy
-    local.get $2
-    local.get $7
-    i32.add
-    local.set $8
-    local.get $9
-    local.get $10
-    i32.add
-    local.set $7
-    br $while-continue|2
-   end
-  end
-  local.get $8
-  if
-   local.get $8
-   local.get $1
-   i32.gt_u
-   if
-    local.get $6
+    local.tee $2
+    if
+     local.get $4
+     local.get $8
+     i32.const 1
+     i32.shl
+     i32.add
+     local.get $0
+     local.get $6
+     i32.const 1
+     i32.shl
+     i32.add
+     local.get $2
+     i32.const 1
+     i32.shl
+     call $~lib/memory/memory.copy
+    end
     local.get $1
-    i32.const 1
-    i32.shl
-    local.tee $1
-    i32.const 1
-    i32.shl
-    call $~lib/rt/tlsf/__realloc
-    local.set $6
-   end
-   local.get $3
-   local.get $7
-   i32.sub
-   local.tee $2
-   if
-    local.get $6
-    local.get $8
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $0
-    local.get $7
-    i32.const 1
-    i32.shl
-    i32.add
     local.get $2
-    i32.const 1
-    i32.shl
-    call $~lib/memory/memory.copy
+    local.get $8
+    i32.add
+    local.tee $0
+    i32.gt_u
+    if (result i32)
+     local.get $4
+     local.get $0
+     i32.const 1
+     i32.shl
+     call $~lib/rt/tlsf/__realloc
+    else
+     local.get $4
+    end
+    call $~lib/rt/pure/__retain
+    local.set $0
+    br $folding-inner0
    end
-   local.get $1
-   local.get $2
-   local.get $8
-   i32.add
-   local.tee $0
-   i32.gt_u
-   if (result i32)
-    local.get $6
-    local.get $0
-    i32.const 1
-    i32.shl
-    call $~lib/rt/tlsf/__realloc
-   else
-    local.get $6
-   end
+   local.get $0
    call $~lib/rt/pure/__retain
+   local.get $7
+   call $~lib/rt/pure/__release
+   local.get $5
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__retain
  )
  (func $~lib/string/String#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -5194,13 +5458,16 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $0
   i32.load offset=12
   local.tee $6
   i32.const 1
   i32.add
   local.tee $3
-  local.set $2
+  local.set $1
   local.get $3
   local.get $0
   i32.load offset=8
@@ -5209,7 +5476,7 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $2
+   local.get $1
    i32.const 268435452
    i32.gt_u
    if
@@ -5224,26 +5491,26 @@
    local.get $0
    i32.load
    local.tee $7
-   local.get $2
+   local.get $1
    i32.const 2
    i32.shl
    local.tee $5
    call $~lib/rt/tlsf/__realloc
-   local.tee $2
+   local.tee $1
    i32.add
    local.get $5
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $2
+   local.get $1
    local.get $7
    i32.ne
    if
     local.get $0
-    local.get $2
+    local.get $1
     i32.store
     local.get $0
-    local.get $2
+    local.get $1
     i32.store offset=4
    end
    local.get $0
@@ -5256,12 +5523,14 @@
   i32.const 2
   i32.shl
   i32.add
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__retain
   i32.store
   local.get $0
   local.get $3
   i32.store offset=12
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $~lib/string/String#split (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -5272,6 +5541,9 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   block $folding-inner0
    local.get $2
    i32.eqz
@@ -5282,17 +5554,19 @@
     i32.const 1
     call $~lib/rt/__allocArray
     call $~lib/rt/pure/__retain
-    local.tee $1
+    local.tee $2
     i32.load offset=4
     local.get $0
     call $~lib/rt/pure/__retain
     i32.store
     local.get $1
+    call $~lib/rt/pure/__release
+    local.get $2
     return
    end
    local.get $0
    call $~lib/string/String#get:length
-   local.set $5
+   local.set $4
    i32.const 2147483647
    local.get $2
    local.get $2
@@ -5302,9 +5576,9 @@
    local.set $2
    local.get $1
    call $~lib/string/String#get:length
-   local.tee $8
+   local.tee $6
    if
-    local.get $5
+    local.get $4
     i32.eqz
     if
      i32.const 1
@@ -5314,34 +5588,36 @@
      i32.load offset=4
      i32.const 1280
      i32.store
+     local.get $1
+     call $~lib/rt/pure/__release
      local.get $0
      return
     end
    else
-    local.get $5
+    local.get $4
     i32.eqz
     br_if $folding-inner0
-    local.get $5
+    local.get $4
     local.get $2
-    local.get $5
+    local.get $4
     local.get $2
     i32.lt_s
     select
-    local.tee $2
+    local.tee $5
     call $~lib/rt/__allocArray
     call $~lib/rt/pure/__retain
     local.tee $4
     i32.load offset=4
-    local.set $5
+    local.set $6
     loop $for-loop|0
      local.get $3
-     local.get $2
+     local.get $5
      i32.lt_s
      if
       i32.const 2
       i32.const 1
       call $~lib/rt/tlsf/__alloc
-      local.tee $1
+      local.tee $2
       local.get $3
       i32.const 1
       i32.shl
@@ -5352,11 +5628,11 @@
       local.get $3
       i32.const 2
       i32.shl
-      local.get $5
+      local.get $6
       i32.add
-      local.get $1
+      local.get $2
       i32.store
-      local.get $1
+      local.get $2
       call $~lib/rt/pure/__retain
       drop
       local.get $3
@@ -5366,6 +5642,8 @@
       br $for-loop|0
      end
     end
+    local.get $1
+    call $~lib/rt/pure/__release
     local.get $4
     return
    end
@@ -5376,32 +5654,32 @@
    loop $while-continue|1
     local.get $0
     local.get $1
-    local.get $4
+    local.get $5
     call $~lib/string/String#indexOf
-    local.tee $7
+    local.tee $8
     i32.const -1
     i32.xor
     if
-     local.get $7
-     local.get $4
+     local.get $8
+     local.get $5
      i32.sub
-     local.tee $6
+     local.tee $7
      i32.const 0
      i32.gt_s
      if
-      local.get $6
+      local.get $7
       i32.const 1
       i32.shl
-      local.tee $6
+      local.tee $7
       i32.const 1
       call $~lib/rt/tlsf/__alloc
       local.tee $9
-      local.get $4
+      local.get $5
       i32.const 1
       i32.shl
       local.get $0
       i32.add
-      local.get $6
+      local.get $7
       call $~lib/memory/memory.copy
       local.get $3
       local.get $9
@@ -5418,60 +5696,68 @@
      local.get $2
      i32.eq
      if
+      local.get $1
+      call $~lib/rt/pure/__release
       local.get $3
       return
      end
-     local.get $7
+     local.get $6
      local.get $8
      i32.add
-     local.set $4
+     local.set $5
      br $while-continue|1
     end
    end
-   local.get $4
+   local.get $5
    i32.eqz
    if
     local.get $3
     local.get $0
     call $~lib/array/Array<~lib/string/String>#push
+    local.get $1
+    call $~lib/rt/pure/__release
     local.get $3
     return
    end
-   local.get $5
    local.get $4
+   local.get $5
    i32.sub
-   local.tee $1
+   local.tee $2
    i32.const 0
    i32.gt_s
    if
-    local.get $1
+    local.get $2
     i32.const 1
     i32.shl
-    local.tee $1
+    local.tee $2
     i32.const 1
     call $~lib/rt/tlsf/__alloc
-    local.tee $2
-    local.get $4
+    local.tee $4
+    local.get $5
     i32.const 1
     i32.shl
     local.get $0
     i32.add
-    local.get $1
+    local.get $2
     call $~lib/memory/memory.copy
     local.get $3
-    local.get $2
+    local.get $4
     call $~lib/array/Array<~lib/string/String>#push
    else
     local.get $3
     i32.const 1280
     call $~lib/array/Array<~lib/string/String>#push
    end
+   local.get $1
+   call $~lib/rt/pure/__release
    local.get $3
    return
   end
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
+  local.get $1
+  call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -7341,7 +7627,7 @@
   (local $70 i32)
   (local $71 i32)
   (local $72 i32)
-  (local $73 i32)
+  (local $73 i64)
   (local $74 i32)
   (local $75 i32)
   (local $76 i32)
@@ -7566,6 +7852,7 @@
   (local $295 i32)
   (local $296 i32)
   (local $297 i32)
+  (local $298 i32)
   global.get $std/string/str
   i32.const 1040
   i32.ne
@@ -7804,17 +8091,17 @@
    i32.const 0
    local.get $12
    call $~lib/string/String#get:length
-   local.tee $11
+   local.tee $3
    i32.const 0
-   local.get $11
+   local.get $3
    i32.lt_s
    select
-   local.tee $8
+   local.tee $9
    local.get $1
    call $~lib/string/String#get:length
    local.tee $0
    i32.add
-   local.get $11
+   local.get $3
    i32.gt_s
    if
     local.get $1
@@ -7824,7 +8111,7 @@
     br $__inlined_func$~lib/string/String#startsWith
    end
    local.get $12
-   local.get $8
+   local.get $9
    local.get $1
    local.get $0
    call $~lib/util/string/compareImpl
@@ -7843,11 +8130,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  block $__inlined_func$~lib/string/String#endsWith (result i32)
-   i32.const 0
+  global.get $std/string/str
+  local.set $9
+  block $__inlined_func$~lib/string/String#endsWith
    i32.const 536870904
-   global.get $std/string/str
-   local.tee $8
+   local.get $9
    call $~lib/string/String#get:length
    local.tee $0
    i32.const 536870904
@@ -7861,15 +8148,24 @@
    local.tee $0
    i32.const 0
    i32.lt_s
-   br_if $__inlined_func$~lib/string/String#endsWith
-   drop
-   local.get $8
+   if
+    i32.const 1680
+    call $~lib/rt/pure/__release
+    i32.const 0
+    local.set $0
+    br $__inlined_func$~lib/string/String#endsWith
+   end
+   local.get $9
    local.get $0
    i32.const 1680
    local.get $1
    call $~lib/util/string/compareImpl
    i32.eqz
+   local.set $0
+   i32.const 1680
+   call $~lib/rt/pure/__release
   end
+  local.get $0
   i32.eqz
   if
    i32.const 0
@@ -7884,7 +8180,10 @@
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const -1
-  i32.eq
+  i32.ne
+  i32.const 1712
+  call $~lib/rt/pure/__release
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -8685,7 +8984,7 @@
    unreachable
   end
   i32.const 2432
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 0
   f64.ne
   if
@@ -8697,7 +8996,7 @@
    unreachable
   end
   i32.const 2464
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 0
   f64.ne
   if
@@ -8709,7 +9008,7 @@
    unreachable
   end
   i32.const 2496
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 1
   f64.ne
   if
@@ -8721,7 +9020,7 @@
    unreachable
   end
   i32.const 2528
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 1
   f64.ne
   if
@@ -8733,7 +9032,7 @@
    unreachable
   end
   i32.const 2560
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 5
   f64.ne
   if
@@ -8745,7 +9044,7 @@
    unreachable
   end
   i32.const 2592
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 455
   f64.ne
   if
@@ -8757,7 +9056,7 @@
    unreachable
   end
   i32.const 2624
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 3855
   f64.ne
   if
@@ -8769,7 +9068,7 @@
    unreachable
   end
   i32.const 2656
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 3855
   f64.ne
   if
@@ -8781,7 +9080,7 @@
    unreachable
   end
   i32.const 2688
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 11
   f64.ne
   if
@@ -8793,7 +9092,7 @@
    unreachable
   end
   i32.const 2720
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 1
   f64.ne
   if
@@ -8805,7 +9104,7 @@
    unreachable
   end
   i32.const 2752
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const -123
   f64.ne
   if
@@ -8817,7 +9116,7 @@
    unreachable
   end
   i32.const 2784
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 123
   f64.ne
   if
@@ -8829,7 +9128,7 @@
    unreachable
   end
   i32.const 2816
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const -12
   f64.ne
   if
@@ -8841,7 +9140,7 @@
    unreachable
   end
   i32.const 2848
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 1
   f64.ne
   if
@@ -8853,7 +9152,7 @@
    unreachable
   end
   i32.const 2880
-  call $~lib/util/string/strtol<f64>
+  call $~lib/string/parseInt
   f64.const 2
   f64.ne
   if
@@ -8864,7 +9163,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 2912
   call $~lib/util/string/strtol<i32>
+  i32.const 2912
+  call $~lib/rt/pure/__release
   i32.const 2147483647
   i32.ne
   if
@@ -8875,7 +9177,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 2960
   call $~lib/util/string/strtol<i64>
+  i32.const 2960
+  call $~lib/rt/pure/__release
   i64.const 9223372036854775807
   i64.ne
   if
@@ -8887,7 +9192,7 @@
    unreachable
   end
   i32.const 2432
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -8899,7 +9204,7 @@
    unreachable
   end
   i32.const 2496
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -8911,7 +9216,7 @@
    unreachable
   end
   i32.const 3200
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -8923,7 +9228,7 @@
    unreachable
   end
   i32.const 3232
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -8935,7 +9240,7 @@
    unreachable
   end
   i32.const 3264
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-05
   f64.ne
   if
@@ -8947,7 +9252,7 @@
    unreachable
   end
   i32.const 3296
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -1e-05
   f64.ne
   if
@@ -8959,7 +9264,7 @@
    unreachable
   end
   i32.const 3328
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -3e-23
   f64.ne
   if
@@ -8971,7 +9276,7 @@
    unreachable
   end
   i32.const 3360
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 3e21
   f64.ne
   if
@@ -8983,7 +9288,7 @@
    unreachable
   end
   i32.const 3392
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.1
   f64.ne
   if
@@ -8995,7 +9300,7 @@
    unreachable
   end
   i32.const 3424
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.1
   f64.ne
   if
@@ -9007,7 +9312,7 @@
    unreachable
   end
   i32.const 3456
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.1
   f64.ne
   if
@@ -9019,7 +9324,7 @@
    unreachable
   end
   i32.const 3488
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.25
   f64.ne
   if
@@ -9031,7 +9336,7 @@
    unreachable
   end
   i32.const 3520
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e3
   f64.ne
   if
@@ -9043,7 +9348,7 @@
    unreachable
   end
   i32.const 3552
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-10
   f64.ne
   if
@@ -9055,7 +9360,7 @@
    unreachable
   end
   i32.const 3584
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-30
   f64.ne
   if
@@ -9067,7 +9372,7 @@
    unreachable
   end
   i32.const 3616
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-323
   f64.ne
   if
@@ -9079,7 +9384,7 @@
    unreachable
   end
   i32.const 3648
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9091,7 +9396,7 @@
    unreachable
   end
   i32.const 3680
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1.e+308
   f64.ne
   if
@@ -9103,7 +9408,7 @@
    unreachable
   end
   i32.const 3712
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const inf
   f64.ne
   if
@@ -9115,7 +9420,7 @@
    unreachable
   end
   i32.const 1280
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9128,7 +9433,7 @@
    unreachable
   end
   i32.const 3744
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.1
   f64.ne
   if
@@ -9140,7 +9445,7 @@
    unreachable
   end
   i32.const 3776
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-10
   f64.ne
   if
@@ -9152,7 +9457,7 @@
    unreachable
   end
   i32.const 3824
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 10
   f64.ne
   if
@@ -9164,7 +9469,7 @@
    unreachable
   end
   i32.const 3856
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -9176,7 +9481,7 @@
    unreachable
   end
   i32.const 3888
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -9188,7 +9493,7 @@
    unreachable
   end
   i32.const 3920
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 10
   f64.ne
   if
@@ -9200,7 +9505,7 @@
    unreachable
   end
   i32.const 3968
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 123456789
   f64.ne
   if
@@ -9212,7 +9517,7 @@
    unreachable
   end
   i32.const 4016
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -9224,7 +9529,7 @@
    unreachable
   end
   i32.const 4064
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-60
   f64.ne
   if
@@ -9236,7 +9541,7 @@
    unreachable
   end
   i32.const 4096
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1.e+60
   f64.ne
   if
@@ -9248,7 +9553,7 @@
    unreachable
   end
   i32.const 4128
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -0
   f64.ne
   if
@@ -9260,7 +9565,7 @@
    unreachable
   end
   i32.const 4160
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -9272,7 +9577,7 @@
    unreachable
   end
   i32.const 4192
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -1.1
   f64.ne
   if
@@ -9284,7 +9589,7 @@
    unreachable
   end
   i32.const 4240
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 10
   f64.ne
   if
@@ -9296,7 +9601,7 @@
    unreachable
   end
   i32.const 4288
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 10
   f64.ne
   if
@@ -9308,7 +9613,7 @@
    unreachable
   end
   i32.const 4336
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.022
   f64.ne
   if
@@ -9320,7 +9625,7 @@
    unreachable
   end
   i32.const 4368
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 11
   f64.ne
   if
@@ -9332,7 +9637,7 @@
    unreachable
   end
   i32.const 4400
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9344,7 +9649,7 @@
    unreachable
   end
   i32.const 4432
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9356,7 +9661,7 @@
    unreachable
   end
   i32.const 4464
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9368,7 +9673,7 @@
    unreachable
   end
   i32.const 4496
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1.1
   f64.ne
   if
@@ -9380,7 +9685,7 @@
    unreachable
   end
   i32.const 4528
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -1.1
   f64.ne
   if
@@ -9392,7 +9697,7 @@
    unreachable
   end
   i32.const 4560
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -1.1
   f64.ne
   if
@@ -9404,7 +9709,7 @@
    unreachable
   end
   i32.const 4592
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -1.1
   f64.ne
   if
@@ -9416,7 +9721,7 @@
    unreachable
   end
   i32.const 4624
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -1.1
   f64.ne
   if
@@ -9428,7 +9733,7 @@
    unreachable
   end
   i32.const 4656
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9440,7 +9745,7 @@
    unreachable
   end
   i32.const 4688
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9452,7 +9757,7 @@
    unreachable
   end
   i32.const 4720
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -9464,7 +9769,7 @@
    unreachable
   end
   i32.const 4752
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9476,7 +9781,7 @@
    unreachable
   end
   i32.const 4784
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9488,7 +9793,7 @@
    unreachable
   end
   i32.const 4816
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 10
   f64.ne
   if
@@ -9500,7 +9805,7 @@
    unreachable
   end
   i32.const 4848
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 10
   f64.ne
   if
@@ -9512,7 +9817,7 @@
    unreachable
   end
   i32.const 4880
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9524,7 +9829,7 @@
    unreachable
   end
   i32.const 4912
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -9536,7 +9841,7 @@
    unreachable
   end
   i32.const 4944
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.1
   f64.ne
   if
@@ -9548,7 +9853,7 @@
    unreachable
   end
   i32.const 4976
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -9560,7 +9865,7 @@
    unreachable
   end
   i32.const 5008
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 10
   f64.ne
   if
@@ -9572,7 +9877,7 @@
    unreachable
   end
   i32.const 5040
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -9584,7 +9889,7 @@
    unreachable
   end
   i32.const 5072
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.1
   f64.ne
   if
@@ -9596,7 +9901,7 @@
    unreachable
   end
   i32.const 5104
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.01
   f64.ne
   if
@@ -9608,7 +9913,7 @@
    unreachable
   end
   i32.const 5136
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9620,7 +9925,7 @@
    unreachable
   end
   i32.const 5168
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9632,7 +9937,7 @@
    unreachable
   end
   i32.const 5200
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9644,7 +9949,7 @@
    unreachable
   end
   i32.const 5232
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.1
   f64.ne
   if
@@ -9656,7 +9961,7 @@
    unreachable
   end
   i32.const 5264
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9668,7 +9973,7 @@
    unreachable
   end
   i32.const 5296
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9680,7 +9985,7 @@
    unreachable
   end
   i32.const 5328
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -9692,7 +9997,7 @@
    unreachable
   end
   i32.const 5360
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.1
   f64.ne
   if
@@ -9704,7 +10009,7 @@
    unreachable
   end
   i32.const 5392
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9716,7 +10021,7 @@
    unreachable
   end
   i32.const 5424
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9728,7 +10033,7 @@
    unreachable
   end
   i32.const 5456
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -0
   f64.ne
   if
@@ -9740,7 +10045,7 @@
    unreachable
   end
   i32.const 5488
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9752,7 +10057,7 @@
    unreachable
   end
   i32.const 5520
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -9764,7 +10069,7 @@
    unreachable
   end
   i32.const 5552
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9777,7 +10082,7 @@
    unreachable
   end
   i32.const 5584
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9790,7 +10095,7 @@
    unreachable
   end
   i32.const 5616
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9803,7 +10108,7 @@
    unreachable
   end
   i32.const 5648
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9816,7 +10121,7 @@
    unreachable
   end
   i32.const 5680
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9829,7 +10134,7 @@
    unreachable
   end
   i32.const 5712
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9842,7 +10147,7 @@
    unreachable
   end
   i32.const 5744
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9855,7 +10160,7 @@
    unreachable
   end
   i32.const 5776
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9868,7 +10173,7 @@
    unreachable
   end
   i32.const 5808
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9881,7 +10186,7 @@
    unreachable
   end
   i32.const 5840
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9894,7 +10199,7 @@
    unreachable
   end
   i32.const 5872
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9907,7 +10212,7 @@
    unreachable
   end
   i32.const 5904
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9920,7 +10225,7 @@
    unreachable
   end
   i32.const 5936
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9933,7 +10238,7 @@
    unreachable
   end
   i32.const 5968
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9946,7 +10251,7 @@
    unreachable
   end
   i32.const 6000
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9959,7 +10264,7 @@
    unreachable
   end
   i32.const 6032
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -9972,7 +10277,7 @@
    unreachable
   end
   i32.const 6064
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e22
   f64.ne
   if
@@ -9984,7 +10289,7 @@
    unreachable
   end
   i32.const 6096
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-22
   f64.ne
   if
@@ -9996,7 +10301,7 @@
    unreachable
   end
   i32.const 6128
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1.e+23
   f64.ne
   if
@@ -10008,7 +10313,7 @@
    unreachable
   end
   i32.const 6160
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-23
   f64.ne
   if
@@ -10020,7 +10325,7 @@
    unreachable
   end
   i32.const 6192
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1.e+37
   f64.ne
   if
@@ -10032,7 +10337,7 @@
    unreachable
   end
   i32.const 6224
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-37
   f64.ne
   if
@@ -10044,7 +10349,7 @@
    unreachable
   end
   i32.const 6256
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1.e+38
   f64.ne
   if
@@ -10056,7 +10361,7 @@
    unreachable
   end
   i32.const 6288
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-38
   f64.ne
   if
@@ -10068,7 +10373,7 @@
    unreachable
   end
   i32.const 6320
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 2.220446049250313e-16
   f64.ne
   if
@@ -10080,7 +10385,7 @@
    unreachable
   end
   i32.const 6384
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1797693134862315708145274e284
   f64.ne
   if
@@ -10092,7 +10397,7 @@
    unreachable
   end
   i32.const 6448
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 5e-324
   f64.ne
   if
@@ -10104,7 +10409,7 @@
    unreachable
   end
   i32.const 6480
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1.e+308
   f64.ne
   if
@@ -10116,7 +10421,7 @@
    unreachable
   end
   i32.const 6528
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1
   f64.ne
   if
@@ -10128,7 +10433,7 @@
    unreachable
   end
   i32.const 6672
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -10140,7 +10445,7 @@
    unreachable
   end
   i32.const 6704
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const inf
   f64.ne
   if
@@ -10152,7 +10457,7 @@
    unreachable
   end
   i32.const 6736
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -10164,7 +10469,7 @@
    unreachable
   end
   i32.const 6768
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -inf
   f64.ne
   if
@@ -10176,7 +10481,7 @@
    unreachable
   end
   i32.const 6800
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -10188,7 +10493,7 @@
    unreachable
   end
   i32.const 6848
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const inf
   f64.ne
   if
@@ -10200,7 +10505,7 @@
    unreachable
   end
   i32.const 6896
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const inf
   f64.ne
   if
@@ -10212,7 +10517,7 @@
    unreachable
   end
   i32.const 6928
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const inf
   f64.ne
   if
@@ -10224,7 +10529,7 @@
    unreachable
   end
   i32.const 6976
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const inf
   f64.ne
   if
@@ -10236,7 +10541,7 @@
    unreachable
   end
   i32.const 7024
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const -inf
   f64.ne
   if
@@ -10248,7 +10553,7 @@
    unreachable
   end
   i32.const 7072
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const inf
   f64.ne
   if
@@ -10260,7 +10565,7 @@
    unreachable
   end
   i32.const 7120
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const inf
   f64.ne
   if
@@ -10272,7 +10577,7 @@
    unreachable
   end
   i32.const 7168
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -10285,7 +10590,7 @@
    unreachable
   end
   i32.const 7200
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -10298,7 +10603,7 @@
    unreachable
   end
   i32.const 7232
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -10311,7 +10616,7 @@
    unreachable
   end
   i32.const 7264
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0
   f64.ne
   if
@@ -10323,7 +10628,7 @@
    unreachable
   end
   i32.const 7456
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1e-323
   f64.ne
   if
@@ -10335,7 +10640,7 @@
    unreachable
   end
   i32.const 7648
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 2.225073858507202e-308
   f64.ne
   if
@@ -10349,17 +10654,17 @@
   i32.const 7840
   i32.const 8000
   call $~lib/string/String.__concat
-  local.tee $73
+  local.tee $74
   i32.const 8160
   call $~lib/string/String.__concat
-  local.tee $74
+  local.tee $75
   i32.const 8320
   call $~lib/string/String.__concat
-  local.tee $75
+  local.tee $76
   i32.const 8480
   call $~lib/string/String.__concat
-  local.tee $76
-  call $~lib/util/string/strtod
+  local.tee $77
+  call $~lib/string/parseFloat
   f64.const 1797693134862315708145274e284
   f64.ne
   if
@@ -10371,7 +10676,7 @@
    unreachable
   end
   i32.const 8640
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 9.753531888799502e-104
   f64.ne
   if
@@ -10383,7 +10688,7 @@
    unreachable
   end
   i32.const 8752
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.5961860348131807
   f64.ne
   if
@@ -10395,7 +10700,7 @@
    unreachable
   end
   i32.const 8864
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.18150131692180388
   f64.ne
   if
@@ -10407,7 +10712,7 @@
    unreachable
   end
   i32.const 8976
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.42070823575344535
   f64.ne
   if
@@ -10419,7 +10724,7 @@
    unreachable
   end
   i32.const 9088
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.6654686306516261
   f64.ne
   if
@@ -10431,7 +10736,7 @@
    unreachable
   end
   i32.const 9200
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.6101852922970868
   f64.ne
   if
@@ -10443,7 +10748,7 @@
    unreachable
   end
   i32.const 9312
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.7696695208236968
   f64.ne
   if
@@ -10455,7 +10760,7 @@
    unreachable
   end
   i32.const 9424
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.25050653222286823
   f64.ne
   if
@@ -10467,7 +10772,7 @@
    unreachable
   end
   i32.const 9536
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.2740037230228005
   f64.ne
   if
@@ -10479,7 +10784,7 @@
    unreachable
   end
   i32.const 9648
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.20723093500497428
   f64.ne
   if
@@ -10491,7 +10796,7 @@
    unreachable
   end
   i32.const 9760
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 7.900280238081605
   f64.ne
   if
@@ -10503,7 +10808,7 @@
    unreachable
   end
   i32.const 9872
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 98.22860653737297
   f64.ne
   if
@@ -10515,7 +10820,7 @@
    unreachable
   end
   i32.const 9984
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 746.894972319037
   f64.ne
   if
@@ -10527,7 +10832,7 @@
    unreachable
   end
   i32.const 10096
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 1630.2683202827284
   f64.ne
   if
@@ -10539,7 +10844,7 @@
    unreachable
   end
   i32.const 10208
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 46371.68629719171
   f64.ne
   if
@@ -10551,7 +10856,7 @@
    unreachable
   end
   i32.const 10320
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 653780.5944497711
   f64.ne
   if
@@ -10563,7 +10868,7 @@
    unreachable
   end
   i32.const 10432
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 234632.43565024371
   f64.ne
   if
@@ -10575,7 +10880,7 @@
    unreachable
   end
   i32.const 10544
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 97094817.16420048
   f64.ne
   if
@@ -10587,7 +10892,7 @@
    unreachable
   end
   i32.const 10656
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 499690852.20518744
   f64.ne
   if
@@ -10599,7 +10904,7 @@
    unreachable
   end
   i32.const 10768
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 7925201200557245595648
   f64.ne
   if
@@ -10611,7 +10916,7 @@
    unreachable
   end
   i32.const 10880
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 6096564585983177528398588e5
   f64.ne
   if
@@ -10623,7 +10928,7 @@
    unreachable
   end
   i32.const 10992
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 4800416117477028695992383e42
   f64.ne
   if
@@ -10635,7 +10940,7 @@
    unreachable
   end
   i32.const 11104
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 8524829079817968137287277e80
   f64.ne
   if
@@ -10647,7 +10952,7 @@
    unreachable
   end
   i32.const 11216
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 3271239291709782092398754e243
   f64.ne
   if
@@ -10659,7 +10964,7 @@
    unreachable
   end
   i32.const 11328
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   local.tee $2
   local.get $2
   f64.eq
@@ -10672,7 +10977,7 @@
    unreachable
   end
   i32.const 11360
-  call $~lib/util/string/strtod
+  call $~lib/string/parseFloat
   f64.const 0.1
   f64.ne
   if
@@ -10686,8 +10991,9 @@
   i32.const 1328
   i32.const 11392
   call $~lib/string/String.__concat
+  local.tee $0
+  call $~lib/rt/pure/__retain
   local.tee $1
-  local.get $1
   i32.const 11424
   call $~lib/string/String.__eq
   i32.eqz
@@ -10699,8 +11005,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
   i32.const 1328
-  call $~lib/string/String.__eq
+  call $~lib/string/String.__ne
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10709,6 +11017,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
   i32.const 1280
@@ -10725,7 +11035,8 @@
   end
   i32.const 1280
   i32.const 0
-  call $~lib/string/String.__eq
+  call $~lib/string/String.__ne
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10736,7 +11047,8 @@
   end
   i32.const 0
   i32.const 1280
-  call $~lib/string/String.__eq
+  call $~lib/string/String.__ne
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10747,7 +11059,8 @@
   end
   i32.const 1328
   i32.const 11392
-  call $~lib/string/String.__eq
+  call $~lib/string/String.__ne
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10770,7 +11083,8 @@
   end
   i32.const 11456
   i32.const 11488
-  call $~lib/string/String.__eq
+  call $~lib/string/String.__ne
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10793,7 +11107,8 @@
   end
   i32.const 11520
   i32.const 11552
-  call $~lib/string/String.__eq
+  call $~lib/string/String.__ne
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10804,7 +11119,8 @@
   end
   i32.const 11584
   i32.const 11616
-  call $~lib/string/String.__eq
+  call $~lib/string/String.__ne
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10827,7 +11143,8 @@
   end
   i32.const 11648
   i32.const 11680
-  call $~lib/string/String.__eq
+  call $~lib/string/String.__ne
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10838,7 +11155,8 @@
   end
   i32.const 11712
   i32.const 11760
-  call $~lib/string/String.__eq
+  call $~lib/string/String.__ne
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10873,7 +11191,8 @@
   end
   i32.const 11808
   i32.const 11840
-  call $~lib/string/String.__lt
+  call $~lib/string/String.__gte
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10953,7 +11272,8 @@
   end
   i32.const 1808
   i32.const 1280
-  call $~lib/string/String.__lt
+  call $~lib/string/String.__gte
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -10962,9 +11282,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1280
   i32.const 1808
-  call $~lib/string/String.__gt
+  call $~lib/string/String.__lte
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -11019,7 +11339,8 @@
   end
   i32.const 1280
   i32.const 1280
-  call $~lib/string/String.__lt
+  call $~lib/string/String.__gte
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -11029,8 +11350,8 @@
    unreachable
   end
   i32.const 1280
-  i32.const 1280
-  call $~lib/string/String.__gt
+  call $~lib/string/String.__lte
+  i32.eqz
   if
    i32.const 0
    i32.const 1088
@@ -11041,14 +11362,16 @@
   end
   i32.const 65377
   call $~lib/string/String.fromCodePoint
-  local.tee $11
+  local.tee $12
   i32.const 55296
   call $~lib/string/String.fromCodePoint
-  local.tee $8
+  local.tee $3
   i32.const 56322
   call $~lib/string/String.fromCodePoint
-  local.tee $1
+  local.tee $9
   call $~lib/string/String.__concat
+  local.tee $1
+  call $~lib/rt/pure/__retain
   local.tee $0
   call $~lib/string/String.__gt
   i32.eqz
@@ -11060,9 +11383,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $11
+  local.get $12
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $9
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -11083,7 +11408,7 @@
   i32.const 1280
   i32.const 100
   call $~lib/string/String#repeat
-  local.tee $77
+  local.tee $78
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -11098,7 +11423,7 @@
   i32.const 1328
   i32.const 0
   call $~lib/string/String#repeat
-  local.tee $78
+  local.tee $79
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -11113,7 +11438,7 @@
   i32.const 1328
   i32.const 1
   call $~lib/string/String#repeat
-  local.tee $79
+  local.tee $80
   i32.const 1328
   call $~lib/string/String.__eq
   i32.eqz
@@ -11128,7 +11453,7 @@
   i32.const 1328
   i32.const 2
   call $~lib/string/String#repeat
-  local.tee $80
+  local.tee $81
   i32.const 11840
   call $~lib/string/String.__eq
   i32.eqz
@@ -11143,7 +11468,7 @@
   i32.const 1328
   i32.const 3
   call $~lib/string/String#repeat
-  local.tee $81
+  local.tee $82
   i32.const 11920
   call $~lib/string/String.__eq
   i32.eqz
@@ -11158,7 +11483,7 @@
   i32.const 11424
   i32.const 4
   call $~lib/string/String#repeat
-  local.tee $82
+  local.tee $83
   i32.const 11952
   call $~lib/string/String.__eq
   i32.eqz
@@ -11173,7 +11498,7 @@
   i32.const 1328
   i32.const 5
   call $~lib/string/String#repeat
-  local.tee $83
+  local.tee $84
   i32.const 11984
   call $~lib/string/String.__eq
   i32.eqz
@@ -11188,7 +11513,7 @@
   i32.const 1328
   i32.const 6
   call $~lib/string/String#repeat
-  local.tee $84
+  local.tee $85
   i32.const 12016
   call $~lib/string/String.__eq
   i32.eqz
@@ -11203,7 +11528,7 @@
   i32.const 1328
   i32.const 7
   call $~lib/string/String#repeat
-  local.tee $85
+  local.tee $86
   i32.const 12048
   call $~lib/string/String.__eq
   i32.eqz
@@ -11219,7 +11544,7 @@
   i32.const 1280
   i32.const 1280
   call $~lib/string/String#replace
-  local.tee $86
+  local.tee $87
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -11235,7 +11560,7 @@
   i32.const 1280
   i32.const 5552
   call $~lib/string/String#replace
-  local.tee $87
+  local.tee $88
   i32.const 5552
   call $~lib/string/String.__eq
   i32.eqz
@@ -11251,7 +11576,7 @@
   i32.const 5552
   i32.const 1280
   call $~lib/string/String#replace
-  local.tee $88
+  local.tee $89
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -11267,7 +11592,7 @@
   i32.const 1280
   i32.const 1280
   call $~lib/string/String#replace
-  local.tee $89
+  local.tee $90
   i32.const 5552
   call $~lib/string/String.__eq
   i32.eqz
@@ -11283,7 +11608,7 @@
   i32.const 5584
   i32.const 5552
   call $~lib/string/String#replace
-  local.tee $90
+  local.tee $91
   i32.const 1808
   call $~lib/string/String.__eq
   i32.eqz
@@ -11299,7 +11624,7 @@
   i32.const 1808
   i32.const 5552
   call $~lib/string/String#replace
-  local.tee $91
+  local.tee $92
   i32.const 5552
   call $~lib/string/String.__eq
   i32.eqz
@@ -11315,7 +11640,7 @@
   i32.const 2256
   i32.const 5552
   call $~lib/string/String#replace
-  local.tee $92
+  local.tee $93
   i32.const 1808
   call $~lib/string/String.__eq
   i32.eqz
@@ -11331,7 +11656,7 @@
   i32.const 11424
   i32.const 11424
   call $~lib/string/String#replace
-  local.tee $93
+  local.tee $94
   i32.const 1808
   call $~lib/string/String.__eq
   i32.eqz
@@ -11347,7 +11672,7 @@
   i32.const 5584
   i32.const 5552
   call $~lib/string/String#replace
-  local.tee $94
+  local.tee $95
   i32.const 12112
   call $~lib/string/String.__eq
   i32.eqz
@@ -11363,7 +11688,7 @@
   i32.const 1280
   i32.const 5552
   call $~lib/string/String#replace
-  local.tee $95
+  local.tee $96
   i32.const 12144
   call $~lib/string/String.__eq
   i32.eqz
@@ -11379,7 +11704,7 @@
   i32.const 12208
   i32.const 5552
   call $~lib/string/String#replace
-  local.tee $96
+  local.tee $97
   i32.const 12144
   call $~lib/string/String.__eq
   i32.eqz
@@ -11395,7 +11720,7 @@
   i32.const 12240
   i32.const 12272
   call $~lib/string/String#replace
-  local.tee $97
+  local.tee $98
   i32.const 12304
   call $~lib/string/String.__eq
   i32.eqz
@@ -11411,7 +11736,7 @@
   i32.const 12240
   i32.const 1280
   call $~lib/string/String#replace
-  local.tee $98
+  local.tee $99
   i32.const 11424
   call $~lib/string/String.__eq
   i32.eqz
@@ -11427,7 +11752,7 @@
   i32.const 1280
   i32.const 1808
   call $~lib/string/String#replaceAll
-  local.tee $99
+  local.tee $100
   i32.const 1808
   call $~lib/string/String.__eq
   i32.eqz
@@ -11443,7 +11768,7 @@
   i32.const 5584
   i32.const 5552
   call $~lib/string/String#replaceAll
-  local.tee $100
+  local.tee $101
   i32.const 1808
   call $~lib/string/String.__eq
   i32.eqz
@@ -11459,7 +11784,7 @@
   i32.const 1808
   i32.const 5552
   call $~lib/string/String#replaceAll
-  local.tee $101
+  local.tee $102
   i32.const 12272
   call $~lib/string/String.__eq
   i32.eqz
@@ -11475,7 +11800,7 @@
   i32.const 1808
   i32.const 5552
   call $~lib/string/String#replaceAll
-  local.tee $102
+  local.tee $103
   i32.const 12384
   call $~lib/string/String.__eq
   i32.eqz
@@ -11491,7 +11816,7 @@
   i32.const 11424
   i32.const 11424
   call $~lib/string/String#replaceAll
-  local.tee $103
+  local.tee $104
   i32.const 2000
   call $~lib/string/String.__eq
   i32.eqz
@@ -11507,7 +11832,7 @@
   i32.const 1328
   i32.const 12384
   call $~lib/string/String#replaceAll
-  local.tee $104
+  local.tee $105
   i32.const 12448
   call $~lib/string/String.__eq
   i32.eqz
@@ -11523,7 +11848,7 @@
   i32.const 11424
   i32.const 12272
   call $~lib/string/String#replaceAll
-  local.tee $105
+  local.tee $106
   i32.const 12496
   call $~lib/string/String.__eq
   i32.eqz
@@ -11539,7 +11864,7 @@
   i32.const 12560
   i32.const 12272
   call $~lib/string/String#replaceAll
-  local.tee $106
+  local.tee $107
   i32.const 12592
   call $~lib/string/String.__eq
   i32.eqz
@@ -11555,7 +11880,7 @@
   i32.const 2256
   i32.const 5552
   call $~lib/string/String#replaceAll
-  local.tee $107
+  local.tee $108
   i32.const 1808
   call $~lib/string/String.__eq
   i32.eqz
@@ -11571,7 +11896,7 @@
   i32.const 12624
   i32.const 12272
   call $~lib/string/String#replaceAll
-  local.tee $108
+  local.tee $109
   i32.const 2256
   call $~lib/string/String.__eq
   i32.eqz
@@ -11587,7 +11912,7 @@
   i32.const 12656
   i32.const 5552
   call $~lib/string/String#replaceAll
-  local.tee $109
+  local.tee $110
   i32.const 12688
   call $~lib/string/String.__eq
   i32.eqz
@@ -11603,7 +11928,7 @@
   i32.const 11424
   i32.const 5552
   call $~lib/string/String#replaceAll
-  local.tee $110
+  local.tee $111
   i32.const 5552
   call $~lib/string/String.__eq
   i32.eqz
@@ -11619,7 +11944,7 @@
   i32.const 5584
   i32.const 5552
   call $~lib/string/String#replaceAll
-  local.tee $111
+  local.tee $112
   i32.const 12720
   call $~lib/string/String.__eq
   i32.eqz
@@ -11635,7 +11960,7 @@
   i32.const 1280
   i32.const 1280
   call $~lib/string/String#replaceAll
-  local.tee $112
+  local.tee $113
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -11651,7 +11976,7 @@
   i32.const 1280
   i32.const 5552
   call $~lib/string/String#replaceAll
-  local.tee $113
+  local.tee $114
   i32.const 5552
   call $~lib/string/String.__eq
   i32.eqz
@@ -11667,7 +11992,7 @@
   i32.const 5552
   i32.const 1280
   call $~lib/string/String#replaceAll
-  local.tee $114
+  local.tee $115
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -11683,7 +12008,7 @@
   i32.const 1280
   i32.const 1280
   call $~lib/string/String#replaceAll
-  local.tee $115
+  local.tee $116
   i32.const 5552
   call $~lib/string/String.__eq
   i32.eqz
@@ -11699,7 +12024,7 @@
   i32.const 1808
   i32.const 5584
   call $~lib/string/String#replaceAll
-  local.tee $116
+  local.tee $117
   i32.const 5584
   call $~lib/string/String.__eq
   i32.eqz
@@ -11715,7 +12040,7 @@
   i32.const 2224
   i32.const 5584
   call $~lib/string/String#replaceAll
-  local.tee $117
+  local.tee $118
   i32.const 1808
   call $~lib/string/String.__eq
   i32.eqz
@@ -11731,7 +12056,7 @@
   i32.const 1280
   i32.const 5552
   call $~lib/string/String#replaceAll
-  local.tee $118
+  local.tee $119
   i32.const 12752
   call $~lib/string/String.__eq
   i32.eqz
@@ -11747,7 +12072,7 @@
   i32.const 1280
   i32.const 1280
   call $~lib/string/String#replaceAll
-  local.tee $119
+  local.tee $120
   i32.const 1808
   call $~lib/string/String.__eq
   i32.eqz
@@ -11767,7 +12092,7 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/string/String#slice
-  local.tee $120
+  local.tee $121
   i32.const 12784
   call $~lib/string/String.__eq
   i32.eqz
@@ -11783,7 +12108,7 @@
   i32.const -1
   i32.const 2147483647
   call $~lib/string/String#slice
-  local.tee $121
+  local.tee $122
   i32.const 12832
   call $~lib/string/String.__eq
   i32.eqz
@@ -11799,7 +12124,7 @@
   i32.const -5
   i32.const 2147483647
   call $~lib/string/String#slice
-  local.tee $122
+  local.tee $123
   i32.const 12864
   call $~lib/string/String.__eq
   i32.eqz
@@ -11815,7 +12140,7 @@
   i32.const 2
   i32.const 7
   call $~lib/string/String#slice
-  local.tee $123
+  local.tee $124
   i32.const 12896
   call $~lib/string/String.__eq
   i32.eqz
@@ -11831,7 +12156,7 @@
   i32.const -11
   i32.const -6
   call $~lib/string/String#slice
-  local.tee $124
+  local.tee $125
   i32.const 12928
   call $~lib/string/String.__eq
   i32.eqz
@@ -11847,7 +12172,7 @@
   i32.const 4
   i32.const 3
   call $~lib/string/String#slice
-  local.tee $125
+  local.tee $126
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -11863,7 +12188,7 @@
   i32.const 0
   i32.const -1
   call $~lib/string/String#slice
-  local.tee $126
+  local.tee $127
   i32.const 12960
   call $~lib/string/String.__eq
   i32.eqz
@@ -11879,7 +12204,7 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/string/String#substr
-  local.tee $127
+  local.tee $128
   i32.const 12784
   call $~lib/string/String.__eq
   i32.eqz
@@ -11895,7 +12220,7 @@
   i32.const -1
   i32.const 2147483647
   call $~lib/string/String#substr
-  local.tee $128
+  local.tee $129
   i32.const 12832
   call $~lib/string/String.__eq
   i32.eqz
@@ -11911,7 +12236,7 @@
   i32.const -5
   i32.const 2147483647
   call $~lib/string/String#substr
-  local.tee $129
+  local.tee $130
   i32.const 12864
   call $~lib/string/String.__eq
   i32.eqz
@@ -11927,7 +12252,7 @@
   i32.const 2
   i32.const 7
   call $~lib/string/String#substr
-  local.tee $130
+  local.tee $131
   i32.const 13008
   call $~lib/string/String.__eq
   i32.eqz
@@ -11943,7 +12268,7 @@
   i32.const -11
   i32.const -6
   call $~lib/string/String#substr
-  local.tee $131
+  local.tee $132
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -11959,7 +12284,7 @@
   i32.const 4
   i32.const 3
   call $~lib/string/String#substr
-  local.tee $132
+  local.tee $133
   i32.const 13040
   call $~lib/string/String.__eq
   i32.eqz
@@ -11975,7 +12300,7 @@
   i32.const 0
   i32.const -1
   call $~lib/string/String#substr
-  local.tee $133
+  local.tee $134
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -11991,7 +12316,7 @@
   i32.const 0
   i32.const 100
   call $~lib/string/String#substr
-  local.tee $134
+  local.tee $135
   i32.const 12784
   call $~lib/string/String.__eq
   i32.eqz
@@ -12007,7 +12332,7 @@
   i32.const 4
   i32.const 4
   call $~lib/string/String#substr
-  local.tee $135
+  local.tee $136
   i32.const 13072
   call $~lib/string/String.__eq
   i32.eqz
@@ -12023,7 +12348,7 @@
   i32.const 4
   i32.const -3
   call $~lib/string/String#substr
-  local.tee $136
+  local.tee $137
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -12039,7 +12364,7 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/string/String#substring
-  local.tee $137
+  local.tee $138
   i32.const 12784
   call $~lib/string/String.__eq
   i32.eqz
@@ -12055,7 +12380,7 @@
   i32.const -1
   i32.const 2147483647
   call $~lib/string/String#substring
-  local.tee $138
+  local.tee $139
   i32.const 12784
   call $~lib/string/String.__eq
   i32.eqz
@@ -12071,7 +12396,7 @@
   i32.const -5
   i32.const 2147483647
   call $~lib/string/String#substring
-  local.tee $139
+  local.tee $140
   i32.const 12784
   call $~lib/string/String.__eq
   i32.eqz
@@ -12087,7 +12412,7 @@
   i32.const 2
   i32.const 7
   call $~lib/string/String#substring
-  local.tee $140
+  local.tee $141
   i32.const 12896
   call $~lib/string/String.__eq
   i32.eqz
@@ -12103,7 +12428,7 @@
   i32.const -11
   i32.const -6
   call $~lib/string/String#substring
-  local.tee $141
+  local.tee $142
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -12119,7 +12444,7 @@
   i32.const 4
   i32.const 3
   call $~lib/string/String#substring
-  local.tee $142
+  local.tee $143
   i32.const 13104
   call $~lib/string/String.__eq
   i32.eqz
@@ -12135,7 +12460,7 @@
   i32.const 0
   i32.const -1
   call $~lib/string/String#substring
-  local.tee $143
+  local.tee $144
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -12151,7 +12476,7 @@
   i32.const 0
   i32.const 100
   call $~lib/string/String#substring
-  local.tee $144
+  local.tee $145
   i32.const 12784
   call $~lib/string/String.__eq
   i32.eqz
@@ -12167,7 +12492,7 @@
   i32.const 4
   i32.const 4
   call $~lib/string/String#substring
-  local.tee $145
+  local.tee $146
   i32.const 1280
   call $~lib/string/String.__eq
   i32.eqz
@@ -12183,7 +12508,7 @@
   i32.const 4
   i32.const -3
   call $~lib/string/String#substring
-  local.tee $146
+  local.tee $147
   i32.const 2256
   call $~lib/string/String.__eq
   i32.eqz
@@ -12210,11 +12535,11 @@
    local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
-   local.set $9
+   local.set $10
    local.get $0
    call $~lib/rt/pure/__release
   end
-  local.get $9
+  local.get $10
   i32.eqz
   if
    i32.const 0
@@ -12245,15 +12570,15 @@
   i32.const 2064
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $9
+  local.set $10
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $10
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $9
+   local.get $10
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12278,7 +12603,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $1
-  local.get $9
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $1
   i32.load offset=12
@@ -12291,11 +12616,11 @@
    local.tee $0
    i32.const 13360
    call $~lib/string/String.__eq
-   local.set $5
+   local.set $6
    local.get $0
    call $~lib/rt/pure/__release
   end
-  local.get $5
+  local.get $6
   i32.eqz
   if
    i32.const 0
@@ -12309,15 +12634,15 @@
   i32.const 2064
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $5
+  local.set $6
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $6
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $5
+   local.get $6
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12329,7 +12654,7 @@
   end
   local.get $14
   if
-   local.get $5
+   local.get $6
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12341,7 +12666,7 @@
   end
   local.get $15
   if
-   local.get $5
+   local.get $6
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12366,7 +12691,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $1
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $1
   i32.load offset=12
@@ -12403,11 +12728,11 @@
    local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
-   local.set $3
+   local.set $4
    local.get $0
    call $~lib/rt/pure/__release
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    i32.const 0
@@ -12421,15 +12746,15 @@
   i32.const 2064
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $3
+  local.set $4
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   i32.load offset=12
   i32.const 4
   i32.eq
   if
-   local.get $3
+   local.get $4
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12441,7 +12766,7 @@
   end
   local.get $19
   if
-   local.get $3
+   local.get $4
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12453,7 +12778,7 @@
   end
   local.get $20
   if
-   local.get $3
+   local.get $4
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12465,7 +12790,7 @@
   end
   local.get $21
   if
-   local.get $3
+   local.get $4
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12490,7 +12815,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $1
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $1
   i32.load offset=12
@@ -12539,11 +12864,11 @@
    local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
-   local.set $4
+   local.set $5
    local.get $0
    call $~lib/rt/pure/__release
   end
-  local.get $4
+  local.get $5
   i32.eqz
   if
    i32.const 0
@@ -12557,15 +12882,15 @@
   i32.const 2064
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $4
+  local.set $5
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   i32.load offset=12
   i32.const 4
   i32.eq
   if
-   local.get $4
+   local.get $5
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12577,7 +12902,7 @@
   end
   local.get $26
   if
-   local.get $4
+   local.get $5
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12589,7 +12914,7 @@
   end
   local.get $27
   if
-   local.get $4
+   local.get $5
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12601,7 +12926,7 @@
   end
   local.get $28
   if
-   local.get $4
+   local.get $5
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12626,7 +12951,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $1
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $1
   i32.load offset=12
@@ -12663,11 +12988,11 @@
    local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
-   local.set $10
+   local.set $11
    local.get $0
    call $~lib/rt/pure/__release
   end
-  local.get $10
+  local.get $11
   i32.eqz
   if
    i32.const 0
@@ -12698,15 +13023,15 @@
   i32.const 1280
   i32.const 1
   call $~lib/string/String#split
-  local.set $10
+  local.set $11
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $11
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $10
+   local.get $11
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12731,7 +13056,7 @@
   i32.const 1
   call $~lib/string/String#split
   local.set $1
-  local.get $10
+  local.get $11
   call $~lib/rt/pure/__release
   local.get $1
   i32.load offset=12
@@ -12744,11 +13069,11 @@
    local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
-   local.set $6
+   local.set $7
    local.get $0
    call $~lib/rt/pure/__release
   end
-  local.get $6
+  local.get $7
   i32.eqz
   if
    i32.const 0
@@ -12762,15 +13087,15 @@
   i32.const 1280
   i32.const 4
   call $~lib/string/String#split
-  local.set $6
+  local.set $7
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $7
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $6
+   local.get $7
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12782,7 +13107,7 @@
   end
   local.get $33
   if
-   local.get $6
+   local.get $7
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12794,17 +13119,17 @@
   end
   local.get $34
   if
-   local.get $6
+   local.get $7
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
-   local.set $7
+   local.set $8
    local.get $0
    call $~lib/rt/pure/__release
   end
-  local.get $7
+  local.get $8
   i32.eqz
   if
    i32.const 0
@@ -12818,15 +13143,15 @@
   i32.const 1280
   i32.const -1
   call $~lib/string/String#split
-  local.set $7
-  local.get $6
-  call $~lib/rt/pure/__release
+  local.set $8
   local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $7
+   local.get $8
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12838,7 +13163,7 @@
   end
   local.get $35
   if
-   local.get $7
+   local.get $8
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12850,7 +13175,7 @@
   end
   local.get $36
   if
-   local.get $7
+   local.get $8
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $0
@@ -12875,7 +13200,7 @@
   i32.const -1
   call $~lib/string/String#split
   local.set $1
-  local.get $7
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $1
   i32.load offset=12
@@ -12931,7 +13256,7 @@
   i32.const 0
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $147
+  local.tee $148
   i32.const 2432
   call $~lib/string/String.__eq
   i32.eqz
@@ -12946,7 +13271,7 @@
   i32.const 1
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $148
+  local.tee $149
   i32.const 2496
   call $~lib/string/String.__eq
   i32.eqz
@@ -12961,7 +13286,7 @@
   i32.const 8
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $149
+  local.tee $150
   i32.const 13840
   call $~lib/string/String.__eq
   i32.eqz
@@ -12976,7 +13301,7 @@
   i32.const 12
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $150
+  local.tee $151
   i32.const 13872
   call $~lib/string/String.__eq
   i32.eqz
@@ -12991,7 +13316,7 @@
   i32.const 123
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $151
+  local.tee $152
   i32.const 1872
   call $~lib/string/String.__eq
   i32.eqz
@@ -13006,7 +13331,7 @@
   i32.const -1000
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $152
+  local.tee $153
   i32.const 13904
   call $~lib/string/String.__eq
   i32.eqz
@@ -13021,7 +13346,7 @@
   i32.const 1234
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $153
+  local.tee $154
   i32.const 13936
   call $~lib/string/String.__eq
   i32.eqz
@@ -13036,7 +13361,7 @@
   i32.const 12345
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $154
+  local.tee $155
   i32.const 13968
   call $~lib/string/String.__eq
   i32.eqz
@@ -13051,7 +13376,7 @@
   i32.const 123456
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $155
+  local.tee $156
   i32.const 14000
   call $~lib/string/String.__eq
   i32.eqz
@@ -13066,7 +13391,7 @@
   i32.const 1111111
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $156
+  local.tee $157
   i32.const 14032
   call $~lib/string/String.__eq
   i32.eqz
@@ -13081,7 +13406,7 @@
   i32.const 1234567
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $157
+  local.tee $158
   i32.const 14064
   call $~lib/string/String.__eq
   i32.eqz
@@ -13096,7 +13421,7 @@
   i32.const 12345678
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $158
+  local.tee $159
   i32.const 14096
   call $~lib/string/String.__eq
   i32.eqz
@@ -13111,7 +13436,7 @@
   i32.const 123456789
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $159
+  local.tee $160
   i32.const 14128
   call $~lib/string/String.__eq
   i32.eqz
@@ -13126,7 +13451,7 @@
   i32.const 2147483646
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $160
+  local.tee $161
   i32.const 14176
   call $~lib/string/String.__eq
   i32.eqz
@@ -13141,7 +13466,7 @@
   i32.const 2147483647
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $161
+  local.tee $162
   i32.const 14224
   call $~lib/string/String.__eq
   i32.eqz
@@ -13156,7 +13481,7 @@
   i32.const -2147483648
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $162
+  local.tee $163
   i32.const 14272
   call $~lib/string/String.__eq
   i32.eqz
@@ -13171,7 +13496,7 @@
   i32.const -1
   i32.const 10
   call $~lib/util/number/itoa32
-  local.tee $163
+  local.tee $164
   i32.const 14320
   call $~lib/string/String.__eq
   i32.eqz
@@ -13186,7 +13511,7 @@
   i32.const 0
   i32.const 10
   call $~lib/util/number/utoa32
-  local.tee $164
+  local.tee $165
   i32.const 2432
   call $~lib/string/String.__eq
   i32.eqz
@@ -13201,7 +13526,7 @@
   i32.const 1000
   i32.const 10
   call $~lib/util/number/utoa32
-  local.tee $165
+  local.tee $166
   i32.const 14352
   call $~lib/string/String.__eq
   i32.eqz
@@ -13216,7 +13541,7 @@
   i32.const 2147483647
   i32.const 10
   call $~lib/util/number/utoa32
-  local.tee $166
+  local.tee $167
   i32.const 14224
   call $~lib/string/String.__eq
   i32.eqz
@@ -13231,7 +13556,7 @@
   i32.const -2147483648
   i32.const 10
   call $~lib/util/number/utoa32
-  local.tee $167
+  local.tee $168
   i32.const 14384
   call $~lib/string/String.__eq
   i32.eqz
@@ -13246,7 +13571,7 @@
   i32.const -1
   i32.const 10
   call $~lib/util/number/utoa32
-  local.tee $168
+  local.tee $169
   i32.const 14432
   call $~lib/string/String.__eq
   i32.eqz
@@ -13261,7 +13586,7 @@
   i32.const 0
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $169
+  local.tee $170
   i32.const 2432
   call $~lib/string/String.__eq
   i32.eqz
@@ -13276,7 +13601,7 @@
   i32.const 1
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $170
+  local.tee $171
   i32.const 2496
   call $~lib/string/String.__eq
   i32.eqz
@@ -13291,7 +13616,7 @@
   i32.const 8
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $171
+  local.tee $172
   i32.const 13840
   call $~lib/string/String.__eq
   i32.eqz
@@ -13306,7 +13631,7 @@
   i32.const 12
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $172
+  local.tee $173
   i32.const 12240
   call $~lib/string/String.__eq
   i32.eqz
@@ -13321,7 +13646,7 @@
   i32.const 123
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $173
+  local.tee $174
   i32.const 14480
   call $~lib/string/String.__eq
   i32.eqz
@@ -13336,7 +13661,7 @@
   i32.const 1234
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $174
+  local.tee $175
   i32.const 14512
   call $~lib/string/String.__eq
   i32.eqz
@@ -13351,7 +13676,7 @@
   i32.const 12345
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $175
+  local.tee $176
   i32.const 14544
   call $~lib/string/String.__eq
   i32.eqz
@@ -13366,7 +13691,7 @@
   i32.const 123456
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $176
+  local.tee $177
   i32.const 14576
   call $~lib/string/String.__eq
   i32.eqz
@@ -13381,7 +13706,7 @@
   i32.const 1111111
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $177
+  local.tee $178
   i32.const 14608
   call $~lib/string/String.__eq
   i32.eqz
@@ -13396,7 +13721,7 @@
   i32.const 1234567
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $178
+  local.tee $179
   i32.const 14640
   call $~lib/string/String.__eq
   i32.eqz
@@ -13411,7 +13736,7 @@
   i32.const 12345678
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $179
+  local.tee $180
   i32.const 14672
   call $~lib/string/String.__eq
   i32.eqz
@@ -13426,7 +13751,7 @@
   i32.const 123456789
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $180
+  local.tee $181
   i32.const 14704
   call $~lib/string/String.__eq
   i32.eqz
@@ -13441,7 +13766,7 @@
   i32.const 2147483646
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $181
+  local.tee $182
   i32.const 14736
   call $~lib/string/String.__eq
   i32.eqz
@@ -13456,7 +13781,7 @@
   i32.const 2147483647
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $182
+  local.tee $183
   i32.const 14768
   call $~lib/string/String.__eq
   i32.eqz
@@ -13471,7 +13796,7 @@
   i32.const -2147483648
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $183
+  local.tee $184
   i32.const 14800
   call $~lib/string/String.__eq
   i32.eqz
@@ -13486,7 +13811,7 @@
   i32.const -1
   i32.const 16
   call $~lib/util/number/utoa32
-  local.tee $184
+  local.tee $185
   i32.const 14832
   call $~lib/string/String.__eq
   i32.eqz
@@ -13501,7 +13826,7 @@
   i32.const 0
   i32.const 16
   call $~lib/util/number/itoa32
-  local.tee $185
+  local.tee $186
   i32.const 2432
   call $~lib/string/String.__eq
   i32.eqz
@@ -13516,7 +13841,7 @@
   i32.const -4096
   i32.const 16
   call $~lib/util/number/itoa32
-  local.tee $186
+  local.tee $187
   i32.const 13904
   call $~lib/string/String.__eq
   i32.eqz
@@ -13531,7 +13856,7 @@
   i32.const 2147483647
   i32.const 16
   call $~lib/util/number/itoa32
-  local.tee $187
+  local.tee $188
   i32.const 14768
   call $~lib/string/String.__eq
   i32.eqz
@@ -13546,7 +13871,7 @@
   i32.const -2147483647
   i32.const 16
   call $~lib/util/number/itoa32
-  local.tee $188
+  local.tee $189
   i32.const 14864
   call $~lib/string/String.__eq
   i32.eqz
@@ -13561,7 +13886,7 @@
   i32.const -268435455
   i32.const 16
   call $~lib/util/number/itoa32
-  local.tee $189
+  local.tee $190
   i32.const 14912
   call $~lib/string/String.__eq
   i32.eqz
@@ -13576,7 +13901,7 @@
   i32.const -2147483648
   i32.const 16
   call $~lib/util/number/itoa32
-  local.tee $190
+  local.tee $191
   i32.const 14944
   call $~lib/string/String.__eq
   i32.eqz
@@ -13591,7 +13916,7 @@
   i32.const -2147483648
   i32.const 16
   call $~lib/util/number/itoa32
-  local.tee $191
+  local.tee $192
   i32.const 14944
   call $~lib/string/String.__eq
   i32.eqz
@@ -13606,7 +13931,7 @@
   i32.const 0
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $192
+  local.tee $193
   i32.const 2432
   call $~lib/string/String.__eq
   i32.eqz
@@ -13621,7 +13946,7 @@
   i32.const 1
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $193
+  local.tee $194
   i32.const 2496
   call $~lib/string/String.__eq
   i32.eqz
@@ -13636,7 +13961,7 @@
   i32.const 3
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $194
+  local.tee $195
   i32.const 14992
   call $~lib/string/String.__eq
   i32.eqz
@@ -13651,7 +13976,7 @@
   i32.const 7
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $195
+  local.tee $196
   i32.const 15024
   call $~lib/string/String.__eq
   i32.eqz
@@ -13666,7 +13991,7 @@
   i32.const 14
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $196
+  local.tee $197
   i32.const 15056
   call $~lib/string/String.__eq
   i32.eqz
@@ -13681,7 +14006,7 @@
   i32.const 29
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $197
+  local.tee $198
   i32.const 15088
   call $~lib/string/String.__eq
   i32.eqz
@@ -13696,7 +14021,7 @@
   i32.const 59
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $198
+  local.tee $199
   i32.const 15120
   call $~lib/string/String.__eq
   i32.eqz
@@ -13711,7 +14036,7 @@
   i32.const 4095
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $199
+  local.tee $200
   i32.const 15152
   call $~lib/string/String.__eq
   i32.eqz
@@ -13726,7 +14051,7 @@
   i32.const 33554431
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $200
+  local.tee $201
   i32.const 15200
   call $~lib/string/String.__eq
   i32.eqz
@@ -13741,7 +14066,7 @@
   i32.const -12
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $201
+  local.tee $202
   i32.const 15280
   call $~lib/string/String.__eq
   i32.eqz
@@ -13756,7 +14081,7 @@
   i32.const -4
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $202
+  local.tee $203
   i32.const 15360
   call $~lib/string/String.__eq
   i32.eqz
@@ -13771,7 +14096,7 @@
   i32.const -2
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $203
+  local.tee $204
   i32.const 15440
   call $~lib/string/String.__eq
   i32.eqz
@@ -13786,7 +14111,7 @@
   i32.const -1
   i32.const 2
   call $~lib/util/number/utoa32
-  local.tee $204
+  local.tee $205
   i32.const 15520
   call $~lib/string/String.__eq
   i32.eqz
@@ -13801,7 +14126,7 @@
   i32.const -2047
   i32.const 2
   call $~lib/util/number/itoa32
-  local.tee $205
+  local.tee $206
   i32.const 15600
   call $~lib/string/String.__eq
   i32.eqz
@@ -13816,7 +14141,7 @@
   i32.const -1
   i32.const 3
   call $~lib/util/number/utoa32
-  local.tee $206
+  local.tee $207
   i32.const 15648
   call $~lib/string/String.__eq
   i32.eqz
@@ -13831,7 +14156,7 @@
   i32.const -1
   i32.const 4
   call $~lib/util/number/utoa32
-  local.tee $207
+  local.tee $208
   i32.const 15712
   call $~lib/string/String.__eq
   i32.eqz
@@ -13846,7 +14171,7 @@
   i32.const -1
   i32.const 5
   call $~lib/util/number/utoa32
-  local.tee $208
+  local.tee $209
   i32.const 15760
   call $~lib/string/String.__eq
   i32.eqz
@@ -13861,7 +14186,7 @@
   i32.const -1
   i32.const 8
   call $~lib/util/number/utoa32
-  local.tee $209
+  local.tee $210
   i32.const 15808
   call $~lib/string/String.__eq
   i32.eqz
@@ -13876,7 +14201,7 @@
   i32.const -1
   i32.const 11
   call $~lib/util/number/utoa32
-  local.tee $210
+  local.tee $211
   i32.const 15856
   call $~lib/string/String.__eq
   i32.eqz
@@ -13891,7 +14216,7 @@
   i32.const -1
   i32.const 15
   call $~lib/util/number/utoa32
-  local.tee $211
+  local.tee $212
   i32.const 15904
   call $~lib/string/String.__eq
   i32.eqz
@@ -13906,7 +14231,7 @@
   i32.const -1
   i32.const 17
   call $~lib/util/number/utoa32
-  local.tee $212
+  local.tee $213
   i32.const 15952
   call $~lib/string/String.__eq
   i32.eqz
@@ -13921,7 +14246,7 @@
   i32.const -1
   i32.const 21
   call $~lib/util/number/utoa32
-  local.tee $213
+  local.tee $214
   i32.const 15984
   call $~lib/string/String.__eq
   i32.eqz
@@ -13936,7 +14261,7 @@
   i32.const -1
   i32.const 27
   call $~lib/util/number/utoa32
-  local.tee $214
+  local.tee $215
   i32.const 16016
   call $~lib/string/String.__eq
   i32.eqz
@@ -13951,7 +14276,7 @@
   i32.const -1
   i32.const 32
   call $~lib/util/number/utoa32
-  local.tee $215
+  local.tee $216
   i32.const 16048
   call $~lib/string/String.__eq
   i32.eqz
@@ -13966,7 +14291,7 @@
   i32.const -1
   i32.const 36
   call $~lib/util/number/utoa32
-  local.tee $216
+  local.tee $217
   i32.const 16080
   call $~lib/string/String.__eq
   i32.eqz
@@ -13981,7 +14306,7 @@
   i64.const 0
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $217
+  local.tee $218
   i32.const 2432
   call $~lib/string/String.__eq
   i32.eqz
@@ -13996,7 +14321,7 @@
   i64.const 12
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $218
+  local.tee $219
   i32.const 13872
   call $~lib/string/String.__eq
   i32.eqz
@@ -14011,7 +14336,7 @@
   i64.const 123
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $219
+  local.tee $220
   i32.const 1872
   call $~lib/string/String.__eq
   i32.eqz
@@ -14026,7 +14351,7 @@
   i64.const 1234
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $220
+  local.tee $221
   i32.const 13936
   call $~lib/string/String.__eq
   i32.eqz
@@ -14041,7 +14366,7 @@
   i64.const 12345
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $221
+  local.tee $222
   i32.const 13968
   call $~lib/string/String.__eq
   i32.eqz
@@ -14056,7 +14381,7 @@
   i64.const 123456
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $222
+  local.tee $223
   i32.const 14000
   call $~lib/string/String.__eq
   i32.eqz
@@ -14071,7 +14396,7 @@
   i64.const 1234567
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $223
+  local.tee $224
   i32.const 14064
   call $~lib/string/String.__eq
   i32.eqz
@@ -14086,7 +14411,7 @@
   i64.const 99999999
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $224
+  local.tee $225
   i32.const 16112
   call $~lib/string/String.__eq
   i32.eqz
@@ -14101,7 +14426,7 @@
   i64.const 100000000
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $225
+  local.tee $226
   i32.const 16144
   call $~lib/string/String.__eq
   i32.eqz
@@ -14116,7 +14441,7 @@
   i64.const 4294967295
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $226
+  local.tee $227
   i32.const 14432
   call $~lib/string/String.__eq
   i32.eqz
@@ -14131,7 +14456,7 @@
   i64.const 4294967297
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $227
+  local.tee $228
   i32.const 16192
   call $~lib/string/String.__eq
   i32.eqz
@@ -14146,7 +14471,7 @@
   i64.const 68719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $228
+  local.tee $229
   i32.const 16240
   call $~lib/string/String.__eq
   i32.eqz
@@ -14161,7 +14486,7 @@
   i64.const 868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $229
+  local.tee $230
   i32.const 16288
   call $~lib/string/String.__eq
   i32.eqz
@@ -14176,7 +14501,7 @@
   i64.const 8687194767350
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $230
+  local.tee $231
   i32.const 16336
   call $~lib/string/String.__eq
   i32.eqz
@@ -14191,7 +14516,7 @@
   i64.const 86871947673501
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $231
+  local.tee $232
   i32.const 16384
   call $~lib/string/String.__eq
   i32.eqz
@@ -14206,7 +14531,7 @@
   i64.const 999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $232
+  local.tee $233
   i32.const 16432
   call $~lib/string/String.__eq
   i32.eqz
@@ -14221,7 +14546,7 @@
   i64.const 9999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $233
+  local.tee $234
   i32.const 16480
   call $~lib/string/String.__eq
   i32.eqz
@@ -14236,7 +14561,7 @@
   i64.const 19999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $234
+  local.tee $235
   i32.const 16528
   call $~lib/string/String.__eq
   i32.eqz
@@ -14251,7 +14576,7 @@
   i64.const 129999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $235
+  local.tee $236
   i32.const 16592
   call $~lib/string/String.__eq
   i32.eqz
@@ -14266,7 +14591,7 @@
   i64.const 1239999868719476735
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $236
+  local.tee $237
   i32.const 16656
   call $~lib/string/String.__eq
   i32.eqz
@@ -14281,7 +14606,7 @@
   i64.const -1
   i32.const 10
   call $~lib/util/number/utoa64
-  local.tee $237
+  local.tee $238
   i32.const 16720
   call $~lib/string/String.__eq
   i32.eqz
@@ -14296,7 +14621,7 @@
   i64.const 0
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $238
+  local.tee $239
   i32.const 2432
   call $~lib/string/String.__eq
   i32.eqz
@@ -14311,7 +14636,7 @@
   i64.const -1234
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $239
+  local.tee $240
   i32.const 16784
   call $~lib/string/String.__eq
   i32.eqz
@@ -14326,7 +14651,7 @@
   i64.const 4294967295
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $240
+  local.tee $241
   i32.const 14432
   call $~lib/string/String.__eq
   i32.eqz
@@ -14341,7 +14666,7 @@
   i64.const 4294967297
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $241
+  local.tee $242
   i32.const 16192
   call $~lib/string/String.__eq
   i32.eqz
@@ -14356,7 +14681,7 @@
   i64.const -4294967295
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $242
+  local.tee $243
   i32.const 16816
   call $~lib/string/String.__eq
   i32.eqz
@@ -14371,7 +14696,7 @@
   i64.const 68719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $243
+  local.tee $244
   i32.const 16240
   call $~lib/string/String.__eq
   i32.eqz
@@ -14386,7 +14711,7 @@
   i64.const -68719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $244
+  local.tee $245
   i32.const 16864
   call $~lib/string/String.__eq
   i32.eqz
@@ -14401,7 +14726,7 @@
   i64.const -868719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $245
+  local.tee $246
   i32.const 16912
   call $~lib/string/String.__eq
   i32.eqz
@@ -14416,7 +14741,7 @@
   i64.const -999868719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $246
+  local.tee $247
   i32.const 16960
   call $~lib/string/String.__eq
   i32.eqz
@@ -14431,7 +14756,7 @@
   i64.const -19999868719476735
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $247
+  local.tee $248
   i32.const 17008
   call $~lib/string/String.__eq
   i32.eqz
@@ -14446,7 +14771,7 @@
   i64.const 9223372036854775807
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $248
+  local.tee $249
   i32.const 17072
   call $~lib/string/String.__eq
   i32.eqz
@@ -14461,7 +14786,7 @@
   i64.const -9223372036854775808
   i32.const 10
   call $~lib/util/number/itoa64
-  local.tee $249
+  local.tee $250
   i32.const 17136
   call $~lib/string/String.__eq
   i32.eqz
@@ -14476,7 +14801,7 @@
   i64.const 0
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $250
+  local.tee $251
   i32.const 2432
   call $~lib/string/String.__eq
   i32.eqz
@@ -14491,7 +14816,7 @@
   i64.const 1
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $251
+  local.tee $252
   i32.const 2496
   call $~lib/string/String.__eq
   i32.eqz
@@ -14506,7 +14831,7 @@
   i64.const 12
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $252
+  local.tee $253
   i32.const 12240
   call $~lib/string/String.__eq
   i32.eqz
@@ -14521,7 +14846,7 @@
   i64.const 1234
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $253
+  local.tee $254
   i32.const 14512
   call $~lib/string/String.__eq
   i32.eqz
@@ -14536,7 +14861,7 @@
   i64.const 1111111
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $254
+  local.tee $255
   i32.const 14608
   call $~lib/string/String.__eq
   i32.eqz
@@ -14551,7 +14876,7 @@
   i64.const 8589934591
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $255
+  local.tee $256
   i32.const 17200
   call $~lib/string/String.__eq
   i32.eqz
@@ -14566,7 +14891,7 @@
   i64.const 5942249508321
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $256
+  local.tee $257
   i32.const 17248
   call $~lib/string/String.__eq
   i32.eqz
@@ -14581,7 +14906,7 @@
   i64.const 76310993685985
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $257
+  local.tee $258
   i32.const 17296
   call $~lib/string/String.__eq
   i32.eqz
@@ -14596,7 +14921,7 @@
   i64.const 920735923817967
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $258
+  local.tee $259
   i32.const 17344
   call $~lib/string/String.__eq
   i32.eqz
@@ -14611,7 +14936,7 @@
   i64.const 9927935178558959
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $259
+  local.tee $260
   i32.const 17392
   call $~lib/string/String.__eq
   i32.eqz
@@ -14626,7 +14951,7 @@
   i64.const 81985529216486895
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $260
+  local.tee $261
   i32.const 17440
   call $~lib/string/String.__eq
   i32.eqz
@@ -14641,7 +14966,7 @@
   i64.const 1311768467463790320
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $261
+  local.tee $262
   i32.const 17488
   call $~lib/string/String.__eq
   i32.eqz
@@ -14656,7 +14981,7 @@
   i64.const 9223372036854775807
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $262
+  local.tee $263
   i32.const 17536
   call $~lib/string/String.__eq
   i32.eqz
@@ -14671,7 +14996,7 @@
   i64.const -1
   i32.const 16
   call $~lib/util/number/utoa64
-  local.tee $263
+  local.tee $264
   i32.const 17584
   call $~lib/string/String.__eq
   i32.eqz
@@ -14686,7 +15011,7 @@
   i64.const -9223372036854775807
   i32.const 16
   call $~lib/util/number/itoa64
-  local.tee $264
+  local.tee $265
   i32.const 17632
   call $~lib/string/String.__eq
   i32.eqz
@@ -14701,7 +15026,7 @@
   i64.const -9223372036854775808
   i32.const 16
   call $~lib/util/number/itoa64
-  local.tee $265
+  local.tee $266
   i32.const 17696
   call $~lib/string/String.__eq
   i32.eqz
@@ -14716,7 +15041,7 @@
   i64.const -9223372036854775808
   i32.const 16
   call $~lib/util/number/itoa64
-  local.tee $266
+  local.tee $267
   i32.const 17696
   call $~lib/string/String.__eq
   i32.eqz
@@ -14731,7 +15056,7 @@
   i64.const 0
   i32.const 2
   call $~lib/util/number/utoa64
-  local.tee $267
+  local.tee $268
   i32.const 2432
   call $~lib/string/String.__eq
   i32.eqz
@@ -14746,7 +15071,7 @@
   i64.const 1
   i32.const 2
   call $~lib/util/number/utoa64
-  local.tee $268
+  local.tee $269
   i32.const 2496
   call $~lib/string/String.__eq
   i32.eqz
@@ -14761,7 +15086,7 @@
   i64.const 7
   i32.const 2
   call $~lib/util/number/utoa64
-  local.tee $269
+  local.tee $270
   i32.const 15024
   call $~lib/string/String.__eq
   i32.eqz
@@ -14776,7 +15101,7 @@
   i64.const 14
   i32.const 2
   call $~lib/util/number/utoa64
-  local.tee $270
+  local.tee $271
   i32.const 15056
   call $~lib/string/String.__eq
   i32.eqz
@@ -14791,7 +15116,7 @@
   i64.const 59
   i32.const 2
   call $~lib/util/number/utoa64
-  local.tee $271
+  local.tee $272
   i32.const 15120
   call $~lib/string/String.__eq
   i32.eqz
@@ -14806,7 +15131,7 @@
   i64.const 4095
   i32.const 2
   call $~lib/util/number/utoa64
-  local.tee $272
+  local.tee $273
   i32.const 15152
   call $~lib/string/String.__eq
   i32.eqz
@@ -14821,7 +15146,7 @@
   i64.const 4294967295
   i32.const 2
   call $~lib/util/number/utoa64
-  local.tee $273
+  local.tee $274
   i32.const 15520
   call $~lib/string/String.__eq
   i32.eqz
@@ -14836,7 +15161,7 @@
   i64.const 562949953421311
   i32.const 2
   call $~lib/util/number/utoa64
-  local.tee $274
+  local.tee $275
   i32.const 17760
   call $~lib/string/String.__eq
   i32.eqz
@@ -14851,7 +15176,7 @@
   i64.const -1
   i32.const 2
   call $~lib/util/number/utoa64
-  local.tee $275
+  local.tee $276
   i32.const 17888
   call $~lib/string/String.__eq
   i32.eqz
@@ -14866,7 +15191,7 @@
   i64.const -8589934591
   i32.const 2
   call $~lib/util/number/itoa64
-  local.tee $276
+  local.tee $277
   i32.const 18032
   call $~lib/string/String.__eq
   i32.eqz
@@ -14881,7 +15206,7 @@
   i64.const -1
   i32.const 3
   call $~lib/util/number/utoa64
-  local.tee $277
+  local.tee $278
   i32.const 18128
   call $~lib/string/String.__eq
   i32.eqz
@@ -14896,7 +15221,7 @@
   i64.const -1
   i32.const 4
   call $~lib/util/number/utoa64
-  local.tee $278
+  local.tee $279
   i32.const 18240
   call $~lib/string/String.__eq
   i32.eqz
@@ -14911,7 +15236,7 @@
   i64.const -1
   i32.const 5
   call $~lib/util/number/utoa64
-  local.tee $279
+  local.tee $280
   i32.const 18320
   call $~lib/string/String.__eq
   i32.eqz
@@ -14926,7 +15251,7 @@
   i64.const -1
   i32.const 8
   call $~lib/util/number/utoa64
-  local.tee $280
+  local.tee $281
   i32.const 18400
   call $~lib/string/String.__eq
   i32.eqz
@@ -14941,7 +15266,7 @@
   i64.const -1
   i32.const 11
   call $~lib/util/number/utoa64
-  local.tee $281
+  local.tee $282
   i32.const 18464
   call $~lib/string/String.__eq
   i32.eqz
@@ -14956,7 +15281,7 @@
   i64.const -1
   i32.const 15
   call $~lib/util/number/utoa64
-  local.tee $282
+  local.tee $283
   i32.const 18528
   call $~lib/string/String.__eq
   i32.eqz
@@ -14971,7 +15296,7 @@
   i64.const -1
   i32.const 17
   call $~lib/util/number/utoa64
-  local.tee $283
+  local.tee $284
   i32.const 18592
   call $~lib/string/String.__eq
   i32.eqz
@@ -14986,7 +15311,7 @@
   i64.const -1
   i32.const 21
   call $~lib/util/number/utoa64
-  local.tee $284
+  local.tee $285
   i32.const 18640
   call $~lib/string/String.__eq
   i32.eqz
@@ -15001,7 +15326,7 @@
   i64.const -1
   i32.const 27
   call $~lib/util/number/utoa64
-  local.tee $285
+  local.tee $286
   i32.const 18688
   call $~lib/string/String.__eq
   i32.eqz
@@ -15016,7 +15341,7 @@
   i64.const -1
   i32.const 32
   call $~lib/util/number/utoa64
-  local.tee $286
+  local.tee $287
   i32.const 18736
   call $~lib/string/String.__eq
   i32.eqz
@@ -15031,7 +15356,7 @@
   i64.const -1
   i32.const 36
   call $~lib/util/number/utoa64
-  local.tee $287
+  local.tee $288
   i32.const 18784
   call $~lib/string/String.__eq
   i32.eqz
@@ -15045,7 +15370,7 @@
   end
   f64.const 0
   call $~lib/util/number/dtoa
-  local.tee $288
+  local.tee $289
   i32.const 18832
   call $~lib/string/String.__eq
   i32.eqz
@@ -15059,7 +15384,7 @@
   end
   f64.const -0
   call $~lib/util/number/dtoa
-  local.tee $289
+  local.tee $290
   i32.const 18832
   call $~lib/string/String.__eq
   i32.eqz
@@ -15073,7 +15398,7 @@
   end
   f64.const nan:0x8000000000000
   call $~lib/util/number/dtoa
-  local.tee $290
+  local.tee $291
   i32.const 5808
   call $~lib/string/String.__eq
   i32.eqz
@@ -15087,7 +15412,7 @@
   end
   f64.const inf
   call $~lib/util/number/dtoa
-  local.tee $291
+  local.tee $292
   i32.const 18864
   call $~lib/string/String.__eq
   i32.eqz
@@ -15101,7 +15426,7 @@
   end
   f64.const -inf
   call $~lib/util/number/dtoa
-  local.tee $292
+  local.tee $293
   i32.const 7024
   call $~lib/string/String.__eq
   i32.eqz
@@ -15115,7 +15440,7 @@
   end
   f64.const 2.220446049250313e-16
   call $~lib/util/number/dtoa
-  local.tee $293
+  local.tee $294
   i32.const 6320
   call $~lib/string/String.__eq
   i32.eqz
@@ -15129,7 +15454,7 @@
   end
   f64.const -2.220446049250313e-16
   call $~lib/util/number/dtoa
-  local.tee $294
+  local.tee $295
   i32.const 19808
   call $~lib/string/String.__eq
   i32.eqz
@@ -15143,7 +15468,7 @@
   end
   f64.const 1797693134862315708145274e284
   call $~lib/util/number/dtoa
-  local.tee $295
+  local.tee $296
   i32.const 6384
   call $~lib/string/String.__eq
   i32.eqz
@@ -15157,7 +15482,7 @@
   end
   f64.const -1797693134862315708145274e284
   call $~lib/util/number/dtoa
-  local.tee $296
+  local.tee $297
   i32.const 19872
   call $~lib/string/String.__eq
   i32.eqz
@@ -15171,7 +15496,7 @@
   end
   f64.const 4185580496821356722454785e274
   call $~lib/util/number/dtoa
-  local.tee $297
+  local.tee $298
   i32.const 19936
   call $~lib/string/String.__eq
   i32.eqz
@@ -15199,7 +15524,7 @@
   end
   f64.const 4.940656e-318
   call $~lib/util/number/dtoa
-  local.tee $11
+  local.tee $3
   i32.const 20064
   call $~lib/string/String.__eq
   i32.eqz
@@ -15213,7 +15538,7 @@
   end
   f64.const 9060801153433600
   call $~lib/util/number/dtoa
-  local.tee $8
+  local.tee $9
   i32.const 20112
   call $~lib/string/String.__eq
   i32.eqz
@@ -15227,7 +15552,7 @@
   end
   f64.const 4708356024711512064
   call $~lib/util/number/dtoa
-  local.tee $9
+  local.tee $10
   i32.const 20176
   call $~lib/string/String.__eq
   i32.eqz
@@ -15255,7 +15580,7 @@
   end
   f64.const 5e-324
   call $~lib/util/number/dtoa
-  local.tee $5
+  local.tee $6
   i32.const 6448
   call $~lib/string/String.__eq
   i32.eqz
@@ -15339,7 +15664,7 @@
   end
   f64.const 1e-06
   call $~lib/util/number/dtoa
-  local.tee $3
+  local.tee $4
   i32.const 20448
   call $~lib/string/String.__eq
   i32.eqz
@@ -15451,7 +15776,7 @@
   end
   f64.const -inf
   call $~lib/util/number/dtoa
-  local.tee $4
+  local.tee $5
   i32.const 7024
   call $~lib/string/String.__eq
   i32.eqz
@@ -15549,7 +15874,7 @@
   end
   f64.const 1.2312145673456234e-08
   call $~lib/util/number/dtoa
-  local.tee $10
+  local.tee $11
   i32.const 20864
   call $~lib/string/String.__eq
   i32.eqz
@@ -15577,7 +15902,7 @@
   end
   f64.const 0.9999999999999999
   call $~lib/util/number/dtoa
-  local.tee $6
+  local.tee $7
   i32.const 20992
   call $~lib/string/String.__eq
   i32.eqz
@@ -15619,7 +15944,7 @@
   end
   f64.const 0.3333333333333333
   call $~lib/util/number/dtoa
-  local.tee $7
+  local.tee $8
   i32.const 21088
   call $~lib/string/String.__eq
   i32.eqz
@@ -15809,25 +16134,23 @@
   call $~lib/rt/pure/__release
   local.get $72
   call $~lib/rt/pure/__release
-  local.get $73
-  call $~lib/rt/pure/__release
   local.get $74
   call $~lib/rt/pure/__release
   local.get $75
   call $~lib/rt/pure/__release
   local.get $76
   call $~lib/rt/pure/__release
-  local.get $80
+  local.get $77
   call $~lib/rt/pure/__release
   local.get $81
+  call $~lib/rt/pure/__release
+  local.get $82
+  call $~lib/rt/pure/__release
+  local.get $80
   call $~lib/rt/pure/__release
   local.get $79
   call $~lib/rt/pure/__release
   local.get $78
-  call $~lib/rt/pure/__release
-  local.get $77
-  call $~lib/rt/pure/__release
-  local.get $82
   call $~lib/rt/pure/__release
   local.get $83
   call $~lib/rt/pure/__release
@@ -15959,11 +16282,11 @@
   call $~lib/rt/pure/__release
   local.get $147
   call $~lib/rt/pure/__release
-  local.get $149
-  call $~lib/rt/pure/__release
   local.get $148
   call $~lib/rt/pure/__release
   local.get $150
+  call $~lib/rt/pure/__release
+  local.get $149
   call $~lib/rt/pure/__release
   local.get $151
   call $~lib/rt/pure/__release
@@ -16259,17 +16582,19 @@
   call $~lib/rt/pure/__release
   local.get $297
   call $~lib/rt/pure/__release
+  local.get $298
+  call $~lib/rt/pure/__release
   local.get $12
   call $~lib/rt/pure/__release
-  local.get $11
-  call $~lib/rt/pure/__release
-  local.get $8
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $14
   call $~lib/rt/pure/__release
@@ -16281,7 +16606,7 @@
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $19
   call $~lib/rt/pure/__release
@@ -16297,7 +16622,7 @@
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
@@ -16311,17 +16636,17 @@
   call $~lib/rt/pure/__release
   local.get $31
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $11
   call $~lib/rt/pure/__release
   local.get $32
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $7
   call $~lib/rt/pure/__release
   local.get $33
   call $~lib/rt/pure/__release
   local.get $34
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $35
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -1,11 +1,11 @@
 (module
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i64_i32_i32_=>_i32 (func (param i64 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $f32_i32_i32_=>_i32 (func (param f32 i32 i32) (result i32)))
@@ -2151,17 +2151,18 @@
   (local $3 i32)
   (local $4 i32)
   local.get $0
-  local.tee $3
+  call $~lib/rt/pure/__retain
+  local.tee $4
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $4
+  local.set $3
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
    local.get $1
-   local.get $4
+   local.get $3
    i32.add
    local.tee $0
    i32.const 0
@@ -2171,9 +2172,9 @@
    select
   else
    local.get $1
-   local.get $4
+   local.get $3
    local.get $1
-   local.get $4
+   local.get $3
    i32.lt_s
    select
   end
@@ -2183,7 +2184,7 @@
   i32.lt_s
   if (result i32)
    local.get $2
-   local.get $4
+   local.get $3
    i32.add
    local.tee $1
    i32.const 0
@@ -2193,9 +2194,9 @@
    select
   else
    local.get $2
-   local.get $4
+   local.get $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.lt_s
    select
   end
@@ -2204,12 +2205,12 @@
   i32.const 8
   call $~lib/rt/tlsf/__alloc
   local.tee $2
-  local.get $3
+  local.get $4
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
   local.get $2
-  local.get $3
+  local.get $4
   i32.load offset=4
   local.get $0
   i32.const 2
@@ -2230,6 +2231,8 @@
   i32.store offset=8
   local.get $2
   call $~lib/rt/pure/__retain
+  local.get $4
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Float64Array#__set (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
@@ -2259,17 +2262,18 @@
   (local $3 i32)
   (local $4 i32)
   local.get $0
-  local.tee $3
+  call $~lib/rt/pure/__retain
+  local.tee $4
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $4
+  local.set $3
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
    local.get $1
-   local.get $4
+   local.get $3
    i32.add
    local.tee $0
    i32.const 0
@@ -2279,9 +2283,9 @@
    select
   else
    local.get $1
-   local.get $4
+   local.get $3
    local.get $1
-   local.get $4
+   local.get $3
    i32.lt_s
    select
   end
@@ -2291,7 +2295,7 @@
   i32.lt_s
   if (result i32)
    local.get $2
-   local.get $4
+   local.get $3
    i32.add
    local.tee $1
    i32.const 0
@@ -2301,9 +2305,9 @@
    select
   else
    local.get $2
-   local.get $4
+   local.get $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.lt_s
    select
   end
@@ -2312,12 +2316,12 @@
   i32.const 13
   call $~lib/rt/tlsf/__alloc
   local.tee $2
-  local.get $3
+  local.get $4
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
   local.get $2
-  local.get $3
+  local.get $4
   i32.load offset=4
   local.get $0
   i32.const 3
@@ -2338,6 +2342,8 @@
   i32.store offset=8
   local.get $2
   call $~lib/rt/pure/__retain
+  local.get $4
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -3164,6 +3170,12 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   block $folding-inner0
    local.get $0
    i32.load offset=8
@@ -3208,24 +3220,33 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/typedarray/Int8Array#subarray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
-  local.tee $3
+  call $~lib/rt/pure/__retain
+  local.tee $4
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
    local.get $1
-   local.get $4
+   local.get $3
    i32.add
    local.tee $0
    i32.const 0
@@ -3235,9 +3256,9 @@
    select
   else
    local.get $1
-   local.get $4
+   local.get $3
    local.get $1
-   local.get $4
+   local.get $3
    i32.lt_s
    select
   end
@@ -3247,7 +3268,7 @@
   i32.lt_s
   if (result i32)
    local.get $2
-   local.get $4
+   local.get $3
    i32.add
    local.tee $1
    i32.const 0
@@ -3257,9 +3278,9 @@
    select
   else
    local.get $2
-   local.get $4
+   local.get $3
    local.get $2
-   local.get $4
+   local.get $3
    i32.lt_s
    select
   end
@@ -3268,13 +3289,13 @@
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   local.tee $2
-  local.get $3
+  local.get $4
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
   local.get $2
   local.get $0
-  local.get $3
+  local.get $4
   i32.load offset=4
   i32.add
   i32.store offset=4
@@ -3290,6 +3311,8 @@
   i32.store offset=8
   local.get $2
   call $~lib/rt/pure/__retain
+  local.get $4
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
@@ -3401,8 +3424,13 @@
  (func $std/typedarray/isInt32ArrayEqual (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
   block $folding-inner0
    local.get $1
+   call $~lib/rt/pure/__retain
+   local.tee $1
    i32.load offset=12
    local.get $0
    i32.load offset=8
@@ -3435,15 +3463,25 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/typedarray/Int32Array#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -3455,9 +3493,9 @@
    local.get $1
    local.get $3
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    select
@@ -3469,7 +3507,7 @@
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $0
   local.get $2
   i32.const 0
   i32.lt_s
@@ -3477,9 +3515,9 @@
    local.get $2
    local.get $3
    i32.add
-   local.tee $2
+   local.tee $1
    i32.const 0
-   local.get $2
+   local.get $1
    i32.const 0
    i32.gt_s
    select
@@ -3491,33 +3529,35 @@
    i32.lt_s
    select
   end
-  local.get $1
+  local.get $0
   i32.sub
-  local.tee $2
+  local.tee $1
   i32.const 0
-  local.get $2
+  local.get $1
   i32.const 0
   i32.gt_s
   select
-  local.tee $2
+  local.tee $1
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $3
+  local.tee $2
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $3
+  i32.load offset=4
+  local.get $4
   i32.load offset=4
   local.get $0
-  i32.load offset=4
-  local.get $1
   i32.const 2
   i32.shl
   i32.add
-  local.get $2
+  local.get $1
   i32.const 2
   i32.shl
   call $~lib/memory/memory.copy
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $4
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
  )
  (func $~lib/typedarray/Int32Array#copyWithin (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
@@ -3659,6 +3699,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $4
   local.get $0
@@ -3690,6 +3732,8 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $~lib/typedarray/Int16Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
@@ -3747,6 +3791,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $4
   local.get $0
@@ -3782,6 +3828,8 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $~lib/typedarray/Uint32Array#__set (param $0 i32) (param $1 i32) (param $2 i32)
@@ -3844,6 +3892,8 @@
   (local $5 i32)
   (local $6 i64)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $4
   local.get $0
@@ -3879,6 +3929,8 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $~lib/typedarray/Uint64Array#__set (param $0 i32) (param $1 i32) (param $2 i64)
@@ -3945,19 +3997,21 @@
   (local $4 i32)
   (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $2
   i32.load offset=4
   local.set $4
-  local.get $0
+  local.get $2
   i32.load offset=8
   i32.const 1
   i32.sub
-  local.set $2
+  local.set $0
   loop $for-loop|0
-   local.get $2
+   local.get $0
    i32.const 0
    i32.ge_s
    if
-    local.get $2
+    local.get $0
     local.get $4
     i32.add
     i32.load8_u
@@ -3966,18 +4020,20 @@
     global.set $~argumentsLength
     local.get $3
     local.get $5
-    local.get $2
     local.get $0
+    local.get $2
     local.get $1
     call_indirect (type $i32_i32_i32_i32_=>_i32)
     local.set $3
-    local.get $2
+    local.get $0
     i32.const 1
     i32.sub
-    local.set $2
+    local.set $0
     br $for-loop|0
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $~lib/typedarray/Int32Array#reduceRight<i32> (param $0 i32) (param $1 i32) (result i32)
@@ -3986,22 +4042,24 @@
   (local $4 i32)
   (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $2
   i32.load offset=4
   local.set $4
-  local.get $0
+  local.get $2
   i32.load offset=8
   i32.const 2
   i32.shr_u
   i32.const 1
   i32.sub
-  local.set $2
+  local.set $0
   loop $for-loop|0
-   local.get $2
+   local.get $0
    i32.const 0
    i32.ge_s
    if
     local.get $4
-    local.get $2
+    local.get $0
     i32.const 2
     i32.shl
     i32.add
@@ -4011,18 +4069,20 @@
     global.set $~argumentsLength
     local.get $3
     local.get $5
-    local.get $2
     local.get $0
+    local.get $2
     local.get $1
     call_indirect (type $i32_i32_i32_i32_=>_i32)
     local.set $3
-    local.get $2
+    local.get $0
     i32.const 1
     i32.sub
-    local.set $2
+    local.set $0
     br $for-loop|0
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $~lib/typedarray/Int64Array#reduceRight<i64> (param $0 i32) (param $1 i32) (result i64)
@@ -4031,22 +4091,24 @@
   (local $4 i32)
   (local $5 i64)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $2
   i32.load offset=4
   local.set $4
-  local.get $0
+  local.get $2
   i32.load offset=8
   i32.const 3
   i32.shr_u
   i32.const 1
   i32.sub
-  local.set $2
+  local.set $0
   loop $for-loop|0
-   local.get $2
+   local.get $0
    i32.const 0
    i32.ge_s
    if
     local.get $4
-    local.get $2
+    local.get $0
     i32.const 3
     i32.shl
     i32.add
@@ -4056,18 +4118,20 @@
     global.set $~argumentsLength
     local.get $3
     local.get $5
-    local.get $2
     local.get $0
+    local.get $2
     local.get $1
     call_indirect (type $i64_i64_i32_i32_=>_i64)
     local.set $3
-    local.get $2
+    local.get $0
     i32.const 1
     i32.sub
-    local.set $2
+    local.set $0
     br $for-loop|0
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $3
  )
  (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -4094,6 +4158,80 @@
   i32.add
   i32.load8_u
  )
+ (func $~lib/typedarray/Int16Array#map (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  local.set $4
+  local.get $3
+  i32.load offset=4
+  local.set $6
+  i32.const 12
+  i32.const 6
+  call $~lib/rt/tlsf/__alloc
+  local.set $0
+  local.get $4
+  i32.const 1
+  i32.shl
+  local.tee $7
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $1
+  loop $for-loop|0
+   local.get $2
+   local.get $4
+   i32.lt_s
+   if
+    local.get $6
+    local.get $2
+    i32.const 1
+    i32.shl
+    local.tee $8
+    i32.add
+    i32.load16_s
+    local.set $5
+    i32.const 3
+    global.set $~argumentsLength
+    local.get $1
+    local.get $8
+    i32.add
+    local.get $5
+    local.get $5
+    i32.mul
+    i32.store16
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $7
+  i32.store offset=8
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
  (func $~lib/typedarray/Int16Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
@@ -4117,6 +4255,80 @@
   i32.add
   i32.load16_s
  )
+ (func $~lib/typedarray/Uint16Array#map (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  local.set $4
+  local.get $3
+  i32.load offset=4
+  local.set $6
+  i32.const 12
+  i32.const 7
+  call $~lib/rt/tlsf/__alloc
+  local.set $0
+  local.get $4
+  i32.const 1
+  i32.shl
+  local.tee $7
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $1
+  loop $for-loop|0
+   local.get $2
+   local.get $4
+   i32.lt_s
+   if
+    local.get $6
+    local.get $2
+    i32.const 1
+    i32.shl
+    local.tee $8
+    i32.add
+    i32.load16_u
+    local.set $5
+    i32.const 3
+    global.set $~argumentsLength
+    local.get $1
+    local.get $8
+    i32.add
+    local.get $5
+    local.get $5
+    i32.mul
+    i32.store16
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $7
+  i32.store offset=8
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
  (func $~lib/typedarray/Uint16Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
@@ -4139,6 +4351,154 @@
   i32.shl
   i32.add
   i32.load16_u
+ )
+ (func $~lib/typedarray/Int32Array#map (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  local.set $4
+  local.get $3
+  i32.load offset=4
+  local.set $6
+  i32.const 12
+  i32.const 8
+  call $~lib/rt/tlsf/__alloc
+  local.set $0
+  local.get $4
+  i32.const 2
+  i32.shl
+  local.tee $7
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $1
+  loop $for-loop|0
+   local.get $2
+   local.get $4
+   i32.lt_s
+   if
+    local.get $6
+    local.get $2
+    i32.const 2
+    i32.shl
+    local.tee $8
+    i32.add
+    i32.load
+    local.set $5
+    i32.const 3
+    global.set $~argumentsLength
+    local.get $1
+    local.get $8
+    i32.add
+    local.get $5
+    local.get $5
+    i32.mul
+    i32.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $7
+  i32.store offset=8
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint32Array#map (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  local.set $4
+  local.get $3
+  i32.load offset=4
+  local.set $6
+  i32.const 12
+  i32.const 9
+  call $~lib/rt/tlsf/__alloc
+  local.set $0
+  local.get $4
+  i32.const 2
+  i32.shl
+  local.tee $7
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $1
+  loop $for-loop|0
+   local.get $2
+   local.get $4
+   i32.lt_s
+   if
+    local.get $6
+    local.get $2
+    i32.const 2
+    i32.shl
+    local.tee $8
+    i32.add
+    i32.load
+    local.set $5
+    i32.const 3
+    global.set $~argumentsLength
+    local.get $1
+    local.get $8
+    i32.add
+    local.get $5
+    local.get $5
+    i32.mul
+    i32.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $7
+  i32.store offset=8
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint32Array#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -4168,6 +4528,80 @@
   local.get $0
   i64.mul
  )
+ (func $~lib/typedarray/Int64Array#map (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i64)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  local.set $4
+  local.get $3
+  i32.load offset=4
+  local.set $6
+  i32.const 12
+  i32.const 10
+  call $~lib/rt/tlsf/__alloc
+  local.set $0
+  local.get $4
+  i32.const 3
+  i32.shl
+  local.tee $7
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $1
+  loop $for-loop|0
+   local.get $2
+   local.get $4
+   i32.lt_s
+   if
+    local.get $6
+    local.get $2
+    i32.const 3
+    i32.shl
+    local.tee $8
+    i32.add
+    i64.load
+    local.set $5
+    i32.const 3
+    global.set $~argumentsLength
+    local.get $1
+    local.get $8
+    i32.add
+    local.get $5
+    local.get $5
+    i64.mul
+    i64.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $7
+  i32.store offset=8
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
  (func $~lib/typedarray/Int64Array#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
@@ -4190,6 +4624,80 @@
   i32.shl
   i32.add
   i64.load
+ )
+ (func $~lib/typedarray/Uint64Array#map (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i64)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  local.set $4
+  local.get $3
+  i32.load offset=4
+  local.set $6
+  i32.const 12
+  i32.const 11
+  call $~lib/rt/tlsf/__alloc
+  local.set $0
+  local.get $4
+  i32.const 3
+  i32.shl
+  local.tee $7
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $1
+  loop $for-loop|0
+   local.get $2
+   local.get $4
+   i32.lt_s
+   if
+    local.get $6
+    local.get $2
+    i32.const 3
+    i32.shl
+    local.tee $8
+    i32.add
+    i64.load
+    local.set $5
+    i32.const 3
+    global.set $~argumentsLength
+    local.get $1
+    local.get $8
+    i32.add
+    local.get $5
+    local.get $5
+    i64.mul
+    i64.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $7
+  i32.store offset=8
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint64Array#__get (param $0 i32) (param $1 i32) (result i64)
   local.get $1
@@ -4219,6 +4727,80 @@
   local.get $0
   f32.mul
  )
+ (func $~lib/typedarray/Float32Array#map (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 f32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  local.set $4
+  local.get $3
+  i32.load offset=4
+  local.set $6
+  i32.const 12
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  local.set $0
+  local.get $4
+  i32.const 2
+  i32.shl
+  local.tee $7
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $1
+  loop $for-loop|0
+   local.get $2
+   local.get $4
+   i32.lt_s
+   if
+    local.get $6
+    local.get $2
+    i32.const 2
+    i32.shl
+    local.tee $8
+    i32.add
+    f32.load
+    local.set $5
+    i32.const 3
+    global.set $~argumentsLength
+    local.get $1
+    local.get $8
+    i32.add
+    local.get $5
+    local.get $5
+    f32.mul
+    f32.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $7
+  i32.store offset=8
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
  (func $~lib/typedarray/Float32Array#__get (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
@@ -4246,6 +4828,80 @@
   local.get $0
   local.get $0
   f64.mul
+ )
+ (func $~lib/typedarray/Float64Array#map (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 f64)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  local.set $4
+  local.get $3
+  i32.load offset=4
+  local.set $6
+  i32.const 12
+  i32.const 13
+  call $~lib/rt/tlsf/__alloc
+  local.set $0
+  local.get $4
+  i32.const 3
+  i32.shl
+  local.tee $7
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $1
+  loop $for-loop|0
+   local.get $2
+   local.get $4
+   i32.lt_s
+   if
+    local.get $6
+    local.get $2
+    i32.const 3
+    i32.shl
+    local.tee $8
+    i32.add
+    f64.load
+    local.set $5
+    i32.const 3
+    global.set $~argumentsLength
+    local.get $1
+    local.get $8
+    i32.add
+    local.get $5
+    local.get $5
+    f64.mul
+    f64.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $7
+  i32.store offset=8
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -4368,8 +5024,7 @@
   i32.const 16
   i32.add
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
-  (local $0 i32)
+ (func $~lib/typedarray/Int8Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4377,68 +5032,48 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  i32.const 6
-  call $~lib/typedarray/Int8Array#constructor
-  local.tee $1
-  i32.const 0
-  i32.const 1
-  call $~lib/typedarray/Int8Array#__set
-  local.get $1
-  i32.const 1
-  i32.const 2
-  call $~lib/typedarray/Int8Array#__set
-  local.get $1
-  i32.const 2
-  i32.const 3
-  call $~lib/typedarray/Int8Array#__set
-  local.get $1
-  i32.const 3
-  i32.const 4
-  call $~lib/typedarray/Int8Array#__set
-  local.get $1
-  i32.const 5
-  i32.const 5
-  call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
   i32.load offset=8
-  local.set $5
+  local.set $0
   i32.const 12
   i32.const 3
   call $~lib/rt/tlsf/__alloc
-  local.set $4
-  local.get $5
+  local.set $2
+  local.get $0
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $1
+  local.set $5
+  local.get $4
   i32.load offset=4
-  local.set $0
+  local.set $7
   loop $for-loop|0
    local.get $3
-   local.get $5
+   local.get $0
    i32.lt_s
    if
-    local.get $0
     local.get $3
+    local.get $7
     i32.add
     i32.load8_s
-    local.set $7
+    local.set $6
     i32.const 3
     global.set $~argumentsLength
-    local.get $7
+    local.get $6
     local.get $3
-    local.get $1
+    local.get $4
     call $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>~anonymous|0
     if
-     local.get $2
-     local.get $6
+     local.get $1
+     local.get $5
      i32.add
-     local.get $7
+     local.get $6
      i32.store8
-     local.get $2
+     local.get $1
      i32.const 1
      i32.add
-     local.set $2
+     local.set $1
     end
     local.get $3
     i32.const 1
@@ -4447,22 +5082,55 @@
     br $for-loop|0
    end
   end
-  local.get $4
-  local.get $6
   local.get $2
+  local.get $5
+  local.get $1
   call $~lib/rt/tlsf/__realloc
   local.tee $0
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $4
   local.get $2
+  local.get $1
   i32.store offset=8
-  local.get $4
+  local.get $2
   local.get $0
   i32.store offset=4
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 6
+  call $~lib/typedarray/Int8Array#constructor
+  local.tee $2
   call $~lib/rt/pure/__retain
   local.tee $0
+  i32.const 0
+  i32.const 1
+  call $~lib/typedarray/Int8Array#__set
+  local.get $0
+  i32.const 1
+  i32.const 2
+  call $~lib/typedarray/Int8Array#__set
+  local.get $0
+  i32.const 2
+  i32.const 3
+  call $~lib/typedarray/Int8Array#__set
+  local.get $0
+  i32.const 3
+  i32.const 4
+  call $~lib/typedarray/Int8Array#__set
+  local.get $0
+  i32.const 5
+  i32.const 5
+  call $~lib/typedarray/Int8Array#__set
+  local.get $0
+  call $~lib/typedarray/Int8Array#filter
+  local.tee $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   if
    i32.const 0
@@ -4472,7 +5140,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -4484,7 +5152,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 3
@@ -4497,7 +5165,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/typedarray/Int8Array#__get
   i32.const 4
@@ -4510,7 +5178,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   call $~lib/typedarray/Int8Array#__get
   i32.const 5
@@ -4523,9 +5191,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -4535,8 +5205,7 @@
   i32.const 2
   i32.gt_u
  )
- (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
-  (local $0 i32)
+ (func $~lib/typedarray/Uint8Array#filter (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4544,68 +5213,48 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  i32.const 6
-  call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
-  i32.const 0
-  i32.const 1
-  call $~lib/typedarray/Uint8Array#__set
-  local.get $1
-  i32.const 1
-  i32.const 2
-  call $~lib/typedarray/Uint8Array#__set
-  local.get $1
-  i32.const 2
-  i32.const 3
-  call $~lib/typedarray/Uint8Array#__set
-  local.get $1
-  i32.const 3
-  i32.const 4
-  call $~lib/typedarray/Uint8Array#__set
-  local.get $1
-  i32.const 5
-  i32.const 5
-  call $~lib/typedarray/Uint8Array#__set
-  local.get $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
   i32.load offset=8
-  local.set $5
+  local.set $0
   i32.const 12
   i32.const 4
   call $~lib/rt/tlsf/__alloc
-  local.set $4
-  local.get $5
+  local.set $2
+  local.get $0
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $1
+  local.set $5
+  local.get $4
   i32.load offset=4
-  local.set $0
+  local.set $7
   loop $for-loop|0
    local.get $3
-   local.get $5
+   local.get $0
    i32.lt_s
    if
-    local.get $0
     local.get $3
+    local.get $7
     i32.add
     i32.load8_u
-    local.set $7
+    local.set $6
     i32.const 3
     global.set $~argumentsLength
-    local.get $7
+    local.get $6
     local.get $3
-    local.get $1
+    local.get $4
     call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0
     if
-     local.get $2
-     local.get $6
+     local.get $1
+     local.get $5
      i32.add
-     local.get $7
+     local.get $6
      i32.store8
-     local.get $2
+     local.get $1
      i32.const 1
      i32.add
-     local.set $2
+     local.set $1
     end
     local.get $3
     i32.const 1
@@ -4614,22 +5263,55 @@
     br $for-loop|0
    end
   end
-  local.get $4
-  local.get $6
   local.get $2
+  local.get $5
+  local.get $1
   call $~lib/rt/tlsf/__realloc
   local.tee $0
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $4
   local.get $2
+  local.get $1
   i32.store offset=8
-  local.get $4
+  local.get $2
   local.get $0
   i32.store offset=4
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 6
+  call $~lib/typedarray/Uint8Array#constructor
+  local.tee $2
   call $~lib/rt/pure/__retain
   local.tee $0
+  i32.const 0
+  i32.const 1
+  call $~lib/typedarray/Uint8Array#__set
+  local.get $0
+  i32.const 1
+  i32.const 2
+  call $~lib/typedarray/Uint8Array#__set
+  local.get $0
+  i32.const 2
+  i32.const 3
+  call $~lib/typedarray/Uint8Array#__set
+  local.get $0
+  i32.const 3
+  i32.const 4
+  call $~lib/typedarray/Uint8Array#__set
+  local.get $0
+  i32.const 5
+  i32.const 5
+  call $~lib/typedarray/Uint8Array#__set
+  local.get $0
+  call $~lib/typedarray/Uint8Array#filter
+  local.tee $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   if
    i32.const 0
@@ -4639,7 +5321,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -4651,7 +5333,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
   i32.const 3
@@ -4664,7 +5346,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/typedarray/Uint8Array#__get
   i32.const 4
@@ -4677,7 +5359,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   call $~lib/typedarray/Uint8Array#__get
   i32.const 5
@@ -4690,106 +5372,120 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#filter (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  i32.load offset=8
+  local.set $0
+  i32.const 12
+  i32.const 5
+  call $~lib/rt/tlsf/__alloc
+  local.set $2
+  local.get $0
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $5
+  local.get $4
+  i32.load offset=4
+  local.set $7
+  loop $for-loop|0
+   local.get $3
+   local.get $0
+   i32.lt_s
+   if
+    local.get $3
+    local.get $7
+    i32.add
+    i32.load8_u
+    local.set $6
+    i32.const 3
+    global.set $~argumentsLength
+    local.get $6
+    local.get $3
+    local.get $4
+    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0
+    if
+     local.get $1
+     local.get $5
+     i32.add
+     local.get $6
+     i32.store8
+     local.get $1
+     i32.const 1
+     i32.add
+     local.set $1
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  local.get $5
+  local.get $1
+  call $~lib/rt/tlsf/__realloc
+  local.tee $0
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $2
+  local.get $1
+  i32.store offset=8
+  local.get $2
+  local.get $0
+  i32.store offset=4
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
   i32.const 6
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $1
+  local.tee $2
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $1
+  local.get $0
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 5
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $1
-  i32.load offset=8
-  local.set $5
-  i32.const 12
-  i32.const 5
-  call $~lib/rt/tlsf/__alloc
-  local.set $4
-  local.get $5
-  i32.const 0
-  call $~lib/rt/tlsf/__alloc
-  local.set $6
-  local.get $1
-  i32.load offset=4
-  local.set $0
-  loop $for-loop|0
-   local.get $3
-   local.get $5
-   i32.lt_s
-   if
-    local.get $0
-    local.get $3
-    i32.add
-    i32.load8_u
-    local.set $7
-    i32.const 3
-    global.set $~argumentsLength
-    local.get $7
-    local.get $3
-    local.get $1
-    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>~anonymous|0
-    if
-     local.get $2
-     local.get $6
-     i32.add
-     local.get $7
-     i32.store8
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-    end
-    local.get $3
-    i32.const 1
-    i32.add
-    local.set $3
-    br $for-loop|0
-   end
-  end
-  local.get $4
-  local.get $6
-  local.get $2
-  call $~lib/rt/tlsf/__realloc
-  local.tee $0
-  call $~lib/rt/pure/__retain
-  i32.store
-  local.get $4
-  local.get $2
-  i32.store offset=8
-  local.get $4
   local.get $0
-  i32.store offset=4
-  local.get $4
-  call $~lib/rt/pure/__retain
-  local.tee $0
+  call $~lib/typedarray/Uint8ClampedArray#filter
+  local.tee $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   if
    i32.const 0
@@ -4799,7 +5495,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -4811,7 +5507,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 3
@@ -4824,7 +5520,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 4
@@ -4837,7 +5533,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 5
@@ -4850,9 +5546,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -4873,30 +5571,32 @@
   (local $6 i32)
   (local $7 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 6
   call $~lib/rt/tlsf/__alloc
   local.set $2
-  local.get $1
+  local.get $0
   i32.const 1
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  local.get $0
+  local.get $4
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $0
    i32.lt_s
    if
     local.get $7
-    local.get $3
+    local.get $1
     i32.const 1
     i32.shl
     i32.add
@@ -4905,32 +5605,32 @@
     i32.const 3
     global.set $~argumentsLength
     local.get $6
-    local.get $3
-    local.get $0
+    local.get $1
+    local.get $4
     call $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0
     if
      local.get $5
-     local.get $4
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
      local.get $6
      i32.store16
-     local.get $4
+     local.get $3
      i32.const 1
      i32.add
-     local.set $4
+     local.set $3
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
   local.get $5
-  local.get $4
+  local.get $3
   i32.const 1
   i32.shl
   local.tee $0
@@ -4946,12 +5646,17 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.get $4
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 6
   call $~lib/typedarray/Int16Array#constructor
+  local.tee $2
+  call $~lib/rt/pure/__retain
   local.tee $0
   i32.const 0
   i32.const 1
@@ -5037,6 +5742,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
@@ -5058,30 +5765,32 @@
   (local $6 i32)
   (local $7 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 7
   call $~lib/rt/tlsf/__alloc
   local.set $2
-  local.get $1
+  local.get $0
   i32.const 1
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  local.get $0
+  local.get $4
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $3
    local.get $1
+   local.get $0
    i32.lt_s
    if
     local.get $7
-    local.get $3
+    local.get $1
     i32.const 1
     i32.shl
     i32.add
@@ -5090,32 +5799,32 @@
     i32.const 3
     global.set $~argumentsLength
     local.get $6
-    local.get $3
-    local.get $0
+    local.get $1
+    local.get $4
     call $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0
     if
      local.get $5
-     local.get $4
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
      local.get $6
      i32.store16
-     local.get $4
+     local.get $3
      i32.const 1
      i32.add
-     local.set $4
+     local.set $3
     end
-    local.get $3
+    local.get $1
     i32.const 1
     i32.add
-    local.set $3
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $2
   local.get $5
-  local.get $4
+  local.get $3
   i32.const 1
   i32.shl
   local.tee $0
@@ -5131,12 +5840,17 @@
   i32.store offset=4
   local.get $2
   call $~lib/rt/pure/__retain
+  local.get $4
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 6
   call $~lib/typedarray/Uint16Array#constructor
+  local.tee $2
+  call $~lib/rt/pure/__retain
   local.tee $0
   i32.const 0
   i32.const 1
@@ -5222,6 +5936,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
@@ -5239,7 +5955,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -5247,77 +5966,82 @@
   i32.const 12
   i32.const 8
   call $~lib/rt/tlsf/__alloc
-  local.set $2
+  local.set $0
   local.get $4
   i32.const 2
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  local.get $0
+  local.get $3
   i32.load offset=4
-  local.set $6
+  local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
-    local.get $6
-    local.get $1
+    local.get $7
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $0
+    local.set $6
     i32.const 3
     global.set $~argumentsLength
-    local.get $0
+    local.get $6
     i32.const 2
     i32.gt_s
     if
      local.get $5
-     local.get $3
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
-     local.get $0
+     local.get $6
      i32.store
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $0
   local.get $5
-  local.get $3
+  local.get $1
   i32.const 2
   i32.shl
-  local.tee $0
+  local.tee $2
   call $~lib/rt/tlsf/__realloc
   local.tee $1
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
   local.get $0
-  i32.store offset=8
   local.get $2
+  i32.store offset=8
+  local.get $0
   local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 6
   call $~lib/typedarray/Int32Array#constructor
+  local.tee $2
+  call $~lib/rt/pure/__retain
   local.tee $0
   i32.const 0
   i32.const 1
@@ -5403,6 +6127,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
@@ -5420,7 +6146,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -5428,77 +6157,82 @@
   i32.const 12
   i32.const 9
   call $~lib/rt/tlsf/__alloc
-  local.set $2
+  local.set $0
   local.get $4
   i32.const 2
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  local.get $0
+  local.get $3
   i32.load offset=4
-  local.set $6
+  local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
-    local.get $6
-    local.get $1
+    local.get $7
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.set $0
+    local.set $6
     i32.const 3
     global.set $~argumentsLength
-    local.get $0
+    local.get $6
     i32.const 2
     i32.gt_u
     if
      local.get $5
-     local.get $3
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
-     local.get $0
+     local.get $6
      i32.store
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $0
   local.get $5
-  local.get $3
+  local.get $1
   i32.const 2
   i32.shl
-  local.tee $0
+  local.tee $2
   call $~lib/rt/tlsf/__realloc
   local.tee $1
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
   local.get $0
-  i32.store offset=8
   local.get $2
+  i32.store offset=8
+  local.get $0
   local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 6
   call $~lib/typedarray/Uint32Array#constructor
+  local.tee $2
+  call $~lib/rt/pure/__retain
   local.tee $0
   i32.const 0
   i32.const 1
@@ -5584,6 +6318,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
@@ -5601,7 +6337,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i64)
+  (local $7 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 3
   i32.shr_u
@@ -5609,23 +6348,23 @@
   i32.const 12
   i32.const 10
   call $~lib/rt/tlsf/__alloc
-  local.set $2
+  local.set $0
   local.get $4
   i32.const 3
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  local.get $0
+  local.get $3
   i32.load offset=4
-  local.set $0
+  local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
-    local.get $0
-    local.get $1
+    local.get $7
+    local.get $2
     i32.const 3
     i32.shl
     i32.add
@@ -5638,48 +6377,53 @@
     i64.gt_s
     if
      local.get $5
-     local.get $3
+     local.get $1
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      i64.store
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $0
   local.get $5
-  local.get $3
+  local.get $1
   i32.const 3
   i32.shl
-  local.tee $0
+  local.tee $2
   call $~lib/rt/tlsf/__realloc
   local.tee $1
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
   local.get $0
-  i32.store offset=8
   local.get $2
+  i32.store offset=8
+  local.get $0
   local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 6
   call $~lib/typedarray/Int64Array#constructor
+  local.tee $2
+  call $~lib/rt/pure/__retain
   local.tee $0
   i32.const 0
   i64.const 1
@@ -5765,6 +6509,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
@@ -5782,7 +6528,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i64)
+  (local $7 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 3
   i32.shr_u
@@ -5790,23 +6539,23 @@
   i32.const 12
   i32.const 11
   call $~lib/rt/tlsf/__alloc
-  local.set $2
+  local.set $0
   local.get $4
   i32.const 3
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  local.get $0
+  local.get $3
   i32.load offset=4
-  local.set $0
+  local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
-    local.get $0
-    local.get $1
+    local.get $7
+    local.get $2
     i32.const 3
     i32.shl
     i32.add
@@ -5819,48 +6568,53 @@
     i64.gt_u
     if
      local.get $5
-     local.get $3
+     local.get $1
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      i64.store
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $0
   local.get $5
-  local.get $3
+  local.get $1
   i32.const 3
   i32.shl
-  local.tee $0
+  local.tee $2
   call $~lib/rt/tlsf/__realloc
   local.tee $1
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
   local.get $0
-  i32.store offset=8
   local.get $2
+  i32.store offset=8
+  local.get $0
   local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 6
   call $~lib/typedarray/Uint64Array#constructor
+  local.tee $2
+  call $~lib/rt/pure/__retain
   local.tee $0
   i32.const 0
   i64.const 1
@@ -5946,6 +6700,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
@@ -5963,7 +6719,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 f32)
+  (local $7 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -5971,23 +6730,23 @@
   i32.const 12
   i32.const 12
   call $~lib/rt/tlsf/__alloc
-  local.set $2
+  local.set $0
   local.get $4
   i32.const 2
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  local.get $0
+  local.get $3
   i32.load offset=4
-  local.set $0
+  local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
-    local.get $0
-    local.get $1
+    local.get $7
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -6000,48 +6759,53 @@
     f32.gt
     if
      local.get $5
-     local.get $3
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
      local.get $6
      f32.store
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $0
   local.get $5
-  local.get $3
+  local.get $1
   i32.const 2
   i32.shl
-  local.tee $0
+  local.tee $2
   call $~lib/rt/tlsf/__realloc
   local.tee $1
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
   local.get $0
-  i32.store offset=8
   local.get $2
+  i32.store offset=8
+  local.get $0
   local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 6
   call $~lib/typedarray/Float32Array#constructor
+  local.tee $2
+  call $~lib/rt/pure/__retain
   local.tee $0
   i32.const 0
   f32.const 1
@@ -6127,6 +6891,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
@@ -6144,7 +6910,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 f64)
+  (local $7 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 3
   i32.shr_u
@@ -6152,23 +6921,23 @@
   i32.const 12
   i32.const 13
   call $~lib/rt/tlsf/__alloc
-  local.set $2
+  local.set $0
   local.get $4
   i32.const 3
   i32.shl
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  local.get $0
+  local.get $3
   i32.load offset=4
-  local.set $0
+  local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
-    local.get $0
-    local.get $1
+    local.get $7
+    local.get $2
     i32.const 3
     i32.shl
     i32.add
@@ -6181,48 +6950,53 @@
     f64.gt
     if
      local.get $5
-     local.get $3
+     local.get $1
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      f64.store
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $0
   local.get $5
-  local.get $3
+  local.get $1
   i32.const 3
   i32.shl
-  local.tee $0
+  local.tee $2
   call $~lib/rt/tlsf/__realloc
   local.tee $1
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
   local.get $0
-  i32.store offset=8
   local.get $2
+  i32.store offset=8
+  local.get $0
   local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   i32.const 6
   call $~lib/typedarray/Float64Array#constructor
+  local.tee $2
+  call $~lib/rt/pure/__retain
   local.tee $0
   i32.const 0
   f64.const 1
@@ -6308,6 +7082,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
@@ -6327,17 +7103,19 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
   i32.load offset=8
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0
+  block $~lib/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0
+   loop $for-loop|0
+    local.get $2
+    local.get $4
+    i32.lt_s
+    if
      local.get $2
      local.get $3
      i32.add
@@ -6349,6 +7127,8 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      if
+      local.get $0
+      call $~lib/rt/pure/__release
       i32.const 1
       local.set $6
       br $~lib/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0
@@ -6360,6 +7140,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
   end
   local.get $6
  )
@@ -6376,17 +7158,19 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
   i32.load offset=8
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0
+  block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0
+   loop $for-loop|0
+    local.get $2
+    local.get $4
+    i32.lt_s
+    if
      local.get $2
      local.get $3
      i32.add
@@ -6398,6 +7182,8 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      if
+      local.get $0
+      call $~lib/rt/pure/__release
       i32.const 1
       local.set $6
       br $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0
@@ -6409,6 +7195,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
   end
   local.get $6
  )
@@ -6426,6 +7214,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6433,12 +7223,12 @@
   i32.const 1
   i32.shr_u
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0
+  block $~lib/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0
+   loop $for-loop|0
+    local.get $2
+    local.get $4
+    i32.lt_s
+    if
      local.get $3
      local.get $2
      i32.const 1
@@ -6452,6 +7242,8 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      if
+      local.get $0
+      call $~lib/rt/pure/__release
       i32.const 1
       local.set $6
       br $~lib/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0
@@ -6463,6 +7255,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
   end
   local.get $6
  )
@@ -6479,6 +7273,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6486,12 +7282,12 @@
   i32.const 1
   i32.shr_u
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0
+  block $~lib/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0
+   loop $for-loop|0
+    local.get $2
+    local.get $4
+    i32.lt_s
+    if
      local.get $3
      local.get $2
      i32.const 1
@@ -6505,6 +7301,8 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      if
+      local.get $0
+      call $~lib/rt/pure/__release
       i32.const 1
       local.set $6
       br $~lib/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0
@@ -6516,6 +7314,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
   end
   local.get $6
  )
@@ -6531,6 +7331,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6538,12 +7340,12 @@
   i32.const 2
   i32.shr_u
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0
+  block $~lib/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0
+   loop $for-loop|0
+    local.get $2
+    local.get $4
+    i32.lt_s
+    if
      local.get $3
      local.get $2
      i32.const 2
@@ -6557,6 +7359,8 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      if
+      local.get $0
+      call $~lib/rt/pure/__release
       i32.const 1
       local.set $6
       br $~lib/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0
@@ -6568,6 +7372,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
   end
   local.get $6
  )
@@ -6587,6 +7393,8 @@
   (local $5 i64)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6594,12 +7402,12 @@
   i32.const 3
   i32.shr_u
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0
+  block $~lib/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0
+   loop $for-loop|0
+    local.get $2
+    local.get $4
+    i32.lt_s
+    if
      local.get $3
      local.get $2
      i32.const 3
@@ -6613,6 +7421,8 @@
      local.get $1
      call_indirect (type $i64_i32_i32_=>_i32)
      if
+      local.get $0
+      call $~lib/rt/pure/__release
       i32.const 1
       local.set $6
       br $~lib/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0
@@ -6624,6 +7434,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
   end
   local.get $6
  )
@@ -6643,6 +7455,8 @@
   (local $5 f32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6650,12 +7464,12 @@
   i32.const 2
   i32.shr_u
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0
+  block $~lib/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0
+   loop $for-loop|0
+    local.get $2
+    local.get $4
+    i32.lt_s
+    if
      local.get $3
      local.get $2
      i32.const 2
@@ -6669,6 +7483,8 @@
      local.get $1
      call_indirect (type $f32_i32_i32_=>_i32)
      if
+      local.get $0
+      call $~lib/rt/pure/__release
       i32.const 1
       local.set $6
       br $~lib/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0
@@ -6680,6 +7496,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
   end
   local.get $6
  )
@@ -6700,6 +7518,8 @@
   (local $5 f64)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6707,12 +7527,12 @@
   i32.const 3
   i32.shr_u
   local.set $4
-  loop $for-loop|0
-   local.get $2
-   local.get $4
-   i32.lt_s
-   if
-    block $~lib/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0
+  block $~lib/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0
+   loop $for-loop|0
+    local.get $2
+    local.get $4
+    i32.lt_s
+    if
      local.get $3
      local.get $2
      i32.const 3
@@ -6726,6 +7546,8 @@
      local.get $1
      call_indirect (type $f64_i32_i32_=>_i32)
      if
+      local.get $0
+      call $~lib/rt/pure/__release
       i32.const 1
       local.set $6
       br $~lib/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0
@@ -6737,6 +7559,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
   end
   local.get $6
  )
@@ -6751,6 +7575,8 @@
   (local $4 i32)
   (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6772,7 +7598,11 @@
      local.get $0
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -6780,6 +7610,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -6798,6 +7630,8 @@
   (local $4 i32)
   (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6819,7 +7653,11 @@
      local.get $0
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -6827,6 +7665,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -6838,6 +7678,8 @@
   (local $4 i32)
   (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6863,7 +7705,11 @@
      local.get $0
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -6871,6 +7717,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -6889,6 +7737,8 @@
   (local $4 i32)
   (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6914,7 +7764,11 @@
      local.get $0
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -6922,6 +7776,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -6933,6 +7789,8 @@
   (local $4 i32)
   (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -6958,7 +7816,11 @@
      local.get $0
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -6966,6 +7828,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -6982,6 +7846,8 @@
   (local $4 i32)
   (local $5 i64)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7007,7 +7873,11 @@
      local.get $0
      local.get $1
      call_indirect (type $i64_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7015,6 +7885,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -7031,6 +7903,8 @@
   (local $4 i32)
   (local $5 f32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7056,7 +7930,11 @@
      local.get $0
      local.get $1
      call_indirect (type $f32_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7064,6 +7942,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -7080,6 +7960,8 @@
   (local $4 i32)
   (local $5 f64)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7105,7 +7987,11 @@
      local.get $0
      local.get $1
      call_indirect (type $f64_i32_i32_=>_i32)
-     br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7113,6 +7999,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -7124,6 +8012,8 @@
   f64.eq
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   i32.const 24
   i32.shl
@@ -7132,6 +8022,9 @@
   i32.const 2
   i32.rem_s
   i32.eqz
+  local.set $0
+  call $~lib/rt/pure/__release
+  local.get $0
  )
  (func $~lib/typedarray/Int8Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -7140,6 +8033,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7162,7 +8057,11 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7170,6 +8069,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
    local.set $6
   end
@@ -7188,6 +8089,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7210,7 +8113,11 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7218,12 +8125,16 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
    local.set $6
   end
   local.get $6
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   i32.const 16
   i32.shl
@@ -7232,6 +8143,9 @@
   i32.const 2
   i32.rem_s
   i32.eqz
+  local.set $0
+  call $~lib/rt/pure/__release
+  local.get $0
  )
  (func $~lib/typedarray/Int16Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -7240,6 +8154,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7266,7 +8182,11 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7274,6 +8194,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
    local.set $6
   end
@@ -7286,6 +8208,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7312,7 +8236,11 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7320,16 +8248,23 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
    local.set $6
   end
   local.get $6
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   i32.const 2
   i32.rem_s
   i32.eqz
+  local.set $0
+  call $~lib/rt/pure/__release
+  local.get $0
  )
  (func $~lib/typedarray/Int32Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -7338,6 +8273,8 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7364,7 +8301,11 @@
      local.get $1
      call_indirect (type $i32_i32_i32_=>_i32)
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7372,16 +8313,23 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
    local.set $6
   end
   local.get $6
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   i64.const 2
   i64.rem_s
   i64.eqz
+  local.set $2
+  call $~lib/rt/pure/__release
+  local.get $2
  )
  (func $~lib/typedarray/Int64Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -7390,6 +8338,8 @@
   (local $5 i64)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7416,7 +8366,11 @@
      local.get $1
      call_indirect (type $i64_i32_i32_=>_i32)
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7424,16 +8378,23 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
    local.set $6
   end
   local.get $6
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   i64.const 2
   i64.rem_u
   i64.eqz
+  local.set $2
+  call $~lib/rt/pure/__release
+  local.get $2
  )
  (func $~lib/math/NativeMathf.mod (param $0 f32) (result f32)
   (local $1 i32)
@@ -7583,10 +8544,15 @@
   f32.mul
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   call $~lib/math/NativeMathf.mod
   f32.const 0
   f32.eq
+  local.set $2
+  call $~lib/rt/pure/__release
+  local.get $2
  )
  (func $~lib/typedarray/Float32Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -7595,6 +8561,8 @@
   (local $5 f32)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7621,7 +8589,11 @@
      local.get $1
      call_indirect (type $f32_i32_i32_=>_i32)
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7629,6 +8601,8 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
    local.set $6
   end
@@ -7789,10 +8763,15 @@
   f64.mul
  )
  (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
   local.get $0
   call $~lib/math/NativeMath.mod
   f64.const 0
   f64.eq
+  local.set $2
+  call $~lib/rt/pure/__release
+  local.get $2
  )
  (func $~lib/typedarray/Float64Array#every (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -7801,6 +8780,8 @@
   (local $5 f64)
   (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7827,7 +8808,11 @@
      local.get $1
      call_indirect (type $f64_i32_i32_=>_i32)
      i32.eqz
-     br_if $~lib/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -7835,12 +8820,17 @@
      br $for-loop|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const 1
    local.set $6
   end
   local.get $6
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $0
   i32.const 255
   i32.and
@@ -7884,6 +8874,8 @@
   i32.const 1
   i32.add
   global.set $std/typedarray/forEachCallCount
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint8Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -7891,6 +8883,8 @@
   (local $4 i32)
   (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -7918,8 +8912,13 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $0
   i32.const 65535
   i32.and
@@ -7963,8 +8962,13 @@
   i32.const 1
   i32.add
   global.set $std/typedarray/forEachCallCount
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   i32.const 2704
   local.get $1
   call $~lib/array/Array<i32>#__get
@@ -8004,6 +9008,8 @@
   i32.const 1
   i32.add
   global.set $std/typedarray/forEachCallCount
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -8011,6 +9017,8 @@
   (local $4 i32)
   (local $5 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -8042,8 +9050,13 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (param $0 i64) (param $1 i32) (param $2 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $0
   i32.const 2704
   local.get $1
@@ -8084,6 +9097,8 @@
   i32.const 1
   i32.add
   global.set $std/typedarray/forEachCallCount
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#forEach (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -8091,6 +9106,8 @@
   (local $4 i32)
   (local $5 i64)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.load offset=4
   local.set $3
   local.get $0
@@ -8122,8 +9139,13 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (param $0 f32) (param $1 i32) (param $2 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $0
   i32.const 2704
   local.get $1
@@ -8164,8 +9186,13 @@
   i32.const 1
   i32.add
   global.set $std/typedarray/forEachCallCount
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (param $0 f64) (param $1 i32) (param $2 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $0
   i32.const 2704
   local.get $1
@@ -8206,6 +9233,8 @@
   i32.const 1
   i32.add
   global.set $std/typedarray/forEachCallCount
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int8Array#reverse (param $0 i32) (result i32)
   (local $1 i32)
@@ -8269,10 +9298,12 @@
   local.tee $1
   call $~lib/typedarray/Int8Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Int8Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -8410,6 +9441,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -8468,61 +9505,65 @@
   (local $3 i32)
   i32.const 4
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
-  local.tee $2
+  local.tee $0
   i32.const 4
-  local.get $2
+  local.get $0
   i32.lt_s
   select
-  local.set $3
+  local.set $2
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
+   local.get $0
    local.get $1
-   local.get $2
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else
    local.get $1
-   local.get $2
+   local.get $0
    local.get $1
-   local.get $2
+   local.get $0
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 4
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $1
+  local.get $3
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
+  local.get $1
   local.get $2
   local.get $3
-  local.get $0
   i32.load offset=4
   i32.add
   i32.store offset=4
+  local.get $1
+  local.get $0
   local.get $2
-  local.get $1
-  local.get $3
-  local.get $1
-  local.get $3
+  local.get $0
+  local.get $2
   i32.gt_s
   select
-  local.get $3
+  local.get $2
   i32.sub
   i32.store offset=8
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
   (local $0 i32)
@@ -8536,10 +9577,12 @@
   local.tee $1
   call $~lib/typedarray/Uint8Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Uint8Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -8670,6 +9713,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -8678,61 +9727,65 @@
   (local $3 i32)
   i32.const 4
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
-  local.tee $2
+  local.tee $0
   i32.const 4
-  local.get $2
+  local.get $0
   i32.lt_s
   select
-  local.set $3
+  local.set $2
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
+   local.get $0
    local.get $1
-   local.get $2
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else
    local.get $1
-   local.get $2
+   local.get $0
    local.get $1
-   local.get $2
+   local.get $0
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 5
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $1
+  local.get $3
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
+  local.get $1
   local.get $2
   local.get $3
-  local.get $0
   i32.load offset=4
   i32.add
   i32.store offset=4
+  local.get $1
+  local.get $0
   local.get $2
-  local.get $1
-  local.get $3
-  local.get $1
-  local.get $3
+  local.get $0
+  local.get $2
   i32.gt_s
   select
-  local.get $3
+  local.get $2
   i32.sub
   i32.store offset=8
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8>
   (local $0 i32)
@@ -8746,10 +9799,12 @@
   local.tee $1
   call $~lib/typedarray/Uint8ClampedArray#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Uint8ClampedArray#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -8880,6 +9935,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -8944,67 +10005,71 @@
   (local $3 i32)
   i32.const 4
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.tee $2
+  local.tee $0
   i32.const 4
-  local.get $2
+  local.get $0
   i32.lt_s
   select
-  local.set $3
+  local.set $2
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
+   local.get $0
    local.get $1
-   local.get $2
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else
    local.get $1
-   local.get $2
+   local.get $0
    local.get $1
-   local.get $2
+   local.get $0
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 6
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $1
+  local.get $3
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.get $3
+  i32.load offset=4
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
   i32.store offset=4
+  local.get $1
+  local.get $0
   local.get $2
-  local.get $1
-  local.get $3
-  local.get $1
-  local.get $3
+  local.get $0
+  local.get $2
   i32.gt_s
   select
-  local.get $3
+  local.get $2
   i32.sub
   i32.const 1
   i32.shl
   i32.store offset=8
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16>
   (local $0 i32)
@@ -9018,10 +10083,12 @@
   local.tee $1
   call $~lib/typedarray/Int16Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Int16Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -9158,6 +10225,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -9222,67 +10295,71 @@
   (local $3 i32)
   i32.const 4
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.tee $2
+  local.tee $0
   i32.const 4
-  local.get $2
+  local.get $0
   i32.lt_s
   select
-  local.set $3
+  local.set $2
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
+   local.get $0
    local.get $1
-   local.get $2
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else
    local.get $1
-   local.get $2
+   local.get $0
    local.get $1
-   local.get $2
+   local.get $0
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 7
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $1
+  local.get $3
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.get $3
+  i32.load offset=4
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
   i32.store offset=4
+  local.get $1
+  local.get $0
   local.get $2
-  local.get $1
-  local.get $3
-  local.get $1
-  local.get $3
+  local.get $0
+  local.get $2
   i32.gt_s
   select
-  local.get $3
+  local.get $2
   i32.sub
   i32.const 1
   i32.shl
   i32.store offset=8
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16>
   (local $0 i32)
@@ -9296,10 +10373,12 @@
   local.tee $1
   call $~lib/typedarray/Uint16Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Uint16Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -9430,6 +10509,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -9501,10 +10586,12 @@
   local.tee $1
   call $~lib/typedarray/Int32Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Int32Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -9630,6 +10717,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -9638,67 +10731,71 @@
   (local $3 i32)
   i32.const 4
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.tee $2
+  local.tee $0
   i32.const 4
-  local.get $2
+  local.get $0
   i32.lt_s
   select
-  local.set $3
+  local.set $2
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
+   local.get $0
    local.get $1
-   local.get $2
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else
    local.get $1
-   local.get $2
+   local.get $0
    local.get $1
-   local.get $2
+   local.get $0
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 9
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $1
+  local.get $3
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.get $3
+  i32.load offset=4
+  local.get $2
   i32.const 2
   i32.shl
   i32.add
   i32.store offset=4
+  local.get $1
+  local.get $0
   local.get $2
-  local.get $1
-  local.get $3
-  local.get $1
-  local.get $3
+  local.get $0
+  local.get $2
   i32.gt_s
   select
-  local.get $3
+  local.get $2
   i32.sub
   i32.const 2
   i32.shl
   i32.store offset=8
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32>
   (local $0 i32)
@@ -9712,10 +10809,12 @@
   local.tee $1
   call $~lib/typedarray/Uint32Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Uint32Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -9840,6 +10939,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -9904,67 +11009,71 @@
   (local $3 i32)
   i32.const 4
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.tee $2
+  local.tee $0
   i32.const 4
-  local.get $2
+  local.get $0
   i32.lt_s
   select
-  local.set $3
+  local.set $2
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
+   local.get $0
    local.get $1
-   local.get $2
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else
    local.get $1
-   local.get $2
+   local.get $0
    local.get $1
-   local.get $2
+   local.get $0
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 10
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $1
+  local.get $3
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.get $3
+  i32.load offset=4
+  local.get $2
   i32.const 3
   i32.shl
   i32.add
   i32.store offset=4
+  local.get $1
+  local.get $0
   local.get $2
-  local.get $1
-  local.get $3
-  local.get $1
-  local.get $3
+  local.get $0
+  local.get $2
   i32.gt_s
   select
-  local.get $3
+  local.get $2
   i32.sub
   i32.const 3
   i32.shl
   i32.store offset=8
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
   (local $0 i32)
@@ -9978,10 +11087,12 @@
   local.tee $1
   call $~lib/typedarray/Int64Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Int64Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -10109,6 +11220,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -10117,67 +11234,71 @@
   (local $3 i32)
   i32.const 4
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.tee $2
+  local.tee $0
   i32.const 4
-  local.get $2
+  local.get $0
   i32.lt_s
   select
-  local.set $3
+  local.set $2
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
+   local.get $0
    local.get $1
-   local.get $2
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else
    local.get $1
-   local.get $2
+   local.get $0
    local.get $1
-   local.get $2
+   local.get $0
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 11
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $1
+  local.get $3
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.get $3
+  i32.load offset=4
+  local.get $2
   i32.const 3
   i32.shl
   i32.add
   i32.store offset=4
+  local.get $1
+  local.get $0
   local.get $2
-  local.get $1
-  local.get $3
-  local.get $1
-  local.get $3
+  local.get $0
+  local.get $2
   i32.gt_s
   select
-  local.get $3
+  local.get $2
   i32.sub
   i32.const 3
   i32.shl
   i32.store offset=8
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64>
   (local $0 i32)
@@ -10191,10 +11312,12 @@
   local.tee $1
   call $~lib/typedarray/Uint64Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Uint64Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -10322,6 +11445,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -10386,67 +11515,71 @@
   (local $3 i32)
   i32.const 4
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.tee $2
+  local.tee $0
   i32.const 4
-  local.get $2
+  local.get $0
   i32.lt_s
   select
-  local.set $3
+  local.set $2
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
+   local.get $0
    local.get $1
-   local.get $2
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 0
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else
    local.get $1
-   local.get $2
+   local.get $0
    local.get $1
-   local.get $2
+   local.get $0
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $0
   i32.const 12
   i32.const 12
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $1
+  local.get $3
   i32.load
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.get $3
+  i32.load offset=4
+  local.get $2
   i32.const 2
   i32.shl
   i32.add
   i32.store offset=4
+  local.get $1
+  local.get $0
   local.get $2
-  local.get $1
-  local.get $3
-  local.get $1
-  local.get $3
+  local.get $0
+  local.get $2
   i32.gt_s
   select
-  local.get $3
+  local.get $2
   i32.sub
   i32.const 2
   i32.shl
   i32.store offset=8
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32>
   (local $0 i32)
@@ -10460,10 +11593,12 @@
   local.tee $1
   call $~lib/typedarray/Float32Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Float32Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -10591,6 +11726,12 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
@@ -10662,10 +11803,12 @@
   local.tee $1
   call $~lib/typedarray/Float64Array#constructor
   local.tee $4
+  call $~lib/rt/pure/__retain
   local.set $2
   local.get $1
   call $~lib/typedarray/Float64Array#constructor
   local.tee $5
+  call $~lib/rt/pure/__retain
   local.set $3
   loop $for-loop|0
    local.get $0
@@ -10794,13 +11937,22 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  i32.const 2800
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int8Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
+  (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    local.tee $3
    if (result i32)
@@ -10811,6 +11963,8 @@
     i32.const 1
    end
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
@@ -10832,21 +11986,25 @@
    end
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $4
    loop $while-continue|0
     local.get $2
     local.get $3
     i32.lt_s
     if
-     local.get $0
      local.get $2
+     local.get $4
      i32.add
      i32.load8_u
      local.get $1
      i32.const 255
      i32.and
      i32.eq
-     br_if $~lib/typedarray/INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -10854,6 +12012,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -10863,10 +12023,14 @@
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    local.tee $3
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
@@ -10889,21 +12053,25 @@
    local.set $2
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $3
    loop $while-continue|0
     local.get $2
     i32.const 0
     i32.ge_s
     if
-     local.get $0
      local.get $2
+     local.get $3
      i32.add
      i32.load8_u
      local.get $1
      i32.const 255
      i32.and
      i32.eq
-     br_if $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.sub
@@ -10911,6 +12079,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -10949,6 +12119,7 @@
   local.get $0
   call $~lib/typedarray/Int8Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -11242,7 +12413,7 @@
   i32.const 4
   i32.const 9
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11256,7 +12427,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11268,7 +12439,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11282,7 +12453,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 9
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11296,7 +12467,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11310,7 +12481,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 11
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11324,7 +12495,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 1
   call $~lib/typedarray/Int8Array#indexOf
@@ -11338,7 +12509,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 2
   call $~lib/typedarray/Int8Array#indexOf
@@ -11354,7 +12525,11 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8>
@@ -11369,6 +12544,7 @@
   local.get $0
   call $~lib/typedarray/Uint8Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -11659,7 +12835,7 @@
   local.get $0
   i32.const 9
   call $~lib/typedarray/Uint8Array#subarray
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11673,7 +12849,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11685,7 +12861,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11699,7 +12875,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 9
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11713,7 +12889,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11727,7 +12903,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 11
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -11741,7 +12917,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 1
   call $~lib/typedarray/Int8Array#indexOf
@@ -11755,7 +12931,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 2
   call $~lib/typedarray/Int8Array#indexOf
@@ -11771,7 +12947,11 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8>
@@ -11786,6 +12966,7 @@
   local.get $0
   call $~lib/typedarray/Uint8ClampedArray#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -12076,7 +13257,7 @@
   local.get $0
   i32.const 9
   call $~lib/typedarray/Uint8ClampedArray#subarray
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -12090,7 +13271,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -12102,7 +13283,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -12116,7 +13297,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 9
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -12130,7 +13311,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -12144,7 +13325,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 11
   i32.const 0
   call $~lib/typedarray/Int8Array#indexOf
@@ -12158,7 +13339,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 1
   call $~lib/typedarray/Int8Array#indexOf
@@ -12172,7 +13353,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 2
   call $~lib/typedarray/Int8Array#indexOf
@@ -12188,13 +13369,20 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
+  (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 1
    i32.shr_u
@@ -12207,6 +13395,8 @@
     i32.const 1
    end
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
@@ -12228,13 +13418,13 @@
    end
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $4
    loop $while-continue|0
     local.get $2
     local.get $3
     i32.lt_s
     if
-     local.get $0
+     local.get $4
      local.get $2
      i32.const 1
      i32.shl
@@ -12244,7 +13434,11 @@
      i32.const 65535
      i32.and
      i32.eq
-     br_if $~lib/typedarray/INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -12252,6 +13446,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -12261,12 +13457,16 @@
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 1
    i32.shr_u
    local.tee $3
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
@@ -12289,13 +13489,13 @@
    local.set $2
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $3
    loop $while-continue|0
     local.get $2
     i32.const 0
     i32.ge_s
     if
-     local.get $0
+     local.get $3
      local.get $2
      i32.const 1
      i32.shl
@@ -12305,7 +13505,11 @@
      i32.const 65535
      i32.and
      i32.eq
-     br_if $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.sub
@@ -12313,6 +13517,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -12353,6 +13559,7 @@
   local.get $0
   call $~lib/typedarray/Int16Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -12645,7 +13852,7 @@
   local.get $0
   i32.const 9
   call $~lib/typedarray/Int16Array#subarray
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -12659,7 +13866,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -12671,7 +13878,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -12685,7 +13892,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 9
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -12699,7 +13906,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -12713,7 +13920,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 11
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -12727,7 +13934,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 1
   call $~lib/typedarray/Int16Array#indexOf
@@ -12741,7 +13948,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 2
   call $~lib/typedarray/Int16Array#indexOf
@@ -12757,7 +13964,11 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16>
@@ -12772,6 +13983,7 @@
   local.get $0
   call $~lib/typedarray/Uint16Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -13062,7 +14274,7 @@
   local.get $0
   i32.const 9
   call $~lib/typedarray/Uint16Array#subarray
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -13076,7 +14288,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -13088,7 +14300,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -13102,7 +14314,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 9
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -13116,7 +14328,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -13130,7 +14342,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 11
   i32.const 0
   call $~lib/typedarray/Int16Array#indexOf
@@ -13144,7 +14356,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 1
   call $~lib/typedarray/Int16Array#indexOf
@@ -13158,7 +14370,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 2
   call $~lib/typedarray/Int16Array#indexOf
@@ -13174,13 +14386,20 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
+  (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 2
    i32.shr_u
@@ -13193,6 +14412,8 @@
     i32.const 1
    end
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
@@ -13214,21 +14435,25 @@
    end
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $4
    loop $while-continue|0
     local.get $2
     local.get $3
     i32.lt_s
     if
      local.get $1
-     local.get $0
+     local.get $4
      local.get $2
      i32.const 2
      i32.shl
      i32.add
      i32.load
      i32.eq
-     br_if $~lib/typedarray/INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -13236,6 +14461,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -13245,12 +14472,16 @@
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 2
    i32.shr_u
    local.tee $3
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
@@ -13273,21 +14504,25 @@
    local.set $2
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $3
    loop $while-continue|0
     local.get $2
     i32.const 0
     i32.ge_s
     if
      local.get $1
-     local.get $0
+     local.get $3
      local.get $2
      i32.const 2
      i32.shl
      i32.add
      i32.load
      i32.eq
-     br_if $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.sub
@@ -13295,6 +14530,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -13335,6 +14572,7 @@
   local.get $0
   call $~lib/typedarray/Int32Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -13624,7 +14862,7 @@
   i32.const 4
   i32.const 9
   call $~lib/typedarray/Int32Array#subarray
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -13638,7 +14876,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -13650,7 +14888,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -13664,7 +14902,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 9
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -13678,7 +14916,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -13692,7 +14930,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 11
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -13706,7 +14944,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 1
   call $~lib/typedarray/Int32Array#indexOf
@@ -13720,7 +14958,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 2
   call $~lib/typedarray/Int32Array#indexOf
@@ -13736,7 +14974,11 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32>
@@ -13751,6 +14993,7 @@
   local.get $0
   call $~lib/typedarray/Uint32Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -14039,7 +15282,7 @@
   local.get $0
   i32.const 9
   call $~lib/typedarray/Uint32Array#subarray
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -14053,7 +15296,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 4
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -14065,7 +15308,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -14079,7 +15322,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 9
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -14093,7 +15336,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -14107,7 +15350,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 11
   i32.const 0
   call $~lib/typedarray/Int32Array#indexOf
@@ -14121,7 +15364,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 1
   call $~lib/typedarray/Int32Array#indexOf
@@ -14135,7 +15378,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 5
   i32.const 2
   call $~lib/typedarray/Int32Array#indexOf
@@ -14151,13 +15394,20 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#indexOf (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
+  (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 3
    i32.shr_u
@@ -14170,6 +15420,8 @@
     i32.const 1
    end
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
@@ -14191,21 +15443,25 @@
    end
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $4
    loop $while-continue|0
     local.get $2
     local.get $3
     i32.lt_s
     if
      local.get $1
-     local.get $0
+     local.get $4
      local.get $2
      i32.const 3
      i32.shl
      i32.add
      i64.load
      i64.eq
-     br_if $~lib/typedarray/INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -14213,6 +15469,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -14222,12 +15480,16 @@
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 3
    i32.shr_u
    local.tee $3
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
@@ -14250,21 +15512,25 @@
    local.set $2
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $3
    loop $while-continue|0
     local.get $2
     i32.const 0
     i32.ge_s
     if
      local.get $1
-     local.get $0
+     local.get $3
      local.get $2
      i32.const 3
      i32.shl
      i32.add
      i64.load
      i64.eq
-     br_if $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.sub
@@ -14272,6 +15538,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -14312,6 +15580,7 @@
   local.get $0
   call $~lib/typedarray/Int64Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -14601,7 +15870,7 @@
   local.get $0
   i32.const 9
   call $~lib/typedarray/Int64Array#subarray
-  local.tee $0
+  local.tee $1
   i64.const 3
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -14615,7 +15884,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 4
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -14627,7 +15896,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 5
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -14641,7 +15910,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 9
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -14655,7 +15924,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 10
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -14669,7 +15938,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 11
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -14683,7 +15952,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 5
   i32.const 1
   call $~lib/typedarray/Int64Array#indexOf
@@ -14697,7 +15966,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 5
   i32.const 2
   call $~lib/typedarray/Int64Array#indexOf
@@ -14713,7 +15982,11 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64>
@@ -14728,6 +16001,7 @@
   local.get $0
   call $~lib/typedarray/Uint64Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -15017,7 +16291,7 @@
   local.get $0
   i32.const 9
   call $~lib/typedarray/Uint64Array#subarray
-  local.tee $0
+  local.tee $1
   i64.const 3
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -15031,7 +16305,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 4
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -15043,7 +16317,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 5
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -15057,7 +16331,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 9
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -15071,7 +16345,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 10
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -15085,7 +16359,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 11
   i32.const 0
   call $~lib/typedarray/Int64Array#indexOf
@@ -15099,7 +16373,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 5
   i32.const 1
   call $~lib/typedarray/Int64Array#indexOf
@@ -15113,7 +16387,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i64.const 5
   i32.const 2
   call $~lib/typedarray/Int64Array#indexOf
@@ -15129,13 +16403,20 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Float32Array#indexOf (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
+  (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 2
    i32.shr_u
@@ -15148,6 +16429,8 @@
     i32.const 1
    end
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
@@ -15169,13 +16452,13 @@
    end
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $4
    loop $while-continue|0
     local.get $2
     local.get $3
     i32.lt_s
     if
-     local.get $0
+     local.get $4
      local.get $2
      i32.const 2
      i32.shl
@@ -15183,7 +16466,11 @@
      f32.load
      local.get $1
      f32.eq
-     br_if $~lib/typedarray/INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -15191,6 +16478,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -15200,12 +16489,16 @@
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 2
    i32.shr_u
    local.tee $3
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
@@ -15228,13 +16521,13 @@
    local.set $2
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $3
    loop $while-continue|0
     local.get $2
     i32.const 0
     i32.ge_s
     if
-     local.get $0
+     local.get $3
      local.get $2
      i32.const 2
      i32.shl
@@ -15242,7 +16535,11 @@
      f32.load
      local.get $1
      f32.eq
-     br_if $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.sub
@@ -15250,6 +16547,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -15290,6 +16589,7 @@
   local.get $0
   call $~lib/typedarray/Float32Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -15579,7 +16879,7 @@
   local.get $0
   i32.const 9
   call $~lib/typedarray/Float32Array#subarray
-  local.tee $0
+  local.tee $1
   f32.const 3
   i32.const 0
   call $~lib/typedarray/Float32Array#indexOf
@@ -15593,7 +16893,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f32.const 4
   i32.const 0
   call $~lib/typedarray/Float32Array#indexOf
@@ -15605,7 +16905,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f32.const 5
   i32.const 0
   call $~lib/typedarray/Float32Array#indexOf
@@ -15619,7 +16919,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f32.const 9
   i32.const 0
   call $~lib/typedarray/Float32Array#indexOf
@@ -15633,7 +16933,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f32.const 10
   i32.const 0
   call $~lib/typedarray/Float32Array#indexOf
@@ -15647,7 +16947,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f32.const 11
   i32.const 0
   call $~lib/typedarray/Float32Array#indexOf
@@ -15661,7 +16961,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f32.const 5
   i32.const 1
   call $~lib/typedarray/Float32Array#indexOf
@@ -15675,7 +16975,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f32.const 5
   i32.const 2
   call $~lib/typedarray/Float32Array#indexOf
@@ -15691,13 +16991,20 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Float64Array#indexOf (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
+  (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 3
    i32.shr_u
@@ -15710,6 +17017,8 @@
     i32.const 1
    end
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
@@ -15731,13 +17040,13 @@
    end
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $4
    loop $while-continue|0
     local.get $2
     local.get $3
     i32.lt_s
     if
-     local.get $0
+     local.get $4
      local.get $2
      i32.const 3
      i32.shl
@@ -15745,7 +17054,11 @@
      f64.load
      local.get $1
      f64.eq
-     br_if $~lib/typedarray/INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.add
@@ -15753,6 +17066,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -15762,12 +17077,16 @@
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
+   call $~lib/rt/pure/__retain
+   local.tee $0
    i32.load offset=8
    i32.const 3
    i32.shr_u
    local.tee $3
    i32.eqz
    if
+    local.get $0
+    call $~lib/rt/pure/__release
     i32.const -1
     local.set $2
     br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
@@ -15790,13 +17109,13 @@
    local.set $2
    local.get $0
    i32.load offset=4
-   local.set $0
+   local.set $3
    loop $while-continue|0
     local.get $2
     i32.const 0
     i32.ge_s
     if
-     local.get $0
+     local.get $3
      local.get $2
      i32.const 3
      i32.shl
@@ -15804,7 +17123,11 @@
      f64.load
      local.get $1
      f64.eq
-     br_if $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
+     if
+      local.get $0
+      call $~lib/rt/pure/__release
+      br $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
+     end
      local.get $2
      i32.const 1
      i32.sub
@@ -15812,6 +17135,8 @@
      br $while-continue|0
     end
    end
+   local.get $0
+   call $~lib/rt/pure/__release
    i32.const -1
    local.set $2
   end
@@ -15852,6 +17177,7 @@
   local.get $0
   call $~lib/typedarray/Float64Array#constructor
   local.tee $3
+  call $~lib/rt/pure/__retain
   local.set $0
   loop $for-loop|0
    local.get $1
@@ -16142,7 +17468,7 @@
   i32.const 4
   i32.const 9
   call $~lib/typedarray/Float64Array#subarray
-  local.tee $0
+  local.tee $1
   f64.const 3
   i32.const 0
   call $~lib/typedarray/Float64Array#indexOf
@@ -16156,7 +17482,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f64.const 4
   i32.const 0
   call $~lib/typedarray/Float64Array#indexOf
@@ -16168,7 +17494,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f64.const 5
   i32.const 0
   call $~lib/typedarray/Float64Array#indexOf
@@ -16182,7 +17508,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f64.const 9
   i32.const 0
   call $~lib/typedarray/Float64Array#indexOf
@@ -16196,7 +17522,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f64.const 10
   i32.const 0
   call $~lib/typedarray/Float64Array#indexOf
@@ -16210,7 +17536,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f64.const 11
   i32.const 0
   call $~lib/typedarray/Float64Array#indexOf
@@ -16224,7 +17550,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f64.const 5
   i32.const 1
   call $~lib/typedarray/Float64Array#indexOf
@@ -16238,7 +17564,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   f64.const 5
   i32.const 2
   call $~lib/typedarray/Float64Array#indexOf
@@ -16254,7 +17580,11 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
+  i32.const 2896
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
@@ -16516,40 +17846,47 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load8_s
    call $~lib/util/number/itoa32
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 3264
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 11
   i32.add
   i32.mul
   i32.const 11
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -16557,53 +17894,53 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $5
+    local.get $6
     i32.add
     i32.load8_s
     call $~lib/util/number/itoa_stream<i8>
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $4
+    local.set $3
+    local.get $5
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $4
+     local.get $2
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.add
   i32.load8_s
   call $~lib/util/number/itoa_stream<i8>
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -16611,10 +17948,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Int8Array#join (param $0 i32) (result i32)
@@ -16622,15 +17963,26 @@
   i32.load offset=4
   local.get $0
   i32.load offset=8
+  i32.const 3264
   call $~lib/util/string/joinIntegerArray<i8>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  local.tee $3
   i32.const 7
   i32.and
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  local.tee $1
   i32.const 7
   i32.and
   i32.or
@@ -16642,16 +17994,16 @@
   select
   if
    loop $do-continue|0
-    local.get $0
+    local.get $3
     i64.load
     local.get $1
     i64.load
     i64.eq
     if
-     local.get $0
+     local.get $3
      i32.const 8
      i32.add
-     local.set $0
+     local.set $3
      local.get $1
      i32.const 8
      i32.add
@@ -16668,29 +18020,33 @@
   end
   loop $while-continue|1
    local.get $2
-   local.tee $3
+   local.tee $0
    i32.const 1
    i32.sub
    local.set $2
-   local.get $3
+   local.get $0
    if
-    local.get $0
+    local.get $3
     i32.load16_u
-    local.tee $3
+    local.tee $0
     local.get $1
     i32.load16_u
-    local.tee $4
+    local.tee $6
     i32.ne
     if
-     local.get $3
      local.get $4
+     call $~lib/rt/pure/__release
+     local.get $5
+     call $~lib/rt/pure/__release
+     local.get $0
+     local.get $6
      i32.sub
      return
     end
-    local.get $0
+    local.get $3
     i32.const 2
     i32.add
-    local.set $0
+    local.set $3
     local.get $1
     i32.const 2
     i32.add
@@ -16698,14 +18054,26 @@
     br $while-continue|1
    end
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.eq
   if
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    i32.const 1
    return
   end
@@ -16728,8 +18096,16 @@
    local.get $2
    call $~lib/util/string/compareImpl
    i32.eqz
+   local.get $0
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    return
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   i32.const 0
  )
  (func $~lib/util/number/utoa32 (param $0 i32) (result i32)
@@ -16790,40 +18166,47 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load8_u
    call $~lib/util/number/utoa32
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 3264
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 10
   i32.add
   i32.mul
   i32.const 10
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -16831,53 +18214,53 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $5
+    local.get $6
     i32.add
     i32.load8_u
     call $~lib/util/number/itoa_stream<u8>
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $4
+    local.set $3
+    local.get $5
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $4
+     local.get $2
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.add
   i32.load8_u
   call $~lib/util/number/itoa_stream<u8>
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -16885,10 +18268,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Uint8Array#join (param $0 i32) (result i32)
@@ -16896,7 +18283,10 @@
   i32.load offset=4
   local.get $0
   i32.load offset=8
+  i32.const 3264
   call $~lib/util/string/joinIntegerArray<u8>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/itoa_stream<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -16964,40 +18354,47 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<i16> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load16_s
    call $~lib/util/number/itoa32
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 3264
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 11
   i32.add
   i32.mul
   i32.const 11
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -17005,57 +18402,57 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s
     call $~lib/util/number/itoa_stream<i16>
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $4
+    local.set $3
+    local.get $5
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $4
+     local.get $2
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.const 1
   i32.shl
   i32.add
   i32.load16_s
   call $~lib/util/number/itoa_stream<i16>
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -17063,10 +18460,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Int16Array#join (param $0 i32) (result i32)
@@ -17076,7 +18477,10 @@
   i32.load offset=8
   i32.const 1
   i32.shr_u
+  i32.const 3264
   call $~lib/util/string/joinIntegerArray<i16>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -17113,40 +18517,47 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load16_u
    call $~lib/util/number/utoa32
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 3264
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 10
   i32.add
   i32.mul
   i32.const 10
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -17154,57 +18565,57 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u
     call $~lib/util/number/itoa_stream<u16>
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $4
+    local.set $3
+    local.get $5
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $4
+     local.get $2
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.const 1
   i32.shl
   i32.add
   i32.load16_u
   call $~lib/util/number/itoa_stream<u16>
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -17212,10 +18623,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Uint16Array#join (param $0 i32) (result i32)
@@ -17225,7 +18640,10 @@
   i32.load offset=8
   i32.const 1
   i32.shr_u
+  i32.const 3264
   call $~lib/util/string/joinIntegerArray<u16>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/itoa_stream<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -17275,40 +18693,47 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load
    call $~lib/util/number/itoa32
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 3264
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 11
   i32.add
   i32.mul
   i32.const 11
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -17316,57 +18741,57 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     i32.load
     call $~lib/util/number/itoa_stream<i32>
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $4
+    local.set $3
+    local.get $5
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $4
+     local.get $2
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
   i32.load
   call $~lib/util/number/itoa_stream<i32>
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -17374,10 +18799,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Int32Array#join (param $0 i32) (result i32)
@@ -17387,7 +18816,10 @@
   i32.load offset=8
   i32.const 2
   i32.shr_u
+  i32.const 3264
   call $~lib/util/string/joinIntegerArray<i32>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/itoa_stream<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -17416,40 +18848,47 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    i32.load
    call $~lib/util/number/utoa32
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 3264
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 10
   i32.add
   i32.mul
   i32.const 10
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -17457,57 +18896,57 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     i32.load
     call $~lib/util/number/itoa_stream<u32>
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $4
+    local.set $3
+    local.get $5
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $4
+     local.get $2
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
   i32.load
   call $~lib/util/number/itoa_stream<u32>
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -17515,10 +18954,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Uint32Array#join (param $0 i32) (result i32)
@@ -17528,7 +18971,10 @@
   i32.load offset=8
   i32.const 2
   i32.shr_u
+  i32.const 3264
   call $~lib/util/string/joinIntegerArray<u32>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
@@ -17672,24 +19118,29 @@
   end
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i64)
-  (local $4 i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $4
+  local.get $5
   i32.eqz
   if
    block $__inlined_func$~lib/util/number/itoa64 (result i32)
@@ -17698,53 +19149,53 @@
     i64.load
     i32.wrap_i64
     i64.extend_i32_s
-    local.tee $3
+    local.tee $4
     i64.eqz
     br_if $__inlined_func$~lib/util/number/itoa64
     drop
-    local.get $3
+    local.get $4
     i64.const 63
     i64.shr_u
     i32.wrap_i64
     local.tee $0
     if
      i64.const 0
-     local.get $3
+     local.get $4
      i64.sub
-     local.set $3
+     local.set $4
     end
-    local.get $3
+    local.get $4
     i64.const 4294967295
     i64.le_u
     if
-     local.get $3
+     local.get $4
      i32.wrap_i64
-     local.tee $2
+     local.tee $3
      call $~lib/util/number/decimalCount32
      local.get $0
      i32.add
-     local.tee $4
+     local.tee $5
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $1
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      call $~lib/util/number/utoa_dec_simple<u32>
     else
-     local.get $3
+     local.get $4
      call $~lib/util/number/decimalCount64High
      local.get $0
      i32.add
-     local.tee $2
+     local.tee $3
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $1
+     local.get $4
      local.get $3
-     local.get $2
      call $~lib/util/number/utoa_dec_simple<u64>
     end
     local.get $0
@@ -17756,18 +19207,20 @@
     local.get $1
     call $~lib/rt/pure/__retain
    end
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $4
-  i32.const 3264
+  local.get $5
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $5
+  local.tee $6
   i32.const 21
   i32.add
   i32.mul
   i32.const 21
   i32.add
-  local.tee $7
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
@@ -17775,57 +19228,57 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
     i64.load
     call $~lib/util/number/itoa_stream<i64>
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $5
+    local.set $3
+    local.get $6
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $5
+     local.get $2
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $5
+     local.get $3
+     local.get $6
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $7
+  local.get $8
   local.get $1
-  local.get $2
+  local.get $3
   local.get $0
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.add
   i64.load
   call $~lib/util/number/itoa_stream<i64>
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -17833,10 +19286,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Int64Array#join (param $0 i32) (result i32)
@@ -17846,7 +19303,10 @@
   i32.load offset=8
   i32.const 3
   i32.shr_u
+  i32.const 3264
   call $~lib/util/string/joinIntegerArray<i64>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/itoa_stream<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
@@ -17891,53 +19351,58 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
-  (local $4 i64)
-  (local $5 i32)
+  (local $4 i32)
+  (local $5 i64)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    block $__inlined_func$~lib/util/number/utoa64 (result i32)
     i32.const 3136
     local.get $0
     i64.load
-    local.tee $4
+    local.tee $5
     i64.eqz
     br_if $__inlined_func$~lib/util/number/utoa64
     drop
-    local.get $4
+    local.get $5
     i64.const 4294967295
     i64.le_u
     if
-     local.get $4
+     local.get $5
      i32.wrap_i64
      local.tee $1
      call $~lib/util/number/decimalCount32
-     local.tee $2
+     local.tee $3
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $0
      local.get $1
-     local.get $2
+     local.get $3
      call $~lib/util/number/utoa_dec_simple<u32>
     else
-     local.get $4
+     local.get $5
      call $~lib/util/number/decimalCount64High
      local.tee $1
      i32.const 1
@@ -17945,25 +19410,27 @@
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $0
-     local.get $4
+     local.get $5
      local.get $1
      call $~lib/util/number/utoa_dec_simple<u64>
     end
     local.get $0
     call $~lib/rt/pure/__retain
    end
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 3264
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $5
+  local.tee $6
   i32.const 20
   i32.add
   i32.mul
   i32.const 20
   i32.add
-  local.tee $7
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
@@ -17971,57 +19438,57 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $6
-   local.get $3
+   local.get $7
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
     i64.load
     call $~lib/util/number/itoa_stream<u64>
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $5
+    local.set $3
+    local.get $6
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $5
+     local.get $2
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $5
+     local.get $3
+     local.get $6
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $7
+  local.get $8
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.const 3
   i32.shl
   i32.add
   i64.load
   call $~lib/util/number/itoa_stream<u64>
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -18029,10 +19496,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Uint64Array#join (param $0 i32) (result i32)
@@ -18042,7 +19513,10 @@
   i32.load offset=8
   i32.const 3
   i32.shr_u
+  i32.const 3264
   call $~lib/util/string/joinIntegerArray<u64>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
@@ -19100,41 +20574,48 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f32> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinFloatArray<f32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    f32.load
    f64.promote_f32
    call $~lib/util/number/dtoa
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 3264
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 28
   i32.add
   i32.mul
   i32.const 28
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -19142,59 +20623,59 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     f32.load
     f64.promote_f32
     call $~lib/util/number/dtoa_stream
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $4
+    local.set $3
+    local.get $5
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $4
+     local.get $2
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
   f32.load
   f64.promote_f32
   call $~lib/util/number/dtoa_stream
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -19202,10 +20683,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Float32Array#join (param $0 i32) (result i32)
@@ -19215,42 +20700,52 @@
   i32.load offset=8
   i32.const 2
   i32.shr_u
+  i32.const 3264
   call $~lib/util/string/joinFloatArray<f32>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $2
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
+   local.get $2
+   call $~lib/rt/pure/__release
    i32.const 2928
    return
   end
-  local.get $3
+  local.get $4
   i32.eqz
   if
    local.get $0
    f64.load
    call $~lib/util/number/dtoa
+   local.get $2
+   call $~lib/rt/pure/__release
    return
   end
-  local.get $3
-  i32.const 3264
+  local.get $4
+  local.get $2
   call $~lib/string/String#get:length
-  local.tee $4
+  local.tee $5
   i32.const 28
   i32.add
   i32.mul
   i32.const 28
   i32.add
-  local.tee $6
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
@@ -19258,57 +20753,57 @@
   call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
-   local.get $5
-   local.get $3
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $2
+    local.get $3
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 3
     i32.shl
     i32.add
     f64.load
     call $~lib/util/number/dtoa_stream
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $4
+    local.set $3
+    local.get $5
     if
      local.get $1
-     local.get $2
+     local.get $3
      i32.const 1
      i32.shl
      i32.add
-     i32.const 3264
-     local.get $4
+     local.get $2
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $3
+     local.get $5
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $6
+  local.get $7
   local.get $1
-  local.get $2
-  local.get $0
   local.get $3
+  local.get $0
+  local.get $4
   i32.const 3
   i32.shl
   i32.add
   f64.load
   call $~lib/util/number/dtoa_stream
-  local.get $2
+  local.get $3
   i32.add
   local.tee $0
   i32.gt_s
@@ -19316,10 +20811,14 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
  )
  (func $~lib/typedarray/Float64Array#join (param $0 i32) (result i32)
@@ -19329,7 +20828,10 @@
   i32.load offset=8
   i32.const 3
   i32.shr_u
+  i32.const 3264
   call $~lib/util/string/joinFloatArray<f64>
+  i32.const 3264
+  call $~lib/rt/pure/__release
  )
  (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (result i32)
   (local $1 i32)
@@ -19355,9 +20857,89 @@
   call $~lib/rt/pure/__retain
   local.tee $0
  )
+ (func $~lib/typedarray/Uint8Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  i32.const 16
+  i32.sub
+  i32.load offset=12
+  local.tee $4
+  i32.gt_u
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1741
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $2
+   i32.const -1
+   i32.eq
+   if (result i32)
+    local.get $4
+    local.get $1
+    i32.sub
+   else
+    i32.const 1040
+    i32.const 1440
+    i32.const 1750
+    i32.const 7
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.set $0
+  else
+   local.get $2
+   local.tee $0
+   local.get $1
+   i32.add
+   local.get $4
+   i32.gt_s
+   if
+    i32.const 1040
+    i32.const 1440
+    i32.const 1755
+    i32.const 7
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 12
+  i32.const 4
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $3
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $2
+  local.get $0
+  i32.store offset=8
+  local.get $2
+  local.get $1
+  local.get $3
+  i32.add
+  i32.store offset=4
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
  (func $~lib/typedarray/Uint8Array.wrap@varargs (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (local $3 i32)
   block $2of2
    block $1of2
     block $0of2
@@ -19373,75 +20955,12 @@
     local.set $1
    end
    i32.const -1
-   local.set $3
+   local.set $2
   end
-  local.get $1
-  local.get $0
-  i32.const 16
-  i32.sub
-  i32.load offset=12
-  local.tee $2
-  i32.gt_u
-  if
-   i32.const 1376
-   i32.const 1440
-   i32.const 1741
-   i32.const 5
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $3
-  i32.const 0
-  i32.lt_s
-  if
-   local.get $3
-   i32.const -1
-   i32.eq
-   if (result i32)
-    local.get $2
-    local.get $1
-    i32.sub
-   else
-    i32.const 1040
-    i32.const 1440
-    i32.const 1750
-    i32.const 7
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.set $3
-  else
-   local.get $1
-   local.get $3
-   i32.add
-   local.get $2
-   i32.gt_s
-   if
-    i32.const 1040
-    i32.const 1440
-    i32.const 1755
-    i32.const 7
-    call $~lib/builtins/abort
-    unreachable
-   end
-  end
-  i32.const 12
-  i32.const 4
-  call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
-  call $~lib/rt/pure/__retain
-  i32.store
-  local.get $2
-  local.get $3
-  i32.store offset=8
-  local.get $2
   local.get $0
   local.get $1
-  i32.add
-  i32.store offset=4
   local.get $2
-  call $~lib/rt/pure/__retain
+  call $~lib/typedarray/Uint8Array.wrap
  )
  (func $~lib/arraybuffer/ArrayBuffer#slice (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -19521,18 +21040,21 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $5
-  local.set $2
+  local.tee $6
+  call $~lib/rt/pure/__retain
+  local.set $1
   loop $for-loop|0
    local.get $0
    local.get $4
    i32.lt_s
    if
-    local.get $2
+    local.get $1
     local.get $0
     i32.const 4528
     local.get $0
@@ -19549,27 +21071,31 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $1
   i32.load
-  local.get $2
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $1
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $1
-  local.set $6
+  local.tee $0
+  local.set $8
   i32.const 0
-  local.get $1
+  local.get $0
   i32.gt_u
   if
    i32.const 1376
@@ -19582,29 +21108,33 @@
   i32.const 12
   i32.const 3
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $1
-  local.get $6
-  i32.store offset=8
-  local.get $1
   local.get $0
+  local.get $8
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $1
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
-    local.get $2
-    local.get $3
-    call $~lib/typedarray/Int8Array#__get
     local.get $1
-    local.get $3
+    local.get $2
+    call $~lib/typedarray/Int8Array#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Int8Array#__get
     i32.ne
     if
@@ -19615,18 +21145,22 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
+  local.get $6
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
@@ -19641,41 +21175,42 @@
   local.tee $3
   call $~lib/typedarray/Uint8Array#constructor
   local.tee $5
-  local.set $1
+  call $~lib/rt/pure/__retain
+  local.set $0
   loop $for-loop|0
-   local.get $0
+   local.get $1
    local.get $3
    i32.lt_s
    if
+    local.get $0
     local.get $1
-    local.get $0
     i32.const 4528
-    local.get $0
+    local.get $1
     call $~lib/array/Array<i32>#__get
     i32.const 255
     i32.and
     call $~lib/typedarray/Uint8Array#__set
-    local.get $0
+    local.get $1
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     br $for-loop|0
    end
   end
-  local.get $1
+  local.get $0
   i32.load
-  local.get $1
+  local.get $0
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $1
+  local.get $0
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $1
+  local.get $0
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $1
   i32.const 1
   global.set $~argumentsLength
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/typedarray/Uint8Array.wrap@varargs
   local.set $4
@@ -19684,7 +21219,7 @@
    local.get $3
    i32.lt_s
    if
-    local.get $1
+    local.get $0
     local.get $2
     call $~lib/typedarray/Uint8Array#__get
     local.get $4
@@ -19708,7 +21243,11 @@
   end
   local.get $5
   call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
@@ -19721,18 +21260,21 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $5
-  local.set $2
+  local.tee $6
+  call $~lib/rt/pure/__retain
+  local.set $1
   loop $for-loop|0
    local.get $0
    local.get $4
    i32.lt_s
    if
-    local.get $2
+    local.get $1
     local.get $0
     i32.const 4528
     local.get $0
@@ -19747,27 +21289,31 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $1
   i32.load
-  local.get $2
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $2
+  local.get $1
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $1
-  local.set $6
+  local.tee $0
+  local.set $8
   i32.const 0
-  local.get $1
+  local.get $0
   i32.gt_u
   if
    i32.const 1376
@@ -19780,29 +21326,33 @@
   i32.const 12
   i32.const 5
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $1
-  local.get $6
-  i32.store offset=8
-  local.get $1
   local.get $0
+  local.get $8
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $1
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
-    local.get $2
-    local.get $3
-    call $~lib/typedarray/Uint8ClampedArray#__get
     local.get $1
-    local.get $3
+    local.get $2
+    call $~lib/typedarray/Uint8ClampedArray#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Uint8ClampedArray#__get
     i32.ne
     if
@@ -19813,18 +21363,22 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
+  local.get $6
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16>
@@ -19835,11 +21389,14 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $6
+  local.tee $7
+  call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
    local.get $0
@@ -19873,15 +21430,19 @@
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $5
+  local.tee $6
   i32.gt_u
   if
    i32.const 1376
@@ -19891,7 +21452,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 1
   i32.and
   if
@@ -19905,29 +21466,33 @@
   i32.const 12
   i32.const 6
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $5
-  i32.store offset=8
-  local.get $2
   local.get $0
+  local.get $6
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $3
-    call $~lib/typedarray/Int16Array#__get
     local.get $2
-    local.get $3
+    call $~lib/typedarray/Int16Array#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Int16Array#__get
     i32.ne
     if
@@ -19938,18 +21503,22 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $6
+  local.get $7
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16>
@@ -19960,11 +21529,14 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $6
+  local.tee $7
+  call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
    local.get $0
@@ -19996,15 +21568,19 @@
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $5
+  local.tee $6
   i32.gt_u
   if
    i32.const 1376
@@ -20014,7 +21590,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 1
   i32.and
   if
@@ -20028,29 +21604,33 @@
   i32.const 12
   i32.const 7
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $5
-  i32.store offset=8
-  local.get $2
   local.get $0
+  local.get $6
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $3
-    call $~lib/typedarray/Uint16Array#__get
     local.get $2
-    local.get $3
+    call $~lib/typedarray/Uint16Array#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Uint16Array#__get
     i32.ne
     if
@@ -20061,18 +21641,22 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $6
+  local.get $7
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32>
@@ -20083,11 +21667,14 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $6
+  local.tee $7
+  call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
    local.get $0
@@ -20117,15 +21704,19 @@
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $5
+  local.tee $6
   i32.gt_u
   if
    i32.const 1376
@@ -20135,7 +21726,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 3
   i32.and
   if
@@ -20149,29 +21740,33 @@
   i32.const 12
   i32.const 8
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $5
-  i32.store offset=8
-  local.get $2
   local.get $0
+  local.get $6
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $3
-    call $~lib/typedarray/Int32Array#__get
     local.get $2
-    local.get $3
+    call $~lib/typedarray/Int32Array#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Int32Array#__get
     i32.ne
     if
@@ -20182,18 +21777,22 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $6
+  local.get $7
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32>
@@ -20204,11 +21803,14 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Uint32Array#constructor
-  local.tee $6
+  local.tee $7
+  call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
    local.get $0
@@ -20238,15 +21840,19 @@
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $5
+  local.tee $6
   i32.gt_u
   if
    i32.const 1376
@@ -20256,7 +21862,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 3
   i32.and
   if
@@ -20270,29 +21876,33 @@
   i32.const 12
   i32.const 9
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $5
-  i32.store offset=8
-  local.get $2
   local.get $0
+  local.get $6
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $3
-    call $~lib/typedarray/Uint32Array#__get
     local.get $2
-    local.get $3
+    call $~lib/typedarray/Uint32Array#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Uint32Array#__get
     i32.ne
     if
@@ -20303,18 +21913,22 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $6
+  local.get $7
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64>
@@ -20325,11 +21939,14 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $6
+  local.tee $7
+  call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
    local.get $0
@@ -20360,15 +21977,19 @@
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $5
+  local.tee $6
   i32.gt_u
   if
    i32.const 1376
@@ -20378,7 +21999,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 7
   i32.and
   if
@@ -20392,29 +22013,33 @@
   i32.const 12
   i32.const 10
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $5
-  i32.store offset=8
-  local.get $2
   local.get $0
+  local.get $6
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $3
-    call $~lib/typedarray/Int64Array#__get
     local.get $2
-    local.get $3
+    call $~lib/typedarray/Int64Array#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Int64Array#__get
     i64.ne
     if
@@ -20425,18 +22050,22 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $6
+  local.get $7
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64>
@@ -20447,11 +22076,14 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Uint64Array#constructor
-  local.tee $6
+  local.tee $7
+  call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
    local.get $0
@@ -20482,15 +22114,19 @@
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $5
+  local.tee $6
   i32.gt_u
   if
    i32.const 1376
@@ -20500,7 +22136,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 7
   i32.and
   if
@@ -20514,29 +22150,33 @@
   i32.const 12
   i32.const 11
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $5
-  i32.store offset=8
-  local.get $2
   local.get $0
+  local.get $6
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $3
-    call $~lib/typedarray/Uint64Array#__get
     local.get $2
-    local.get $3
+    call $~lib/typedarray/Uint64Array#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Uint64Array#__get
     i64.ne
     if
@@ -20547,18 +22187,22 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $6
+  local.get $7
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32>
@@ -20569,11 +22213,14 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $6
+  local.tee $7
+  call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
    local.get $0
@@ -20604,15 +22251,19 @@
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $5
+  local.tee $6
   i32.gt_u
   if
    i32.const 1376
@@ -20622,7 +22273,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 3
   i32.and
   if
@@ -20636,29 +22287,33 @@
   i32.const 12
   i32.const 12
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $5
-  i32.store offset=8
-  local.get $2
   local.get $0
+  local.get $6
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $3
-    call $~lib/typedarray/Float32Array#__get
     local.get $2
-    local.get $3
+    call $~lib/typedarray/Float32Array#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Float32Array#__get
     f32.ne
     if
@@ -20669,18 +22324,22 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $6
+  local.get $7
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64>
@@ -20691,11 +22350,14 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 4540
   i32.load
   local.tee $4
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $6
+  local.tee $7
+  call $~lib/rt/pure/__retain
   local.set $1
   loop $for-loop|0
    local.get $0
@@ -20726,15 +22388,19 @@
   i32.load offset=8
   i32.add
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
-  local.get $0
+  local.get $5
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $~lib/rt/pure/__retain
+  local.tee $3
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $5
+  local.tee $6
   i32.gt_u
   if
    i32.const 1376
@@ -20744,7 +22410,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 7
   i32.and
   if
@@ -20758,29 +22424,33 @@
   i32.const 12
   i32.const 13
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $0
+  local.tee $0
+  local.get $3
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
-  local.get $5
-  i32.store offset=8
-  local.get $2
   local.get $0
+  local.get $6
+  i32.store offset=8
+  local.get $0
+  local.get $3
   i32.store offset=4
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
   loop $for-loop|1
-   local.get $3
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $1
-    local.get $3
-    call $~lib/typedarray/Float64Array#__get
     local.get $2
-    local.get $3
+    call $~lib/typedarray/Float64Array#__get
+    local.get $0
+    local.get $2
     call $~lib/typedarray/Float64Array#__get
     f64.ne
     if
@@ -20791,26 +22461,37 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $6
+  local.get $7
+  call $~lib/rt/pure/__release
+  i32.const 4528
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  i32.const 4604
-  i32.load
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4592
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
   local.get $0
   i32.load offset=8
   i32.gt_s
@@ -20824,22 +22505,22 @@
   end
   local.get $0
   i32.load offset=4
-  local.set $0
-  i32.const 4596
-  i32.load
-  local.set $2
-  i32.const 4604
-  i32.load
   local.set $3
+  local.get $2
+  i32.load offset=4
+  local.set $4
+  local.get $2
+  i32.load offset=12
+  local.set $5
   loop $for-loop|0
    local.get $1
-   local.get $3
+   local.get $5
    i32.lt_s
    if
-    local.get $0
     local.get $1
+    local.get $3
     i32.add
-    local.get $2
+    local.get $4
     local.get $1
     i32.const 2
     i32.shl
@@ -20853,12 +22534,24 @@
     br $for-loop|0
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4592
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   local.tee $3
@@ -20915,11 +22608,104 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 3
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $1
+    local.get $4
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.tee $3
+    local.get $3
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f32_s
+    else
+     i32.const 0
+    end
+    i32.store8
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
@@ -20940,24 +22726,24 @@
   i32.load offset=4
   i32.const 6
   i32.add
-  local.set $0
+  local.set $4
   local.get $1
   i32.load offset=4
-  local.set $3
+  local.set $5
   local.get $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $1
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $1
+   local.get $6
    i32.lt_s
    if
-    local.get $0
     local.get $2
+    local.get $4
     i32.add
-    local.get $3
+    local.get $5
     local.get $2
     i32.const 3
     i32.shl
@@ -20971,9 +22757,102 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4736
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 2
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 2
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $1
+    local.get $4
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.tee $3
+    local.get $3
+    f64.sub
+    f64.const 0
+    f64.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f64_s
+    else
+     i32.const 0
+    end
+    i32.store8
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4736
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $2
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   local.get $0
   i32.load offset=8
@@ -20993,11 +22872,28 @@
   local.get $1
   i32.load offset=8
   call $~lib/memory/memory.copy
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   i32.const 1
   i32.shr_u
@@ -21018,24 +22914,24 @@
   i32.load offset=4
   i32.const 4
   i32.add
-  local.set $0
+  local.set $4
   local.get $1
   i32.load offset=4
-  local.set $3
+  local.set $5
   local.get $1
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $1
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $1
+   local.get $6
    i32.lt_s
    if
-    local.get $0
     local.get $2
+    local.get $4
     i32.add
-    local.get $3
+    local.get $5
     local.get $2
     i32.const 1
     i32.shl
@@ -21049,10 +22945,22 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (param $0 i32)
-  i32.const 4812
-  i32.load
+  (local $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4800
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=12
   i32.const 7
   i32.add
   local.get $0
@@ -21070,11 +22978,17 @@
   i32.load offset=4
   i32.const 7
   i32.add
-  i32.const 4804
-  i32.load
-  i32.const 4808
-  i32.load
+  local.get $1
+  i32.load offset=4
+  local.get $1
+  i32.load offset=8
   call $~lib/memory/memory.copy
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4800
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array>
   (local $0 i32)
@@ -21085,250 +22999,139 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
-  (local $9 f64)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+  (local $8 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $2
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $4
+  local.tee $3
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $1
+  local.tee $5
+  call $~lib/rt/pure/__retain
+  local.tee $0
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>>
-  local.get $1
+  local.get $0
   i32.const 10
   i32.const 0
   i32.const 14
   i32.const 4832
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-  block $folding-inner0
-   i32.const 4668
-   i32.load
-   i32.const 3
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 3
-   i32.add
-   local.set $5
-   i32.const 4660
-   i32.load
-   local.set $6
-   i32.const 4668
-   i32.load
-   local.set $7
-   loop $for-loop|0
-    local.get $0
-    local.get $7
-    i32.lt_s
-    if
-     local.get $0
-     local.get $5
-     i32.add
-     local.get $6
-     local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     local.tee $8
-     local.get $8
-     f32.sub
-     f32.const 0
-     f32.eq
-     if (result i32)
-      local.get $8
-      i32.trunc_f32_s
-     else
-      i32.const 0
-     end
-     i32.store8
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|0
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 14
-   i32.const 4912
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $5
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-   local.get $1
-   local.get $3
-   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array>
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 14
-   i32.const 4944
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $6
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-   i32.const 0
-   local.set $0
-   i32.const 4748
-   i32.load
-   i32.const 2
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 2
-   i32.add
-   local.set $7
-   i32.const 4740
-   i32.load
-   local.set $11
-   i32.const 4748
-   i32.load
-   local.set $12
-   loop $for-loop|00
-    local.get $0
-    local.get $12
-    i32.lt_s
-    if
-     local.get $0
-     local.get $7
-     i32.add
-     local.get $11
-     local.get $0
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     local.tee $9
-     local.get $9
-     f64.sub
-     f64.const 0
-     f64.eq
-     if (result i32)
-      local.get $9
-      i32.trunc_f64_s
-     else
-      i32.const 0
-     end
-     i32.store8
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|00
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 14
-   i32.const 4976
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   local.get $2
-   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array>
-   local.get $1
-   local.get $4
-   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array>
-   local.get $1
-   call $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>>
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 14
-   i32.const 5008
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
-   local.get $6
-   call $~lib/rt/pure/__release
-   return
-  end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
-  call $~lib/builtins/abort
-  unreachable
+  local.get $0
+  call $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 14
+  i32.const 4912
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
+  local.get $0
+  local.get $2
+  call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 14
+  i32.const 4944
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
+  local.get $0
+  call $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 14
+  i32.const 4976
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  call $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array>
+  local.get $0
+  local.get $3
+  call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 14
+  i32.const 5008
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int8Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint8Array#__uget (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -21349,6 +23152,12 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   local.tee $3
@@ -21403,6 +23212,166 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 3
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $1
+    local.get $4
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.tee $3
+    local.get $3
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f32_u
+    else
+     i32.const 0
+    end
+    i32.store8
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4736
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 2
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 2
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $1
+    local.get $4
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.tee $3
+    local.get $3
+    f64.sub
+    f64.const 0
+    f64.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f64_u
+    else
+     i32.const 0
+    end
+    i32.store8
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4736
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array>
   (local $0 i32)
@@ -21413,256 +23382,227 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
-  (local $9 f64)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+  (local $8 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $2
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $4
+  local.tee $3
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $1
+  local.tee $5
+  call $~lib/rt/pure/__retain
+  local.tee $0
   call $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>>
-  local.get $1
+  local.get $0
   i32.const 10
   i32.const 0
   i32.const 18
   i32.const 5040
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-  block $folding-inner0
-   i32.const 4668
-   i32.load
-   i32.const 3
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 3
-   i32.add
-   local.set $5
-   i32.const 4660
-   i32.load
-   local.set $6
-   i32.const 4668
-   i32.load
-   local.set $7
-   loop $for-loop|0
-    local.get $0
-    local.get $7
-    i32.lt_s
-    if
-     local.get $0
-     local.get $5
-     i32.add
-     local.get $6
-     local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     local.tee $8
-     local.get $8
-     f32.sub
-     f32.const 0
-     f32.eq
-     if (result i32)
-      local.get $8
-      i32.trunc_f32_u
-     else
-      i32.const 0
-     end
-     i32.store8
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|0
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 18
-   i32.const 5120
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $5
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-   local.get $1
-   local.get $3
-   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array>
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 18
-   i32.const 5152
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $6
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-   i32.const 0
-   local.set $0
-   i32.const 4748
-   i32.load
-   i32.const 2
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 2
-   i32.add
-   local.set $7
-   i32.const 4740
-   i32.load
-   local.set $11
-   i32.const 4748
-   i32.load
-   local.set $12
-   loop $for-loop|00
-    local.get $0
-    local.get $12
-    i32.lt_s
-    if
-     local.get $0
-     local.get $7
-     i32.add
-     local.get $11
-     local.get $0
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     local.tee $9
-     local.get $9
-     f64.sub
-     f64.const 0
-     f64.eq
-     if (result i32)
-      local.get $9
-      i32.trunc_f64_u
-     else
-      i32.const 0
-     end
-     i32.store8
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|00
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 18
-   i32.const 5184
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   local.get $2
-   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array>
-   local.get $1
-   local.get $4
-   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array>
-   local.get $1
-   call $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>>
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 18
-   i32.const 5216
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
-   local.get $6
-   call $~lib/rt/pure/__release
-   return
+  local.get $0
+  call $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 18
+  i32.const 5120
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
+  local.get $0
+  local.get $2
+  call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 18
+  i32.const 5152
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
+  local.get $0
+  call $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 18
+  i32.const 5184
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  call $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array>
+  local.get $0
+  local.get $3
+  call $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 18
+  i32.const 5216
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4592
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  local.get $0
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
-  call $~lib/builtins/abort
-  unreachable
+  local.get $0
+  i32.load offset=4
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $1
+    local.get $4
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.tee $3
+    i32.const 31
+    i32.shr_s
+    i32.const -1
+    i32.xor
+    local.get $3
+    i32.const 255
+    local.get $3
+    i32.sub
+    i32.const 31
+    i32.shr_s
+    i32.or
+    i32.and
+    i32.store8
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4592
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   local.tee $3
@@ -21717,26 +23657,26 @@
     br $for-loop|0
    end
   end
- )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i64)
-  local.get $2
-  i32.const 0
-  i32.lt_s
-  if
-   i32.const 1376
-   i32.const 1440
-   i32.const 1774
-   i32.const 19
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $2
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $1
-  i32.load offset=8
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
   i32.const 3
-  i32.shr_u
   i32.add
   local.get $0
   i32.load offset=8
@@ -21749,43 +23689,141 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $0
   i32.load offset=4
+  i32.const 3
   i32.add
-  local.set $0
-  local.get $1
+  local.set $4
+  local.get $2
   i32.load offset=4
-  local.set $2
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $1
+    local.get $4
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.tee $3
+    local.get $3
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i32)
+     f32.const 0
+     f32.const 255
+     local.get $3
+     f32.min
+     f32.max
+     i32.trunc_f32_u
+    else
+     i32.const 0
+    end
+    i32.store8
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i64)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $4
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $1
+  local.get $4
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1774
+   i32.const 19
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  local.get $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $1
+  i32.add
+  local.get $1
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  local.get $1
+  i32.load offset=4
+  i32.add
+  local.set $2
+  local.get $0
+  i32.load offset=4
+  local.set $6
+  local.get $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  local.set $7
   loop $for-loop|0
    local.get $3
-   local.get $1
+   local.get $7
    i32.lt_s
    if
-    local.get $0
+    local.get $2
     local.get $3
     i32.add
-    local.get $2
+    local.get $6
     local.get $3
     i32.const 3
     i32.shl
     i32.add
     i64.load
-    local.tee $4
+    local.tee $5
     i32.wrap_i64
     i32.const 31
     i32.shr_s
     i32.const -1
     i32.xor
     i64.extend_i32_s
-    local.get $4
+    local.get $5
     i32.const 255
-    local.get $4
+    local.get $5
     i32.wrap_i64
     i32.sub
     i32.const 31
@@ -21801,26 +23839,28 @@
     br $for-loop|0
    end
   end
- )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  local.get $2
-  i32.const 0
-  i32.lt_s
-  if
-   i32.const 1376
-   i32.const 1440
-   i32.const 1774
-   i32.const 19
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $2
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $1
-  i32.load offset=8
-  i32.const 1
-  i32.shr_u
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4736
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 2
   i32.add
   local.get $0
   i32.load offset=8
@@ -21833,41 +23873,139 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $0
   i32.load offset=4
+  i32.const 2
   i32.add
-  local.set $2
-  local.get $1
-  i32.load offset=4
   local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $1
+    local.get $4
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.tee $3
+    local.get $3
+    f64.sub
+    f64.const 0
+    f64.eq
+    if (result i32)
+     f64.const 0
+     f64.const 255
+     local.get $3
+     f64.min
+     f64.max
+     i32.trunc_f64_u
+    else
+     i32.const 0
+    end
+    i32.store8
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4736
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $4
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $1
+  local.get $4
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1774
+   i32.const 19
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  local.get $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $1
+  i32.add
+  local.get $1
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  local.get $1
+  i32.load offset=4
+  i32.add
+  local.set $5
+  local.get $0
+  i32.load offset=4
+  local.set $6
+  local.get $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  local.set $7
   loop $for-loop|0
    local.get $3
-   local.get $1
+   local.get $7
    i32.lt_s
    if
-    local.get $2
     local.get $3
+    local.get $5
     i32.add
-    local.get $4
+    local.get $6
     local.get $3
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s
-    local.tee $0
+    local.tee $2
     i32.const 31
     i32.shr_s
     i32.const -1
     i32.xor
-    local.get $0
+    local.get $2
     i32.const 255
-    local.get $0
+    local.get $2
     i32.sub
     i32.const 31
     i32.shr_s
@@ -21881,6 +24019,90 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4800
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 7
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 7
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $1
+    local.get $4
+    i32.add
+    local.get $1
+    local.get $5
+    i32.add
+    i32.load8_s
+    local.tee $3
+    i32.const 31
+    i32.shr_s
+    i32.const -1
+    i32.xor
+    local.get $3
+    i32.const 255
+    local.get $3
+    i32.sub
+    i32.const 31
+    i32.shr_s
+    i32.or
+    i32.and
+    i32.store8
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4800
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray>
   (local $0 i32)
@@ -21894,20 +24116,17 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 i32)
-  (local $12 f32)
-  (local $13 f64)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $7
+  local.tee $3
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $7
+  local.get $3
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $7
+  local.get $3
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -21931,342 +24150,151 @@
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $8
+  local.tee $4
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $8
+  local.get $4
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $8
+  local.get $4
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Uint8ClampedArray#constructor
+  local.tee $7
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 18
+  i32.const 5248
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
+  local.get $0
+  call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 18
+  i32.const 5344
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $9
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
+  local.get $0
+  local.get $3
+  i32.const 6
+  call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 18
+  i32.const 5376
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $10
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
+  local.get $0
+  call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 18
+  i32.const 5408
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
   local.tee $1
-  local.set $3
-  block $folding-inner0
-   i32.const 4604
-   i32.load
-   local.get $1
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $3
-   i32.load offset=4
-   local.set $9
-   i32.const 4596
-   i32.load
-   local.set $4
-   i32.const 4604
-   i32.load
-   local.set $5
-   loop $for-loop|0
-    local.get $0
-    local.get $5
-    i32.lt_s
-    if
-     local.get $0
-     local.get $9
-     i32.add
-     local.get $4
-     local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
-     i32.load
-     local.tee $3
-     i32.const 31
-     i32.shr_s
-     i32.const -1
-     i32.xor
-     local.get $3
-     i32.const 255
-     local.get $3
-     i32.sub
-     i32.const 31
-     i32.shr_s
-     i32.or
-     i32.and
-     i32.store8
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|0
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 18
-   i32.const 5248
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $9
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-   i32.const 0
-   local.set $0
-   i32.const 4668
-   i32.load
-   i32.const 3
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 3
-   i32.add
-   local.set $4
-   i32.const 4660
-   i32.load
-   local.set $5
-   i32.const 4668
-   i32.load
-   local.set $6
-   loop $for-loop|00
-    local.get $0
-    local.get $6
-    i32.lt_s
-    if
-     local.get $0
-     local.get $4
-     i32.add
-     local.get $5
-     local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     local.tee $12
-     local.get $12
-     f32.sub
-     f32.const 0
-     f32.eq
-     if (result i32)
-      f32.const 0
-      f32.const 255
-      local.get $12
-      f32.min
-      f32.max
-      i32.trunc_f32_u
-     else
-      i32.const 0
-     end
-     i32.store8
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|00
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 18
-   i32.const 5344
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $4
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-   local.get $1
-   local.get $7
-   i32.const 6
-   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 18
-   i32.const 5376
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $5
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-   i32.const 0
-   local.set $0
-   i32.const 4748
-   i32.load
-   i32.const 2
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 2
-   i32.add
-   local.set $6
-   i32.const 4740
-   i32.load
-   local.set $10
-   i32.const 4748
-   i32.load
-   local.set $11
-   loop $for-loop|01
-    local.get $0
-    local.get $11
-    i32.lt_s
-    if
-     local.get $0
-     local.get $6
-     i32.add
-     local.get $10
-     local.get $0
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     local.tee $13
-     local.get $13
-     f64.sub
-     f64.const 0
-     f64.eq
-     if (result i32)
-      f64.const 0
-      f64.const 255
-      local.get $13
-      f64.min
-      f64.max
-      i32.trunc_f64_u
-     else
-      i32.const 0
-     end
-     i32.store8
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|01
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 18
-   i32.const 5408
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $2
-   i32.load offset=8
-   local.get $1
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   local.get $2
-   i32.load offset=4
-   local.get $2
-   i32.load offset=8
-   call $~lib/memory/memory.copy
-   local.get $1
-   local.get $8
-   i32.const 4
-   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
-   i32.const 0
-   local.set $0
-   i32.const 4812
-   i32.load
-   i32.const 7
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 7
-   i32.add
-   local.set $6
-   i32.const 4804
-   i32.load
-   local.set $10
-   i32.const 4812
-   i32.load
-   local.set $11
-   loop $for-loop|02
-    local.get $0
-    local.get $11
-    i32.lt_s
-    if
-     local.get $0
-     local.get $6
-     i32.add
-     local.get $0
-     local.get $10
-     i32.add
-     i32.load8_s
-     local.tee $3
-     i32.const 31
-     i32.shr_s
-     i32.const -1
-     i32.xor
-     local.get $3
-     i32.const 255
-     local.get $3
-     i32.sub
-     i32.const 31
-     i32.shr_s
-     i32.or
-     i32.and
-     i32.store8
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|02
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 0
-   i32.const 18
-   i32.const 5440
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $7
-   call $~lib/rt/pure/__release
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $8
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $9
-   call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
-   return
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.set $6
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $1
+  local.get $6
+  call $~lib/rt/pure/__retain
+  local.tee $5
+  i32.load offset=8
+  local.get $1
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
-  call $~lib/builtins/abort
-  unreachable
+  local.get $1
+  i32.load offset=4
+  local.get $5
+  i32.load offset=4
+  local.get $5
+  i32.load offset=8
+  call $~lib/memory/memory.copy
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $4
+  i32.const 4
+  call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>>
+  local.get $0
+  i32.const 10
+  i32.const 0
+  i32.const 18
+  i32.const 5440
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $9
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  i32.const 4604
-  i32.load
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4592
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
   local.get $0
   i32.load offset=8
   i32.const 1
@@ -22282,24 +24310,24 @@
   end
   local.get $0
   i32.load offset=4
-  local.set $0
-  i32.const 4596
-  i32.load
-  local.set $2
-  i32.const 4604
-  i32.load
   local.set $3
+  local.get $2
+  i32.load offset=4
+  local.set $4
+  local.get $2
+  i32.load offset=12
+  local.set $5
   loop $for-loop|0
    local.get $1
-   local.get $3
+   local.get $5
    i32.lt_s
    if
-    local.get $0
+    local.get $3
     local.get $1
     i32.const 1
     i32.shl
     i32.add
-    local.get $2
+    local.get $4
     local.get $1
     i32.const 2
     i32.shl
@@ -22313,6 +24341,12 @@
     br $for-loop|0
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4592
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#__uget (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -22328,6 +24362,12 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   i32.const 1
@@ -22384,11 +24424,108 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 3
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 6
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $1
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.tee $3
+    local.get $3
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f32_s
+    else
+     i32.const 0
+    end
+    i32.store16
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
@@ -22411,26 +24548,26 @@
   i32.load offset=4
   i32.const 12
   i32.add
-  local.set $0
+  local.set $4
   local.get $1
   i32.load offset=4
-  local.set $3
+  local.set $5
   local.get $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $1
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $1
+   local.get $6
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
     i32.const 1
     i32.shl
     i32.add
-    local.get $3
+    local.get $5
     local.get $2
     i32.const 3
     i32.shl
@@ -22444,11 +24581,110 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4736
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 2
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 4
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $1
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.tee $3
+    local.get $3
+    f64.sub
+    f64.const 0
+    f64.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f64_s
+    else
+     i32.const 0
+    end
+    i32.store16
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4736
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   local.get $0
   i32.load offset=8
@@ -22465,25 +24701,25 @@
   end
   local.get $0
   i32.load offset=4
-  local.set $0
+  local.set $4
   local.get $1
   i32.load offset=4
-  local.set $3
+  local.set $5
   local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $1
+   local.get $6
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     local.get $2
-    local.get $3
+    local.get $5
     i32.add
     i32.load8_u
     i32.store16
@@ -22494,9 +24730,24 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $2
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   i32.const 1
   i32.shr_u
@@ -22524,13 +24775,26 @@
   local.get $1
   i32.load offset=8
   call $~lib/memory/memory.copy
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  i32.const 4812
-  i32.load
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4800
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
   i32.const 7
   i32.add
   local.get $0
@@ -22550,25 +24814,25 @@
   i32.load offset=4
   i32.const 14
   i32.add
-  local.set $0
-  i32.const 4804
-  i32.load
-  local.set $2
-  i32.const 4812
-  i32.load
   local.set $3
+  local.get $2
+  i32.load offset=4
+  local.set $4
+  local.get $2
+  i32.load offset=12
+  local.set $5
   loop $for-loop|0
    local.get $1
-   local.get $3
+   local.get $5
    i32.lt_s
    if
-    local.get $0
+    local.get $3
     local.get $1
     i32.const 1
     i32.shl
     i32.add
     local.get $1
-    local.get $2
+    local.get $4
     i32.add
     i32.load8_s
     i32.store16
@@ -22579,6 +24843,12 @@
     br $for-loop|0
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4800
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array>
   (local $0 i32)
@@ -22589,258 +24859,139 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
-  (local $9 f64)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+  (local $8 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $2
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $4
+  local.tee $3
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $1
+  local.tee $5
+  call $~lib/rt/pure/__retain
+  local.tee $0
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>>
-  local.get $1
+  local.get $0
   i32.const 10
   i32.const 1
   i32.const 19
   i32.const 5472
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-  block $folding-inner0
-   i32.const 4668
-   i32.load
-   i32.const 3
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 6
-   i32.add
-   local.set $5
-   i32.const 4660
-   i32.load
-   local.set $6
-   i32.const 4668
-   i32.load
-   local.set $7
-   loop $for-loop|0
-    local.get $0
-    local.get $7
-    i32.lt_s
-    if
-     local.get $5
-     local.get $0
-     i32.const 1
-     i32.shl
-     i32.add
-     local.get $6
-     local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     local.tee $8
-     local.get $8
-     f32.sub
-     f32.const 0
-     f32.eq
-     if (result i32)
-      local.get $8
-      i32.trunc_f32_s
-     else
-      i32.const 0
-     end
-     i32.store16
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|0
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 1
-   i32.const 19
-   i32.const 5568
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $5
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-   local.get $1
-   local.get $3
-   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array>
-   local.get $1
-   i32.const 10
-   i32.const 1
-   i32.const 19
-   i32.const 5616
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $6
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-   i32.const 0
-   local.set $0
-   i32.const 4748
-   i32.load
-   i32.const 2
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 4
-   i32.add
-   local.set $7
-   i32.const 4740
-   i32.load
-   local.set $11
-   i32.const 4748
-   i32.load
-   local.set $12
-   loop $for-loop|00
-    local.get $0
-    local.get $12
-    i32.lt_s
-    if
-     local.get $7
-     local.get $0
-     i32.const 1
-     i32.shl
-     i32.add
-     local.get $11
-     local.get $0
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     local.tee $9
-     local.get $9
-     f64.sub
-     f64.const 0
-     f64.eq
-     if (result i32)
-      local.get $9
-      i32.trunc_f64_s
-     else
-      i32.const 0
-     end
-     i32.store16
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|00
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 1
-   i32.const 19
-   i32.const 5664
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   local.get $2
-   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array>
-   local.get $1
-   local.get $4
-   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array>
-   local.get $1
-   call $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>>
-   local.get $1
-   i32.const 10
-   i32.const 1
-   i32.const 19
-   i32.const 5712
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
-   local.get $6
-   call $~lib/rt/pure/__release
-   return
-  end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
-  call $~lib/builtins/abort
-  unreachable
+  local.get $0
+  call $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>>
+  local.get $0
+  i32.const 10
+  i32.const 1
+  i32.const 19
+  i32.const 5568
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
+  local.get $0
+  local.get $2
+  call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array>
+  local.get $0
+  i32.const 10
+  i32.const 1
+  i32.const 19
+  i32.const 5616
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>>
+  local.get $0
+  i32.const 10
+  i32.const 1
+  i32.const 19
+  i32.const 5664
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  call $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array>
+  local.get $0
+  local.get $3
+  call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>>
+  local.get $0
+  i32.const 10
+  i32.const 1
+  i32.const 19
+  i32.const 5712
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int16Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Uint16Array#__uget (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -22856,6 +25007,12 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   i32.const 1
@@ -22912,6 +25069,174 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 3
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 6
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $1
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.tee $3
+    local.get $3
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f32_u
+    else
+     i32.const 0
+    end
+    i32.store16
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4736
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 2
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 4
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $1
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.tee $3
+    local.get $3
+    f64.sub
+    f64.const 0
+    f64.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f64_u
+    else
+     i32.const 0
+    end
+    i32.store16
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4736
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array>
   (local $0 i32)
@@ -22922,262 +25247,149 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
-  (local $9 f64)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+  (local $8 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $2
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $4
+  local.tee $3
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Uint16Array#constructor
-  local.tee $1
+  local.tee $5
+  call $~lib/rt/pure/__retain
+  local.tee $0
   call $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>>
-  local.get $1
+  local.get $0
   i32.const 10
   i32.const 1
   i32.const 20
   i32.const 5760
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-  block $folding-inner0
-   i32.const 4668
-   i32.load
-   i32.const 3
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 6
-   i32.add
-   local.set $5
-   i32.const 4660
-   i32.load
-   local.set $6
-   i32.const 4668
-   i32.load
-   local.set $7
-   loop $for-loop|0
-    local.get $0
-    local.get $7
-    i32.lt_s
-    if
-     local.get $5
-     local.get $0
-     i32.const 1
-     i32.shl
-     i32.add
-     local.get $6
-     local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     local.tee $8
-     local.get $8
-     f32.sub
-     f32.const 0
-     f32.eq
-     if (result i32)
-      local.get $8
-      i32.trunc_f32_u
-     else
-      i32.const 0
-     end
-     i32.store16
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|0
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 1
-   i32.const 20
-   i32.const 5856
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $5
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-   local.get $1
-   local.get $3
-   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array>
-   local.get $1
-   i32.const 10
-   i32.const 1
-   i32.const 20
-   i32.const 5904
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $6
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-   i32.const 0
-   local.set $0
-   i32.const 4748
-   i32.load
-   i32.const 2
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 4
-   i32.add
-   local.set $7
-   i32.const 4740
-   i32.load
-   local.set $11
-   i32.const 4748
-   i32.load
-   local.set $12
-   loop $for-loop|00
-    local.get $0
-    local.get $12
-    i32.lt_s
-    if
-     local.get $7
-     local.get $0
-     i32.const 1
-     i32.shl
-     i32.add
-     local.get $11
-     local.get $0
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     local.tee $9
-     local.get $9
-     f64.sub
-     f64.const 0
-     f64.eq
-     if (result i32)
-      local.get $9
-      i32.trunc_f64_u
-     else
-      i32.const 0
-     end
-     i32.store16
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|00
-    end
-   end
-   local.get $1
-   i32.const 10
-   i32.const 1
-   i32.const 20
-   i32.const 5952
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $1
-   local.get $2
-   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array>
-   local.get $1
-   local.get $4
-   call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array>
-   local.get $1
-   call $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>>
-   local.get $1
-   i32.const 10
-   i32.const 1
-   i32.const 20
-   i32.const 6000
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $0
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
-   local.get $6
-   call $~lib/rt/pure/__release
-   return
-  end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
-  call $~lib/builtins/abort
-  unreachable
+  local.get $0
+  call $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>>
+  local.get $0
+  i32.const 10
+  i32.const 1
+  i32.const 20
+  i32.const 5856
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
+  local.get $0
+  local.get $2
+  call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array>
+  local.get $0
+  i32.const 10
+  i32.const 1
+  i32.const 20
+  i32.const 5904
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
+  local.get $0
+  call $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>>
+  local.get $0
+  i32.const 10
+  i32.const 1
+  i32.const 20
+  i32.const 5952
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  call $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array>
+  local.get $0
+  local.get $3
+  call $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>>
+  local.get $0
+  i32.const 10
+  i32.const 1
+  i32.const 20
+  i32.const 6000
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (param $0 i32)
-  i32.const 4604
-  i32.load
+  (local $1 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4592
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=12
   local.get $0
   i32.load offset=8
   i32.const 2
@@ -23193,17 +25405,29 @@
   end
   local.get $0
   i32.load offset=4
-  i32.const 4596
-  i32.load
-  i32.const 4600
-  i32.load
+  local.get $1
+  i32.load offset=4
+  local.get $1
+  i32.load offset=8
   call $~lib/memory/memory.copy
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4592
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   i32.const 2
@@ -23260,11 +25484,108 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=12
+  i32.const 3
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 12
+  i32.add
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $5
+  local.get $1
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $2
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    i32.const 2
+    i32.shl
+    local.tee $7
+    i32.add
+    local.get $5
+    local.get $7
+    i32.add
+    f32.load
+    local.tee $3
+    local.get $3
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f32_s
+    else
+     i32.const 0
+    end
+    i32.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
@@ -23287,26 +25608,26 @@
   i32.load offset=4
   i32.const 24
   i32.add
-  local.set $0
+  local.set $4
   local.get $1
   i32.load offset=4
-  local.set $3
+  local.set $5
   local.get $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $1
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $1
+   local.get $6
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
     i32.const 2
     i32.shl
     i32.add
-    local.get $3
+    local.get $5
     local.get $2
     i32.const 3
     i32.shl
@@ -23320,11 +25641,110 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4736
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 2
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 8
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.tee $3
+    local.get $3
+    f64.sub
+    f64.const 0
+    f64.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f64_s
+    else
+     i32.const 0
+    end
+    i32.store
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4736
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   local.get $0
   i32.load offset=8
@@ -23341,25 +25761,25 @@
   end
   local.get $0
   i32.load offset=4
-  local.set $0
+  local.set $4
   local.get $1
   i32.load offset=4
-  local.set $3
+  local.set $5
   local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $1
+   local.get $6
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
     i32.const 2
     i32.shl
     i32.add
     local.get $2
-    local.get $3
+    local.get $5
     i32.add
     i32.load8_u
     i32.store
@@ -23370,11 +25790,28 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   i32.const 1
   i32.shr_u
@@ -23397,26 +25834,26 @@
   i32.load offset=4
   i32.const 16
   i32.add
-  local.set $0
+  local.set $4
   local.get $1
   i32.load offset=4
-  local.set $3
+  local.set $5
   local.get $1
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $1
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $1
+   local.get $6
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
     i32.const 2
     i32.shl
     i32.add
-    local.get $3
+    local.get $5
     local.get $2
     i32.const 1
     i32.shl
@@ -23430,13 +25867,26 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  i32.const 4812
-  i32.load
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4800
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
   i32.const 7
   i32.add
   local.get $0
@@ -23456,25 +25906,25 @@
   i32.load offset=4
   i32.const 28
   i32.add
-  local.set $0
-  i32.const 4804
-  i32.load
-  local.set $2
-  i32.const 4812
-  i32.load
   local.set $3
+  local.get $2
+  i32.load offset=4
+  local.set $4
+  local.get $2
+  i32.load offset=12
+  local.set $5
   loop $for-loop|0
    local.get $1
-   local.get $3
+   local.get $5
    i32.lt_s
    if
-    local.get $0
+    local.get $3
     local.get $1
     i32.const 2
     i32.shl
     i32.add
     local.get $1
-    local.get $2
+    local.get $4
     i32.add
     i32.load8_s
     i32.store
@@ -23485,6 +25935,12 @@
     br $for-loop|0
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4800
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array>
   (local $0 i32)
@@ -23496,58 +25952,56 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f32)
-  (local $10 f64)
-  (local $11 i32)
-  (local $12 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $2
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $4
+  local.tee $3
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Int32Array#constructor
+  local.tee $5
+  call $~lib/rt/pure/__retain
   local.tee $0
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>>
   local.get $0
@@ -23557,201 +26011,91 @@
   i32.const 6048
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-  block $folding-inner0
-   i32.const 4668
-   i32.load
-   i32.const 3
-   i32.add
-   local.get $0
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $0
-   i32.load offset=4
-   i32.const 12
-   i32.add
-   local.set $5
-   i32.const 4660
-   i32.load
-   local.set $6
-   i32.const 4668
-   i32.load
-   local.set $7
-   loop $for-loop|0
-    local.get $1
-    local.get $7
-    i32.lt_s
-    if
-     local.get $5
-     local.get $1
-     i32.const 2
-     i32.shl
-     local.tee $8
-     i32.add
-     local.get $6
-     local.get $8
-     i32.add
-     f32.load
-     local.tee $9
-     local.get $9
-     f32.sub
-     f32.const 0
-     f32.eq
-     if (result i32)
-      local.get $9
-      i32.trunc_f32_s
-     else
-      i32.const 0
-     end
-     i32.store
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|0
-    end
-   end
-   local.get $0
-   i32.const 10
-   i32.const 2
-   i32.const 15
-   i32.const 6160
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $5
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-   local.get $0
-   local.get $3
-   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array>
-   local.get $0
-   i32.const 10
-   i32.const 2
-   i32.const 15
-   i32.const 6224
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $6
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-   i32.const 0
-   local.set $1
-   i32.const 4748
-   i32.load
-   i32.const 2
-   i32.add
-   local.get $0
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $0
-   i32.load offset=4
-   i32.const 8
-   i32.add
-   local.set $7
-   i32.const 4740
-   i32.load
-   local.set $8
-   i32.const 4748
-   i32.load
-   local.set $12
-   loop $for-loop|00
-    local.get $1
-    local.get $12
-    i32.lt_s
-    if
-     local.get $7
-     local.get $1
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $8
-     local.get $1
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     local.tee $10
-     local.get $10
-     f64.sub
-     f64.const 0
-     f64.eq
-     if (result i32)
-      local.get $10
-      i32.trunc_f64_s
-     else
-      i32.const 0
-     end
-     i32.store
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|00
-    end
-   end
-   local.get $0
-   i32.const 10
-   i32.const 2
-   i32.const 15
-   i32.const 6288
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $1
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $0
-   local.get $2
-   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array>
-   local.get $0
-   local.get $4
-   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array>
-   local.get $0
-   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>>
-   local.get $0
-   i32.const 10
-   i32.const 2
-   i32.const 15
-   i32.const 6352
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $1
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $11
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
-   local.get $6
-   call $~lib/rt/pure/__release
-   return
-  end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
-  call $~lib/builtins/abort
-  unreachable
+  local.get $0
+  call $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>>
+  local.get $0
+  i32.const 10
+  i32.const 2
+  i32.const 15
+  i32.const 6160
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
+  local.get $0
+  local.get $2
+  call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array>
+  local.get $0
+  i32.const 10
+  i32.const 2
+  i32.const 15
+  i32.const 6224
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
+  local.get $0
+  call $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>>
+  local.get $0
+  i32.const 10
+  i32.const 2
+  i32.const 15
+  i32.const 6288
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  call $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array>
+  local.get $0
+  local.get $3
+  call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>>
+  local.get $0
+  i32.const 10
+  i32.const 2
+  i32.const 15
+  i32.const 6352
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int32Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   i32.const 2
@@ -23808,6 +26152,174 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=12
+  i32.const 3
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 12
+  i32.add
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $5
+  local.get $1
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $2
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    i32.const 2
+    i32.shl
+    local.tee $7
+    i32.add
+    local.get $5
+    local.get $7
+    i32.add
+    f32.load
+    local.tee $3
+    local.get $3
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f32_u
+    else
+     i32.const 0
+    end
+    i32.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4736
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 2
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 8
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.tee $3
+    local.get $3
+    f64.sub
+    f64.const 0
+    f64.eq
+    if (result i32)
+     local.get $3
+     i32.trunc_f64_u
+    else
+     i32.const 0
+    end
+    i32.store
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4736
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array>
   (local $0 i32)
@@ -23819,58 +26331,56 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f32)
-  (local $10 f64)
-  (local $11 i32)
-  (local $12 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $2
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $4
+  local.tee $3
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Uint32Array#constructor
+  local.tee $5
+  call $~lib/rt/pure/__retain
   local.tee $0
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>>
   local.get $0
@@ -23880,202 +26390,93 @@
   i32.const 6416
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-  block $folding-inner0
-   i32.const 4668
-   i32.load
-   i32.const 3
-   i32.add
-   local.get $0
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $0
-   i32.load offset=4
-   i32.const 12
-   i32.add
-   local.set $5
-   i32.const 4660
-   i32.load
-   local.set $6
-   i32.const 4668
-   i32.load
-   local.set $7
-   loop $for-loop|0
-    local.get $1
-    local.get $7
-    i32.lt_s
-    if
-     local.get $5
-     local.get $1
-     i32.const 2
-     i32.shl
-     local.tee $8
-     i32.add
-     local.get $6
-     local.get $8
-     i32.add
-     f32.load
-     local.tee $9
-     local.get $9
-     f32.sub
-     f32.const 0
-     f32.eq
-     if (result i32)
-      local.get $9
-      i32.trunc_f32_u
-     else
-      i32.const 0
-     end
-     i32.store
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|0
-    end
-   end
-   local.get $0
-   i32.const 10
-   i32.const 2
-   i32.const 21
-   i32.const 6528
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $5
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-   local.get $0
-   local.get $3
-   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array>
-   local.get $0
-   i32.const 10
-   i32.const 2
-   i32.const 21
-   i32.const 6592
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $6
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-   i32.const 0
-   local.set $1
-   i32.const 4748
-   i32.load
-   i32.const 2
-   i32.add
-   local.get $0
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $0
-   i32.load offset=4
-   i32.const 8
-   i32.add
-   local.set $7
-   i32.const 4740
-   i32.load
-   local.set $8
-   i32.const 4748
-   i32.load
-   local.set $12
-   loop $for-loop|00
-    local.get $1
-    local.get $12
-    i32.lt_s
-    if
-     local.get $7
-     local.get $1
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $8
-     local.get $1
-     i32.const 3
-     i32.shl
-     i32.add
-     f64.load
-     local.tee $10
-     local.get $10
-     f64.sub
-     f64.const 0
-     f64.eq
-     if (result i32)
-      local.get $10
-      i32.trunc_f64_u
-     else
-      i32.const 0
-     end
-     i32.store
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|00
-    end
-   end
-   local.get $0
-   i32.const 10
-   i32.const 2
-   i32.const 21
-   i32.const 6656
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $1
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $0
-   local.get $2
-   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array>
-   local.get $0
-   local.get $4
-   call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array>
-   local.get $0
-   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>>
-   local.get $0
-   i32.const 10
-   i32.const 2
-   i32.const 21
-   i32.const 6720
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $1
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $11
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
-   local.get $6
-   call $~lib/rt/pure/__release
-   return
-  end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
-  call $~lib/builtins/abort
-  unreachable
+  local.get $0
+  call $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>>
+  local.get $0
+  i32.const 10
+  i32.const 2
+  i32.const 21
+  i32.const 6528
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
+  local.get $0
+  local.get $2
+  call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array>
+  local.get $0
+  i32.const 10
+  i32.const 2
+  i32.const 21
+  i32.const 6592
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
+  local.get $0
+  call $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>>
+  local.get $0
+  i32.const 10
+  i32.const 2
+  i32.const 21
+  i32.const 6656
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  call $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array>
+  local.get $0
+  local.get $3
+  call $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>>
+  local.get $0
+  i32.const 10
+  i32.const 2
+  i32.const 21
+  i32.const 6720
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  i32.const 4604
-  i32.load
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4592
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
   local.get $0
   i32.load offset=8
   i32.const 3
@@ -24091,24 +26492,24 @@
   end
   local.get $0
   i32.load offset=4
-  local.set $0
-  i32.const 4596
-  i32.load
-  local.set $2
-  i32.const 4604
-  i32.load
   local.set $3
+  local.get $2
+  i32.load offset=4
+  local.set $4
+  local.get $2
+  i32.load offset=12
+  local.set $5
   loop $for-loop|0
    local.get $1
-   local.get $3
+   local.get $5
    i32.lt_s
    if
-    local.get $0
+    local.get $3
     local.get $1
     i32.const 3
     i32.shl
     i32.add
-    local.get $2
+    local.get $4
     local.get $1
     i32.const 2
     i32.shl
@@ -24122,6 +26523,12 @@
     br $for-loop|0
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4592
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#__uget (param $0 i32) (param $1 i32) (result i64)
   local.get $0
@@ -24137,6 +26544,12 @@
   (local $3 i32)
   (local $4 i64)
   (local $5 i64)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   i32.const 3
@@ -24193,9 +26606,104 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 3
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 24
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.tee $3
+    local.get $3
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i64)
+     local.get $3
+     i64.trunc_f32_s
+    else
+     i64.const 0
+    end
+    i64.store
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $2
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
@@ -24223,11 +26731,110 @@
   local.get $1
   i32.load offset=8
   call $~lib/memory/memory.copy
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4736
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=12
+  i32.const 2
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 16
+  i32.add
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $5
+  local.get $1
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $2
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    i32.const 3
+    i32.shl
+    local.tee $7
+    i32.add
+    local.get $5
+    local.get $7
+    i32.add
+    f64.load
+    local.tee $3
+    local.get $3
+    f64.sub
+    f64.const 0
+    f64.eq
+    if (result i64)
+     local.get $3
+     i64.trunc_f64_s
+    else
+     i64.const 0
+    end
+    i64.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4736
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   local.get $0
   i32.load offset=8
@@ -24244,25 +26851,25 @@
   end
   local.get $0
   i32.load offset=4
-  local.set $0
+  local.set $4
   local.get $1
   i32.load offset=4
-  local.set $3
+  local.set $5
   local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $1
+   local.get $6
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
     i32.const 3
     i32.shl
     i32.add
     local.get $2
-    local.get $3
+    local.get $5
     i32.add
     i64.load8_u
     i64.store
@@ -24273,11 +26880,28 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.load offset=8
   i32.const 1
   i32.shr_u
@@ -24300,26 +26924,26 @@
   i32.load offset=4
   i32.const 32
   i32.add
-  local.set $0
+  local.set $4
   local.get $1
   i32.load offset=4
-  local.set $3
+  local.set $5
   local.get $1
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $1
+  local.set $6
   loop $for-loop|0
    local.get $2
-   local.get $1
+   local.get $6
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
     i32.const 3
     i32.shl
     i32.add
-    local.get $3
+    local.get $5
     local.get $2
     i32.const 1
     i32.shl
@@ -24333,13 +26957,26 @@
     br $for-loop|0
    end
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  i32.const 4812
-  i32.load
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4800
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
   i32.const 7
   i32.add
   local.get $0
@@ -24359,25 +26996,25 @@
   i32.load offset=4
   i32.const 56
   i32.add
-  local.set $0
-  i32.const 4804
-  i32.load
-  local.set $2
-  i32.const 4812
-  i32.load
   local.set $3
+  local.get $2
+  i32.load offset=4
+  local.set $4
+  local.get $2
+  i32.load offset=12
+  local.set $5
   loop $for-loop|0
    local.get $1
-   local.get $3
+   local.get $5
    i32.lt_s
    if
-    local.get $0
+    local.get $3
     local.get $1
     i32.const 3
     i32.shl
     i32.add
     local.get $1
-    local.get $2
+    local.get $4
     i32.add
     i64.load8_s
     i64.store
@@ -24388,6 +27025,12 @@
     br $for-loop|0
    end
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4800
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array>
   (local $0 i32)
@@ -24398,60 +27041,57 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
-  (local $9 f64)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
+  (local $8 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $2
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $4
+  local.tee $3
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Int64Array#constructor
+  local.tee $5
+  call $~lib/rt/pure/__retain
   local.tee $0
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>>
   local.get $0
@@ -24461,201 +27101,91 @@
   i32.const 6784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-  block $folding-inner0
-   i32.const 4668
-   i32.load
-   i32.const 3
-   i32.add
-   local.get $0
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $0
-   i32.load offset=4
-   i32.const 24
-   i32.add
-   local.set $5
-   i32.const 4660
-   i32.load
-   local.set $6
-   i32.const 4668
-   i32.load
-   local.set $7
-   loop $for-loop|0
-    local.get $1
-    local.get $7
-    i32.lt_s
-    if
-     local.get $5
-     local.get $1
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $6
-     local.get $1
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     local.tee $8
-     local.get $8
-     f32.sub
-     f32.const 0
-     f32.eq
-     if (result i64)
-      local.get $8
-      i64.trunc_f32_s
-     else
-      i64.const 0
-     end
-     i64.store
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|0
-    end
-   end
-   local.get $0
-   i32.const 10
-   i32.const 3
-   i32.const 22
-   i32.const 6928
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $5
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-   local.get $0
-   local.get $3
-   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array>
-   local.get $0
-   i32.const 10
-   i32.const 3
-   i32.const 22
-   i32.const 7024
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $6
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-   i32.const 0
-   local.set $1
-   i32.const 4748
-   i32.load
-   i32.const 2
-   i32.add
-   local.get $0
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $0
-   i32.load offset=4
-   i32.const 16
-   i32.add
-   local.set $7
-   i32.const 4740
-   i32.load
-   local.set $11
-   i32.const 4748
-   i32.load
-   local.set $12
-   loop $for-loop|00
-    local.get $1
-    local.get $12
-    i32.lt_s
-    if
-     local.get $7
-     local.get $1
-     i32.const 3
-     i32.shl
-     local.tee $13
-     i32.add
-     local.get $11
-     local.get $13
-     i32.add
-     f64.load
-     local.tee $9
-     local.get $9
-     f64.sub
-     f64.const 0
-     f64.eq
-     if (result i64)
-      local.get $9
-      i64.trunc_f64_s
-     else
-      i64.const 0
-     end
-     i64.store
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|00
-    end
-   end
-   local.get $0
-   i32.const 10
-   i32.const 3
-   i32.const 22
-   i32.const 7120
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $1
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $0
-   local.get $2
-   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array>
-   local.get $0
-   local.get $4
-   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array>
-   local.get $0
-   call $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>>
-   local.get $0
-   i32.const 10
-   i32.const 3
-   i32.const 22
-   i32.const 7216
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $1
-   call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
-   local.get $6
-   call $~lib/rt/pure/__release
-   return
-  end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
-  call $~lib/builtins/abort
-  unreachable
+  local.get $0
+  call $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>>
+  local.get $0
+  i32.const 10
+  i32.const 3
+  i32.const 22
+  i32.const 6928
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
+  local.get $0
+  local.get $2
+  call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array>
+  local.get $0
+  i32.const 10
+  i32.const 3
+  i32.const 22
+  i32.const 7024
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
+  local.get $0
+  call $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>>
+  local.get $0
+  i32.const 10
+  i32.const 3
+  i32.const 22
+  i32.const 7120
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  call $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array>
+  local.get $0
+  local.get $3
+  call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>>
+  local.get $0
+  i32.const 10
+  i32.const 3
+  i32.const 22
+  i32.const 7216
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Int64Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i64)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   i32.const 3
@@ -24712,6 +27242,174 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 3
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 24
+  i32.add
+  local.set $4
+  local.get $2
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $1
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.tee $3
+    local.get $3
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i64)
+     local.get $3
+     i64.trunc_f32_u
+    else
+     i64.const 0
+    end
+    i64.store
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4736
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=12
+  i32.const 2
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 16
+  i32.add
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $5
+  local.get $1
+  i32.load offset=12
+  local.set $6
+  loop $for-loop|0
+   local.get $2
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    i32.const 3
+    i32.shl
+    local.tee $7
+    i32.add
+    local.get $5
+    local.get $7
+    i32.add
+    f64.load
+    local.tee $3
+    local.get $3
+    f64.sub
+    f64.const 0
+    f64.eq
+    if (result i64)
+     local.get $3
+     i64.trunc_f64_u
+    else
+     i64.const 0
+    end
+    i64.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4736
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array>
   (local $0 i32)
@@ -24722,60 +27420,57 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
-  (local $9 f64)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
+  (local $8 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $3
+  local.tee $2
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $3
+  local.get $2
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $2
+  local.get $1
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $4
+  local.tee $3
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $4
+  local.get $3
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Uint64Array#constructor
+  local.tee $5
+  call $~lib/rt/pure/__retain
   local.tee $0
   call $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>>
   local.get $0
@@ -24785,195 +27480,79 @@
   i32.const 7312
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $6
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-  block $folding-inner0
-   i32.const 4668
-   i32.load
-   i32.const 3
-   i32.add
-   local.get $0
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $0
-   i32.load offset=4
-   i32.const 24
-   i32.add
-   local.set $5
-   i32.const 4660
-   i32.load
-   local.set $6
-   i32.const 4668
-   i32.load
-   local.set $7
-   loop $for-loop|0
-    local.get $1
-    local.get $7
-    i32.lt_s
-    if
-     local.get $5
-     local.get $1
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $6
-     local.get $1
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     local.tee $8
-     local.get $8
-     f32.sub
-     f32.const 0
-     f32.eq
-     if (result i64)
-      local.get $8
-      i64.trunc_f32_u
-     else
-      i64.const 0
-     end
-     i64.store
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|0
-    end
-   end
-   local.get $0
-   i32.const 10
-   i32.const 3
-   i32.const 23
-   i32.const 7456
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $5
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-   local.get $0
-   local.get $3
-   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array>
-   local.get $0
-   i32.const 10
-   i32.const 3
-   i32.const 23
-   i32.const 7552
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $6
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-   i32.const 0
-   local.set $1
-   i32.const 4748
-   i32.load
-   i32.const 2
-   i32.add
-   local.get $0
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $0
-   i32.load offset=4
-   i32.const 16
-   i32.add
-   local.set $7
-   i32.const 4740
-   i32.load
-   local.set $11
-   i32.const 4748
-   i32.load
-   local.set $12
-   loop $for-loop|00
-    local.get $1
-    local.get $12
-    i32.lt_s
-    if
-     local.get $7
-     local.get $1
-     i32.const 3
-     i32.shl
-     local.tee $13
-     i32.add
-     local.get $11
-     local.get $13
-     i32.add
-     f64.load
-     local.tee $9
-     local.get $9
-     f64.sub
-     f64.const 0
-     f64.eq
-     if (result i64)
-      local.get $9
-      i64.trunc_f64_u
-     else
-      i64.const 0
-     end
-     i64.store
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $for-loop|00
-    end
-   end
-   local.get $0
-   i32.const 10
-   i32.const 3
-   i32.const 23
-   i32.const 7648
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $1
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $0
-   local.get $2
-   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array>
-   local.get $0
-   local.get $4
-   call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array>
-   local.get $0
-   call $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>>
-   local.get $0
-   i32.const 10
-   i32.const 3
-   i32.const 23
-   i32.const 7744
-   call $~lib/rt/__allocArray
-   call $~lib/rt/pure/__retain
-   local.tee $1
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $0
-   call $~lib/rt/pure/__release
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
-   local.get $6
-   call $~lib/rt/pure/__release
-   return
-  end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
-  call $~lib/builtins/abort
-  unreachable
+  local.get $0
+  call $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>>
+  local.get $0
+  i32.const 10
+  i32.const 3
+  i32.const 23
+  i32.const 7456
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $7
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
+  local.get $0
+  local.get $2
+  call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array>
+  local.get $0
+  i32.const 10
+  i32.const 3
+  i32.const 23
+  i32.const 7552
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $8
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
+  local.get $0
+  call $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>>
+  local.get $0
+  i32.const 10
+  i32.const 3
+  i32.const 23
+  i32.const 7648
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  call $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array>
+  local.get $0
+  local.get $3
+  call $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array>
+  local.get $0
+  call $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>>
+  local.get $0
+  i32.const 10
+  i32.const 3
+  i32.const 23
+  i32.const 7744
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $4
+  call $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array>
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
  )
  (func $~lib/typedarray/Float32Array#__uget (param $0 i32) (param $1 i32) (result f32)
   local.get $0
@@ -24989,6 +27568,12 @@
   (local $3 i32)
   (local $4 f32)
   (local $5 f32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   i32.const 2
@@ -25045,6 +27630,166 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.const 6
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 24
+  i32.add
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $5
+  local.get $1
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  local.set $6
+  loop $for-loop|0
+   local.get $2
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $2
+    i32.const 3
+    i32.shl
+    i32.add
+    i64.load
+    f32.convert_i64_s
+    f32.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.const 4
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 16
+  i32.add
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $5
+  local.get $1
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  local.set $6
+  loop $for-loop|0
+   local.get $2
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.load16_s
+    f32.convert_i32_s
+    f32.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array>
   (local $0 i32)
@@ -25058,86 +27803,95 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $5
+  local.tee $7
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $5
+  local.get $7
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $5
+  local.get $7
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $3
+  local.tee $5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $3
+  local.get $5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $3
+  local.get $5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $3
+  local.get $5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $6
+  local.tee $8
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $6
+  local.get $8
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $6
+  local.get $8
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Float32Array#constructor
-  local.tee $1
-  local.set $7
+  local.tee $14
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  call $~lib/rt/pure/__retain
+  local.set $1
   block $folding-inner0
-   i32.const 4604
-   i32.load
+   i32.const 4592
+   call $~lib/rt/pure/__retain
+   local.tee $2
+   i32.load offset=12
    local.get $1
    i32.load offset=8
    i32.const 2
    i32.shr_u
    i32.gt_s
    br_if $folding-inner0
-   local.get $7
+   local.get $1
    i32.load offset=4
-   local.set $7
-   i32.const 4596
-   i32.load
+   local.set $9
+   local.get $2
+   i32.load offset=4
    local.set $10
-   i32.const 4604
-   i32.load
-   local.set $8
+   local.get $2
+   i32.load offset=12
+   local.set $11
    loop $for-loop|0
     local.get $0
-    local.get $8
+    local.get $11
     i32.lt_s
     if
-     local.get $7
+     local.get $9
      local.get $0
      i32.const 2
      i32.shl
-     local.tee $2
+     local.tee $6
      i32.add
-     local.get $2
+     local.get $6
      local.get $10
      i32.add
      i32.load
@@ -25150,35 +27904,52 @@
      br $for-loop|0
     end
    end
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 4592
+   call $~lib/rt/pure/__release
+   local.get $3
    i32.const 10
    i32.const 2
    i32.const 16
    i32.const 7840
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $7
+   local.tee $9
    call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
-   i32.const 4668
-   i32.load
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $0
+   i32.const 4656
+   call $~lib/rt/pure/__retain
+   local.tee $1
+   i32.load offset=12
    i32.const 3
    i32.add
-   local.get $1
+   local.get $0
    i32.load offset=8
    i32.const 2
    i32.shr_u
    i32.gt_s
    br_if $folding-inner0
-   local.get $1
+   local.get $0
    i32.load offset=4
    i32.const 12
    i32.add
-   i32.const 4660
-   i32.load
-   i32.const 4664
-   i32.load
+   local.get $1
+   i32.load offset=4
+   local.get $1
+   i32.load offset=8
    call $~lib/memory/memory.copy
    local.get $1
+   call $~lib/rt/pure/__release
+   local.get $0
+   call $~lib/rt/pure/__release
+   i32.const 4656
+   call $~lib/rt/pure/__release
+   local.get $3
    i32.const 10
    i32.const 2
    i32.const 16
@@ -25187,70 +27958,29 @@
    call $~lib/rt/pure/__retain
    local.tee $10
    call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
-   i32.const 0
-   local.set $0
-   local.get $5
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   i32.const 6
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 24
-   i32.add
-   local.set $8
-   local.get $5
-   i32.load offset=4
-   local.set $2
-   local.get $5
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   local.set $4
-   loop $for-loop|00
-    local.get $0
-    local.get $4
-    i32.lt_s
-    if
-     local.get $8
-     local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $2
-     local.get $0
-     i32.const 3
-     i32.shl
-     i32.add
-     i64.load
-     f32.convert_i64_s
-     f32.store
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|00
-    end
-   end
-   local.get $1
+   local.get $3
+   local.get $7
+   call $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array>
+   local.get $3
    i32.const 10
    i32.const 2
    i32.const 16
    i32.const 8016
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $8
+   local.tee $11
    call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
    i32.const 0
    local.set $0
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $4
+   call $~lib/rt/pure/__retain
+   local.tee $2
    i32.load offset=8
    local.get $1
    i32.load offset=8
@@ -25260,25 +27990,25 @@
    br_if $folding-inner0
    local.get $1
    i32.load offset=4
-   local.set $2
-   local.get $3
+   local.set $6
+   local.get $2
    i32.load offset=4
-   local.set $4
-   local.get $3
+   local.set $12
+   local.get $2
    i32.load offset=8
-   local.set $9
-   loop $for-loop|01
+   local.set $13
+   loop $for-loop|00
     local.get $0
-    local.get $9
+    local.get $13
     i32.lt_s
     if
-     local.get $2
+     local.get $6
      local.get $0
      i32.const 2
      i32.shl
      i32.add
      local.get $0
-     local.get $4
+     local.get $12
      i32.add
      i32.load8_u
      f32.convert_i32_u
@@ -25287,65 +28017,27 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|01
+     br $for-loop|00
     end
    end
+   local.get $2
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   local.get $4
+   call $~lib/rt/pure/__release
+   local.get $3
+   local.get $8
+   call $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array>
    i32.const 0
    local.set $0
-   local.get $6
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-   i32.const 4
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 16
-   i32.add
-   local.set $2
-   local.get $6
-   i32.load offset=4
-   local.set $4
-   local.get $6
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-   local.set $9
-   loop $for-loop|02
-    local.get $0
-    local.get $9
-    i32.lt_s
-    if
-     local.get $2
-     local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $4
-     local.get $0
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_s
-     f32.convert_i32_s
-     f32.store
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|02
-    end
-   end
-   i32.const 0
-   local.set $0
-   i32.const 4812
-   i32.load
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $1
+   i32.const 4800
+   call $~lib/rt/pure/__retain
+   local.tee $2
+   i32.load offset=12
    i32.const 7
    i32.add
    local.get $1
@@ -25358,25 +28050,25 @@
    i32.load offset=4
    i32.const 28
    i32.add
-   local.set $2
-   i32.const 4804
-   i32.load
-   local.set $4
-   i32.const 4812
-   i32.load
-   local.set $9
-   loop $for-loop|03
+   local.set $6
+   local.get $2
+   i32.load offset=4
+   local.set $12
+   local.get $2
+   i32.load offset=12
+   local.set $13
+   loop $for-loop|01
     local.get $0
-    local.get $9
+    local.get $13
     i32.lt_s
     if
-     local.get $2
+     local.get $6
      local.get $0
      i32.const 2
      i32.shl
      i32.add
      local.get $0
-     local.get $4
+     local.get $12
      i32.add
      i32.load8_s
      f32.convert_i32_s
@@ -25385,10 +28077,16 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|03
+     br $for-loop|01
     end
    end
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 4800
+   call $~lib/rt/pure/__release
+   local.get $3
    i32.const 10
    i32.const 2
    i32.const 16
@@ -25399,19 +28097,21 @@
    call $std/typedarray/valuesEqual<~lib/typedarray/Float32Array>
    local.get $0
    call $~lib/rt/pure/__release
+   local.get $7
+   call $~lib/rt/pure/__release
    local.get $5
+   call $~lib/rt/pure/__release
+   local.get $8
+   call $~lib/rt/pure/__release
+   local.get $14
    call $~lib/rt/pure/__release
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $6
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   local.get $7
+   local.get $9
    call $~lib/rt/pure/__release
    local.get $10
    call $~lib/rt/pure/__release
-   local.get $8
+   local.get $11
    call $~lib/rt/pure/__release
    return
   end
@@ -25436,6 +28136,12 @@
   (local $3 i32)
   (local $4 f64)
   (local $5 f64)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $1
   local.get $0
   i32.load offset=8
   i32.const 3
@@ -25490,6 +28196,166 @@
     br $for-loop|0
    end
   end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.const 6
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 48
+  i32.add
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $5
+  local.get $1
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  local.set $6
+  loop $for-loop|0
+   local.get $2
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    i32.const 3
+    i32.shl
+    local.tee $7
+    i32.add
+    local.get $5
+    local.get $7
+    i32.add
+    i64.load
+    f64.convert_i64_s
+    f64.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.const 4
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 32
+  i32.add
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $5
+  local.get $1
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  local.set $6
+  loop $for-loop|0
+   local.get $2
+   local.get $6
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    i32.const 3
+    i32.shl
+    i32.add
+    local.get $5
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.load16_s
+    f64.convert_i32_s
+    f64.store
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array>
   (local $0 i32)
@@ -25503,6 +28369,10 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
   local.tee $7
@@ -25519,19 +28389,19 @@
   call $~lib/typedarray/Int64Array#__set
   i32.const 4
   call $~lib/typedarray/Uint8Array#constructor
-  local.tee $3
+  local.tee $5
   i32.const 0
   i32.const 100
   call $~lib/typedarray/Uint8Array#__set
-  local.get $3
+  local.get $5
   i32.const 1
   i32.const 101
   call $~lib/typedarray/Uint8Array#__set
-  local.get $3
+  local.get $5
   i32.const 2
   i32.const 102
   call $~lib/typedarray/Uint8Array#__set
-  local.get $3
+  local.get $5
   i32.const 3
   i32.const 103
   call $~lib/typedarray/Uint8Array#__set
@@ -25551,37 +28421,42 @@
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $1
-  local.set $9
-  block $folding-inner0
-   i32.const 4604
-   i32.load
+  local.tee $13
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  call $~lib/rt/pure/__retain
+  local.set $1
+  block $folding-inner1
+   i32.const 4592
+   call $~lib/rt/pure/__retain
+   local.tee $2
+   i32.load offset=12
    local.get $1
    i32.load offset=8
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner0
-   local.get $9
+   br_if $folding-inner1
+   local.get $1
+   i32.load offset=4
+   local.set $4
+   local.get $2
    i32.load offset=4
    local.set $9
-   i32.const 4596
-   i32.load
-   local.set $10
-   i32.const 4604
-   i32.load
-   local.set $4
+   local.get $2
+   i32.load offset=12
+   local.set $6
    loop $for-loop|0
     local.get $0
-    local.get $4
+    local.get $6
     i32.lt_s
     if
-     local.get $9
+     local.get $4
      local.get $0
      i32.const 3
      i32.shl
      i32.add
-     local.get $10
+     local.get $9
      local.get $0
      i32.const 2
      i32.shl
@@ -25596,7 +28471,13 @@
      br $for-loop|0
     end
    end
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 4592
+   call $~lib/rt/pure/__release
+   local.get $3
    i32.const 10
    i32.const 3
    i32.const 17
@@ -25607,8 +28488,13 @@
    call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
    i32.const 0
    local.set $0
-   i32.const 4668
-   i32.load
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $1
+   i32.const 4656
+   call $~lib/rt/pure/__retain
+   local.tee $2
+   i32.load offset=12
    i32.const 3
    i32.add
    local.get $1
@@ -25616,29 +28502,29 @@
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner0
+   br_if $folding-inner1
    local.get $1
    i32.load offset=4
    i32.const 24
    i32.add
-   local.set $10
-   i32.const 4660
-   i32.load
    local.set $4
-   i32.const 4668
-   i32.load
-   local.set $2
+   local.get $2
+   i32.load offset=4
+   local.set $6
+   local.get $2
+   i32.load offset=12
+   local.set $10
    loop $for-loop|00
     local.get $0
-    local.get $2
+    local.get $10
     i32.lt_s
     if
-     local.get $10
+     local.get $4
      local.get $0
      i32.const 3
      i32.shl
      i32.add
-     local.get $4
+     local.get $6
      local.get $0
      i32.const 2
      i32.shl
@@ -25653,106 +28539,72 @@
      br $for-loop|00
     end
    end
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 4656
+   call $~lib/rt/pure/__release
+   local.get $3
    i32.const 10
    i32.const 3
    i32.const 17
    i32.const 8288
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $10
+   local.tee $6
    call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
-   i32.const 0
-   local.set $0
+   local.get $3
    local.get $7
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   i32.const 6
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 48
-   i32.add
-   local.set $4
-   local.get $7
-   i32.load offset=4
-   local.set $2
-   local.get $7
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   local.set $5
-   loop $for-loop|01
-    local.get $0
-    local.get $5
-    i32.lt_s
-    if
-     local.get $4
-     local.get $0
-     i32.const 3
-     i32.shl
-     local.tee $6
-     i32.add
-     local.get $2
-     local.get $6
-     i32.add
-     i64.load
-     f64.convert_i64_s
-     f64.store
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|01
-    end
-   end
-   local.get $1
+   call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array>
+   local.get $3
    i32.const 10
    i32.const 3
    i32.const 17
    i32.const 8384
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $4
+   local.tee $10
    call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
    i32.const 0
    local.set $0
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $4
    local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $4
+   call $~lib/rt/pure/__retain
+   local.tee $2
    i32.load offset=8
    local.get $1
    i32.load offset=8
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner0
+   br_if $folding-inner1
    local.get $1
    i32.load offset=4
-   local.set $2
-   local.get $3
+   local.set $11
+   local.get $2
    i32.load offset=4
-   local.set $5
-   local.get $3
+   local.set $12
+   local.get $2
    i32.load offset=8
-   local.set $6
-   loop $for-loop|02
+   local.set $14
+   loop $for-loop|001
     local.get $0
-    local.get $6
+    local.get $14
     i32.lt_s
     if
-     local.get $2
+     local.get $11
      local.get $0
      i32.const 3
      i32.shl
      i32.add
      local.get $0
-     local.get $5
+     local.get $12
      i32.add
      i32.load8_u
      f64.convert_i32_u
@@ -25761,65 +28613,27 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|02
+     br $for-loop|001
     end
    end
+   local.get $2
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   local.get $4
+   call $~lib/rt/pure/__release
+   local.get $3
+   local.get $8
+   call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array>
    i32.const 0
    local.set $0
-   local.get $8
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-   i32.const 4
-   i32.add
-   local.get $1
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $1
-   i32.load offset=4
-   i32.const 32
-   i32.add
-   local.set $2
-   local.get $8
-   i32.load offset=4
-   local.set $5
-   local.get $8
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-   local.set $6
-   loop $for-loop|03
-    local.get $0
-    local.get $6
-    i32.lt_s
-    if
-     local.get $2
-     local.get $0
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $5
-     local.get $0
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.load16_s
-     f64.convert_i32_s
-     f64.store
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|03
-    end
-   end
-   i32.const 0
-   local.set $0
-   i32.const 4812
-   i32.load
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $1
+   i32.const 4800
+   call $~lib/rt/pure/__retain
+   local.tee $2
+   i32.load offset=12
    i32.const 7
    i32.add
    local.get $1
@@ -25827,30 +28641,30 @@
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner0
+   br_if $folding-inner1
    local.get $1
    i32.load offset=4
    i32.const 56
    i32.add
-   local.set $2
-   i32.const 4804
-   i32.load
-   local.set $5
-   i32.const 4812
-   i32.load
-   local.set $6
-   loop $for-loop|04
+   local.set $4
+   local.get $2
+   i32.load offset=4
+   local.set $11
+   local.get $2
+   i32.load offset=12
+   local.set $12
+   loop $for-loop|01
     local.get $0
-    local.get $6
+    local.get $12
     i32.lt_s
     if
-     local.get $2
+     local.get $4
      local.get $0
      i32.const 3
      i32.shl
      i32.add
      local.get $0
-     local.get $5
+     local.get $11
      i32.add
      i32.load8_s
      f64.convert_i32_s
@@ -25859,10 +28673,16 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|04
+     br $for-loop|01
     end
    end
+   local.get $2
+   call $~lib/rt/pure/__release
    local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 4800
+   call $~lib/rt/pure/__release
+   local.get $3
    i32.const 10
    i32.const 3
    i32.const 17
@@ -25875,17 +28695,19 @@
    call $~lib/rt/pure/__release
    local.get $7
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $5
    call $~lib/rt/pure/__release
    local.get $8
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $13
+   call $~lib/rt/pure/__release
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $9
    call $~lib/rt/pure/__release
-   local.get $10
+   local.get $6
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $10
    call $~lib/rt/pure/__release
    return
   end
@@ -25895,6 +28717,258 @@
   i32.const 47
   call $~lib/builtins/abort
   unreachable
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 f32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.const 1
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 1
+  i32.add
+  local.set $5
+  local.get $1
+  i32.load offset=4
+  local.set $6
+  local.get $1
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  local.set $7
+  loop $for-loop|0
+   local.get $2
+   local.get $7
+   i32.lt_s
+   if
+    local.get $2
+    local.get $5
+    i32.add
+    local.get $6
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.tee $4
+    local.get $4
+    f32.sub
+    f32.const 0
+    f32.eq
+    if (result i32)
+     f32.const 0
+     f32.const 255
+     local.get $4
+     f32.min
+     f32.max
+     i32.trunc_f32_u
+    else
+     i32.const 0
+    end
+    i32.store8
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.const 8
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 8
+  i32.add
+  local.set $5
+  local.get $1
+  i32.load offset=4
+  local.set $6
+  local.get $1
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  local.set $7
+  loop $for-loop|0
+   local.get $2
+   local.get $7
+   i32.lt_s
+   if
+    local.get $2
+    local.get $5
+    i32.add
+    local.get $6
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.tee $4
+    i32.const 31
+    i32.shr_s
+    i32.const -1
+    i32.xor
+    local.get $4
+    i32.const 255
+    local.get $4
+    i32.sub
+    i32.const 31
+    i32.shr_s
+    i32.or
+    i32.and
+    i32.store8
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.tee $1
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  local.get $0
+  i32.load offset=8
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $5
+  local.get $1
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  local.set $6
+  loop $for-loop|0
+   local.get $2
+   local.get $6
+   i32.lt_s
+   if
+    local.get $2
+    local.get $4
+    i32.add
+    i32.const 255
+    local.get $5
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.tee $7
+    i32.const 255
+    local.get $7
+    i32.lt_u
+    select
+    i32.store8
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
  )
  (func $start:std/typedarray
   (local $0 i32)
@@ -25913,13 +28987,13 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  (local $16 f32)
+  (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 i32)
-  (local $20 i64)
-  (local $21 f64)
-  (local $22 f32)
+  (local $19 f32)
+  (local $20 f64)
+  (local $21 f32)
+  (local $22 i32)
   (local $23 f64)
   (local $24 i32)
   (local $25 i32)
@@ -25927,7 +29001,6 @@
   (local $27 i32)
   (local $28 i32)
   (local $29 i32)
-  (local $30 i32)
   i32.const 0
   call $std/typedarray/testInstantiate
   i32.const 5
@@ -26165,18 +29238,18 @@
   block $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
    call $~lib/rt/pure/__retain
-   local.tee $29
+   local.tee $28
    i32.load offset=8
    i32.const 3
    i32.shr_u
-   local.tee $30
+   local.tee $29
    i32.const 1
    i32.le_s
    br_if $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
-   local.get $29
+   local.get $28
    i32.load offset=4
    local.set $1
-   local.get $30
+   local.get $29
    i32.const 2
    i32.eq
    if
@@ -26185,17 +29258,17 @@
     local.set $23
     local.get $1
     f64.load
-    local.set $21
+    local.set $20
     i32.const 2
     global.set $~argumentsLength
     local.get $23
-    local.get $21
+    local.get $20
     call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
     i32.const 0
     i32.lt_s
     if
      local.get $1
-     local.get $21
+     local.get $20
      f64.store offset=8
      local.get $1
      local.get $23
@@ -26203,20 +29276,20 @@
     end
     br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
-   local.get $30
+   local.get $29
    i32.const 256
    i32.lt_s
    if
     local.get $1
-    local.get $30
+    local.get $29
     call $~lib/util/sort/insertionSort<f64>
    else
     local.get $1
-    local.get $30
+    local.get $29
     call $~lib/util/sort/weakHeapSort<f64>
    end
   end
-  local.get $29
+  local.get $28
   call $~lib/rt/pure/__release
   local.get $0
   i32.const 0
@@ -26349,7 +29422,7 @@
   i32.const 1504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $30
+  local.tee $29
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26373,7 +29446,7 @@
   i32.const 1584
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $28
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26397,7 +29470,7 @@
   i32.const 1616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $28
+  local.tee $27
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26421,7 +29494,7 @@
   i32.const 1648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $26
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26445,7 +29518,7 @@
   i32.const 1680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $25
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26509,7 +29582,7 @@
   i32.const 1712
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $24
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26527,7 +29600,7 @@
   i32.const 1744
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $22
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -26540,8 +29613,6 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $30
-  call $~lib/rt/pure/__release
   local.get $29
   call $~lib/rt/pure/__release
   local.get $28
@@ -26550,11 +29621,13 @@
   call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $24
+  call $~lib/rt/pure/__release
+  local.get $22
   call $~lib/rt/pure/__release
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
@@ -26591,7 +29664,7 @@
   i32.const 1776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $30
+  local.tee $29
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26615,7 +29688,7 @@
   i32.const 1824
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $28
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26639,7 +29712,7 @@
   i32.const 1872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $28
+  local.tee $27
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26663,7 +29736,7 @@
   i32.const 1920
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $26
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26687,7 +29760,7 @@
   i32.const 1968
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $25
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26753,7 +29826,7 @@
   i32.const 2016
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $24
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26771,7 +29844,7 @@
   i32.const 2048
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $22
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -26784,8 +29857,6 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $30
-  call $~lib/rt/pure/__release
   local.get $29
   call $~lib/rt/pure/__release
   local.get $28
@@ -26794,11 +29865,13 @@
   call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
   local.get $24
+  call $~lib/rt/pure/__release
+  local.get $22
   call $~lib/rt/pure/__release
   i32.const 6
   call $~lib/typedarray/Int8Array#constructor
@@ -26883,7 +29956,7 @@
   i32.const 1
   i32.const 5
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $30
+  local.tee $29
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 3
@@ -26896,7 +29969,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -26908,7 +29981,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 2
   i32.ne
@@ -26920,7 +29993,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -26932,11 +30005,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $29
+  local.tee $28
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 4
@@ -26949,7 +30022,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $28
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -26961,7 +30034,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $28
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 3
   i32.ne
@@ -26973,7 +30046,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $28
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -26989,9 +30062,9 @@
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $30
-  call $~lib/rt/pure/__release
   local.get $29
+  call $~lib/rt/pure/__release
+  local.get $28
   call $~lib/rt/pure/__release
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
@@ -27019,7 +30092,7 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.set $30
+  local.set $29
   local.get $1
   i32.const 0
   i32.const 3
@@ -27043,7 +30116,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27073,14 +30146,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.set $29
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $29
+  local.tee $0
   i32.const 1
   i32.const 2
   i32.const 2147483647
@@ -27092,7 +30164,7 @@
   i32.const 2192
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $22
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -27103,25 +30175,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $29
+  local.get $0
   call $~lib/rt/pure/__release
   local.tee $0
   i32.const 2
   i32.const 2
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $29
+  local.tee $18
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2240
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $17
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -27132,7 +30204,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27143,7 +30215,7 @@
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $17
+  local.tee $16
   i32.const 5
   i32.const 2
   i32.const 15
@@ -27161,7 +30233,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27190,7 +30262,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27219,7 +30291,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27248,7 +30320,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27277,7 +30349,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
@@ -27306,13 +30378,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
+  local.set $1
   local.get $0
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.get $1
   i32.const -4
   i32.const -3
   i32.const -1
@@ -27335,19 +30408,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $0
+  local.tee $1
   i32.const 5
   i32.const 2
   i32.const 15
@@ -27365,9 +30438,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $29
   call $~lib/rt/pure/__release
   local.get $28
   call $~lib/rt/pure/__release
@@ -27379,13 +30452,13 @@
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $29
+  local.get $22
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
   local.get $17
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $15
   call $~lib/rt/pure/__release
@@ -27413,7 +30486,7 @@
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -27443,7 +30516,7 @@
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#subarray
-  local.tee $30
+  local.tee $29
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -27457,7 +30530,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 4
   i32.ne
@@ -27469,7 +30542,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.load offset=8
   i32.const 12
   i32.ne
@@ -27547,11 +30620,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $30
+  local.get $29
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#slice
-  local.tee $29
+  local.tee $28
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -27564,7 +30637,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $28
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -27578,7 +30651,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $28
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   if
    i32.const 0
@@ -27588,7 +30661,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $28
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -27605,7 +30678,7 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.tee $28
+  local.tee $27
   i32.eq
   if
    i32.const 0
@@ -27615,7 +30688,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $27
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -27632,7 +30705,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $27
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
@@ -27645,7 +30718,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $27
   i32.load offset=8
   local.get $1
   i32.load offset=8
@@ -27660,276 +30733,799 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $30
+  local.get $29
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $29
-  call $~lib/rt/pure/__release
   local.get $28
+  call $~lib/rt/pure/__release
+  local.get $27
   call $~lib/rt/pure/__release
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $30
+  local.tee $27
+  call $~lib/rt/pure/__retain
+  local.tee $29
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $30
+  local.get $29
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $30
+  local.get $29
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
   i32.const 0
-  local.set $0
-  i32.const 0
   local.set $1
-  local.get $30
+  i32.const 0
+  local.set $0
+  local.get $29
+  call $~lib/rt/pure/__retain
+  local.tee $28
   i32.load offset=4
-  local.set $29
-  local.get $30
+  local.set $26
+  local.get $28
   i32.load offset=8
-  local.set $28
+  local.set $25
   loop $for-loop|0
-   local.get $0
-   local.get $28
+   local.get $1
+   local.get $25
    i32.lt_s
    if
-    local.get $0
-    local.get $29
+    local.get $1
+    local.get $26
     i32.add
     i32.load8_s
-    local.set $27
+    local.set $24
     i32.const 4
     global.set $~argumentsLength
-    local.get $1
-    local.get $27
-    i32.add
-    local.set $1
     local.get $0
-    i32.const 1
+    local.get $24
     i32.add
     local.set $0
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
     br $for-loop|0
    end
   end
-  block $folding-inner19
-   block $folding-inner18
-    block $folding-inner0
-     block $folding-inner17
-      block $folding-inner16
-       block $folding-inner13
-        block $folding-inner12
-         block $folding-inner11
-          block $folding-inner10
-           block $folding-inner9
-            block $folding-inner8
-             block $folding-inner7
-              block $folding-inner6
-               block $folding-inner5
-                block $folding-inner4
-                 block $folding-inner3
-                  block $folding-inner2
+  local.get $28
+  call $~lib/rt/pure/__release
+  block $folding-inner18
+   block $folding-inner0
+    block $folding-inner17
+     block $folding-inner16
+      block $folding-inner13
+       block $folding-inner12
+        block $folding-inner11
+         block $folding-inner10
+          block $folding-inner9
+           block $folding-inner8
+            block $folding-inner7
+             block $folding-inner6
+              block $folding-inner5
+               block $folding-inner4
+                block $folding-inner3
+                 block $folding-inner2
+                  local.get $0
+                  i32.const 255
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner2
+                  local.get $27
+                  call $~lib/rt/pure/__release
+                  local.get $29
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Uint8Array#constructor
+                  local.tee $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $1
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Uint8Array#__set
+                  local.get $1
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Uint8Array#__set
+                  local.get $1
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Uint8Array#__set
+                  local.get $1
+                  i32.const 3
+                  call $~lib/typedarray/Uint8Array#reduce<u8>
+                  i32.const 255
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner2
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  local.get $1
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Uint8ClampedArray#constructor
+                  local.tee $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $1
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Uint8ClampedArray#__set
+                  local.get $1
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Uint8ClampedArray#__set
+                  local.get $1
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Uint8ClampedArray#__set
+                  local.get $1
+                  i32.const 4
+                  call $~lib/typedarray/Uint8Array#reduce<u8>
+                  i32.const 255
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner2
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  local.get $1
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Int16Array#constructor
+                  local.tee $27
+                  call $~lib/rt/pure/__retain
+                  local.tee $29
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Int16Array#__set
+                  local.get $29
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Int16Array#__set
+                  local.get $29
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Int16Array#__set
+                  i32.const 0
+                  local.set $1
+                  i32.const 0
+                  local.set $0
+                  local.get $29
+                  call $~lib/rt/pure/__retain
+                  local.tee $28
+                  i32.load offset=4
+                  local.set $26
+                  local.get $28
+                  i32.load offset=8
+                  i32.const 1
+                  i32.shr_u
+                  local.set $25
+                  loop $for-loop|00
                    local.get $1
-                   i32.const 255
-                   i32.and
-                   i32.const 6
-                   i32.ne
-                   br_if $folding-inner2
-                   local.get $30
-                   call $~lib/rt/pure/__release
-                   i32.const 3
-                   call $~lib/typedarray/Uint8Array#constructor
-                   local.tee $1
-                   i32.const 0
-                   i32.const 1
-                   call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
-                   i32.const 1
-                   i32.const 2
-                   call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
-                   i32.const 2
-                   i32.const 3
-                   call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
-                   i32.const 3
-                   call $~lib/typedarray/Uint8Array#reduce<u8>
-                   i32.const 255
-                   i32.and
-                   i32.const 6
-                   i32.ne
-                   br_if $folding-inner2
-                   local.get $1
-                   call $~lib/rt/pure/__release
-                   i32.const 3
-                   call $~lib/typedarray/Uint8ClampedArray#constructor
-                   local.tee $1
-                   i32.const 0
-                   i32.const 1
-                   call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
-                   i32.const 1
-                   i32.const 2
-                   call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
-                   i32.const 2
-                   i32.const 3
-                   call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
-                   i32.const 4
-                   call $~lib/typedarray/Uint8Array#reduce<u8>
-                   i32.const 255
-                   i32.and
-                   i32.const 6
-                   i32.ne
-                   br_if $folding-inner2
-                   local.get $1
-                   call $~lib/rt/pure/__release
-                   i32.const 3
-                   call $~lib/typedarray/Int16Array#constructor
-                   local.tee $30
-                   i32.const 0
-                   i32.const 1
-                   call $~lib/typedarray/Int16Array#__set
-                   local.get $30
-                   i32.const 1
-                   i32.const 2
-                   call $~lib/typedarray/Int16Array#__set
-                   local.get $30
-                   i32.const 2
-                   i32.const 3
-                   call $~lib/typedarray/Int16Array#__set
-                   i32.const 0
-                   local.set $0
-                   i32.const 0
-                   local.set $1
-                   local.get $30
-                   i32.load offset=4
-                   local.set $29
-                   local.get $30
-                   i32.load offset=8
-                   i32.const 1
-                   i32.shr_u
-                   local.set $28
-                   loop $for-loop|00
+                   local.get $25
+                   i32.lt_s
+                   if
+                    local.get $26
+                    local.get $1
+                    i32.const 1
+                    i32.shl
+                    i32.add
+                    i32.load16_s
+                    local.set $24
+                    i32.const 4
+                    global.set $~argumentsLength
                     local.get $0
-                    local.get $28
-                    i32.lt_s
-                    if
-                     local.get $29
-                     local.get $0
-                     i32.const 1
-                     i32.shl
-                     i32.add
-                     i32.load16_s
-                     local.set $27
-                     i32.const 4
-                     global.set $~argumentsLength
-                     local.get $1
-                     local.get $27
-                     i32.add
-                     local.set $1
-                     local.get $0
-                     i32.const 1
-                     i32.add
-                     local.set $0
-                     br $for-loop|00
-                    end
+                    local.get $24
+                    i32.add
+                    local.set $0
+                    local.get $1
+                    i32.const 1
+                    i32.add
+                    local.set $1
+                    br $for-loop|00
                    end
+                  end
+                  local.get $28
+                  call $~lib/rt/pure/__release
+                  local.get $0
+                  i32.const 65535
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner2
+                  local.get $27
+                  call $~lib/rt/pure/__release
+                  local.get $29
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Uint16Array#constructor
+                  local.tee $27
+                  call $~lib/rt/pure/__retain
+                  local.tee $29
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Uint16Array#__set
+                  local.get $29
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Uint16Array#__set
+                  local.get $29
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Uint16Array#__set
+                  i32.const 0
+                  local.set $1
+                  i32.const 0
+                  local.set $0
+                  local.get $29
+                  call $~lib/rt/pure/__retain
+                  local.tee $28
+                  i32.load offset=4
+                  local.set $26
+                  local.get $28
+                  i32.load offset=8
+                  i32.const 1
+                  i32.shr_u
+                  local.set $25
+                  loop $for-loop|01
                    local.get $1
-                   i32.const 65535
-                   i32.and
-                   i32.const 6
-                   i32.ne
-                   br_if $folding-inner2
-                   local.get $30
-                   call $~lib/rt/pure/__release
-                   i32.const 3
-                   call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $30
-                   i32.const 0
-                   i32.const 1
-                   call $~lib/typedarray/Uint16Array#__set
-                   local.get $30
-                   i32.const 1
-                   i32.const 2
-                   call $~lib/typedarray/Uint16Array#__set
-                   local.get $30
-                   i32.const 2
-                   i32.const 3
-                   call $~lib/typedarray/Uint16Array#__set
-                   i32.const 0
-                   local.set $0
-                   i32.const 0
-                   local.set $1
-                   local.get $30
-                   i32.load offset=4
-                   local.set $29
-                   local.get $30
-                   i32.load offset=8
-                   i32.const 1
-                   i32.shr_u
-                   local.set $28
-                   loop $for-loop|01
+                   local.get $25
+                   i32.lt_s
+                   if
+                    local.get $26
+                    local.get $1
+                    i32.const 1
+                    i32.shl
+                    i32.add
+                    i32.load16_u
+                    local.set $24
+                    i32.const 4
+                    global.set $~argumentsLength
                     local.get $0
-                    local.get $28
-                    i32.lt_s
-                    if
-                     local.get $29
-                     local.get $0
-                     i32.const 1
-                     i32.shl
-                     i32.add
-                     i32.load16_u
-                     local.set $27
-                     i32.const 4
-                     global.set $~argumentsLength
-                     local.get $1
-                     local.get $27
-                     i32.add
-                     local.set $1
-                     local.get $0
-                     i32.const 1
-                     i32.add
-                     local.set $0
-                     br $for-loop|01
-                    end
+                    local.get $24
+                    i32.add
+                    local.set $0
+                    local.get $1
+                    i32.const 1
+                    i32.add
+                    local.set $1
+                    br $for-loop|01
                    end
+                  end
+                  local.get $28
+                  call $~lib/rt/pure/__release
+                  local.get $0
+                  i32.const 65535
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner2
+                  local.get $27
+                  call $~lib/rt/pure/__release
+                  local.get $29
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Int32Array#constructor
+                  local.tee $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $1
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Int32Array#__set
+                  local.get $1
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Int32Array#__set
+                  local.get $1
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Int32Array#__set
+                  local.get $1
+                  i32.const 7
+                  call $~lib/typedarray/Int32Array#reduce<i32>
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner2
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  local.get $1
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Uint32Array#constructor
+                  local.tee $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $1
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Uint32Array#__set
+                  local.get $1
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Uint32Array#__set
+                  local.get $1
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Uint32Array#__set
+                  local.get $1
+                  i32.const 8
+                  call $~lib/typedarray/Int32Array#reduce<i32>
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner2
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  local.get $1
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Int64Array#constructor
+                  local.tee $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $1
+                  i32.const 0
+                  i64.const 1
+                  call $~lib/typedarray/Int64Array#__set
+                  local.get $1
+                  i32.const 1
+                  i64.const 2
+                  call $~lib/typedarray/Int64Array#__set
+                  local.get $1
+                  i32.const 2
+                  i64.const 3
+                  call $~lib/typedarray/Int64Array#__set
+                  local.get $1
+                  i32.const 9
+                  call $~lib/typedarray/Int64Array#reduce<i64>
+                  i64.const 6
+                  i64.ne
+                  br_if $folding-inner2
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  local.get $1
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Uint64Array#constructor
+                  local.tee $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $1
+                  i32.const 0
+                  i64.const 1
+                  call $~lib/typedarray/Uint64Array#__set
+                  local.get $1
+                  i32.const 1
+                  i64.const 2
+                  call $~lib/typedarray/Uint64Array#__set
+                  local.get $1
+                  i32.const 2
+                  i64.const 3
+                  call $~lib/typedarray/Uint64Array#__set
+                  local.get $1
+                  i32.const 10
+                  call $~lib/typedarray/Int64Array#reduce<i64>
+                  i64.const 6
+                  i64.ne
+                  br_if $folding-inner2
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  local.get $1
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Float32Array#constructor
+                  local.tee $28
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
+                  i32.const 0
+                  f32.const 1
+                  call $~lib/typedarray/Float32Array#__set
+                  local.get $0
+                  i32.const 1
+                  f32.const 2
+                  call $~lib/typedarray/Float32Array#__set
+                  local.get $0
+                  i32.const 2
+                  f32.const 3
+                  call $~lib/typedarray/Float32Array#__set
+                  i32.const 0
+                  local.set $1
+                  local.get $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $29
+                  i32.load offset=4
+                  local.set $27
+                  local.get $29
+                  i32.load offset=8
+                  i32.const 2
+                  i32.shr_u
+                  local.set $26
+                  loop $for-loop|02
                    local.get $1
-                   i32.const 65535
-                   i32.and
-                   i32.const 6
-                   i32.ne
-                   br_if $folding-inner2
-                   local.get $30
-                   call $~lib/rt/pure/__release
-                   i32.const 3
-                   call $~lib/typedarray/Int32Array#constructor
-                   local.tee $1
+                   local.get $26
+                   i32.lt_s
+                   if
+                    local.get $27
+                    local.get $1
+                    i32.const 2
+                    i32.shl
+                    i32.add
+                    f32.load
+                    local.set $19
+                    i32.const 4
+                    global.set $~argumentsLength
+                    local.get $21
+                    local.get $19
+                    f32.add
+                    local.set $21
+                    local.get $1
+                    i32.const 1
+                    i32.add
+                    local.set $1
+                    br $for-loop|02
+                   end
+                  end
+                  local.get $29
+                  call $~lib/rt/pure/__release
+                  local.get $21
+                  f32.const 6
+                  f32.ne
+                  br_if $folding-inner2
+                  local.get $28
+                  call $~lib/rt/pure/__release
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Float64Array#constructor
+                  local.tee $28
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
+                  i32.const 0
+                  f64.const 1
+                  call $~lib/typedarray/Float64Array#__set
+                  local.get $0
+                  i32.const 1
+                  f64.const 2
+                  call $~lib/typedarray/Float64Array#__set
+                  local.get $0
+                  i32.const 2
+                  f64.const 3
+                  call $~lib/typedarray/Float64Array#__set
+                  i32.const 0
+                  local.set $1
+                  f64.const 0
+                  local.set $23
+                  local.get $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $29
+                  i32.load offset=4
+                  local.set $27
+                  local.get $29
+                  i32.load offset=8
+                  i32.const 3
+                  i32.shr_u
+                  local.set $26
+                  loop $for-loop|03
+                   local.get $1
+                   local.get $26
+                   i32.lt_s
+                   if
+                    local.get $27
+                    local.get $1
+                    i32.const 3
+                    i32.shl
+                    i32.add
+                    f64.load
+                    local.set $20
+                    i32.const 4
+                    global.set $~argumentsLength
+                    local.get $23
+                    local.get $20
+                    f64.add
+                    local.set $23
+                    local.get $1
+                    i32.const 1
+                    i32.add
+                    local.set $1
+                    br $for-loop|03
+                   end
+                  end
+                  local.get $29
+                  call $~lib/rt/pure/__release
+                  local.get $23
+                  f64.const 6
+                  f64.ne
+                  br_if $folding-inner2
+                  local.get $28
+                  call $~lib/rt/pure/__release
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Int8Array#constructor
+                  local.tee $27
+                  call $~lib/rt/pure/__retain
+                  local.tee $29
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Int8Array#__set
+                  local.get $29
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Int8Array#__set
+                  local.get $29
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Int8Array#__set
+                  i32.const 0
+                  local.set $0
+                  local.get $29
+                  call $~lib/rt/pure/__retain
+                  local.tee $28
+                  i32.load offset=4
+                  local.set $26
+                  local.get $28
+                  i32.load offset=8
+                  i32.const 1
+                  i32.sub
+                  local.set $1
+                  loop $for-loop|04
+                   local.get $1
                    i32.const 0
-                   i32.const 1
-                   call $~lib/typedarray/Int32Array#__set
+                   i32.ge_s
+                   if
+                    local.get $1
+                    local.get $26
+                    i32.add
+                    i32.load8_s
+                    local.set $25
+                    i32.const 4
+                    global.set $~argumentsLength
+                    local.get $0
+                    local.get $25
+                    i32.add
+                    local.set $0
+                    local.get $1
+                    i32.const 1
+                    i32.sub
+                    local.set $1
+                    br $for-loop|04
+                   end
+                  end
+                  local.get $28
+                  call $~lib/rt/pure/__release
+                  local.get $0
+                  i32.const 255
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner3
+                  local.get $27
+                  call $~lib/rt/pure/__release
+                  local.get $29
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Uint8Array#constructor
+                  local.tee $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $1
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Uint8Array#__set
+                  local.get $1
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Uint8Array#__set
+                  local.get $1
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Uint8Array#__set
+                  local.get $1
+                  i32.const 14
+                  call $~lib/typedarray/Uint8Array#reduceRight<u8>
+                  i32.const 255
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner3
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  local.get $1
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Uint8ClampedArray#constructor
+                  local.tee $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $1
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Uint8ClampedArray#__set
+                  local.get $1
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Uint8ClampedArray#__set
+                  local.get $1
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Uint8ClampedArray#__set
+                  local.get $1
+                  i32.const 15
+                  call $~lib/typedarray/Uint8Array#reduceRight<u8>
+                  i32.const 255
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner3
+                  local.get $0
+                  call $~lib/rt/pure/__release
+                  local.get $1
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Int16Array#constructor
+                  local.tee $27
+                  call $~lib/rt/pure/__retain
+                  local.tee $29
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Int16Array#__set
+                  local.get $29
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Int16Array#__set
+                  local.get $29
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Int16Array#__set
+                  i32.const 0
+                  local.set $0
+                  local.get $29
+                  call $~lib/rt/pure/__retain
+                  local.tee $28
+                  i32.load offset=4
+                  local.set $26
+                  local.get $28
+                  i32.load offset=8
+                  i32.const 1
+                  i32.shr_u
+                  i32.const 1
+                  i32.sub
+                  local.set $1
+                  loop $for-loop|05
                    local.get $1
-                   i32.const 1
-                   i32.const 2
-                   call $~lib/typedarray/Int32Array#__set
+                   i32.const 0
+                   i32.ge_s
+                   if
+                    local.get $26
+                    local.get $1
+                    i32.const 1
+                    i32.shl
+                    i32.add
+                    i32.load16_s
+                    local.set $25
+                    i32.const 4
+                    global.set $~argumentsLength
+                    local.get $0
+                    local.get $25
+                    i32.add
+                    local.set $0
+                    local.get $1
+                    i32.const 1
+                    i32.sub
+                    local.set $1
+                    br $for-loop|05
+                   end
+                  end
+                  local.get $28
+                  call $~lib/rt/pure/__release
+                  local.get $0
+                  i32.const 65535
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner3
+                  local.get $27
+                  call $~lib/rt/pure/__release
+                  local.get $29
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Uint16Array#constructor
+                  local.tee $27
+                  call $~lib/rt/pure/__retain
+                  local.tee $29
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Uint16Array#__set
+                  local.get $29
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Uint16Array#__set
+                  local.get $29
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Uint16Array#__set
+                  i32.const 0
+                  local.set $0
+                  local.get $29
+                  call $~lib/rt/pure/__retain
+                  local.tee $28
+                  i32.load offset=4
+                  local.set $26
+                  local.get $28
+                  i32.load offset=8
+                  i32.const 1
+                  i32.shr_u
+                  i32.const 1
+                  i32.sub
+                  local.set $1
+                  loop $for-loop|06
                    local.get $1
-                   i32.const 2
-                   i32.const 3
-                   call $~lib/typedarray/Int32Array#__set
+                   i32.const 0
+                   i32.ge_s
+                   if
+                    local.get $26
+                    local.get $1
+                    i32.const 1
+                    i32.shl
+                    i32.add
+                    i32.load16_u
+                    local.set $25
+                    i32.const 4
+                    global.set $~argumentsLength
+                    local.get $0
+                    local.get $25
+                    i32.add
+                    local.set $0
+                    local.get $1
+                    i32.const 1
+                    i32.sub
+                    local.set $1
+                    br $for-loop|06
+                   end
+                  end
+                  local.get $28
+                  call $~lib/rt/pure/__release
+                  local.get $0
+                  i32.const 65535
+                  i32.and
+                  i32.const 6
+                  i32.ne
+                  br_if $folding-inner3
+                  local.get $27
+                  call $~lib/rt/pure/__release
+                  local.get $29
+                  call $~lib/rt/pure/__release
+                  i32.const 3
+                  call $~lib/typedarray/Int32Array#constructor
+                  local.tee $0
+                  call $~lib/rt/pure/__retain
+                  local.tee $1
+                  i32.const 0
+                  i32.const 1
+                  call $~lib/typedarray/Int32Array#__set
+                  local.get $1
+                  i32.const 1
+                  i32.const 2
+                  call $~lib/typedarray/Int32Array#__set
+                  local.get $1
+                  i32.const 2
+                  i32.const 3
+                  call $~lib/typedarray/Int32Array#__set
+                  block $folding-inner1
                    local.get $1
-                   i32.const 7
-                   call $~lib/typedarray/Int32Array#reduce<i32>
+                   i32.const 18
+                   call $~lib/typedarray/Int32Array#reduceRight<i32>
                    i32.const 6
                    i32.ne
-                   br_if $folding-inner2
+                   br_if $folding-inner1
+                   local.get $0
+                   call $~lib/rt/pure/__release
                    local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
                    local.tee $1
                    i32.const 0
                    i32.const 1
@@ -27943,15 +31539,19 @@
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#__set
                    local.get $1
-                   i32.const 8
-                   call $~lib/typedarray/Int32Array#reduce<i32>
+                   i32.const 19
+                   call $~lib/typedarray/Int32Array#reduceRight<i32>
                    i32.const 6
                    i32.ne
-                   br_if $folding-inner2
+                   br_if $folding-inner1
+                   local.get $0
+                   call $~lib/rt/pure/__release
                    local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
                    local.tee $1
                    i32.const 0
                    i64.const 1
@@ -27965,15 +31565,19 @@
                    i64.const 3
                    call $~lib/typedarray/Int64Array#__set
                    local.get $1
-                   i32.const 9
-                   call $~lib/typedarray/Int64Array#reduce<i64>
+                   i32.const 20
+                   call $~lib/typedarray/Int64Array#reduceRight<i64>
                    i64.const 6
                    i64.ne
-                   br_if $folding-inner2
+                   br_if $folding-inner1
+                   local.get $0
+                   call $~lib/rt/pure/__release
                    local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
                    local.tee $1
                    i32.const 0
                    i64.const 1
@@ -27987,15 +31591,698 @@
                    i64.const 3
                    call $~lib/typedarray/Uint64Array#__set
                    local.get $1
-                   i32.const 10
-                   call $~lib/typedarray/Int64Array#reduce<i64>
+                   i32.const 21
+                   call $~lib/typedarray/Int64Array#reduceRight<i64>
                    i64.const 6
                    i64.ne
-                   br_if $folding-inner2
+                   br_if $folding-inner1
+                   local.get $0
+                   call $~lib/rt/pure/__release
                    local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float32Array#constructor
+                   local.tee $28
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   i32.const 0
+                   f32.const 1
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $0
+                   i32.const 1
+                   f32.const 2
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $0
+                   i32.const 2
+                   f32.const 3
+                   call $~lib/typedarray/Float32Array#__set
+                   f32.const 0
+                   local.set $21
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $29
+                   i32.load offset=4
+                   local.set $27
+                   local.get $29
+                   i32.load offset=8
+                   i32.const 2
+                   i32.shr_u
+                   i32.const 1
+                   i32.sub
+                   local.set $1
+                   loop $for-loop|07
+                    local.get $1
+                    i32.const 0
+                    i32.ge_s
+                    if
+                     local.get $27
+                     local.get $1
+                     i32.const 2
+                     i32.shl
+                     i32.add
+                     f32.load
+                     local.set $19
+                     i32.const 4
+                     global.set $~argumentsLength
+                     local.get $21
+                     local.get $19
+                     f32.add
+                     local.set $21
+                     local.get $1
+                     i32.const 1
+                     i32.sub
+                     local.set $1
+                     br $for-loop|07
+                    end
+                   end
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $21
+                   f32.const 6
+                   f32.ne
+                   br_if $folding-inner1
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Float64Array#constructor
+                   local.tee $28
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   i32.const 0
+                   f64.const 1
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $0
+                   i32.const 1
+                   f64.const 2
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $0
+                   i32.const 2
+                   f64.const 3
+                   call $~lib/typedarray/Float64Array#__set
+                   f64.const 0
+                   local.set $23
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $29
+                   i32.load offset=4
+                   local.set $27
+                   local.get $29
+                   i32.load offset=8
+                   i32.const 3
+                   i32.shr_u
+                   i32.const 1
+                   i32.sub
+                   local.set $1
+                   loop $for-loop|08
+                    local.get $1
+                    i32.const 0
+                    i32.ge_s
+                    if
+                     local.get $27
+                     local.get $1
+                     i32.const 3
+                     i32.shl
+                     i32.add
+                     f64.load
+                     local.set $20
+                     i32.const 4
+                     global.set $~argumentsLength
+                     local.get $23
+                     local.get $20
+                     f64.add
+                     local.set $23
+                     local.get $1
+                     i32.const 1
+                     i32.sub
+                     local.set $1
+                     br $for-loop|08
+                    end
+                   end
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $23
+                   f64.const 6
+                   f64.ne
+                   br_if $folding-inner1
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int8Array#constructor
+                   local.tee $24
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $0
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $0
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Int8Array#__set
+                   i32.const 0
+                   local.set $1
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $26
+                   i32.load offset=8
+                   local.set $28
+                   local.get $26
+                   i32.load offset=4
+                   local.set $22
+                   i32.const 12
+                   i32.const 3
+                   call $~lib/rt/tlsf/__alloc
+                   local.set $29
+                   local.get $28
+                   i32.const 0
+                   call $~lib/rt/tlsf/__alloc
+                   local.set $27
+                   loop $for-loop|09
+                    local.get $1
+                    local.get $28
+                    i32.lt_s
+                    if
+                     local.get $1
+                     local.get $22
+                     i32.add
+                     i32.load8_s
+                     local.set $25
+                     i32.const 3
+                     global.set $~argumentsLength
+                     local.get $1
+                     local.get $27
+                     i32.add
+                     local.get $25
+                     local.get $25
+                     i32.mul
+                     i32.store8
+                     local.get $1
+                     i32.const 1
+                     i32.add
+                     local.set $1
+                     br $for-loop|09
+                    end
+                   end
+                   local.get $29
+                   local.get $27
+                   call $~lib/rt/pure/__retain
+                   i32.store
+                   local.get $29
+                   local.get $27
+                   i32.store offset=4
+                   local.get $29
+                   local.get $28
+                   i32.store offset=8
+                   local.get $29
+                   call $~lib/rt/pure/__retain
+                   local.set $1
+                   local.get $26
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   i32.const 0
+                   call $~lib/typedarray/Int8Array#__get
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner4
+                   local.get $1
+                   i32.const 1
+                   call $~lib/typedarray/Int8Array#__get
+                   i32.const 4
+                   i32.ne
+                   br_if $folding-inner5
+                   local.get $1
+                   i32.const 2
+                   call $~lib/typedarray/Int8Array#__get
+                   i32.const 9
+                   i32.ne
+                   br_if $folding-inner6
+                   local.get $24
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint8Array#constructor
+                   local.tee $24
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $0
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $0
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint8Array#__set
+                   i32.const 0
+                   local.set $1
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $26
+                   i32.load offset=8
+                   local.set $28
+                   local.get $26
+                   i32.load offset=4
+                   local.set $22
+                   i32.const 12
+                   i32.const 4
+                   call $~lib/rt/tlsf/__alloc
+                   local.set $29
+                   local.get $28
+                   i32.const 0
+                   call $~lib/rt/tlsf/__alloc
+                   local.set $27
+                   loop $for-loop|010
+                    local.get $1
+                    local.get $28
+                    i32.lt_s
+                    if
+                     local.get $1
+                     local.get $22
+                     i32.add
+                     i32.load8_u
+                     local.set $25
+                     i32.const 3
+                     global.set $~argumentsLength
+                     local.get $1
+                     local.get $27
+                     i32.add
+                     local.get $25
+                     local.get $25
+                     i32.mul
+                     i32.store8
+                     local.get $1
+                     i32.const 1
+                     i32.add
+                     local.set $1
+                     br $for-loop|010
+                    end
+                   end
+                   local.get $29
+                   local.get $27
+                   call $~lib/rt/pure/__retain
+                   i32.store
+                   local.get $29
+                   local.get $27
+                   i32.store offset=4
+                   local.get $29
+                   local.get $28
+                   i32.store offset=8
+                   local.get $29
+                   call $~lib/rt/pure/__retain
+                   local.set $1
+                   local.get $26
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   i32.const 0
+                   call $~lib/typedarray/Uint8Array#__get
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner4
+                   local.get $1
+                   i32.const 1
+                   call $~lib/typedarray/Uint8Array#__get
+                   i32.const 4
+                   i32.ne
+                   br_if $folding-inner5
+                   local.get $1
+                   i32.const 2
+                   call $~lib/typedarray/Uint8Array#__get
+                   i32.const 9
+                   i32.ne
+                   br_if $folding-inner6
+                   local.get $24
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint8ClampedArray#constructor
+                   local.tee $24
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $0
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $0
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   i32.const 0
+                   local.set $1
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $26
+                   i32.load offset=8
+                   local.set $28
+                   local.get $26
+                   i32.load offset=4
+                   local.set $22
+                   i32.const 12
+                   i32.const 5
+                   call $~lib/rt/tlsf/__alloc
+                   local.set $29
+                   local.get $28
+                   i32.const 0
+                   call $~lib/rt/tlsf/__alloc
+                   local.set $27
+                   loop $for-loop|011
+                    local.get $1
+                    local.get $28
+                    i32.lt_s
+                    if
+                     local.get $1
+                     local.get $22
+                     i32.add
+                     i32.load8_u
+                     local.set $25
+                     i32.const 3
+                     global.set $~argumentsLength
+                     local.get $1
+                     local.get $27
+                     i32.add
+                     local.get $25
+                     local.get $25
+                     i32.mul
+                     i32.store8
+                     local.get $1
+                     i32.const 1
+                     i32.add
+                     local.set $1
+                     br $for-loop|011
+                    end
+                   end
+                   local.get $29
+                   local.get $27
+                   call $~lib/rt/pure/__retain
+                   i32.store
+                   local.get $29
+                   local.get $27
+                   i32.store offset=4
+                   local.get $29
+                   local.get $28
+                   i32.store offset=8
+                   local.get $29
+                   call $~lib/rt/pure/__retain
+                   local.set $1
+                   local.get $26
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   i32.const 0
+                   call $~lib/typedarray/Uint8ClampedArray#__get
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner4
+                   local.get $1
+                   i32.const 1
+                   call $~lib/typedarray/Uint8ClampedArray#__get
+                   i32.const 4
+                   i32.ne
+                   br_if $folding-inner5
+                   local.get $1
+                   i32.const 2
+                   call $~lib/typedarray/Uint8ClampedArray#__get
+                   i32.const 9
+                   i32.ne
+                   br_if $folding-inner6
+                   local.get $24
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int16Array#constructor
+                   local.tee $29
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Int16Array#map
+                   local.tee $0
+                   i32.const 0
+                   call $~lib/typedarray/Int16Array#__get
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner4
+                   local.get $0
+                   i32.const 1
+                   call $~lib/typedarray/Int16Array#__get
+                   i32.const 4
+                   i32.ne
+                   br_if $folding-inner5
+                   local.get $0
+                   i32.const 2
+                   call $~lib/typedarray/Int16Array#__get
+                   i32.const 9
+                   i32.ne
+                   br_if $folding-inner6
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint16Array#constructor
+                   local.tee $29
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Uint16Array#map
+                   local.tee $0
+                   i32.const 0
+                   call $~lib/typedarray/Uint16Array#__get
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner4
+                   local.get $0
+                   i32.const 1
+                   call $~lib/typedarray/Uint16Array#__get
+                   i32.const 4
+                   i32.ne
+                   br_if $folding-inner5
+                   local.get $0
+                   i32.const 2
+                   call $~lib/typedarray/Uint16Array#__get
+                   i32.const 9
+                   i32.ne
+                   br_if $folding-inner6
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int32Array#constructor
+                   local.tee $29
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Int32Array#map
+                   local.tee $0
+                   i32.const 0
+                   call $~lib/typedarray/Int32Array#__get
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner4
+                   local.get $0
+                   i32.const 1
+                   call $~lib/typedarray/Int32Array#__get
+                   i32.const 4
+                   i32.ne
+                   br_if $folding-inner5
+                   local.get $0
+                   i32.const 2
+                   call $~lib/typedarray/Int32Array#__get
+                   i32.const 9
+                   i32.ne
+                   br_if $folding-inner6
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint32Array#constructor
+                   local.tee $29
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Uint32Array#map
+                   local.tee $0
+                   i32.const 0
+                   call $~lib/typedarray/Uint32Array#__get
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner4
+                   local.get $0
+                   i32.const 1
+                   call $~lib/typedarray/Uint32Array#__get
+                   i32.const 4
+                   i32.ne
+                   br_if $folding-inner5
+                   local.get $0
+                   i32.const 2
+                   call $~lib/typedarray/Uint32Array#__get
+                   i32.const 9
+                   i32.ne
+                   br_if $folding-inner6
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int64Array#constructor
+                   local.tee $29
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 1
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 2
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 3
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Int64Array#map
+                   local.tee $0
+                   i32.const 0
+                   call $~lib/typedarray/Int64Array#__get
+                   i64.const 1
+                   i64.ne
+                   br_if $folding-inner4
+                   local.get $0
+                   i32.const 1
+                   call $~lib/typedarray/Int64Array#__get
+                   i64.const 4
+                   i64.ne
+                   br_if $folding-inner5
+                   local.get $0
+                   i32.const 2
+                   call $~lib/typedarray/Int64Array#__get
+                   i64.const 9
+                   i64.ne
+                   br_if $folding-inner6
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint64Array#constructor
+                   local.tee $29
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 1
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 2
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 3
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Uint64Array#map
+                   local.tee $0
+                   i32.const 0
+                   call $~lib/typedarray/Uint64Array#__get
+                   i64.const 1
+                   i64.ne
+                   br_if $folding-inner4
+                   local.get $0
+                   i32.const 1
+                   call $~lib/typedarray/Uint64Array#__get
+                   i64.const 4
+                   i64.ne
+                   br_if $folding-inner5
+                   local.get $0
+                   i32.const 2
+                   call $~lib/typedarray/Uint64Array#__get
+                   i64.const 9
+                   i64.ne
+                   br_if $folding-inner6
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Float32Array#constructor
+                   local.tee $29
+                   call $~lib/rt/pure/__retain
                    local.tee $1
                    i32.const 0
                    f32.const 1
@@ -28008,49 +32295,36 @@
                    i32.const 2
                    f32.const 3
                    call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Float32Array#map
+                   local.tee $0
                    i32.const 0
-                   local.set $0
-                   local.get $1
-                   i32.load offset=4
-                   local.set $30
-                   local.get $1
-                   i32.load offset=8
-                   i32.const 2
-                   i32.shr_u
-                   local.set $29
-                   loop $for-loop|02
-                    local.get $0
-                    local.get $29
-                    i32.lt_s
-                    if
-                     local.get $30
-                     local.get $0
-                     i32.const 2
-                     i32.shl
-                     i32.add
-                     f32.load
-                     local.set $16
-                     i32.const 4
-                     global.set $~argumentsLength
-                     local.get $22
-                     local.get $16
-                     f32.add
-                     local.set $22
-                     local.get $0
-                     i32.const 1
-                     i32.add
-                     local.set $0
-                     br $for-loop|02
-                    end
-                   end
-                   local.get $22
-                   f32.const 6
+                   call $~lib/typedarray/Float32Array#__get
+                   f32.const 1
                    f32.ne
-                   br_if $folding-inner2
+                   br_if $folding-inner4
+                   local.get $0
+                   i32.const 1
+                   call $~lib/typedarray/Float32Array#__get
+                   f32.const 4
+                   f32.ne
+                   br_if $folding-inner5
+                   local.get $0
+                   i32.const 2
+                   call $~lib/typedarray/Float32Array#__get
+                   f32.const 9
+                   f32.ne
+                   br_if $folding-inner6
+                   local.get $29
+                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float64Array#constructor
+                   local.tee $29
+                   call $~lib/rt/pure/__retain
                    local.tee $1
                    i32.const 0
                    f64.const 1
@@ -28063,130 +32337,430 @@
                    i32.const 2
                    f64.const 3
                    call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Float64Array#map
+                   local.tee $0
                    i32.const 0
-                   local.set $0
-                   f64.const 0
-                   local.set $23
-                   local.get $1
-                   i32.load offset=4
-                   local.set $30
-                   local.get $1
-                   i32.load offset=8
-                   i32.const 3
-                   i32.shr_u
-                   local.set $29
-                   loop $for-loop|03
-                    local.get $0
-                    local.get $29
-                    i32.lt_s
-                    if
-                     local.get $30
-                     local.get $0
-                     i32.const 3
-                     i32.shl
-                     i32.add
-                     f64.load
-                     local.set $21
-                     i32.const 4
-                     global.set $~argumentsLength
-                     local.get $23
-                     local.get $21
-                     f64.add
-                     local.set $23
-                     local.get $0
-                     i32.const 1
-                     i32.add
-                     local.set $0
-                     br $for-loop|03
-                    end
-                   end
-                   local.get $23
-                   f64.const 6
+                   call $~lib/typedarray/Float64Array#__get
+                   f64.const 1
                    f64.ne
-                   br_if $folding-inner2
+                   br_if $folding-inner4
+                   local.get $0
+                   i32.const 1
+                   call $~lib/typedarray/Float64Array#__get
+                   f64.const 4
+                   f64.ne
+                   br_if $folding-inner5
+                   local.get $0
+                   i32.const 2
+                   call $~lib/typedarray/Float64Array#__get
+                   f64.const 9
+                   f64.ne
+                   br_if $folding-inner6
+                   local.get $29
+                   call $~lib/rt/pure/__release
                    local.get $1
                    call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>
+                   call $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
                    i32.const 3
                    call $~lib/typedarray/Int8Array#constructor
-                   local.tee $30
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
                    i32.const 0
-                   i32.const 1
-                   call $~lib/typedarray/Int8Array#__set
-                   local.get $30
-                   i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $30
-                   i32.const 2
-                   i32.const 3
-                   call $~lib/typedarray/Int8Array#__set
-                   i32.const 0
-                   local.set $0
-                   local.get $30
-                   i32.load offset=4
-                   local.set $29
-                   local.get $30
-                   i32.load offset=8
+                   local.get $1
                    i32.const 1
-                   i32.sub
-                   local.set $1
-                   loop $for-loop|04
-                    local.get $1
-                    i32.const 0
-                    i32.ge_s
-                    if
-                     local.get $1
-                     local.get $29
-                     i32.add
-                     i32.load8_s
-                     local.set $28
-                     i32.const 4
-                     global.set $~argumentsLength
-                     local.get $0
-                     local.get $28
-                     i32.add
-                     local.set $0
-                     local.get $1
-                     i32.const 1
-                     i32.sub
-                     local.set $1
-                     br $for-loop|04
-                    end
-                   end
-                   local.get $0
-                   i32.const 255
-                   i32.and
+                   i32.const 4
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 2
                    i32.const 6
-                   i32.ne
-                   br_if $folding-inner3
-                   local.get $30
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 46
+                   call $~lib/typedarray/Int8Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 47
+                   call $~lib/typedarray/Int8Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
                    local.tee $1
                    i32.const 0
-                   i32.const 1
-                   call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
-                   i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint8Array#__set
                    local.get $1
-                   i32.const 2
-                   i32.const 3
+                   i32.const 1
+                   i32.const 4
                    call $~lib/typedarray/Uint8Array#__set
                    local.get $1
-                   i32.const 14
-                   call $~lib/typedarray/Uint8Array#reduceRight<u8>
-                   i32.const 255
-                   i32.and
+                   i32.const 2
                    i32.const 6
-                   i32.ne
-                   br_if $folding-inner3
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 48
+                   call $~lib/typedarray/Uint8Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 49
+                   call $~lib/typedarray/Uint8Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
                    local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 50
+                   call $~lib/typedarray/Uint8Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 51
+                   call $~lib/typedarray/Uint8Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int16Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 52
+                   call $~lib/typedarray/Int16Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 53
+                   call $~lib/typedarray/Int16Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint16Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 54
+                   call $~lib/typedarray/Uint16Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 55
+                   call $~lib/typedarray/Uint16Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 56
+                   call $~lib/typedarray/Int32Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 57
+                   call $~lib/typedarray/Int32Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 58
+                   call $~lib/typedarray/Int32Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 59
+                   call $~lib/typedarray/Int32Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 2
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 4
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 6
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 60
+                   call $~lib/typedarray/Int64Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 61
+                   call $~lib/typedarray/Int64Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 2
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 4
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 6
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 62
+                   call $~lib/typedarray/Int64Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 63
+                   call $~lib/typedarray/Int64Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Float32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   f32.const 2
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 1
+                   f32.const 4
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 2
+                   f32.const 6
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 64
+                   call $~lib/typedarray/Float32Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 65
+                   call $~lib/typedarray/Float32Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Float64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   f64.const 2
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 1
+                   f64.const 4
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 2
+                   f64.const 6
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 66
+                   call $~lib/typedarray/Float64Array#some
+                   i32.eqz
+                   br_if $folding-inner7
+                   local.get $1
+                   i32.const 67
+                   call $~lib/typedarray/Float64Array#some
+                   br_if $folding-inner8
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int8Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 68
+                   call $~lib/typedarray/Int8Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 69
+                   call $~lib/typedarray/Int8Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint8Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 70
+                   call $~lib/typedarray/Uint8Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 71
+                   call $~lib/typedarray/Uint8Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint8ClampedArray#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
                    local.tee $1
                    i32.const 0
                    i32.const 1
@@ -28200,135 +32774,1679 @@
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#__set
                    local.get $1
-                   i32.const 15
-                   call $~lib/typedarray/Uint8Array#reduceRight<u8>
-                   i32.const 255
-                   i32.and
-                   i32.const 6
+                   i32.const 72
+                   call $~lib/typedarray/Uint8Array#findIndex
+                   i32.const 1
                    i32.ne
-                   br_if $folding-inner3
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 73
+                   call $~lib/typedarray/Uint8Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
                    local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $30
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $30
+                   local.get $1
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $30
+                   local.get $1
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 74
+                   call $~lib/typedarray/Int16Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 75
+                   call $~lib/typedarray/Int16Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint16Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
                    i32.const 0
-                   local.set $0
-                   local.get $30
+                   i32.const 1
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 76
+                   call $~lib/typedarray/Uint16Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 77
+                   call $~lib/typedarray/Uint16Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 78
+                   call $~lib/typedarray/Int32Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 79
+                   call $~lib/typedarray/Int32Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 80
+                   call $~lib/typedarray/Int32Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 81
+                   call $~lib/typedarray/Int32Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 1
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 2
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 3
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 82
+                   call $~lib/typedarray/Int64Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 83
+                   call $~lib/typedarray/Int64Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 1
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 2
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 3
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 84
+                   call $~lib/typedarray/Int64Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 85
+                   call $~lib/typedarray/Int64Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Float32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   f32.const 1
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 1
+                   f32.const 2
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 2
+                   f32.const 3
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 86
+                   call $~lib/typedarray/Float32Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 87
+                   call $~lib/typedarray/Float32Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Float64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   f64.const 1
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 1
+                   f64.const 2
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 2
+                   f64.const 3
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 88
+                   call $~lib/typedarray/Float64Array#findIndex
+                   i32.const 1
+                   i32.ne
+                   br_if $folding-inner9
+                   local.get $1
+                   i32.const 89
+                   call $~lib/typedarray/Float64Array#findIndex
+                   i32.const -1
+                   i32.ne
+                   br_if $folding-inner10
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int8Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 90
+                   call $~lib/typedarray/Int8Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 91
+                   call $~lib/typedarray/Int8Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint8Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 92
+                   call $~lib/typedarray/Uint8Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 93
+                   call $~lib/typedarray/Uint8Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint8ClampedArray#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 94
+                   call $~lib/typedarray/Uint8Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 95
+                   call $~lib/typedarray/Uint8Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int16Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 96
+                   call $~lib/typedarray/Int16Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 97
+                   call $~lib/typedarray/Int16Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint16Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 98
+                   call $~lib/typedarray/Uint16Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 99
+                   call $~lib/typedarray/Uint16Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 100
+                   call $~lib/typedarray/Int32Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 101
+                   call $~lib/typedarray/Int32Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 2
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 4
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 6
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 102
+                   call $~lib/typedarray/Int32Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 103
+                   call $~lib/typedarray/Int32Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Int64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 2
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 4
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 6
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 104
+                   call $~lib/typedarray/Int64Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 105
+                   call $~lib/typedarray/Int64Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Uint64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 2
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 4
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 6
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 106
+                   call $~lib/typedarray/Int64Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 107
+                   call $~lib/typedarray/Int64Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Float32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   f32.const 2
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 1
+                   f32.const 4
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 2
+                   f32.const 6
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 108
+                   call $~lib/typedarray/Float32Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 109
+                   call $~lib/typedarray/Float32Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 3
+                   call $~lib/typedarray/Float64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   f64.const 2
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 1
+                   f64.const 4
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 2
+                   f64.const 6
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 110
+                   call $~lib/typedarray/Float64Array#every
+                   i32.eqz
+                   br_if $folding-inner11
+                   local.get $1
+                   i32.const 111
+                   call $~lib/typedarray/Float64Array#every
+                   br_if $folding-inner12
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Int8Array#constructor
+                   local.tee $28
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   global.set $std/typedarray/forEachSelf
+                   local.get $0
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 24
+                   i32.shl
+                   i32.const 24
+                   i32.shr_s
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $0
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 24
+                   i32.shl
+                   i32.const 24
+                   i32.shr_s
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $0
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 24
+                   i32.shl
+                   i32.const 24
+                   i32.shr_s
+                   call $~lib/typedarray/Int8Array#__set
+                   i32.const 0
+                   local.set $1
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $29
                    i32.load offset=4
-                   local.set $29
-                   local.get $30
+                   local.set $27
+                   local.get $29
+                   i32.load offset=8
+                   local.set $26
+                   loop $for-loop|012
+                    local.get $1
+                    local.get $26
+                    i32.lt_s
+                    if
+                     local.get $1
+                     local.get $27
+                     i32.add
+                     i32.load8_s
+                     i32.const 3
+                     global.set $~argumentsLength
+                     local.get $1
+                     local.get $29
+                     call $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0
+                     local.get $1
+                     i32.const 1
+                     i32.add
+                     local.set $1
+                     br $for-loop|012
+                    end
+                   end
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Uint8Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   global.set $std/typedarray/forEachSelf
+                   local.get $1
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 255
+                   i32.and
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 255
+                   i32.and
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 255
+                   i32.and
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 113
+                   call $~lib/typedarray/Uint8Array#forEach
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Uint8ClampedArray#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   global.set $std/typedarray/forEachSelf
+                   local.get $1
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 255
+                   i32.and
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 255
+                   i32.and
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 255
+                   i32.and
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 114
+                   call $~lib/typedarray/Uint8Array#forEach
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Int16Array#constructor
+                   local.tee $28
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   global.set $std/typedarray/forEachSelf
+                   local.get $0
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 16
+                   i32.shl
+                   i32.const 16
+                   i32.shr_s
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $0
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 16
+                   i32.shl
+                   i32.const 16
+                   i32.shr_s
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $0
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 16
+                   i32.shl
+                   i32.const 16
+                   i32.shr_s
+                   call $~lib/typedarray/Int16Array#__set
+                   i32.const 0
+                   local.set $1
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $29
+                   i32.load offset=4
+                   local.set $27
+                   local.get $29
                    i32.load offset=8
                    i32.const 1
                    i32.shr_u
-                   i32.const 1
-                   i32.sub
-                   local.set $1
-                   loop $for-loop|05
+                   local.set $26
+                   loop $for-loop|013
                     local.get $1
-                    i32.const 0
-                    i32.ge_s
+                    local.get $26
+                    i32.lt_s
                     if
-                     local.get $29
+                     local.get $27
                      local.get $1
                      i32.const 1
                      i32.shl
                      i32.add
                      i32.load16_s
-                     local.set $28
-                     i32.const 4
+                     i32.const 3
                      global.set $~argumentsLength
-                     local.get $0
-                     local.get $28
-                     i32.add
-                     local.set $0
+                     local.get $1
+                     local.get $29
+                     call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0
                      local.get $1
                      i32.const 1
-                     i32.sub
+                     i32.add
                      local.set $1
-                     br $for-loop|05
+                     br $for-loop|013
                     end
                    end
-                   local.get $0
-                   i32.const 65535
-                   i32.and
-                   i32.const 6
-                   i32.ne
-                   br_if $folding-inner3
-                   local.get $30
+                   local.get $29
                    call $~lib/rt/pure/__release
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $30
+                   local.tee $28
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   global.set $std/typedarray/forEachSelf
+                   local.get $0
                    i32.const 0
-                   i32.const 1
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 65535
+                   i32.and
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $30
+                   local.get $0
                    i32.const 1
-                   i32.const 2
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 65535
+                   i32.and
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $30
+                   local.get $0
                    i32.const 2
-                   i32.const 3
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   i32.const 65535
+                   i32.and
                    call $~lib/typedarray/Uint16Array#__set
                    i32.const 0
-                   local.set $0
-                   local.get $30
+                   local.set $1
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $29
                    i32.load offset=4
-                   local.set $29
-                   local.get $30
+                   local.set $27
+                   local.get $29
                    i32.load offset=8
                    i32.const 1
                    i32.shr_u
-                   i32.const 1
-                   i32.sub
-                   local.set $1
-                   loop $for-loop|06
+                   local.set $26
+                   loop $for-loop|014
                     local.get $1
-                    i32.const 0
-                    i32.ge_s
+                    local.get $26
+                    i32.lt_s
                     if
-                     local.get $29
+                     local.get $27
                      local.get $1
                      i32.const 1
                      i32.shl
                      i32.add
                      i32.load16_u
-                     local.set $28
-                     i32.const 4
+                     i32.const 3
                      global.set $~argumentsLength
-                     local.get $0
-                     local.get $28
-                     i32.add
-                     local.set $0
+                     local.get $1
+                     local.get $29
+                     call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0
                      local.get $1
                      i32.const 1
-                     i32.sub
+                     i32.add
                      local.set $1
-                     br $for-loop|06
+                     br $for-loop|014
                     end
                    end
-                   local.get $0
-                   i32.const 65535
-                   i32.and
-                   i32.const 6
-                   i32.ne
-                   br_if $folding-inner3
-                   local.get $30
+                   local.get $29
                    call $~lib/rt/pure/__release
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Int32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   global.set $std/typedarray/forEachSelf
+                   local.get $1
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 117
+                   call $~lib/typedarray/Int32Array#forEach
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Uint32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   global.set $std/typedarray/forEachSelf
+                   local.get $1
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 118
+                   call $~lib/typedarray/Int32Array#forEach
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Int64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   global.set $std/typedarray/forEachSelf
+                   local.get $1
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   i64.extend_i32_s
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   i64.extend_i32_s
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   i64.extend_i32_s
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 119
+                   call $~lib/typedarray/Int64Array#forEach
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Uint64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   global.set $std/typedarray/forEachSelf
+                   local.get $1
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   i64.extend_i32_s
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   i64.extend_i32_s
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   i64.extend_i32_s
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 120
+                   call $~lib/typedarray/Int64Array#forEach
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Float32Array#constructor
+                   local.tee $28
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   global.set $std/typedarray/forEachSelf
+                   local.get $0
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   f32.convert_i32_s
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $0
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   f32.convert_i32_s
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $0
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   f32.convert_i32_s
+                   call $~lib/typedarray/Float32Array#__set
+                   i32.const 0
+                   local.set $1
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $29
+                   i32.load offset=4
+                   local.set $27
+                   local.get $29
+                   i32.load offset=8
+                   i32.const 2
+                   i32.shr_u
+                   local.set $26
+                   loop $for-loop|015
+                    local.get $1
+                    local.get $26
+                    i32.lt_s
+                    if
+                     local.get $27
+                     local.get $1
+                     i32.const 2
+                     i32.shl
+                     i32.add
+                     f32.load
+                     i32.const 3
+                     global.set $~argumentsLength
+                     local.get $1
+                     local.get $29
+                     call $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0
+                     local.get $1
+                     i32.const 1
+                     i32.add
+                     local.set $1
+                     br $for-loop|015
+                    end
+                   end
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Float64Array#constructor
+                   local.tee $28
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
+                   global.set $std/typedarray/forEachSelf
+                   local.get $0
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   f64.convert_i32_s
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $0
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   f64.convert_i32_s
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $0
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   f64.convert_i32_s
+                   call $~lib/typedarray/Float64Array#__set
+                   i32.const 0
+                   local.set $1
+                   local.get $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $29
+                   i32.load offset=4
+                   local.set $27
+                   local.get $29
+                   i32.load offset=8
+                   i32.const 3
+                   i32.shr_u
+                   local.set $26
+                   loop $for-loop|016
+                    local.get $1
+                    local.get $26
+                    i32.lt_s
+                    if
+                     local.get $27
+                     local.get $1
+                     i32.const 3
+                     i32.shl
+                     i32.add
+                     f64.load
+                     i32.const 3
+                     global.set $~argumentsLength
+                     local.get $1
+                     local.get $29
+                     call $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0
+                     local.get $1
+                     i32.const 1
+                     i32.add
+                     local.set $1
+                     br $for-loop|016
+                    end
+                   end
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32>
+                   call $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32>
+                   call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64>
+                   i32.const 1
+                   call $~lib/typedarray/Float64Array#constructor
+                   local.tee $29
+                   i32.const 0
+                   f64.const nan:0x8000000000000
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $29
+                   f64.const nan:0x8000000000000
+                   i32.const 0
+                   call $~lib/typedarray/Float64Array#indexOf
+                   i32.const -1
+                   i32.ne
+                   if
+                    i32.const 0
+                    i32.const 1312
+                    i32.const 607
+                    i32.const 3
+                    call $~lib/builtins/abort
+                    unreachable
+                   end
+                   i32.const 0
+                   local.set $1
+                   i32.const 0
+                   local.set $28
+                   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
+                    local.get $29
+                    call $~lib/rt/pure/__retain
+                    local.tee $0
+                    i32.load offset=8
+                    i32.const 3
+                    i32.shr_u
+                    local.tee $27
+                    if (result i32)
+                     i32.const 0
+                     local.get $27
+                     i32.ge_s
+                    else
+                     i32.const 1
+                    end
+                    if
+                     local.get $0
+                     call $~lib/rt/pure/__release
+                     br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
+                    end
+                    local.get $0
+                    i32.load offset=4
+                    local.set $25
+                    loop $while-continue|0
+                     local.get $1
+                     local.get $27
+                     i32.lt_s
+                     if
+                      local.get $25
+                      local.get $1
+                      i32.const 3
+                      i32.shl
+                      i32.add
+                      f64.load
+                      local.tee $23
+                      f64.const nan:0x8000000000000
+                      f64.eq
+                      if (result i32)
+                       i32.const 1
+                      else
+                       local.get $23
+                       local.get $23
+                       f64.ne
+                      end
+                      if
+                       local.get $0
+                       call $~lib/rt/pure/__release
+                       i32.const 1
+                       local.set $28
+                       br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
+                      end
+                      local.get $1
+                      i32.const 1
+                      i32.add
+                      local.set $1
+                      br $while-continue|0
+                     end
+                    end
+                    local.get $0
+                    call $~lib/rt/pure/__release
+                   end
+                   local.get $28
+                   i32.const 0
+                   i32.ne
+                   i32.const 1
+                   i32.ne
+                   if
+                    i32.const 0
+                    i32.const 1312
+                    i32.const 608
+                    i32.const 3
+                    call $~lib/builtins/abort
+                    unreachable
+                   end
+                   i32.const 1
+                   call $~lib/typedarray/Float32Array#constructor
+                   local.tee $28
+                   i32.const 0
+                   f32.const nan:0x400000
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $28
+                   f32.const nan:0x400000
+                   i32.const 0
+                   call $~lib/typedarray/Float32Array#indexOf
+                   i32.const -1
+                   i32.ne
+                   if
+                    i32.const 0
+                    i32.const 1312
+                    i32.const 613
+                    i32.const 3
+                    call $~lib/builtins/abort
+                    unreachable
+                   end
+                   i32.const 0
+                   local.set $1
+                   i32.const 0
+                   local.set $27
+                   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
+                    local.get $28
+                    call $~lib/rt/pure/__retain
+                    local.tee $0
+                    i32.load offset=8
+                    i32.const 2
+                    i32.shr_u
+                    local.tee $26
+                    if (result i32)
+                     i32.const 0
+                     local.get $26
+                     i32.ge_s
+                    else
+                     i32.const 1
+                    end
+                    if
+                     local.get $0
+                     call $~lib/rt/pure/__release
+                     br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
+                    end
+                    local.get $0
+                    i32.load offset=4
+                    local.set $24
+                    loop $while-continue|017
+                     local.get $1
+                     local.get $26
+                     i32.lt_s
+                     if
+                      local.get $24
+                      local.get $1
+                      i32.const 2
+                      i32.shl
+                      i32.add
+                      f32.load
+                      local.tee $21
+                      f32.const nan:0x400000
+                      f32.eq
+                      if (result i32)
+                       i32.const 1
+                      else
+                       local.get $21
+                       local.get $21
+                       f32.ne
+                      end
+                      if
+                       local.get $0
+                       call $~lib/rt/pure/__release
+                       i32.const 1
+                       local.set $27
+                       br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
+                      end
+                      local.get $1
+                      i32.const 1
+                      i32.add
+                      local.set $1
+                      br $while-continue|017
+                     end
+                    end
+                    local.get $0
+                    call $~lib/rt/pure/__release
+                   end
+                   local.get $27
+                   i32.const 0
+                   i32.ne
+                   i32.const 1
+                   i32.ne
+                   if
+                    i32.const 0
+                    i32.const 1312
+                    i32.const 614
+                    i32.const 3
+                    call $~lib/builtins/abort
+                    unreachable
+                   end
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Int8Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 3
+                   i32.const 4
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   i32.const 4
+                   i32.const 5
+                   call $~lib/typedarray/Int8Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Int8Array#join
+                   local.tee $29
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner0
+                   local.get $1
+                   call $~lib/typedarray/Int8Array#join
+                   local.tee $28
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner18
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Uint8Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 3
+                   i32.const 4
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   i32.const 4
+                   i32.const 5
+                   call $~lib/typedarray/Uint8Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Uint8Array#join
+                   local.tee $29
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner0
+                   local.get $1
+                   call $~lib/typedarray/Uint8Array#join
+                   local.tee $28
+                   local.get $28
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner18
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Uint8ClampedArray#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 3
+                   i32.const 4
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   i32.const 4
+                   i32.const 5
+                   call $~lib/typedarray/Uint8ClampedArray#__set
+                   local.get $1
+                   call $~lib/typedarray/Uint8Array#join
+                   local.tee $29
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner0
+                   local.get $1
+                   call $~lib/typedarray/Uint8Array#join
+                   local.tee $28
+                   local.get $28
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner18
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Int16Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 3
+                   i32.const 4
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   i32.const 4
+                   i32.const 5
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Int16Array#join
+                   local.tee $29
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner0
+                   local.get $1
+                   call $~lib/typedarray/Int16Array#join
+                   local.tee $28
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner18
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Uint16Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 3
+                   i32.const 4
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   i32.const 4
+                   i32.const 5
+                   call $~lib/typedarray/Uint16Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Uint16Array#join
+                   local.tee $29
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner0
+                   local.get $1
+                   call $~lib/typedarray/Uint16Array#join
+                   local.tee $28
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner18
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Int32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
                    local.tee $1
                    i32.const 0
                    i32.const 1
@@ -28341,3826 +34459,578 @@
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int32Array#__set
-                   block $folding-inner1
-                    local.get $1
-                    i32.const 18
-                    call $~lib/typedarray/Int32Array#reduceRight<i32>
-                    i32.const 6
-                    i32.ne
-                    br_if $folding-inner1
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 19
-                    call $~lib/typedarray/Int32Array#reduceRight<i32>
-                    i32.const 6
-                    i32.ne
-                    br_if $folding-inner1
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 1
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 2
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 3
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 20
-                    call $~lib/typedarray/Int64Array#reduceRight<i64>
-                    i64.const 6
-                    i64.ne
-                    br_if $folding-inner1
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 1
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 2
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 3
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 21
-                    call $~lib/typedarray/Int64Array#reduceRight<i64>
-                    i64.const 6
-                    i64.ne
-                    br_if $folding-inner1
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float32Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    f32.const 1
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $0
-                    i32.const 1
-                    f32.const 2
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $0
-                    i32.const 2
-                    f32.const 3
-                    call $~lib/typedarray/Float32Array#__set
-                    f32.const 0
-                    local.set $22
-                    local.get $0
-                    i32.load offset=4
-                    local.set $30
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    i32.const 1
-                    i32.sub
-                    local.set $1
-                    loop $for-loop|07
-                     local.get $1
-                     i32.const 0
-                     i32.ge_s
-                     if
-                      local.get $30
-                      local.get $1
-                      i32.const 2
-                      i32.shl
-                      i32.add
-                      f32.load
-                      local.set $16
-                      i32.const 4
-                      global.set $~argumentsLength
-                      local.get $22
-                      local.get $16
-                      f32.add
-                      local.set $22
-                      local.get $1
-                      i32.const 1
-                      i32.sub
-                      local.set $1
-                      br $for-loop|07
-                     end
-                    end
-                    local.get $22
-                    f32.const 6
-                    f32.ne
-                    br_if $folding-inner1
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float64Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    f64.const 1
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $0
-                    i32.const 1
-                    f64.const 2
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $0
-                    i32.const 2
-                    f64.const 3
-                    call $~lib/typedarray/Float64Array#__set
-                    f64.const 0
-                    local.set $23
-                    local.get $0
-                    i32.load offset=4
-                    local.set $30
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 3
-                    i32.shr_u
-                    i32.const 1
-                    i32.sub
-                    local.set $1
-                    loop $for-loop|08
-                     local.get $1
-                     i32.const 0
-                     i32.ge_s
-                     if
-                      local.get $30
-                      local.get $1
-                      i32.const 3
-                      i32.shl
-                      i32.add
-                      f64.load
-                      local.set $21
-                      i32.const 4
-                      global.set $~argumentsLength
-                      local.get $23
-                      local.get $21
-                      f64.add
-                      local.set $23
-                      local.get $1
-                      i32.const 1
-                      i32.sub
-                      local.set $1
-                      br $for-loop|08
-                     end
-                    end
-                    local.get $23
-                    f64.const 6
-                    f64.ne
-                    br_if $folding-inner1
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int8Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Int8Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    local.set $29
-                    local.get $0
-                    i32.load offset=4
-                    local.set $26
-                    i32.const 12
-                    i32.const 3
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $29
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $28
-                    loop $for-loop|09
-                     local.get $1
-                     local.get $29
-                     i32.lt_s
-                     if
-                      local.get $1
-                      local.get $26
-                      i32.add
-                      i32.load8_s
-                      local.set $27
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $1
-                      local.get $28
-                      i32.add
-                      local.get $27
-                      local.get $27
-                      i32.mul
-                      i32.store8
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|09
-                     end
-                    end
-                    local.get $30
-                    local.get $28
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $28
-                    i32.store offset=4
-                    local.get $30
-                    local.get $29
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Int8Array#__get
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Int8Array#__get
-                    i32.const 4
-                    i32.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Int8Array#__get
-                    i32.const 9
-                    i32.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint8Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint8Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    local.set $29
-                    local.get $0
-                    i32.load offset=4
-                    local.set $26
-                    i32.const 12
-                    i32.const 4
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $29
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $28
-                    loop $for-loop|010
-                     local.get $1
-                     local.get $29
-                     i32.lt_s
-                     if
-                      local.get $1
-                      local.get $26
-                      i32.add
-                      i32.load8_u
-                      local.set $27
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $1
-                      local.get $28
-                      i32.add
-                      local.get $27
-                      local.get $27
-                      i32.mul
-                      i32.store8
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|010
-                     end
-                    end
-                    local.get $30
-                    local.get $28
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $28
-                    i32.store offset=4
-                    local.get $30
-                    local.get $29
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Uint8Array#__get
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Uint8Array#__get
-                    i32.const 4
-                    i32.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Uint8Array#__get
-                    i32.const 9
-                    i32.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                    local.tee $0
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    local.set $29
-                    local.get $0
-                    i32.load offset=4
-                    local.set $26
-                    i32.const 12
-                    i32.const 5
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $29
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $28
-                    loop $for-loop|011
-                     local.get $1
-                     local.get $29
-                     i32.lt_s
-                     if
-                      local.get $1
-                      local.get $26
-                      i32.add
-                      i32.load8_u
-                      local.set $27
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $1
-                      local.get $28
-                      i32.add
-                      local.get $27
-                      local.get $27
-                      i32.mul
-                      i32.store8
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|011
-                     end
-                    end
-                    local.get $30
-                    local.get $28
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $28
-                    i32.store offset=4
-                    local.get $30
-                    local.get $29
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Uint8ClampedArray#__get
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Uint8ClampedArray#__get
-                    i32.const 4
-                    i32.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Uint8ClampedArray#__get
-                    i32.const 9
-                    i32.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int16Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Int16Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 1
-                    i32.shr_u
-                    local.set $28
-                    local.get $0
-                    i32.load offset=4
-                    local.set $26
-                    i32.const 12
-                    i32.const 6
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
-                    i32.const 1
-                    i32.shl
-                    local.tee $25
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $29
-                    loop $for-loop|012
-                     local.get $1
-                     local.get $28
-                     i32.lt_s
-                     if
-                      local.get $26
-                      local.get $1
-                      i32.const 1
-                      i32.shl
-                      local.tee $24
-                      i32.add
-                      i32.load16_s
-                      local.set $27
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $24
-                      local.get $29
-                      i32.add
-                      local.get $27
-                      local.get $27
-                      i32.mul
-                      i32.store16
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|012
-                     end
-                    end
-                    local.get $30
-                    local.get $29
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $29
-                    i32.store offset=4
-                    local.get $30
-                    local.get $25
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Int16Array#__get
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Int16Array#__get
-                    i32.const 4
-                    i32.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Int16Array#__get
-                    i32.const 9
-                    i32.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint16Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint16Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 1
-                    i32.shr_u
-                    local.set $28
-                    local.get $0
-                    i32.load offset=4
-                    local.set $26
-                    i32.const 12
-                    i32.const 7
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
-                    i32.const 1
-                    i32.shl
-                    local.tee $25
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $29
-                    loop $for-loop|013
-                     local.get $1
-                     local.get $28
-                     i32.lt_s
-                     if
-                      local.get $26
-                      local.get $1
-                      i32.const 1
-                      i32.shl
-                      local.tee $24
-                      i32.add
-                      i32.load16_u
-                      local.set $27
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $24
-                      local.get $29
-                      i32.add
-                      local.get $27
-                      local.get $27
-                      i32.mul
-                      i32.store16
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|013
-                     end
-                    end
-                    local.get $30
-                    local.get $29
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $29
-                    i32.store offset=4
-                    local.get $30
-                    local.get $25
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Uint16Array#__get
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Uint16Array#__get
-                    i32.const 4
-                    i32.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Uint16Array#__get
-                    i32.const 9
-                    i32.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int32Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Int32Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    local.set $28
-                    local.get $0
-                    i32.load offset=4
-                    local.set $26
-                    i32.const 12
-                    i32.const 8
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
-                    i32.const 2
-                    i32.shl
-                    local.tee $25
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $29
-                    loop $for-loop|014
-                     local.get $1
-                     local.get $28
-                     i32.lt_s
-                     if
-                      local.get $26
-                      local.get $1
-                      i32.const 2
-                      i32.shl
-                      local.tee $24
-                      i32.add
-                      i32.load
-                      local.set $27
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $24
-                      local.get $29
-                      i32.add
-                      local.get $27
-                      local.get $27
-                      i32.mul
-                      i32.store
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|014
-                     end
-                    end
-                    local.get $30
-                    local.get $29
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $29
-                    i32.store offset=4
-                    local.get $30
-                    local.get $25
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Int32Array#__get
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Int32Array#__get
-                    i32.const 4
-                    i32.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Int32Array#__get
-                    i32.const 9
-                    i32.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    local.set $28
-                    local.get $0
-                    i32.load offset=4
-                    local.set $26
-                    i32.const 12
-                    i32.const 9
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
-                    i32.const 2
-                    i32.shl
-                    local.tee $25
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $29
-                    loop $for-loop|015
-                     local.get $1
-                     local.get $28
-                     i32.lt_s
-                     if
-                      local.get $26
-                      local.get $1
-                      i32.const 2
-                      i32.shl
-                      local.tee $24
-                      i32.add
-                      i32.load
-                      local.set $27
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $24
-                      local.get $29
-                      i32.add
-                      local.get $27
-                      local.get $27
-                      i32.mul
-                      i32.store
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|015
-                     end
-                    end
-                    local.get $30
-                    local.get $29
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $29
-                    i32.store offset=4
-                    local.get $30
-                    local.get $25
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Uint32Array#__get
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Uint32Array#__get
-                    i32.const 4
-                    i32.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Uint32Array#__get
-                    i32.const 9
-                    i32.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int64Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    i64.const 1
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $0
-                    i32.const 1
-                    i64.const 2
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $0
-                    i32.const 2
-                    i64.const 3
-                    call $~lib/typedarray/Int64Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 3
-                    i32.shr_u
-                    local.set $28
-                    local.get $0
-                    i32.load offset=4
-                    local.set $27
-                    i32.const 12
-                    i32.const 10
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
-                    i32.const 3
-                    i32.shl
-                    local.tee $26
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $29
-                    loop $for-loop|016
-                     local.get $1
-                     local.get $28
-                     i32.lt_s
-                     if
-                      local.get $27
-                      local.get $1
-                      i32.const 3
-                      i32.shl
-                      local.tee $25
-                      i32.add
-                      i64.load
-                      local.set $20
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $25
-                      local.get $29
-                      i32.add
-                      local.get $20
-                      local.get $20
-                      i64.mul
-                      i64.store
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|016
-                     end
-                    end
-                    local.get $30
-                    local.get $29
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $29
-                    i32.store offset=4
-                    local.get $30
-                    local.get $26
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Int64Array#__get
-                    i64.const 1
-                    i64.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Int64Array#__get
-                    i64.const 4
-                    i64.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Int64Array#__get
-                    i64.const 9
-                    i64.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint64Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    i64.const 1
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $0
-                    i32.const 1
-                    i64.const 2
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $0
-                    i32.const 2
-                    i64.const 3
-                    call $~lib/typedarray/Uint64Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 3
-                    i32.shr_u
-                    local.set $28
-                    local.get $0
-                    i32.load offset=4
-                    local.set $27
-                    i32.const 12
-                    i32.const 11
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
-                    i32.const 3
-                    i32.shl
-                    local.tee $26
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $29
-                    loop $for-loop|017
-                     local.get $1
-                     local.get $28
-                     i32.lt_s
-                     if
-                      local.get $27
-                      local.get $1
-                      i32.const 3
-                      i32.shl
-                      local.tee $25
-                      i32.add
-                      i64.load
-                      local.set $20
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $25
-                      local.get $29
-                      i32.add
-                      local.get $20
-                      local.get $20
-                      i64.mul
-                      i64.store
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|017
-                     end
-                    end
-                    local.get $30
-                    local.get $29
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $29
-                    i32.store offset=4
-                    local.get $30
-                    local.get $26
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Uint64Array#__get
-                    i64.const 1
-                    i64.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Uint64Array#__get
-                    i64.const 4
-                    i64.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Uint64Array#__get
-                    i64.const 9
-                    i64.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float32Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    f32.const 1
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $0
-                    i32.const 1
-                    f32.const 2
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $0
-                    i32.const 2
-                    f32.const 3
-                    call $~lib/typedarray/Float32Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    local.set $28
-                    local.get $0
-                    i32.load offset=4
-                    local.set $27
-                    i32.const 12
-                    i32.const 12
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
-                    i32.const 2
-                    i32.shl
-                    local.tee $26
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $29
-                    loop $for-loop|018
-                     local.get $1
-                     local.get $28
-                     i32.lt_s
-                     if
-                      local.get $27
-                      local.get $1
-                      i32.const 2
-                      i32.shl
-                      local.tee $25
-                      i32.add
-                      f32.load
-                      local.set $22
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $25
-                      local.get $29
-                      i32.add
-                      local.get $22
-                      local.get $22
-                      f32.mul
-                      f32.store
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|018
-                     end
-                    end
-                    local.get $30
-                    local.get $29
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $29
-                    i32.store offset=4
-                    local.get $30
-                    local.get $26
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Float32Array#__get
-                    f32.const 1
-                    f32.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Float32Array#__get
-                    f32.const 4
-                    f32.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Float32Array#__get
-                    f32.const 9
-                    f32.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float64Array#constructor
-                    local.tee $0
-                    i32.const 0
-                    f64.const 1
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $0
-                    i32.const 1
-                    f64.const 2
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $0
-                    i32.const 2
-                    f64.const 3
-                    call $~lib/typedarray/Float64Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 3
-                    i32.shr_u
-                    local.set $28
-                    local.get $0
-                    i32.load offset=4
-                    local.set $27
-                    i32.const 12
-                    i32.const 13
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $30
-                    local.get $28
-                    i32.const 3
-                    i32.shl
-                    local.tee $26
-                    i32.const 0
-                    call $~lib/rt/tlsf/__alloc
-                    local.set $29
-                    loop $for-loop|019
-                     local.get $1
-                     local.get $28
-                     i32.lt_s
-                     if
-                      local.get $27
-                      local.get $1
-                      i32.const 3
-                      i32.shl
-                      local.tee $25
-                      i32.add
-                      f64.load
-                      local.set $23
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $25
-                      local.get $29
-                      i32.add
-                      local.get $23
-                      local.get $23
-                      f64.mul
-                      f64.store
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|019
-                     end
-                    end
-                    local.get $30
-                    local.get $29
-                    call $~lib/rt/pure/__retain
-                    i32.store
-                    local.get $30
-                    local.get $29
-                    i32.store offset=4
-                    local.get $30
-                    local.get $26
-                    i32.store offset=8
-                    local.get $30
-                    call $~lib/rt/pure/__retain
-                    local.tee $1
-                    i32.const 0
-                    call $~lib/typedarray/Float64Array#__get
-                    f64.const 1
-                    f64.ne
-                    br_if $folding-inner4
-                    local.get $1
-                    i32.const 1
-                    call $~lib/typedarray/Float64Array#__get
-                    f64.const 4
-                    f64.ne
-                    br_if $folding-inner5
-                    local.get $1
-                    i32.const 2
-                    call $~lib/typedarray/Float64Array#__get
-                    f64.const 9
-                    f64.ne
-                    br_if $folding-inner6
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8ClampedArray,u8>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Int32Array,i32>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint32Array,u32>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Int64Array,i64>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint64Array,u64>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Float32Array,f32>
-                    call $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
-                    i32.const 3
-                    call $~lib/typedarray/Int8Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 46
-                    call $~lib/typedarray/Int8Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 47
-                    call $~lib/typedarray/Int8Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint8Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 48
-                    call $~lib/typedarray/Uint8Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 49
-                    call $~lib/typedarray/Uint8Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 50
-                    call $~lib/typedarray/Uint8Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 51
-                    call $~lib/typedarray/Uint8Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int16Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 52
-                    call $~lib/typedarray/Int16Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 53
-                    call $~lib/typedarray/Int16Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint16Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 54
-                    call $~lib/typedarray/Uint16Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 55
-                    call $~lib/typedarray/Uint16Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 56
-                    call $~lib/typedarray/Int32Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 57
-                    call $~lib/typedarray/Int32Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 58
-                    call $~lib/typedarray/Int32Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 59
-                    call $~lib/typedarray/Int32Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 2
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 4
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 6
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 60
-                    call $~lib/typedarray/Int64Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 61
-                    call $~lib/typedarray/Int64Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 2
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 4
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 6
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 62
-                    call $~lib/typedarray/Int64Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 63
-                    call $~lib/typedarray/Int64Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    f32.const 2
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 1
-                    f32.const 4
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 2
-                    f32.const 6
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 64
-                    call $~lib/typedarray/Float32Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 65
-                    call $~lib/typedarray/Float32Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    f64.const 2
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 1
-                    f64.const 4
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 2
-                    f64.const 6
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 66
-                    call $~lib/typedarray/Float64Array#some
-                    i32.eqz
-                    br_if $folding-inner7
-                    local.get $1
-                    i32.const 67
-                    call $~lib/typedarray/Float64Array#some
-                    br_if $folding-inner8
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int8Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 68
-                    call $~lib/typedarray/Int8Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 69
-                    call $~lib/typedarray/Int8Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint8Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 70
-                    call $~lib/typedarray/Uint8Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 71
-                    call $~lib/typedarray/Uint8Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 72
-                    call $~lib/typedarray/Uint8Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 73
-                    call $~lib/typedarray/Uint8Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int16Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 74
-                    call $~lib/typedarray/Int16Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 75
-                    call $~lib/typedarray/Int16Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint16Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 76
-                    call $~lib/typedarray/Uint16Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 77
-                    call $~lib/typedarray/Uint16Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 78
-                    call $~lib/typedarray/Int32Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 79
-                    call $~lib/typedarray/Int32Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 80
-                    call $~lib/typedarray/Int32Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 81
-                    call $~lib/typedarray/Int32Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 1
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 2
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 3
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 82
-                    call $~lib/typedarray/Int64Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 83
-                    call $~lib/typedarray/Int64Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 1
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 2
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 3
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 84
-                    call $~lib/typedarray/Int64Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 85
-                    call $~lib/typedarray/Int64Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    f32.const 1
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 1
-                    f32.const 2
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 2
-                    f32.const 3
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 86
-                    call $~lib/typedarray/Float32Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 87
-                    call $~lib/typedarray/Float32Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    f64.const 1
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 1
-                    f64.const 2
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 2
-                    f64.const 3
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 88
-                    call $~lib/typedarray/Float64Array#findIndex
-                    i32.const 1
-                    i32.ne
-                    br_if $folding-inner9
-                    local.get $1
-                    i32.const 89
-                    call $~lib/typedarray/Float64Array#findIndex
-                    i32.const -1
-                    i32.ne
-                    br_if $folding-inner10
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int8Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 90
-                    call $~lib/typedarray/Int8Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 91
-                    call $~lib/typedarray/Int8Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint8Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 92
-                    call $~lib/typedarray/Uint8Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 93
-                    call $~lib/typedarray/Uint8Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 94
-                    call $~lib/typedarray/Uint8Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 95
-                    call $~lib/typedarray/Uint8Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int16Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 96
-                    call $~lib/typedarray/Int16Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 97
-                    call $~lib/typedarray/Int16Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint16Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 98
-                    call $~lib/typedarray/Uint16Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 99
-                    call $~lib/typedarray/Uint16Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 100
-                    call $~lib/typedarray/Int32Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 101
-                    call $~lib/typedarray/Int32Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 2
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 4
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 6
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 102
-                    call $~lib/typedarray/Int32Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 103
-                    call $~lib/typedarray/Int32Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Int64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 2
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 4
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 6
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 104
-                    call $~lib/typedarray/Int64Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 105
-                    call $~lib/typedarray/Int64Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Uint64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 2
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 4
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 6
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 106
-                    call $~lib/typedarray/Int64Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 107
-                    call $~lib/typedarray/Int64Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    f32.const 2
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 1
-                    f32.const 4
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 2
-                    f32.const 6
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 108
-                    call $~lib/typedarray/Float32Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 109
-                    call $~lib/typedarray/Float32Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 3
-                    call $~lib/typedarray/Float64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    f64.const 2
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 1
-                    f64.const 4
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 2
-                    f64.const 6
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 110
-                    call $~lib/typedarray/Float64Array#every
-                    i32.eqz
-                    br_if $folding-inner11
-                    local.get $1
-                    i32.const 111
-                    call $~lib/typedarray/Float64Array#every
-                    br_if $folding-inner12
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Int8Array#constructor
-                    local.tee $0
-                    global.set $std/typedarray/forEachSelf
-                    local.get $0
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 24
-                    i32.shl
-                    i32.const 24
-                    i32.shr_s
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 24
-                    i32.shl
-                    i32.const 24
-                    i32.shr_s
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 24
-                    i32.shl
-                    i32.const 24
-                    i32.shr_s
-                    call $~lib/typedarray/Int8Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=4
-                    local.set $30
-                    local.get $0
-                    i32.load offset=8
-                    local.set $29
-                    loop $for-loop|020
-                     local.get $1
-                     local.get $29
-                     i32.lt_s
-                     if
-                      local.get $1
-                      local.get $30
-                      i32.add
-                      i32.load8_s
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $1
-                      local.get $0
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|020
-                     end
-                    end
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Uint8Array#constructor
-                    local.tee $1
-                    global.set $std/typedarray/forEachSelf
-                    local.get $1
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 255
-                    i32.and
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 255
-                    i32.and
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 255
-                    i32.and
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 113
-                    call $~lib/typedarray/Uint8Array#forEach
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                    local.tee $1
-                    global.set $std/typedarray/forEachSelf
-                    local.get $1
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 255
-                    i32.and
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 255
-                    i32.and
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 255
-                    i32.and
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 114
-                    call $~lib/typedarray/Uint8Array#forEach
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Int16Array#constructor
-                    local.tee $0
-                    global.set $std/typedarray/forEachSelf
-                    local.get $0
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 16
-                    i32.shl
-                    i32.const 16
-                    i32.shr_s
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 16
-                    i32.shl
-                    i32.const 16
-                    i32.shr_s
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 16
-                    i32.shl
-                    i32.const 16
-                    i32.shr_s
-                    call $~lib/typedarray/Int16Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=4
-                    local.set $30
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 1
-                    i32.shr_u
-                    local.set $29
-                    loop $for-loop|021
-                     local.get $1
-                     local.get $29
-                     i32.lt_s
-                     if
-                      local.get $30
-                      local.get $1
-                      i32.const 1
-                      i32.shl
-                      i32.add
-                      i32.load16_s
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $1
-                      local.get $0
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|021
-                     end
-                    end
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Uint16Array#constructor
-                    local.tee $0
-                    global.set $std/typedarray/forEachSelf
-                    local.get $0
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 65535
-                    i32.and
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $0
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 65535
-                    i32.and
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $0
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    i32.const 65535
-                    i32.and
-                    call $~lib/typedarray/Uint16Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $0
-                    i32.load offset=4
-                    local.set $30
-                    local.get $0
-                    i32.load offset=8
-                    i32.const 1
-                    i32.shr_u
-                    local.set $29
-                    loop $for-loop|022
-                     local.get $1
-                     local.get $29
-                     i32.lt_s
-                     if
-                      local.get $30
-                      local.get $1
-                      i32.const 1
-                      i32.shl
-                      i32.add
-                      i32.load16_u
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $1
-                      local.get $0
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|022
-                     end
-                    end
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Int32Array#constructor
-                    local.tee $1
-                    global.set $std/typedarray/forEachSelf
-                    local.get $1
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 117
-                    call $~lib/typedarray/Int32Array#forEach
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#constructor
-                    local.tee $1
-                    global.set $std/typedarray/forEachSelf
-                    local.get $1
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 118
-                    call $~lib/typedarray/Int32Array#forEach
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Int64Array#constructor
-                    local.tee $1
-                    global.set $std/typedarray/forEachSelf
-                    local.get $1
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    i64.extend_i32_s
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    i64.extend_i32_s
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    i64.extend_i32_s
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 119
-                    call $~lib/typedarray/Int64Array#forEach
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Uint64Array#constructor
-                    local.tee $1
-                    global.set $std/typedarray/forEachSelf
-                    local.get $1
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    i64.extend_i32_s
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    i64.extend_i32_s
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    i64.extend_i32_s
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 120
-                    call $~lib/typedarray/Int64Array#forEach
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Float32Array#constructor
-                    local.tee $1
-                    global.set $std/typedarray/forEachSelf
-                    local.get $1
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    f32.convert_i32_s
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    f32.convert_i32_s
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    f32.convert_i32_s
-                    call $~lib/typedarray/Float32Array#__set
-                    i32.const 0
-                    local.set $0
-                    local.get $1
-                    i32.load offset=4
-                    local.set $30
-                    local.get $1
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    local.set $29
-                    loop $for-loop|023
-                     local.get $0
-                     local.get $29
-                     i32.lt_s
-                     if
-                      local.get $30
-                      local.get $0
-                      i32.const 2
-                      i32.shl
-                      i32.add
-                      f32.load
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $0
-                      local.get $1
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0
-                      local.get $0
-                      i32.const 1
-                      i32.add
-                      local.set $0
-                      br $for-loop|023
-                     end
-                    end
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    global.set $std/typedarray/forEachCallCount
-                    i32.const 3
-                    call $~lib/typedarray/Float64Array#constructor
-                    local.tee $1
-                    global.set $std/typedarray/forEachSelf
-                    local.get $1
-                    i32.const 0
-                    i32.const 2704
-                    i32.const 0
-                    call $~lib/array/Array<i32>#__get
-                    f64.convert_i32_s
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2704
-                    i32.const 1
-                    call $~lib/array/Array<i32>#__get
-                    f64.convert_i32_s
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 2704
-                    i32.const 2
-                    call $~lib/array/Array<i32>#__get
-                    f64.convert_i32_s
-                    call $~lib/typedarray/Float64Array#__set
-                    i32.const 0
-                    local.set $0
-                    local.get $1
-                    i32.load offset=4
-                    local.set $30
-                    local.get $1
-                    i32.load offset=8
-                    i32.const 3
-                    i32.shr_u
-                    local.set $29
-                    loop $for-loop|024
-                     local.get $0
-                     local.get $29
-                     i32.lt_s
-                     if
-                      local.get $30
-                      local.get $0
-                      i32.const 3
-                      i32.shl
-                      i32.add
-                      f64.load
-                      i32.const 3
-                      global.set $~argumentsLength
-                      local.get $0
-                      local.get $1
-                      call $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0
-                      local.get $0
-                      i32.const 1
-                      i32.add
-                      local.set $0
-                      br $for-loop|024
-                     end
-                    end
-                    global.get $std/typedarray/forEachCallCount
-                    i32.const 3
-                    i32.ne
-                    br_if $folding-inner13
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32>
-                    call $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32>
-                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64>
-                    i32.const 1
-                    call $~lib/typedarray/Float64Array#constructor
-                    local.tee $30
-                    i32.const 0
-                    f64.const nan:0x8000000000000
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $30
-                    f64.const nan:0x8000000000000
-                    i32.const 0
-                    call $~lib/typedarray/Float64Array#indexOf
-                    i32.const -1
-                    i32.ne
-                    if
-                     i32.const 0
-                     i32.const 1312
-                     i32.const 607
-                     i32.const 3
-                     call $~lib/builtins/abort
-                     unreachable
-                    end
-                    i32.const 0
-                    local.set $0
-                    i32.const 0
-                    local.set $1
-                    block $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
-                     local.get $30
-                     i32.load offset=8
-                     i32.const 3
-                     i32.shr_u
-                     local.tee $29
-                     if (result i32)
-                      i32.const 0
-                      local.get $29
-                      i32.ge_s
-                     else
-                      i32.const 1
-                     end
-                     br_if $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
-                     local.get $30
-                     i32.load offset=4
-                     local.set $27
-                     loop $while-continue|0
-                      local.get $0
-                      local.get $29
-                      i32.lt_s
-                      if
-                       local.get $27
-                       local.get $0
-                       i32.const 3
-                       i32.shl
-                       i32.add
-                       f64.load
-                       local.tee $23
-                       f64.const nan:0x8000000000000
-                       f64.eq
-                       if (result i32)
-                        i32.const 1
-                       else
-                        local.get $23
-                        local.get $23
-                        f64.ne
-                       end
-                       if
-                        i32.const 1
-                        local.set $1
-                        br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
-                       end
-                       local.get $0
-                       i32.const 1
-                       i32.add
-                       local.set $0
-                       br $while-continue|0
-                      end
-                     end
-                    end
-                    local.get $1
-                    i32.const 0
-                    i32.ne
-                    i32.const 1
-                    i32.ne
-                    if
-                     i32.const 0
-                     i32.const 1312
-                     i32.const 608
-                     i32.const 3
-                     call $~lib/builtins/abort
-                     unreachable
-                    end
-                    i32.const 1
-                    call $~lib/typedarray/Float32Array#constructor
-                    local.tee $29
-                    i32.const 0
-                    f32.const nan:0x400000
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $29
-                    f32.const nan:0x400000
-                    i32.const 0
-                    call $~lib/typedarray/Float32Array#indexOf
-                    i32.const -1
-                    i32.ne
-                    if
-                     i32.const 0
-                     i32.const 1312
-                     i32.const 613
-                     i32.const 3
-                     call $~lib/builtins/abort
-                     unreachable
-                    end
-                    i32.const 0
-                    local.set $1
-                    i32.const 0
-                    local.set $0
-                    block $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
-                     local.get $29
-                     i32.load offset=8
-                     i32.const 2
-                     i32.shr_u
-                     local.tee $28
-                     if (result i32)
-                      i32.const 0
-                      local.get $28
-                      i32.ge_s
-                     else
-                      i32.const 1
-                     end
-                     br_if $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
-                     local.get $29
-                     i32.load offset=4
-                     local.set $26
-                     loop $while-continue|025
-                      local.get $1
-                      local.get $28
-                      i32.lt_s
-                      if
-                       local.get $26
-                       local.get $1
-                       i32.const 2
-                       i32.shl
-                       i32.add
-                       f32.load
-                       local.tee $22
-                       f32.const nan:0x400000
-                       f32.eq
-                       if (result i32)
-                        i32.const 1
-                       else
-                        local.get $22
-                        local.get $22
-                        f32.ne
-                       end
-                       if
-                        i32.const 1
-                        local.set $0
-                        br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
-                       end
-                       local.get $1
-                       i32.const 1
-                       i32.add
-                       local.set $1
-                       br $while-continue|025
-                      end
-                     end
-                    end
-                    local.get $0
-                    i32.const 0
-                    i32.ne
-                    i32.const 1
-                    i32.ne
-                    if
-                     i32.const 0
-                     i32.const 1312
-                     i32.const 614
-                     i32.const 3
-                     call $~lib/builtins/abort
-                     unreachable
-                    end
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $29
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Int8Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 3
-                    i32.const 4
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    i32.const 4
-                    i32.const 5
-                    call $~lib/typedarray/Int8Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Int8Array#join
-                    local.tee $0
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner0
-                    local.get $1
-                    call $~lib/typedarray/Int8Array#join
-                    local.tee $30
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner18
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Uint8Array#constructor
-                    local.tee $1
-                    local.get $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 3
-                    i32.const 4
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    i32.const 4
-                    i32.const 5
-                    call $~lib/typedarray/Uint8Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Uint8Array#join
-                    local.tee $30
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner0
-                    call $~lib/typedarray/Uint8Array#join
-                    local.tee $0
-                    local.get $0
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner18
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                    local.tee $1
-                    local.get $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 3
-                    i32.const 4
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    i32.const 4
-                    i32.const 5
-                    call $~lib/typedarray/Uint8ClampedArray#__set
-                    local.get $1
-                    call $~lib/typedarray/Uint8Array#join
-                    local.tee $30
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner0
-                    call $~lib/typedarray/Uint8Array#join
-                    local.tee $0
-                    local.get $0
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner18
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Int16Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 3
-                    i32.const 4
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    i32.const 4
-                    i32.const 5
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Int16Array#join
-                    local.tee $0
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner0
-                    local.get $1
-                    call $~lib/typedarray/Int16Array#join
-                    local.tee $30
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner18
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Uint16Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 3
-                    i32.const 4
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    i32.const 4
-                    i32.const 5
-                    call $~lib/typedarray/Uint16Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Uint16Array#join
-                    local.tee $0
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner0
-                    local.get $1
-                    call $~lib/typedarray/Uint16Array#join
-                    local.tee $30
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner18
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Int32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 3
-                    i32.const 4
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    i32.const 4
-                    i32.const 5
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Int32Array#join
-                    local.tee $0
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner0
-                    local.get $1
-                    call $~lib/typedarray/Int32Array#join
-                    local.tee $30
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner18
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Uint32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 2
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 3
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 3
-                    i32.const 4
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 4
-                    i32.const 5
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Uint32Array#join
-                    local.tee $0
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner0
-                    local.get $1
-                    call $~lib/typedarray/Uint32Array#join
-                    local.tee $30
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner18
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Int64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 1
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 2
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 3
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 3
-                    i64.const 4
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    i32.const 4
-                    i64.const 5
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Int64Array#join
-                    local.tee $0
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner0
-                    local.get $1
-                    call $~lib/typedarray/Int64Array#join
-                    local.tee $30
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner18
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Uint64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i64.const 1
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 1
-                    i64.const 2
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 2
-                    i64.const 3
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 3
-                    i64.const 4
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    i32.const 4
-                    i64.const 5
-                    call $~lib/typedarray/Uint64Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Uint64Array#join
-                    local.tee $0
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner0
-                    local.get $1
-                    call $~lib/typedarray/Uint64Array#join
-                    local.tee $30
-                    i32.const 3296
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner18
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Float32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    f32.const 1
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 1
-                    f32.const 2
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 2
-                    f32.const 3
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 3
-                    f32.const 4
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    i32.const 4
-                    f32.const 5
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Float32Array#join
-                    local.tee $0
-                    i32.const 4400
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner16
-                    local.get $1
-                    call $~lib/typedarray/Float32Array#join
-                    local.tee $30
-                    i32.const 4400
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner17
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 5
-                    call $~lib/typedarray/Float64Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    f64.const 1
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 1
-                    f64.const 2
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 2
-                    f64.const 3
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 3
-                    f64.const 4
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    i32.const 4
-                    f64.const 5
-                    call $~lib/typedarray/Float64Array#__set
-                    local.get $1
-                    call $~lib/typedarray/Float64Array#join
-                    local.tee $0
-                    i32.const 4400
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner16
-                    local.get $1
-                    call $~lib/typedarray/Float64Array#join
-                    local.tee $30
-                    i32.const 4400
-                    call $~lib/string/String.__eq
-                    i32.eqz
-                    br_if $folding-inner17
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 0
-                    call $~lib/arraybuffer/ArrayBuffer#constructor
-                    local.set $1
-                    i32.const 2
-                    global.set $~argumentsLength
-                    local.get $1
-                    i32.const 0
-                    call $~lib/typedarray/Uint8Array.wrap@varargs
-                    local.tee $30
-                    i32.load offset=8
-                    if
-                     i32.const 0
-                     i32.const 1312
-                     i32.const 691
-                     i32.const 3
-                     call $~lib/builtins/abort
-                     unreachable
-                    end
-                    i32.const 2
-                    call $~lib/arraybuffer/ArrayBuffer#constructor
-                    local.set $0
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    i32.const 2
-                    global.set $~argumentsLength
-                    local.get $0
-                    i32.const 2
-                    call $~lib/typedarray/Uint8Array.wrap@varargs
-                    local.set $1
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    i32.load offset=8
-                    if
-                     i32.const 0
-                     i32.const 1312
-                     i32.const 695
-                     i32.const 3
-                     call $~lib/builtins/abort
-                     unreachable
-                    end
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32>
-                    call $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array>
-                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array>
-                    i32.const 10
-                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                    local.set $0
-                    i32.const 3
-                    call $~lib/typedarray/Float32Array#constructor
-                    local.tee $30
-                    i32.const 0
-                    f32.const 400
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $30
-                    i32.const 1
-                    f32.const nan:0x400000
-                    call $~lib/typedarray/Float32Array#__set
-                    local.get $30
-                    i32.const 2
-                    f32.const inf
-                    call $~lib/typedarray/Float32Array#__set
-                    i32.const 4
-                    call $~lib/typedarray/Int64Array#constructor
-                    local.tee $29
-                    i32.const 0
-                    i64.const -10
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $29
-                    i32.const 1
-                    i64.const 100
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $29
-                    i32.const 2
-                    i64.const 10
-                    call $~lib/typedarray/Int64Array#__set
-                    local.get $29
-                    i32.const 3
-                    i64.const 300
-                    call $~lib/typedarray/Int64Array#__set
-                    i32.const 2
-                    call $~lib/typedarray/Int32Array#constructor
-                    local.tee $28
-                    i32.const 0
-                    i32.const 300
-                    call $~lib/typedarray/Int32Array#__set
-                    local.get $28
-                    i32.const 1
-                    i32.const -1
-                    call $~lib/typedarray/Int32Array#__set
-                    i32.const 0
-                    local.set $1
-                    local.get $30
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    i32.const 1
-                    i32.add
-                    local.get $0
-                    i32.load offset=8
-                    i32.gt_s
-                    br_if $folding-inner19
-                    local.get $0
-                    i32.load offset=4
-                    i32.const 1
-                    i32.add
-                    local.set $26
-                    local.get $30
-                    i32.load offset=4
-                    local.set $25
-                    local.get $30
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    local.set $24
-                    loop $for-loop|026
-                     local.get $1
-                     local.get $24
-                     i32.lt_s
-                     if
-                      local.get $1
-                      local.get $26
-                      i32.add
-                      local.get $25
-                      local.get $1
-                      i32.const 2
-                      i32.shl
-                      i32.add
-                      f32.load
-                      local.tee $22
-                      local.get $22
-                      f32.sub
-                      f32.const 0
-                      f32.eq
-                      if (result i32)
-                       f32.const 0
-                       f32.const 255
-                       local.get $22
-                       f32.min
-                       f32.max
-                       i32.trunc_f32_u
-                      else
-                       i32.const 0
-                      end
-                      i32.store8
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|026
-                     end
-                    end
-                    local.get $0
-                    local.get $29
-                    i32.const 4
-                    call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
-                    i32.const 0
-                    local.set $1
-                    local.get $28
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    i32.const 8
-                    i32.add
-                    local.get $0
-                    i32.load offset=8
-                    i32.gt_s
-                    br_if $folding-inner19
-                    local.get $0
-                    i32.load offset=4
-                    i32.const 8
-                    i32.add
-                    local.set $26
-                    local.get $28
-                    i32.load offset=4
-                    local.set $25
-                    local.get $28
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    local.set $24
-                    loop $for-loop|027
-                     local.get $1
-                     local.get $24
-                     i32.lt_s
-                     if
-                      local.get $1
-                      local.get $26
-                      i32.add
-                      local.get $25
-                      local.get $1
-                      i32.const 2
-                      i32.shl
-                      i32.add
-                      i32.load
-                      local.tee $27
-                      i32.const 31
-                      i32.shr_s
-                      i32.const -1
-                      i32.xor
-                      local.get $27
-                      i32.const 255
-                      local.get $27
-                      i32.sub
-                      i32.const 31
-                      i32.shr_s
-                      i32.or
-                      i32.and
-                      i32.store8
-                      local.get $1
-                      i32.const 1
-                      i32.add
-                      local.set $1
-                      br $for-loop|027
-                     end
-                    end
-                    local.get $0
-                    i32.const 10
-                    i32.const 0
-                    i32.const 18
-                    i32.const 8576
-                    call $~lib/rt/__allocArray
-                    call $~lib/rt/pure/__retain
-                    local.tee $25
-                    call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-                    i32.const 4
-                    call $~lib/typedarray/Uint32Array#constructor
-                    local.tee $1
-                    i32.const 0
-                    i32.const 1
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 1
-                    i32.const 300
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 2
-                    i32.const 100
-                    call $~lib/typedarray/Uint32Array#__set
-                    local.get $1
-                    i32.const 3
-                    i32.const -1
-                    call $~lib/typedarray/Uint32Array#__set
-                    i32.const 4
-                    call $~lib/typedarray/Int16Array#constructor
-                    local.tee $27
-                    i32.const 0
-                    i32.const -10
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $27
-                    i32.const 1
-                    i32.const 100
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $27
-                    i32.const 2
-                    i32.const 10
-                    call $~lib/typedarray/Int16Array#__set
-                    local.get $27
-                    i32.const 3
-                    i32.const 300
-                    call $~lib/typedarray/Int16Array#__set
-                    i32.const 0
-                    local.set $26
-                    local.get $1
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    local.get $0
-                    i32.load offset=8
-                    i32.gt_s
-                    br_if $folding-inner19
-                    local.get $0
-                    i32.load offset=4
-                    local.set $24
-                    local.get $1
-                    i32.load offset=4
-                    local.set $19
-                    local.get $1
-                    i32.load offset=8
-                    i32.const 2
-                    i32.shr_u
-                    local.set $18
-                    loop $for-loop|028
-                     local.get $26
-                     local.get $18
-                     i32.lt_s
-                     if
-                      local.get $24
-                      local.get $26
-                      i32.add
-                      i32.const 255
-                      local.get $19
-                      local.get $26
-                      i32.const 2
-                      i32.shl
-                      i32.add
-                      i32.load
-                      local.tee $17
-                      i32.const 255
-                      local.get $17
-                      i32.lt_u
-                      select
-                      i32.store8
-                      local.get $26
-                      i32.const 1
-                      i32.add
-                      local.set $26
-                      br $for-loop|028
-                     end
-                    end
-                    local.get $0
-                    local.get $27
-                    i32.const 5
-                    call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
-                    local.get $0
-                    i32.const 10
-                    i32.const 0
-                    i32.const 18
-                    i32.const 8608
-                    call $~lib/rt/__allocArray
-                    call $~lib/rt/pure/__retain
-                    local.tee $26
-                    call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-                    local.get $0
-                    call $~lib/rt/pure/__release
-                    local.get $30
-                    call $~lib/rt/pure/__release
-                    local.get $29
-                    call $~lib/rt/pure/__release
-                    local.get $28
-                    call $~lib/rt/pure/__release
-                    local.get $25
-                    call $~lib/rt/pure/__release
-                    local.get $1
-                    call $~lib/rt/pure/__release
-                    local.get $27
-                    call $~lib/rt/pure/__release
-                    local.get $26
-                    call $~lib/rt/pure/__release
-                    return
+                   local.get $1
+                   i32.const 3
+                   i32.const 4
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   i32.const 4
+                   i32.const 5
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Int32Array#join
+                   local.tee $29
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner0
+                   local.get $1
+                   call $~lib/typedarray/Int32Array#join
+                   local.tee $28
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner18
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Uint32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 1
+                   i32.const 2
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 2
+                   i32.const 3
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 3
+                   i32.const 4
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   i32.const 4
+                   i32.const 5
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Uint32Array#join
+                   local.tee $29
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner0
+                   local.get $1
+                   call $~lib/typedarray/Uint32Array#join
+                   local.tee $28
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner18
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Int64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 1
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 2
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 3
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 3
+                   i64.const 4
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   i32.const 4
+                   i64.const 5
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Int64Array#join
+                   local.tee $29
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner0
+                   local.get $1
+                   call $~lib/typedarray/Int64Array#join
+                   local.tee $28
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner18
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Uint64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   i64.const 1
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 1
+                   i64.const 2
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 2
+                   i64.const 3
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 3
+                   i64.const 4
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   i32.const 4
+                   i64.const 5
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Uint64Array#join
+                   local.tee $29
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner0
+                   local.get $1
+                   call $~lib/typedarray/Uint64Array#join
+                   local.tee $28
+                   i32.const 3296
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner18
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Float32Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   f32.const 1
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 1
+                   f32.const 2
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 2
+                   f32.const 3
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 3
+                   f32.const 4
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   i32.const 4
+                   f32.const 5
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Float32Array#join
+                   local.tee $29
+                   i32.const 4400
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner16
+                   local.get $1
+                   call $~lib/typedarray/Float32Array#join
+                   local.tee $28
+                   i32.const 4400
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner17
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 5
+                   call $~lib/typedarray/Float64Array#constructor
+                   local.tee $0
+                   call $~lib/rt/pure/__retain
+                   local.tee $1
+                   i32.const 0
+                   f64.const 1
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 1
+                   f64.const 2
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 2
+                   f64.const 3
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 3
+                   f64.const 4
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   i32.const 4
+                   f64.const 5
+                   call $~lib/typedarray/Float64Array#__set
+                   local.get $1
+                   call $~lib/typedarray/Float64Array#join
+                   local.tee $29
+                   i32.const 4400
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner16
+                   local.get $1
+                   call $~lib/typedarray/Float64Array#join
+                   local.tee $28
+                   i32.const 4400
+                   call $~lib/string/String.__eq
+                   i32.eqz
+                   br_if $folding-inner17
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   call $~lib/arraybuffer/ArrayBuffer#constructor
+                   local.set $1
+                   i32.const 2
+                   global.set $~argumentsLength
+                   local.get $1
+                   i32.const 0
+                   call $~lib/typedarray/Uint8Array.wrap@varargs
+                   local.tee $29
+                   i32.load offset=8
+                   if
+                    i32.const 0
+                    i32.const 1312
+                    i32.const 691
+                    i32.const 3
+                    call $~lib/builtins/abort
+                    unreachable
                    end
-                   br $folding-inner3
+                   i32.const 2
+                   call $~lib/arraybuffer/ArrayBuffer#constructor
+                   local.set $0
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   i32.const 2
+                   global.set $~argumentsLength
+                   local.get $0
+                   i32.const 2
+                   call $~lib/typedarray/Uint8Array.wrap@varargs
+                   local.set $1
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   i32.load offset=8
+                   if
+                    i32.const 0
+                    i32.const 1312
+                    i32.const 695
+                    i32.const 3
+                    call $~lib/builtins/abort
+                    unreachable
+                   end
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32>
+                   call $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array>
+                   call $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array>
+                   i32.const 10
+                   call $~lib/typedarray/Uint8ClampedArray#constructor
+                   local.set $1
+                   i32.const 3
+                   call $~lib/typedarray/Float32Array#constructor
+                   local.tee $27
+                   i32.const 0
+                   f32.const 400
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $27
+                   i32.const 1
+                   f32.const nan:0x400000
+                   call $~lib/typedarray/Float32Array#__set
+                   local.get $27
+                   i32.const 2
+                   f32.const inf
+                   call $~lib/typedarray/Float32Array#__set
+                   i32.const 4
+                   call $~lib/typedarray/Int64Array#constructor
+                   local.tee $0
+                   i32.const 0
+                   i64.const -10
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $0
+                   i32.const 1
+                   i64.const 100
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $0
+                   i32.const 2
+                   i64.const 10
+                   call $~lib/typedarray/Int64Array#__set
+                   local.get $0
+                   i32.const 3
+                   i64.const 300
+                   call $~lib/typedarray/Int64Array#__set
+                   i32.const 2
+                   call $~lib/typedarray/Int32Array#constructor
+                   local.tee $26
+                   i32.const 0
+                   i32.const 300
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $26
+                   i32.const 1
+                   i32.const -1
+                   call $~lib/typedarray/Int32Array#__set
+                   local.get $1
+                   local.get $27
+                   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array>
+                   local.get $1
+                   local.get $0
+                   i32.const 4
+                   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
+                   local.get $1
+                   local.get $26
+                   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array>
+                   local.get $1
+                   i32.const 10
+                   i32.const 0
+                   i32.const 18
+                   i32.const 8576
+                   call $~lib/rt/__allocArray
+                   call $~lib/rt/pure/__retain
+                   local.tee $25
+                   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
+                   i32.const 4
+                   call $~lib/typedarray/Uint32Array#constructor
+                   local.tee $29
+                   i32.const 0
+                   i32.const 1
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $29
+                   i32.const 1
+                   i32.const 300
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $29
+                   i32.const 2
+                   i32.const 100
+                   call $~lib/typedarray/Uint32Array#__set
+                   local.get $29
+                   i32.const 3
+                   i32.const -1
+                   call $~lib/typedarray/Uint32Array#__set
+                   i32.const 4
+                   call $~lib/typedarray/Int16Array#constructor
+                   local.tee $28
+                   i32.const 0
+                   i32.const -10
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $28
+                   i32.const 1
+                   i32.const 100
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $28
+                   i32.const 2
+                   i32.const 10
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $28
+                   i32.const 3
+                   i32.const 300
+                   call $~lib/typedarray/Int16Array#__set
+                   local.get $1
+                   local.get $29
+                   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array>
+                   local.get $1
+                   local.get $28
+                   i32.const 5
+                   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
+                   local.get $1
+                   i32.const 10
+                   i32.const 0
+                   i32.const 18
+                   i32.const 8608
+                   call $~lib/rt/__allocArray
+                   call $~lib/rt/pure/__retain
+                   local.tee $24
+                   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $27
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $26
+                   call $~lib/rt/pure/__release
+                   local.get $25
+                   call $~lib/rt/pure/__release
+                   local.get $29
+                   call $~lib/rt/pure/__release
+                   local.get $28
+                   call $~lib/rt/pure/__release
+                   local.get $24
+                   call $~lib/rt/pure/__release
+                   return
                   end
-                  i32.const 0
-                  i32.const 1312
-                  i32.const 323
-                  i32.const 3
-                  call $~lib/builtins/abort
-                  unreachable
+                  br $folding-inner3
                  end
                  i32.const 0
                  i32.const 1312
-                 i32.const 344
+                 i32.const 323
                  i32.const 3
                  call $~lib/builtins/abort
                  unreachable
                 end
                 i32.const 0
                 i32.const 1312
-                i32.const 365
+                i32.const 344
                 i32.const 3
                 call $~lib/builtins/abort
                 unreachable
                end
                i32.const 0
                i32.const 1312
-               i32.const 366
+               i32.const 365
                i32.const 3
                call $~lib/builtins/abort
                unreachable
               end
               i32.const 0
               i32.const 1312
-              i32.const 367
+              i32.const 366
               i32.const 3
               call $~lib/builtins/abort
               unreachable
              end
              i32.const 0
              i32.const 1312
-             i32.const 415
+             i32.const 367
              i32.const 3
              call $~lib/builtins/abort
              unreachable
             end
             i32.const 0
             i32.const 1312
-            i32.const 417
+            i32.const 415
             i32.const 3
             call $~lib/builtins/abort
             unreachable
            end
            i32.const 0
            i32.const 1312
-           i32.const 438
+           i32.const 417
            i32.const 3
            call $~lib/builtins/abort
            unreachable
           end
           i32.const 0
           i32.const 1312
-          i32.const 440
+          i32.const 438
           i32.const 3
           call $~lib/builtins/abort
           unreachable
          end
          i32.const 0
          i32.const 1312
-         i32.const 461
+         i32.const 440
          i32.const 3
          call $~lib/builtins/abort
          unreachable
         end
         i32.const 0
         i32.const 1312
-        i32.const 463
+        i32.const 461
         i32.const 3
         call $~lib/builtins/abort
         unreachable
        end
        i32.const 0
        i32.const 1312
-       i32.const 495
+       i32.const 463
        i32.const 3
        call $~lib/builtins/abort
        unreachable
       end
       i32.const 0
       i32.const 1312
-      i32.const 626
-      i32.const 5
+      i32.const 495
+      i32.const 3
       call $~lib/builtins/abort
       unreachable
      end
      i32.const 0
      i32.const 1312
-     i32.const 627
+     i32.const 626
      i32.const 5
      call $~lib/builtins/abort
      unreachable
     end
     i32.const 0
     i32.const 1312
-    i32.const 629
+    i32.const 627
     i32.const 5
     call $~lib/builtins/abort
     unreachable
    end
    i32.const 0
    i32.const 1312
-   i32.const 630
+   i32.const 629
    i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1376
-  i32.const 1440
-  i32.const 1775
-  i32.const 47
+  i32.const 0
+  i32.const 1312
+  i32.const 630
+  i32.const 5
   call $~lib/builtins/abort
   unreachable
  )


### PR DESCRIPTION
Disables the problematic half of ARC optimizations for now due to https://github.com/AssemblyScript/assemblyscript/issues/1288. Keeping my eyes open for a proper fix.

- [x] I've read the contributing guidelines