### PR TITLE
fix: Fix version string in SDK dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "asinit": "bin/asinit"
   },
   "scripts": {
-    "build": "npm run build:bundle && npm run build:dts && npm run build:sdk",
+    "build": "npm run build:bundle && npm run build:dts",
     "build:bundle": "webpack --mode production --display-modules",
     "build:dts": "node scripts/build-dts && tsc --noEmit --target ESNEXT --module commonjs --experimentalDecorators tests/require/index-release",
     "build:sdk": "node scripts/build-sdk",
@@ -67,7 +67,7 @@
     "make": "npm run clean && npm test && npm run build && npm test",
     "all": "npm run check && npm run make",
     "docs": "typedoc --tsconfig tsconfig-docs.json --mode modules --name \"AssemblyScript Compiler API\" --out ./docs/api --ignoreCompilerErrors --excludeNotExported --excludePrivate --excludeExternals --exclude **/std/** --includeDeclarations --readme src/README.md",
-    "postversion": "node scripts/postversion",
+    "postversion": "node scripts/postversion && npm run build:sdk",
     "prepublishOnly": "node scripts/prepublish",
     "postpublish": "node scripts/postpublish",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",


### PR DESCRIPTION
Turns out the switch to semantic releases with `0.0.0` in the package.json broke the SDK's dist files, so this reorders the SDK build step to happen after the version has been written during publish.

- [x] I've read the contributing guidelines