### PR TITLE
Update Binaryen and other dependencies

### DIFF
--- a/lib/parse/src/index.ts
+++ b/lib/parse/src/index.ts
@@ -5,7 +5,10 @@ export { Type, SectionId, ExternalKind };
 var compiled: WebAssembly.Module | null = null;
 
 declare var WASM_DATA: string; // injected by webpack
-if (typeof WASM_DATA !== "string") WASM_DATA = require("fs").readFileSync(__dirname + "/../build/index.wasm", "base64");
+if (typeof WASM_DATA !== "string") {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  WASM_DATA = require("fs").readFileSync(__dirname + "/../build/index.wasm", "base64");
+}
 
 /** Options specified to the parser. The `onSection` callback determines the sections being evaluated in detail. */
 export interface ParseOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.1"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
+        "@babel/helper-validator-identifier": "^7.10.1",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -43,24 +43,24 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-      "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==",
+      "version": "14.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.0.1.tgz",
-      "integrity": "sha512-RxGldRQD3hgOK2xtBfNfA5MMV3rn5gVChe+MIf14hKm51jO2urqF64xOyVrGtzThkrd4rS1Kihqx2nkSxkXHvA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.2.0.tgz",
+      "integrity": "sha512-t9RTk/GyYilIXt6BmZurhBzuMT9kLKw3fQoJtK9ayv0tXTlznXEAnx07sCLXdkN3/tZDep1s1CEV95CWuARYWA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "3.0.1",
+        "@typescript-eslint/experimental-utils": "3.2.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
@@ -72,34 +72,25 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
-        },
-        "tsutils": {
-          "version": "3.17.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
         }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.0.1.tgz",
-      "integrity": "sha512-GdwOVz80MOWxbc/br1DC30eeqlxfpVzexHgHtf3L0hcbOu1xAs1wSCNcaBTLMOMZbh1gj/cKZt0eB207FxWfFA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.2.0.tgz",
+      "integrity": "sha512-UbJBsk+xO9dIFKtj16+m42EvUvsjZbbgQ2O5xSTSfVT1Z3yGkL90DVu0Hd3029FZ5/uBgl+F3Vo8FAcEcqc6aQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "3.0.1",
+        "@typescript-eslint/typescript-estree": "3.2.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
       "dependencies": {
         "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
@@ -109,21 +100,21 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.0.1.tgz",
-      "integrity": "sha512-Pn2tDmOc4Ri93VQnT70W0pqQr6i/pEZqIPXfWXm4RuiIprL0t6SG13ViVXHgfScknL2Fm2G4IqXhUzxSRCWXCw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.2.0.tgz",
+      "integrity": "sha512-Vhu+wwdevDLVDjK1lIcoD6ZbuOa93fzqszkaO3iCnmrScmKwyW/AGkzc2UvfE5TCoCXqq7Jyt6SOXjsIlpqF4A==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "3.0.1",
-        "@typescript-eslint/typescript-estree": "3.0.1",
+        "@typescript-eslint/experimental-utils": "3.2.0",
+        "@typescript-eslint/typescript-estree": "3.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.0.1.tgz",
-      "integrity": "sha512-FrbMdgVCeIGHKaP9OYTttFTlF8Ds7AkjMca2GzYCE7pVch10PAJc1mmAFt+DfQPgu/2TrLAprg2vI0PK/WTdcg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.2.0.tgz",
+      "integrity": "sha512-uh+Y2QO7dxNrdLw7mVnjUqkwO/InxEqwN0wF+Za6eo3coxls9aH9kQ/5rSvW2GcNanebRTmsT5w1/92lAOb1bA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -155,15 +146,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
-        },
-        "tsutils": {
-          "version": "3.17.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
         }
       }
     },
@@ -732,9 +714,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "93.0.0-nightly.20200514",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-93.0.0-nightly.20200514.tgz",
-      "integrity": "sha512-SRRItmNvhRVfoWWbRloO4i8IqkKH8rZ7/0QWRgLpM3umupK8gBpo9MY7Zp3pDysRSp+rVoqxvM5x4tFyCSa9zw=="
+      "version": "93.0.0-nightly.20200609",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-93.0.0-nightly.20200609.tgz",
+      "integrity": "sha512-CIaeav05u+fWRN2h1ecwIoSaOF/Mk6U85M/G6eg1nOHAXYYmOuh9TztF9Fu8krRWnl98J3W+VfDClApMV5zCtw=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -1485,9 +1467,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.1.0.tgz",
-      "integrity": "sha512-DfS3b8iHMK5z/YLSme8K5cge168I8j8o1uiVmFCgnnjxZQbCGyraF8bMl7Ju4yfBmCuxD7shOF7eqGkcuIHfsA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.2.0.tgz",
+      "integrity": "sha512-B3BtEyaDKC5MlfDa2Ha8/D6DsS4fju95zs0hjS3HdGazw+LNayai38A25qMppK37wWGWNYSPOR6oYzlz5MHsRQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1496,10 +1478,10 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
+        "eslint-scope": "^5.1.0",
         "eslint-utils": "^2.0.0",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^7.0.0",
+        "eslint-visitor-keys": "^1.2.0",
+        "espree": "^7.1.0",
         "esquery": "^1.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
@@ -1545,9 +1527,9 @@
           }
         },
         "chalk": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1590,9 +1572,9 @@
           }
         },
         "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
@@ -1696,20 +1678,20 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
+      "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==",
       "dev": true
     },
     "espree": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.0.0.tgz",
-      "integrity": "sha512-/r2XEx5Mw4pgKdyb7GNLQNsu++asx/dltf/CI8RFi9oGHxmQFgvLbc5Op4U6i8Oaj+kdslhJtVlEZeAqH5qOTw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
+      "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.1",
+        "acorn": "^7.2.0",
         "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.1.0"
+        "eslint-visitor-keys": "^1.2.0"
       },
       "dependencies": {
         "acorn": {
@@ -3350,9 +3332,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -5021,6 +5003,15 @@
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -5049,9 +5040,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -21,24 +21,24 @@
     "url": "https://github.com/AssemblyScript/assemblyscript/issues"
   },
   "dependencies": {
-    "binaryen": "93.0.0-nightly.20200514",
+    "binaryen": "93.0.0-nightly.20200609",
     "long": "^4.0.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^6.2.0"
   },
   "devDependencies": {
-    "@types/node": "^14.0.5",
-    "@typescript-eslint/eslint-plugin": "^3.0.1",
-    "@typescript-eslint/parser": "^3.0.1",
+    "@types/node": "^14.0.13",
+    "@typescript-eslint/eslint-plugin": "^3.2.0",
+    "@typescript-eslint/parser": "^3.2.0",
     "browser-process-hrtime": "^1.0.0",
     "diff": "^4.0.2",
-    "eslint": "^7.1.0",
+    "eslint": "^7.2.0",
     "glob": "^7.1.6",
     "physical-cpu-count": "^2.0.0",
     "source-map-support": "^0.5.19",
     "ts-loader": "^7.0.5",
     "ts-node": "^6.2.0",
-    "typescript": "^3.9.3",
+    "typescript": "^3.9.5",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
   },

--- a/scripts/update-constants.js
+++ b/scripts/update-constants.js
@@ -13,7 +13,7 @@ binaryen.ready.then(() => {
       var match = val.match(/\b(_(?:Binaryen|Relooper|ExpressionRunner)\w+)\b/);
       if (match) {
         let fn = match[1];
-        if (typeof binaryen[fn] !== "function") throw Error("API mismatch: Is Binaryen up to date?");
+        if (typeof binaryen[fn] !== "function") throw Error("API mismatch on '" + fn + "': Is Binaryen up to date?");
         let id = binaryen[fn]();
         console.log(fn + " = " + id);
         return key + " = " + id + " /* " + fn + " */";

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -358,6 +358,10 @@ export namespace BuiltinNames {
   export const v128_avgr = "~lib/builtins/v128.avgr";
   export const v128_abs = "~lib/builtins/v128.abs";
   export const v128_sqrt = "~lib/builtins/v128.sqrt";
+  export const v128_ceil = "~lib/builtins/v128.ceil";
+  export const v128_floor = "~lib/builtins/v128.floor";
+  export const v128_trunc = "~lib/builtins/v128.trunc";
+  export const v128_nearest = "~lib/builtins/v128.nearest";
   export const v128_eq = "~lib/builtins/v128.eq";
   export const v128_ne = "~lib/builtins/v128.ne";
   export const v128_lt = "~lib/builtins/v128.lt";
@@ -527,6 +531,10 @@ export namespace BuiltinNames {
   export const f32x4_pmax = "~lib/builtins/f32x4.pmax";
   export const f32x4_abs = "~lib/builtins/f32x4.abs";
   export const f32x4_sqrt = "~lib/builtins/f32x4.sqrt";
+  export const f32x4_ceil = "~lib/builtins/f32x4.ceil";
+  export const f32x4_floor = "~lib/builtins/f32x4.floor";
+  export const f32x4_trunc = "~lib/builtins/f32x4.trunc";
+  export const f32x4_nearest = "~lib/builtins/f32x4.nearest";
   export const f32x4_eq = "~lib/builtins/f32x4.eq";
   export const f32x4_ne = "~lib/builtins/f32x4.ne";
   export const f32x4_lt = "~lib/builtins/f32x4.lt";
@@ -552,6 +560,10 @@ export namespace BuiltinNames {
   export const f64x2_pmax = "~lib/builtins/f64x2.pmax";
   export const f64x2_abs = "~lib/builtins/f64x2.abs";
   export const f64x2_sqrt = "~lib/builtins/f64x2.sqrt";
+  export const f64x2_ceil = "~lib/builtins/f64x2.ceil";
+  export const f64x2_floor = "~lib/builtins/f64x2.floor";
+  export const f64x2_trunc = "~lib/builtins/f64x2.trunc";
+  export const f64x2_nearest = "~lib/builtins/f64x2.nearest";
   export const f64x2_eq = "~lib/builtins/f64x2.eq";
   export const f64x2_ne = "~lib/builtins/f64x2.ne";
   export const f64x2_lt = "~lib/builtins/f64x2.lt";
@@ -4538,6 +4550,126 @@ function builtin_v128_sqrt(ctx: BuiltinContext): ExpressionRef {
 }
 builtins.set(BuiltinNames.v128_sqrt, builtin_v128_sqrt);
 
+// v128.ceil<T!>(a: v128) -> v128
+function builtin_v128_ceil(ctx: BuiltinContext): ExpressionRef {
+  var compiler = ctx.compiler;
+  var module = compiler.module;
+  if (
+    checkFeatureEnabled(ctx, Feature.SIMD) |
+    checkTypeRequired(ctx) |
+    checkArgsRequired(ctx, 1)
+  ) {
+    compiler.currentType = Type.v128;
+    return module.unreachable();
+  }
+  var operands = ctx.operands;
+  var typeArguments = ctx.typeArguments!;
+  var type = typeArguments[0];
+  var arg0 = compiler.compileExpression(operands[0], Type.v128, Constraints.CONV_IMPLICIT);
+  if (!type.is(TypeFlags.REFERENCE)) {
+    switch (type.kind) {
+      case TypeKind.F32: return module.unary(UnaryOp.CeilF32x4, arg0);
+      case TypeKind.F64: return module.unary(UnaryOp.CeilF64x2, arg0);
+    }
+  }
+  compiler.error(
+    DiagnosticCode.Operation_0_cannot_be_applied_to_type_1,
+    ctx.reportNode.typeArgumentsRange, "v128.ceil", type.toString()
+  );
+  return module.unreachable();
+}
+builtins.set(BuiltinNames.v128_ceil, builtin_v128_ceil);
+
+// v128.floor<T!>(a: v128) -> v128
+function builtin_v128_floor(ctx: BuiltinContext): ExpressionRef {
+  var compiler = ctx.compiler;
+  var module = compiler.module;
+  if (
+    checkFeatureEnabled(ctx, Feature.SIMD) |
+    checkTypeRequired(ctx) |
+    checkArgsRequired(ctx, 1)
+  ) {
+    compiler.currentType = Type.v128;
+    return module.unreachable();
+  }
+  var operands = ctx.operands;
+  var typeArguments = ctx.typeArguments!;
+  var type = typeArguments[0];
+  var arg0 = compiler.compileExpression(operands[0], Type.v128, Constraints.CONV_IMPLICIT);
+  if (!type.is(TypeFlags.REFERENCE)) {
+    switch (type.kind) {
+      case TypeKind.F32: return module.unary(UnaryOp.FloorF32x4, arg0);
+      case TypeKind.F64: return module.unary(UnaryOp.FloorF64x2, arg0);
+    }
+  }
+  compiler.error(
+    DiagnosticCode.Operation_0_cannot_be_applied_to_type_1,
+    ctx.reportNode.typeArgumentsRange, "v128.floor", type.toString()
+  );
+  return module.unreachable();
+}
+builtins.set(BuiltinNames.v128_floor, builtin_v128_floor);
+
+// v128.trunc<T!>(a: v128) -> v128
+function builtin_v128_trunc(ctx: BuiltinContext): ExpressionRef {
+  var compiler = ctx.compiler;
+  var module = compiler.module;
+  if (
+    checkFeatureEnabled(ctx, Feature.SIMD) |
+    checkTypeRequired(ctx) |
+    checkArgsRequired(ctx, 1)
+  ) {
+    compiler.currentType = Type.v128;
+    return module.unreachable();
+  }
+  var operands = ctx.operands;
+  var typeArguments = ctx.typeArguments!;
+  var type = typeArguments[0];
+  var arg0 = compiler.compileExpression(operands[0], Type.v128, Constraints.CONV_IMPLICIT);
+  if (!type.is(TypeFlags.REFERENCE)) {
+    switch (type.kind) {
+      case TypeKind.F32: return module.unary(UnaryOp.TruncF32x4, arg0);
+      case TypeKind.F64: return module.unary(UnaryOp.TruncF64x2, arg0);
+    }
+  }
+  compiler.error(
+    DiagnosticCode.Operation_0_cannot_be_applied_to_type_1,
+    ctx.reportNode.typeArgumentsRange, "v128.trunc", type.toString()
+  );
+  return module.unreachable();
+}
+builtins.set(BuiltinNames.v128_trunc, builtin_v128_trunc);
+
+// v128.nearest<T!>(a: v128) -> v128
+function builtin_v128_nearest(ctx: BuiltinContext): ExpressionRef {
+  var compiler = ctx.compiler;
+  var module = compiler.module;
+  if (
+    checkFeatureEnabled(ctx, Feature.SIMD) |
+    checkTypeRequired(ctx) |
+    checkArgsRequired(ctx, 1)
+  ) {
+    compiler.currentType = Type.v128;
+    return module.unreachable();
+  }
+  var operands = ctx.operands;
+  var typeArguments = ctx.typeArguments!;
+  var type = typeArguments[0];
+  var arg0 = compiler.compileExpression(operands[0], Type.v128, Constraints.CONV_IMPLICIT);
+  if (!type.is(TypeFlags.REFERENCE)) {
+    switch (type.kind) {
+      case TypeKind.F32: return module.unary(UnaryOp.NearestF32x4, arg0);
+      case TypeKind.F64: return module.unary(UnaryOp.NearestF64x2, arg0);
+    }
+  }
+  compiler.error(
+    DiagnosticCode.Operation_0_cannot_be_applied_to_type_1,
+    ctx.reportNode.typeArgumentsRange, "v128.nearest", type.toString()
+  );
+  return module.unreachable();
+}
+builtins.set(BuiltinNames.v128_nearest, builtin_v128_nearest);
+
 // v128.convert<T!>(a: v128) -> v128
 function builtin_v128_convert(ctx: BuiltinContext): ExpressionRef {
   var compiler = ctx.compiler;
@@ -7550,6 +7682,42 @@ function builtin_f32x4_sqrt(ctx: BuiltinContext): ExpressionRef {
 }
 builtins.set(BuiltinNames.f32x4_sqrt, builtin_f32x4_sqrt);
 
+// f32x4.ceil -> v128.ceil<f32>
+function builtin_f32x4_ceil(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.f32 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_ceil(ctx);
+}
+builtins.set(BuiltinNames.f32x4_ceil, builtin_f32x4_ceil);
+
+// f32x4.floor -> v128.floor<f32>
+function builtin_f32x4_floor(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.f32 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_floor(ctx);
+}
+builtins.set(BuiltinNames.f32x4_floor, builtin_f32x4_floor);
+
+// f32x4.trunc -> v128.trunc<f32>
+function builtin_f32x4_trunc(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.f32 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_trunc(ctx);
+}
+builtins.set(BuiltinNames.f32x4_trunc, builtin_f32x4_trunc);
+
+// f32x4.nearest -> v128.nearest<f32>
+function builtin_f32x4_nearest(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.f32 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_nearest(ctx);
+}
+builtins.set(BuiltinNames.f32x4_nearest, builtin_f32x4_nearest);
+
 // f32x4.eq -> v128.eq<f32>
 function builtin_f32x4_eq(ctx: BuiltinContext): ExpressionRef {
   checkTypeAbsent(ctx);
@@ -7765,6 +7933,42 @@ function builtin_f64x2_sqrt(ctx: BuiltinContext): ExpressionRef {
   return builtin_v128_sqrt(ctx);
 }
 builtins.set(BuiltinNames.f64x2_sqrt, builtin_f64x2_sqrt);
+
+// f64x2.ceil -> v128.ceil<f64>
+function builtin_f64x2_ceil(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.f64 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_ceil(ctx);
+}
+builtins.set(BuiltinNames.f64x2_ceil, builtin_f64x2_ceil);
+
+// f64x2.floor -> v128.floor<f64>
+function builtin_f64x2_floor(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.f64 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_floor(ctx);
+}
+builtins.set(BuiltinNames.f64x2_floor, builtin_f64x2_floor);
+
+// f64x2.trunc -> v128.trunc<f64>
+function builtin_f64x2_trunc(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.f64 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_trunc(ctx);
+}
+builtins.set(BuiltinNames.f64x2_trunc, builtin_f64x2_trunc);
+
+// f64x2.nearest -> v128.nearest<f64>
+function builtin_f64x2_nearest(ctx: BuiltinContext): ExpressionRef {
+  checkTypeAbsent(ctx);
+  ctx.typeArguments = [ Type.f64 ];
+  ctx.contextualType = Type.v128;
+  return builtin_v128_nearest(ctx);
+}
+builtins.set(BuiltinNames.f64x2_nearest, builtin_f64x2_nearest);
 
 // f64x2.eq -> v128.eq<f64>
 function builtin_f64x2_eq(ctx: BuiltinContext): ExpressionRef {

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -108,7 +108,6 @@ export declare function _BinaryenRethrowId(): BinaryenExpressionId;
 export declare function _BinaryenBrOnExnId(): BinaryenExpressionId;
 export declare function _BinaryenTupleMakeId(): BinaryenExpressionId;
 export declare function _BinaryenTupleExtractId(): BinaryenExpressionId;
-export declare function _BinaryenPushId(): BinaryenExpressionId;
 export declare function _BinaryenPopId(): BinaryenExpressionId;
 
 type BinaryenModuleRef = usize;
@@ -526,7 +525,6 @@ export declare function _BinaryenTupleExtract(module: BinaryenModuleRef, tuple: 
 export declare function _BinaryenTupleExtractGetTuple(expr: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenTupleExtractGetIndex(expr: BinaryenExpressionRef): BinaryenIndex;
 
-export declare function _BinaryenPush(module: BinaryenModuleRef, value: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenPop(module: BinaryenModuleRef, type: BinaryenType): BinaryenExpressionRef;
 
 export declare function _BinaryenExpressionGetId(expr: BinaryenExpressionRef): BinaryenExpressionId;
@@ -694,8 +692,6 @@ export declare function _BinaryenRethrowGetExnref(expr: BinaryenExpressionRef): 
 export declare function _BinaryenBrOnExnGetEvent(expr: BinaryenExpressionRef): usize;
 export declare function _BinaryenBrOnExnGetName(expr: BinaryenExpressionRef): usize;
 export declare function _BinaryenBrOnExnGetExnref(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-
-export declare function _BinaryenPushGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
 
 type BinaryenFunctionRef = usize;
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -2239,6 +2239,7 @@ export enum SideEffects {
   ImplicitTrap = 256 /* _BinaryenSideEffectImplicitTrap */,
   IsAtomic = 512 /* _BinaryenSideEffectIsAtomic */,
   Throws = 1024 /* _BinaryenSideEffectThrows */,
+  DanglingPop = 2048 /* _BinaryenSideEffectDanglingPop */,
   Any = 4095 /* _BinaryenSideEffectAny */
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -98,17 +98,16 @@ export enum ExpressionId {
   DataDrop = 35 /* _BinaryenDataDropId */,
   MemoryCopy = 36 /* _BinaryenMemoryCopyId */,
   MemoryFill = 37 /* _BinaryenMemoryFillId */,
-  Push = 38 /* _BinaryenPushId */,
-  Pop = 39 /* _BinaryenPopId */,
-  RefNull = 40 /* _BinaryenRefNullId */,
-  RefIsNull = 41 /* _BinaryenRefIsNullId */,
-  RefFunc = 42 /* _BinaryenRefFuncId */,
-  Try = 43 /* _BinaryenTryId */,
-  Throw = 44 /* _BinaryenThrowId */,
-  Rethrow = 45 /* _BinaryenRethrowId */,
-  BrOnExn = 46 /* _BinaryenBrOnExnId */,
-  TupleMake = 47 /* _BinaryenTupleMakeId */,
-  TupleExtract = 48 /* _BinaryenTupleExtractId */
+  Pop = 38 /* _BinaryenPopId */,
+  RefNull = 39 /* _BinaryenRefNullId */,
+  RefIsNull = 40 /* _BinaryenRefIsNullId */,
+  RefFunc = 41 /* _BinaryenRefFuncId */,
+  Try = 42 /* _BinaryenTryId */,
+  Throw = 43 /* _BinaryenThrowId */,
+  Rethrow = 44 /* _BinaryenRethrowId */,
+  BrOnExn = 45 /* _BinaryenBrOnExnId */,
+  TupleMake = 46 /* _BinaryenTupleMakeId */,
+  TupleExtract = 47 /* _BinaryenTupleExtractId */
 }
 
 export enum UnaryOp {
@@ -206,25 +205,33 @@ export enum UnaryOp {
   AbsF32x4 = 85 /* _BinaryenAbsVecF32x4 */,
   NegF32x4 = 86 /* _BinaryenNegVecF32x4 */,
   SqrtF32x4 = 87 /* _BinaryenSqrtVecF32x4 */,
-  AbsF64x2 = 88 /* _BinaryenAbsVecF64x2 */,
-  NegF64x2 = 89 /* _BinaryenNegVecF64x2 */,
-  SqrtF64x2 = 90 /* _BinaryenSqrtVecF64x2 */,
-  TruncSatF32x4ToI32x4 = 91 /* _BinaryenTruncSatSVecF32x4ToVecI32x4 */,
-  TruncSatF32x4ToU32x4 = 92 /* _BinaryenTruncSatUVecF32x4ToVecI32x4 */,
-  TruncSatF64x2ToI64x2 = 93 /* _BinaryenTruncSatSVecF64x2ToVecI64x2 */,
-  TruncSatF64x2ToU64x2 = 94 /* _BinaryenTruncSatUVecF64x2ToVecI64x2 */,
-  ConvertI32x4ToF32x4 = 95 /* _BinaryenConvertSVecI32x4ToVecF32x4 */,
-  ConvertU32x4ToF32x4 = 96 /* _BinaryenConvertUVecI32x4ToVecF32x4 */,
-  ConvertI64x2ToF64x2 = 97 /* _BinaryenConvertSVecI64x2ToVecF64x2 */,
-  ConvertU64x2ToF64x2 = 98 /* _BinaryenConvertUVecI64x2ToVecF64x2 */,
-  WidenLowI8x16ToI16x8 = 99 /* _BinaryenWidenLowSVecI8x16ToVecI16x8 */,
-  WidenHighI8x16ToI16x8 = 100 /* _BinaryenWidenHighSVecI8x16ToVecI16x8 */,
-  WidenLowU8x16ToU16x8 = 101 /* _BinaryenWidenLowUVecI8x16ToVecI16x8 */,
-  WidenHighU8x16ToU16x8 = 102 /* _BinaryenWidenHighUVecI8x16ToVecI16x8 */,
-  WidenLowI16x8ToI32x4 = 103 /* _BinaryenWidenLowSVecI16x8ToVecI32x4 */,
-  WidenHighI16x8ToI32x4 = 104 /* _BinaryenWidenHighSVecI16x8ToVecI32x4 */,
-  WidenLowU16x8ToU32x4 = 105 /* _BinaryenWidenLowUVecI16x8ToVecI32x4 */,
-  WidenHighU16x8ToU32x4 = 106 /* _BinaryenWidenHighUVecI16x8ToVecI32x4 */
+  CeilF32x4 = 88 /* _BinaryenCeilVecF32x4 */,
+  FloorF32x4 = 89 /* _BinaryenFloorVecF32x4 */,
+  TruncF32x4 = 90 /* BinaryenTruncVecF32x4 */,
+  NearestF32x4 = 91 /* BinaryenNearestVecF32x4 */,
+  AbsF64x2 = 92 /* _BinaryenAbsVecF64x2 */,
+  NegF64x2 = 93 /* _BinaryenNegVecF64x2 */,
+  SqrtF64x2 = 94 /* _BinaryenSqrtVecF64x2 */,
+  CeilF64x2 = 95 /* _BinaryenCeilVecF64x2 */,
+  FloorF64x2 = 96 /* _BinaryenFloorVecF64x2 */,
+  TruncF64x2 = 97 /* BinaryenTruncVecF64x2 */,
+  NearestF64x2 = 98 /* BinaryenNearestVecF64x2 */,
+  TruncSatF32x4ToI32x4 = 99 /* _BinaryenTruncSatSVecF32x4ToVecI32x4 */,
+  TruncSatF32x4ToU32x4 = 100 /* _BinaryenTruncSatUVecF32x4ToVecI32x4 */,
+  TruncSatF64x2ToI64x2 = 101 /* _BinaryenTruncSatSVecF64x2ToVecI64x2 */,
+  TruncSatF64x2ToU64x2 = 102 /* _BinaryenTruncSatUVecF64x2ToVecI64x2 */,
+  ConvertI32x4ToF32x4 = 103 /* _BinaryenConvertSVecI32x4ToVecF32x4 */,
+  ConvertU32x4ToF32x4 = 104 /* _BinaryenConvertUVecI32x4ToVecF32x4 */,
+  ConvertI64x2ToF64x2 = 105 /* _BinaryenConvertSVecI64x2ToVecF64x2 */,
+  ConvertU64x2ToF64x2 = 106 /* _BinaryenConvertUVecI64x2ToVecF64x2 */,
+  WidenLowI8x16ToI16x8 = 107 /* _BinaryenWidenLowSVecI8x16ToVecI16x8 */,
+  WidenHighI8x16ToI16x8 = 108 /* _BinaryenWidenHighSVecI8x16ToVecI16x8 */,
+  WidenLowU8x16ToU16x8 = 109 /* _BinaryenWidenLowUVecI8x16ToVecI16x8 */,
+  WidenHighU8x16ToU16x8 = 110 /* _BinaryenWidenHighUVecI8x16ToVecI16x8 */,
+  WidenLowI16x8ToI32x4 = 111 /* _BinaryenWidenLowSVecI16x8ToVecI32x4 */,
+  WidenHighI16x8ToI32x4 = 112 /* _BinaryenWidenHighSVecI16x8ToVecI32x4 */,
+  WidenLowU16x8ToU32x4 = 113 /* _BinaryenWidenLowUVecI16x8ToVecI32x4 */,
+  WidenHighU16x8ToU32x4 = 114 /* _BinaryenWidenHighUVecI16x8ToVecI32x4 */
 }
 
 export enum BinaryOp {
@@ -386,27 +393,28 @@ export enum BinaryOp {
   DotI16x8 = 153 /* _BinaryenDotSVecI16x8ToVecI32x4 */,
   AddI64x2 = 154 /* _BinaryenAddVecI64x2 */,
   SubI64x2 = 155 /* _BinaryenSubVecI64x2 */,
-  AddF32x4 = 156 /* _BinaryenAddVecF32x4 */,
-  SubF32x4 = 157 /* _BinaryenSubVecF32x4 */,
-  MulF32x4 = 158 /* _BinaryenMulVecF32x4 */,
-  DivF32x4 = 159 /* _BinaryenDivVecF32x4 */,
-  MinF32x4 = 160 /* _BinaryenMinVecF32x4 */,
-  MaxF32x4 = 161 /* _BinaryenMaxVecF32x4 */,
-  PminF32x4 = 162 /* _BinaryenPMinVecF32x4 */,
-  PmaxF32x4 = 163 /* _BinaryenPMaxVecF32x4 */,
-  AddF64x2 = 164 /* _BinaryenAddVecF64x2 */,
-  SubF64x2 = 165 /* _BinaryenSubVecF64x2 */,
-  MulF64x2 = 166 /* _BinaryenMulVecF64x2 */,
-  DivF64x2 = 167 /* _BinaryenDivVecF64x2 */,
-  MinF64x2 = 168 /* _BinaryenMinVecF64x2 */,
-  MaxF64x2 = 169 /* _BinaryenMaxVecF64x2 */,
-  PminF64x2 = 170 /* _BinaryenPMinVecF64x2 */,
-  PmaxF64x2 = 171 /* _BinaryenPMaxVecF64x2 */,
-  NarrowI16x8ToI8x16 = 172 /* _BinaryenNarrowSVecI16x8ToVecI8x16 */,
-  NarrowU16x8ToU8x16 = 173 /* _BinaryenNarrowUVecI16x8ToVecI8x16 */,
-  NarrowI32x4ToI16x8 = 174 /* _BinaryenNarrowSVecI32x4ToVecI16x8 */,
-  NarrowU32x4ToU16x8 = 175 /* _BinaryenNarrowUVecI32x4ToVecI16x8 */,
-  SwizzleV8x16 = 176 /* _BinaryenSwizzleVec8x16 */
+
+  AddF32x4 = 157 /* _BinaryenAddVecF32x4 */,
+  SubF32x4 = 158 /* _BinaryenSubVecF32x4 */,
+  MulF32x4 = 159 /* _BinaryenMulVecF32x4 */,
+  DivF32x4 = 160 /* _BinaryenDivVecF32x4 */,
+  MinF32x4 = 161 /* _BinaryenMinVecF32x4 */,
+  MaxF32x4 = 162 /* _BinaryenMaxVecF32x4 */,
+  PminF32x4 = 163 /* _BinaryenPMinVecF32x4 */,
+  PmaxF32x4 = 164 /* _BinaryenPMaxVecF32x4 */,
+  AddF64x2 = 165 /* _BinaryenAddVecF64x2 */,
+  SubF64x2 = 166 /* _BinaryenSubVecF64x2 */,
+  MulF64x2 = 167 /* _BinaryenMulVecF64x2 */,
+  DivF64x2 = 168 /* _BinaryenDivVecF64x2 */,
+  MinF64x2 = 169 /* _BinaryenMinVecF64x2 */,
+  MaxF64x2 = 170 /* _BinaryenMaxVecF64x2 */,
+  PminF64x2 = 171 /* _BinaryenPMinVecF64x2 */,
+  PmaxF64x2 = 172 /* _BinaryenPMaxVecF64x2 */,
+  NarrowI16x8ToI8x16 = 173 /* _BinaryenNarrowSVecI16x8ToVecI8x16 */,
+  NarrowU16x8ToU8x16 = 174 /* _BinaryenNarrowUVecI16x8ToVecI8x16 */,
+  NarrowI32x4ToI16x8 = 175 /* _BinaryenNarrowSVecI32x4ToVecI16x8 */,
+  NarrowU32x4ToU16x8 = 176 /* _BinaryenNarrowUVecI32x4ToVecI16x8 */,
+  SwizzleV8x16 = 177 /* _BinaryenSwizzleVec8x16 */
 }
 
 export enum HostOp {
@@ -933,18 +941,23 @@ export class Module {
     return binaryen._BinaryenBrOnExn(this.ref, cStr1, cStr2, exnref);
   }
 
-  // push / pop (multi value?)
-
-  push(
-    value: ExpressionRef
-  ): ExpressionRef {
-    return binaryen._BinaryenPush(this.ref, value);
-  }
+  // multi value (pseudo instructions)
 
   pop(
     type: NativeType
   ): ExpressionRef {
     return binaryen._BinaryenPop(this.ref, type);
+  }
+
+  tuple_make(operands: ExpressionRef[]): ExpressionRef {
+    var cArr = allocPtrArray(operands);
+    var ret = binaryen._BinaryenTupleMake(this.ref, cArr, operands.length);
+    binaryen._free(cArr);
+    return ret;
+  }
+
+  tuple_extract(tuple: ExpressionRef, index: Index): ExpressionRef {
+    return binaryen._BinaryenTupleExtract(this.ref, tuple, index);
   }
 
   // simd
@@ -1017,19 +1030,6 @@ export class Module {
   ): ExpressionRef {
     var cStr = this.allocStringCached(name);
     return binaryen._BinaryenRefFunc(this.ref, cStr);
-  }
-
-  // tuples (pseudo instructions)
-
-  tuple_make(operands: ExpressionRef[]): ExpressionRef {
-    var cArr = allocPtrArray(operands);
-    var ret = binaryen._BinaryenTupleMake(this.ref, cArr, operands.length);
-    binaryen._free(cArr);
-    return ret;
-  }
-
-  tuple_extract(tuple: ExpressionRef, index: Index): ExpressionRef {
-    return binaryen._BinaryenTupleExtract(this.ref, tuple, index);
   }
 
   // globals
@@ -2239,7 +2239,7 @@ export enum SideEffects {
   ImplicitTrap = 256 /* _BinaryenSideEffectImplicitTrap */,
   IsAtomic = 512 /* _BinaryenSideEffectIsAtomic */,
   Throws = 1024 /* _BinaryenSideEffectThrows */,
-  Any = 2047 /* _BinaryenSideEffectAny */
+  Any = 4095 /* _BinaryenSideEffectAny */
 }
 
 export function getSideEffects(expr: ExpressionRef, features: FeatureFlags = FeatureFlags.All): SideEffects {
@@ -2626,10 +2626,6 @@ export function traverse<T>(expr: ExpressionRef, data: T, visit: (expr: Expressi
       visit(binaryen._BinaryenMemoryFillGetDest(expr), data);
       visit(binaryen._BinaryenMemoryFillGetValue(expr), data);
       visit(binaryen._BinaryenMemoryFillGetSize(expr), data);
-      break;
-    }
-    case ExpressionId.Push: {
-      visit(binaryen._BinaryenPushGetValue(expr), data);
       break;
     }
     case ExpressionId.Pop: {

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -1121,6 +1121,22 @@ export namespace v128 {
 
   // @ts-ignore: decorator
   @builtin
+  export declare function ceil<T>(a: v128): v128; // f32, f64 only
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function floor<T>(a: v128): v128; // f32, f64 only
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function trunc<T>(a: v128): v128; // f32, f64 only
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function nearest<T>(a: v128): v128; // f32, f64 only
+
+  // @ts-ignore: decorator
+  @builtin
   export declare function eq<T>(a: v128, b: v128): v128;
 
   // @ts-ignore: decorator
@@ -1791,6 +1807,22 @@ export namespace f32x4 {
 
   // @ts-ignore: decorator
   @builtin
+  export declare function ceil(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function floor(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function trunc(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function nearest(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
   export declare function eq(a: v128, b: v128): v128;
 
   // @ts-ignore: decorator
@@ -1891,6 +1923,22 @@ export namespace f64x2 {
   // @ts-ignore: decorator
   @builtin
   export declare function sqrt(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function ceil(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function floor(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function trunc(a: v128): v128;
+
+  // @ts-ignore: decorator
+  @builtin
+  export declare function nearest(a: v128): v128;
 
   // @ts-ignore: decorator
   @builtin

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -609,6 +609,14 @@ declare namespace v128 {
   export function abs<T = f32 | f64>(a: v128): v128;
   /** Computes the square root of each lane. */
   export function sqrt<T = f32 | f64>(a: v128): v128;
+  /** Performs the ceiling operation on each lane. */
+  export function ceil<T = f32 | f64>(a: v128): v128;
+  /** Performs the floor operation on each lane. */
+  export function floor<T = f32 | f64>(a: v128): v128;
+  /** Rounds to the nearest integer towards zero of each lane. */
+  export function trunc<T = f32 | f64>(a: v128): v128;
+  /** Rounds to the nearest integer tied to even of each lane. */
+  export function nearest<T = f32 | f64>(a: v128): v128;
   /** Computes which lanes are equal. */
   export function eq<T>(a: v128, b: v128): v128;
   /** Computes which lanes are not equal. */
@@ -945,6 +953,14 @@ declare namespace f32x4 {
   export function abs(a: v128): v128;
   /** Computes the square root of each 32-bit float lane. */
   export function sqrt(a: v128): v128;
+  /** Performs the ceiling operation on each 32-bit float lane. */
+  export function ceil(a: v128): v128;
+  /** Performs the floor operation on each each 32-bit float lane. */
+  export function floor(a: v128): v128;
+  /** Rounds to the nearest integer towards zero of each 32-bit float lane. */
+  export function trunc(a: v128): v128;
+  /** Rounds to the nearest integer tied to even of each 32-bit float lane. */
+  export function nearest(a: v128): v128;
   /** Computes which 32-bit float lanes are equal. */
   export function eq(a: v128, b: v128): v128;
   /** Computes which 32-bit float lanes are not equal. */
@@ -997,6 +1013,14 @@ declare namespace f64x2 {
   export function abs(a: v128): v128;
   /** Computes the square root of each 64-bit float lane. */
   export function sqrt(a: v128): v128;
+  /** Performs the ceiling operation on each 64-bit float lane. */
+  export function ceil(a: v128): v128;
+  /** Performs the floor operation on each each 64-bit float lane. */
+  export function floor(a: v128): v128;
+  /** Rounds to the nearest integer towards zero of each 64-bit float lane. */
+  export function trunc(a: v128): v128;
+  /** Rounds to the nearest integer tied to even of each 64-bit float lane. */
+  export function nearest(a: v128): v128;
   /** Computes which 64-bit float lanes are equal. */
   export function eq(a: v128, b: v128): v128;
   /** Computes which 64-bit float lanes are not equal. */


### PR DESCRIPTION
This gets up to to date with Binaryen again, that is right before https://github.com/WebAssembly/binaryen/pull/2900 where `anyref` has been renamed to `externref`, which will be a breaking change and is tracked in https://github.com/AssemblyScript/assemblyscript/pull/1319.

Also includes bindings for https://github.com/WebAssembly/binaryen/pull/2895 's prototype SIMD instructions

* `f32x4.ceil` / `f64x2.ceil` ↔ `v128.ceil<T>`
* `f32x4.floor` / `f64x2.floor` ↔ `v128.floor<T>`
* `f32x4.trunc` / `f64x2.trunc` ↔ `v128.trunc<T>`
* `f32x4.nearest` / `f64x2.nearest` ↔ `v128.nearest<T>`

- [x] I've read the contributing guidelines