### PR TITLE
refactor: Rename (dtoa|itoa)_stream to (dtoa|itoa)_buffered + simplify signature

### DIFF
--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -290,7 +290,7 @@ export function utoa32_dec_core(buffer: usize, num: u32, offset: usize): void {
 
 // @ts-ignore: decorator
 @inline
-export function utoa32_hex_core(buffer: usize, num: u32, offset: usize): void {
+function utoa32_hex_core(buffer: usize, num: u32, offset: usize): void {
   if (ASC_SHRINK_LEVEL >= 1) {
     utoa_hex_simple<u32>(buffer, num, offset);
   } else {
@@ -300,7 +300,7 @@ export function utoa32_hex_core(buffer: usize, num: u32, offset: usize): void {
 
 // @ts-ignore: decorator
 @inline
-export function utoa64_dec_core(buffer: usize, num: u64, offset: usize): void {
+function utoa64_dec_core(buffer: usize, num: u64, offset: usize): void {
   if (ASC_SHRINK_LEVEL >= 1) {
     utoa_dec_simple<u64>(buffer, num, offset);
   } else {
@@ -310,7 +310,7 @@ export function utoa64_dec_core(buffer: usize, num: u64, offset: usize): void {
 
 // @ts-ignore: decorator
 @inline
-export function utoa64_hex_core(buffer: usize, num: u64, offset: usize): void {
+function utoa64_hex_core(buffer: usize, num: u64, offset: usize): void {
   if (ASC_SHRINK_LEVEL >= 1) {
     utoa_hex_simple<u64>(buffer, num, offset);
   } else {
@@ -318,7 +318,7 @@ export function utoa64_hex_core(buffer: usize, num: u64, offset: usize): void {
   }
 }
 
-export function utoa64_any_core(buffer: usize, num: u64, offset: usize, radix: i32): void {
+function utoa64_any_core(buffer: usize, num: u64, offset: usize, radix: i32): void {
   const lut = changetype<usize>(ANY_DIGITS);
   var base = u64(radix);
   if ((radix & (radix - 1)) == 0) { // for radix which pow of two
@@ -710,7 +710,7 @@ function prettify(buffer: usize, length: i32, k: i32): i32 {
   }
 }
 
-export function dtoa_core(buffer: usize, value: f64): i32 {
+function dtoa_core(buffer: usize, value: f64): i32 {
   var sign = i32(value < 0);
   if (sign) {
     value = -value;
@@ -736,8 +736,7 @@ export function dtoa(value: f64): String {
   return result;
 }
 
-export function itoa_buffered<T extends number>(buffer: usize, offset: usize, value: T): u32 {
-  buffer += offset << 1;
+export function itoa_buffered<T extends number>(buffer: usize, value: T): u32 {
   var sign: u32 = 0;
   if (isSigned<T>()) {
     sign = u32(value < 0);
@@ -783,8 +782,7 @@ export function itoa_buffered<T extends number>(buffer: usize, offset: usize, va
   return decimals;
 }
 
-export function dtoa_buffered(buffer: usize, offset: usize, value: f64): u32 {
-  buffer += offset << 1;
+export function dtoa_buffered(buffer: usize, value: f64): u32 {
   if (value == 0) {
     store<u16>(buffer, CharCode._0);
     store<u16>(buffer, CharCode.DOT, 2);

--- a/std/assembly/util/number.ts
+++ b/std/assembly/util/number.ts
@@ -736,7 +736,7 @@ export function dtoa(value: f64): String {
   return result;
 }
 
-export function itoa_stream<T extends number>(buffer: usize, offset: usize, value: T): u32 {
+export function itoa_buffered<T extends number>(buffer: usize, offset: usize, value: T): u32 {
   buffer += offset << 1;
   var sign: u32 = 0;
   if (isSigned<T>()) {
@@ -783,7 +783,7 @@ export function itoa_stream<T extends number>(buffer: usize, offset: usize, valu
   return decimals;
 }
 
-export function dtoa_stream(buffer: usize, offset: usize, value: f64): u32 {
+export function dtoa_buffered(buffer: usize, offset: usize, value: f64): u32 {
   buffer += offset << 1;
   if (value == 0) {
     store<u16>(buffer, CharCode._0);

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -889,7 +889,7 @@ export function joinIntegerArray<T>(dataStart: usize, length: i32, separator: st
   for (let i = 0; i < lastIndex; ++i) {
     value = load<T>(dataStart + (<usize>i << alignof<T>()));
     // @ts-ignore: type
-    offset += itoa_buffered<T>(changetype<usize>(result), offset, value);
+    offset += itoa_buffered<T>(changetype<usize>(result) + (<usize>offset << 1), value);
     if (sepLen) {
       memory.copy(
         changetype<usize>(result) + (<usize>offset << 1),
@@ -901,7 +901,7 @@ export function joinIntegerArray<T>(dataStart: usize, length: i32, separator: st
   }
   value = load<T>(dataStart + (<usize>lastIndex << alignof<T>()));
   // @ts-ignore: type
-  offset += itoa_buffered<T>(changetype<usize>(result), offset, value);
+  offset += itoa_buffered<T>(changetype<usize>(result) + (<usize>offset << 1), value);
   if (estLen > offset) return result.substring(0, offset);
   return result;
 }
@@ -924,10 +924,8 @@ export function joinFloatArray<T>(dataStart: usize, length: i32, separator: stri
   var value: T;
   for (let i = 0; i < lastIndex; ++i) {
     value = load<T>(dataStart + (<usize>i << alignof<T>()));
-    offset += dtoa_buffered(changetype<usize>(result), offset,
-      // @ts-ignore: type
-      value
-    );
+    // @ts-ignore: type
+    offset += dtoa_buffered(changetype<usize>(result) + (<usize>offset << 1), value);
     if (sepLen) {
       memory.copy(
         changetype<usize>(result) + (<usize>offset << 1),
@@ -938,10 +936,8 @@ export function joinFloatArray<T>(dataStart: usize, length: i32, separator: stri
     }
   }
   value = load<T>(dataStart + (<usize>lastIndex << alignof<T>()));
-  offset += dtoa_buffered(changetype<usize>(result), offset,
-    // @ts-ignore: type
-    value
-  );
+  // @ts-ignore: type
+  offset += dtoa_buffered(changetype<usize>(result) + (<usize>offset << 1), value);
   if (estLen > offset) return result.substring(0, offset);
   return result;
 }

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -1,4 +1,4 @@
-import { itoa32, utoa32, itoa64, utoa64, dtoa, itoa_stream, dtoa_stream, MAX_DOUBLE_LENGTH } from "./number";
+import { itoa32, utoa32, itoa64, utoa64, dtoa, itoa_buffered, dtoa_buffered, MAX_DOUBLE_LENGTH } from "./number";
 import { ipow32 } from "../math";
 
 // All tables are stored as two staged lookup tables (static tries)
@@ -889,7 +889,7 @@ export function joinIntegerArray<T>(dataStart: usize, length: i32, separator: st
   for (let i = 0; i < lastIndex; ++i) {
     value = load<T>(dataStart + (<usize>i << alignof<T>()));
     // @ts-ignore: type
-    offset += itoa_stream<T>(changetype<usize>(result), offset, value);
+    offset += itoa_buffered<T>(changetype<usize>(result), offset, value);
     if (sepLen) {
       memory.copy(
         changetype<usize>(result) + (<usize>offset << 1),
@@ -901,7 +901,7 @@ export function joinIntegerArray<T>(dataStart: usize, length: i32, separator: st
   }
   value = load<T>(dataStart + (<usize>lastIndex << alignof<T>()));
   // @ts-ignore: type
-  offset += itoa_stream<T>(changetype<usize>(result), offset, value);
+  offset += itoa_buffered<T>(changetype<usize>(result), offset, value);
   if (estLen > offset) return result.substring(0, offset);
   return result;
 }
@@ -924,7 +924,7 @@ export function joinFloatArray<T>(dataStart: usize, length: i32, separator: stri
   var value: T;
   for (let i = 0; i < lastIndex; ++i) {
     value = load<T>(dataStart + (<usize>i << alignof<T>()));
-    offset += dtoa_stream(changetype<usize>(result), offset,
+    offset += dtoa_buffered(changetype<usize>(result), offset,
       // @ts-ignore: type
       value
     );
@@ -938,7 +938,7 @@ export function joinFloatArray<T>(dataStart: usize, length: i32, separator: stri
     }
   }
   value = load<T>(dataStart + (<usize>lastIndex << alignof<T>()));
-  offset += dtoa_stream(changetype<usize>(result), offset,
+  offset += dtoa_buffered(changetype<usize>(result), offset,
     // @ts-ignore: type
     value
   );

--- a/std/assembly/wasi/index.ts
+++ b/std/assembly/wasi/index.ts
@@ -8,7 +8,7 @@ import {
 import {
   MAX_DOUBLE_LENGTH,
   decimalCount32,
-  dtoa_stream
+  dtoa_buffered
 } from "util/number";
 
 // @ts-ignore: decorator
@@ -81,19 +81,19 @@ function trace( // eslint-disable-line @typescript-eslint/no-unused-vars
   fd_write(2, iovPtr, 1, lenPtr);
   if (n) {
     store<u8>(bufPtr++, 0x20); // space
-    changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_stream(bufPtr, 0, a0), bufPtr);
+    changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a0), bufPtr);
     fd_write(2, iovPtr, 1, lenPtr);
     if (n > 1) {
-      changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_stream(bufPtr, 0, a1), bufPtr);
+      changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a1), bufPtr);
       fd_write(2, iovPtr, 1, lenPtr);
       if (n > 2) {
-        changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_stream(bufPtr, 0, a2), bufPtr);
+        changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a2), bufPtr);
         fd_write(2, iovPtr, 1, lenPtr);
         if (n > 3) {
-          changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_stream(bufPtr, 0, a3), bufPtr);
+          changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a3), bufPtr);
           fd_write(2, iovPtr, 1, lenPtr);
           if (n > 4) {
-            changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_stream(bufPtr, 0, a4), bufPtr);
+            changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a4), bufPtr);
             fd_write(2, iovPtr, 1, lenPtr);
           }
         }

--- a/std/assembly/wasi/index.ts
+++ b/std/assembly/wasi/index.ts
@@ -81,19 +81,19 @@ function trace( // eslint-disable-line @typescript-eslint/no-unused-vars
   fd_write(2, iovPtr, 1, lenPtr);
   if (n) {
     store<u8>(bufPtr++, 0x20); // space
-    changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a0), bufPtr);
+    changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, a0), bufPtr);
     fd_write(2, iovPtr, 1, lenPtr);
     if (n > 1) {
-      changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a1), bufPtr);
+      changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, a1), bufPtr);
       fd_write(2, iovPtr, 1, lenPtr);
       if (n > 2) {
-        changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a2), bufPtr);
+        changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, a2), bufPtr);
         fd_write(2, iovPtr, 1, lenPtr);
         if (n > 3) {
-          changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a3), bufPtr);
+          changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, a3), bufPtr);
           fd_write(2, iovPtr, 1, lenPtr);
           if (n > 4) {
-            changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, 0, a4), bufPtr);
+            changetype<iovec>(iovPtr).buf_len = 1 + String.UTF8.encodeUnsafe(bufPtr, dtoa_buffered(bufPtr, a4), bufPtr);
             fd_write(2, iovPtr, 1, lenPtr);
           }
         }

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6391,7 +6391,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -6499,7 +6499,7 @@
     i32.shl
     i32.add
     i32.load
-    call $~lib/util/number/itoa_stream<i32>
+    call $~lib/util/number/itoa_buffered<i32>
     local.get $3
     i32.add
     local.set $3
@@ -6536,7 +6536,7 @@
   i32.shl
   i32.add
   i32.load
-  call $~lib/util/number/itoa_stream<i32>
+  call $~lib/util/number/itoa_buffered<i32>
   local.get $3
   i32.add
   local.tee $0
@@ -6591,7 +6591,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -6678,7 +6678,7 @@
     i32.shl
     i32.add
     i32.load
-    call $~lib/util/number/itoa_stream<u32>
+    call $~lib/util/number/itoa_buffered<u32>
     local.get $3
     i32.add
     local.set $3
@@ -6715,7 +6715,7 @@
   i32.shl
   i32.add
   i32.load
-  call $~lib/util/number/itoa_stream<u32>
+  call $~lib/util/number/itoa_buffered<u32>
   local.get $3
   i32.add
   local.tee $0
@@ -7674,7 +7674,7 @@
   local.get $8
   i32.add
  )
- (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -7868,7 +7868,7 @@
     i32.shl
     i32.add
     f64.load
-    call $~lib/util/number/dtoa_stream
+    call $~lib/util/number/dtoa_buffered
     local.get $2
     i32.add
     local.set $2
@@ -7905,7 +7905,7 @@
   i32.shl
   i32.add
   f64.load
-  call $~lib/util/number/dtoa_stream
+  call $~lib/util/number/dtoa_buffered
   local.get $2
   i32.add
   local.tee $0
@@ -8285,7 +8285,7 @@
   i32.const 6304
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -8410,7 +8410,7 @@
     local.get $6
     i32.add
     i32.load8_s
-    call $~lib/util/number/itoa_stream<i8>
+    call $~lib/util/number/itoa_buffered<i8>
     local.get $2
     i32.add
     local.set $2
@@ -8445,7 +8445,7 @@
   local.get $4
   i32.add
   i32.load8_s
-  call $~lib/util/number/itoa_stream<i8>
+  call $~lib/util/number/itoa_buffered<i8>
   local.get $2
   i32.add
   local.tee $0
@@ -8464,7 +8464,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -8560,7 +8560,7 @@
     i32.shl
     i32.add
     i32.load16_u
-    call $~lib/util/number/itoa_stream<u16>
+    call $~lib/util/number/itoa_buffered<u16>
     local.get $2
     i32.add
     local.set $2
@@ -8597,7 +8597,7 @@
   i32.shl
   i32.add
   i32.load16_u
-  call $~lib/util/number/itoa_stream<u16>
+  call $~lib/util/number/itoa_buffered<u16>
   local.get $2
   i32.add
   local.tee $0
@@ -8692,7 +8692,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa_stream<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -8835,7 +8835,7 @@
     i32.shl
     i32.add
     i64.load
-    call $~lib/util/number/itoa_stream<u64>
+    call $~lib/util/number/itoa_buffered<u64>
     local.get $2
     i32.add
     local.set $2
@@ -8872,7 +8872,7 @@
   i32.shl
   i32.add
   i64.load
-  call $~lib/util/number/itoa_stream<u64>
+  call $~lib/util/number/itoa_buffered<u64>
   local.get $2
   i32.add
   local.tee $0
@@ -8891,7 +8891,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_stream<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -9080,7 +9080,7 @@
     i32.shl
     i32.add
     i64.load
-    call $~lib/util/number/itoa_stream<i64>
+    call $~lib/util/number/itoa_buffered<i64>
     local.get $2
     i32.add
     local.set $2
@@ -9117,7 +9117,7 @@
   i32.shl
   i32.add
   i64.load
-  call $~lib/util/number/itoa_stream<i64>
+  call $~lib/util/number/itoa_buffered<i64>
   local.get $2
   i32.add
   local.tee $0
@@ -9313,7 +9313,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_stream<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -9406,7 +9406,7 @@
     local.get $6
     i32.add
     i32.load8_u
-    call $~lib/util/number/itoa_stream<u8>
+    call $~lib/util/number/itoa_buffered<u8>
     local.get $3
     i32.add
     local.set $3
@@ -9441,7 +9441,7 @@
   local.get $4
   i32.add
   i32.load8_u
-  call $~lib/util/number/itoa_stream<u8>
+  call $~lib/util/number/itoa_buffered<u8>
   local.get $3
   i32.add
   local.tee $0

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -9,13 +9,12 @@
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_f64 (func (result f64)))
  (type $none_=>_none (func))
- (type $i32_i32_i64_=>_i32 (func (param i32 i32 i64) (result i32)))
+ (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
+ (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i64_=>_none (func (param i64)))
- (type $i32_i32_f64_=>_i32 (func (param i32 i32 f64) (result i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $f32_f32_=>_i32 (func (param f32 f32) (result i32)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
@@ -6391,49 +6390,44 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 0
   i32.lt_s
-  local.tee $1
+  local.tee $2
   if
    local.get $0
    i32.const 45
    i32.store16
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $1
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 48
    i32.or
    i32.store16
-   local.get $1
+   local.get $2
    i32.const 1
    i32.add
    return
   end
   local.get $0
-  local.get $2
-  local.get $2
-  call $~lib/util/number/decimalCount32
   local.get $1
+  local.get $1
+  call $~lib/util/number/decimalCount32
+  local.get $2
   i32.add
   local.tee $0
   call $~lib/util/number/utoa_dec_simple<u32>
@@ -6493,6 +6487,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.const 2
@@ -6530,6 +6527,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 2
@@ -6591,19 +6591,13 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (result i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 48
    i32.or
    i32.store16
@@ -6611,8 +6605,8 @@
    return
   end
   local.get $0
-  local.get $2
-  local.get $2
+  local.get $1
+  local.get $1
   call $~lib/util/number/decimalCount32
   local.tee $0
   call $~lib/util/number/utoa_dec_simple<u32>
@@ -6672,6 +6666,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.const 2
@@ -6709,6 +6706,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 2
@@ -7674,14 +7674,9 @@
   local.get $8
   i32.add
  )
- (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  local.get $0
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 f64) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   f64.const 0
   f64.eq
   if
@@ -7697,14 +7692,14 @@
    i32.const 3
    return
   end
-  local.get $2
-  local.get $2
+  local.get $1
+  local.get $1
   f64.sub
   f64.const 0
   f64.ne
   if
-   local.get $2
-   local.get $2
+   local.get $1
+   local.get $1
    f64.ne
    if
     local.get $0
@@ -7719,10 +7714,10 @@
     i32.const 3
     return
    else
-    local.get $2
+    local.get $1
     f64.const 0
     f64.lt
-    local.tee $1
+    local.tee $2
     if
      local.get $0
      i32.const 45
@@ -7738,7 +7733,7 @@
     local.get $0
     i64.const 34058970405077102
     i64.store offset=8
-    local.get $1
+    local.get $2
     i32.const 8
     i32.add
     return
@@ -7746,7 +7741,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $1
   call $~lib/util/number/dtoa_core
  )
  (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (result i32)
@@ -7862,6 +7857,9 @@
    if
     local.get $1
     local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $7
     i32.const 3
@@ -7899,6 +7897,9 @@
   local.get $8
   local.get $1
   local.get $2
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $5
   i32.const 3
@@ -8285,31 +8286,26 @@
   i32.const 6304
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
   i32.const 0
   i32.lt_s
-  local.tee $1
+  local.tee $2
   if
    local.get $0
    i32.const 45
    i32.store16
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
@@ -8318,11 +8314,11 @@
   i32.lt_u
   if
    local.get $0
-   local.get $1
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 24
    i32.shl
    i32.const 24
@@ -8330,19 +8326,19 @@
    i32.const 48
    i32.or
    i32.store16
-   local.get $1
+   local.get $2
    i32.const 1
    i32.add
    return
   end
   local.get $2
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
   local.tee $2
   call $~lib/util/number/decimalCount32
-  local.get $1
   i32.add
   local.set $1
   local.get $0
@@ -8406,6 +8402,9 @@
    if
     local.get $1
     local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.add
@@ -8441,6 +8440,9 @@
   local.get $7
   local.get $1
   local.get $2
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.add
@@ -8464,21 +8466,16 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 65535
   i32.and
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 65535
    i32.and
    i32.const 48
@@ -8487,7 +8484,7 @@
    i32.const 1
    return
   end
-  local.get $2
+  local.get $1
   i32.const 65535
   i32.and
   local.tee $2
@@ -8554,6 +8551,9 @@
    if
     local.get $1
     local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.const 1
@@ -8591,6 +8591,9 @@
   local.get $7
   local.get $1
   local.get $2
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 1
@@ -8692,48 +8695,43 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i32)
   (local $3 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  local.get $0
-  i32.add
-  local.set $0
-  local.get $2
   i64.const 10
   i64.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
    return
   end
-  local.get $2
+  local.get $1
   i64.const 4294967295
   i64.le_u
   if
-   local.get $2
+   local.get $1
    i32.wrap_i64
    local.tee $3
    call $~lib/util/number/decimalCount32
-   local.set $1
+   local.set $2
    local.get $0
    local.get $3
-   local.get $1
+   local.get $2
    call $~lib/util/number/utoa_dec_simple<u32>
   else
    local.get $0
-   local.get $2
-   local.get $2
+   local.get $1
+   local.get $1
    call $~lib/util/number/decimalCount64High
-   local.tee $1
+   local.tee $2
    call $~lib/util/number/utoa_dec_simple<u64>
   end
-  local.get $1
+  local.get $2
  )
  (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -8829,6 +8827,9 @@
    if
     local.get $1
     local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $7
     i32.const 3
@@ -8866,6 +8867,9 @@
   local.get $8
   local.get $1
   local.get $2
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 3
@@ -8891,71 +8895,66 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i32)
   (local $3 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  local.get $0
-  i32.add
-  local.set $1
-  local.get $2
   i64.const 0
   i64.lt_s
-  local.tee $0
+  local.tee $2
   if
-   local.get $1
+   local.get $0
    i32.const 45
    i32.store16
    i64.const 0
-   local.get $2
+   local.get $1
    i64.sub
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
   i64.const 10
   i64.lt_u
   if
-   local.get $0
+   local.get $2
    i32.const 1
    i32.shl
-   local.get $1
+   local.get $0
    i32.add
-   local.get $2
+   local.get $1
    i64.const 48
    i64.or
    i64.store16
-   local.get $0
+   local.get $2
    i32.const 1
    i32.add
    return
   end
-  local.get $2
+  local.get $1
   i64.const 4294967295
   i64.le_u
   if
    local.get $2
-   i32.wrap_i64
-   local.tee $3
-   call $~lib/util/number/decimalCount32
-   local.get $0
-   i32.add
-   local.set $0
    local.get $1
-   local.get $3
+   i32.wrap_i64
+   local.tee $2
+   call $~lib/util/number/decimalCount32
+   i32.add
+   local.set $3
    local.get $0
+   local.get $2
+   local.get $3
    call $~lib/util/number/utoa_dec_simple<u32>
   else
-   local.get $1
-   local.get $2
-   local.get $2
-   call $~lib/util/number/decimalCount64High
    local.get $0
+   local.get $1
+   local.get $1
+   call $~lib/util/number/decimalCount64High
+   local.get $2
    i32.add
-   local.tee $0
+   local.tee $3
    call $~lib/util/number/utoa_dec_simple<u64>
   end
-  local.get $0
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -9074,6 +9073,9 @@
    if
     local.get $1
     local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $7
     i32.const 3
@@ -9111,6 +9113,9 @@
   local.get $8
   local.get $1
   local.get $2
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $5
   i32.const 3
@@ -9313,21 +9318,16 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 255
   i32.and
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 255
    i32.and
    i32.const 48
@@ -9336,7 +9336,7 @@
    i32.const 1
    return
   end
-  local.get $2
+  local.get $1
   i32.const 255
   i32.and
   local.tee $2
@@ -9402,6 +9402,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.add
@@ -9437,6 +9440,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.add

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -13220,7 +13220,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13395,7 +13395,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<i32>
+    call $~lib/util/number/itoa_buffered<i32>
     i32.add
     local.set $10
     local.get $7
@@ -13433,7 +13433,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<i32>
+  call $~lib/util/number/itoa_buffered<i32>
   i32.add
   local.set $10
   local.get $8
@@ -13602,7 +13602,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13753,7 +13753,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<u32>
+    call $~lib/util/number/itoa_buffered<u32>
     i32.add
     local.set $10
     local.get $7
@@ -13791,7 +13791,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<u32>
+  call $~lib/util/number/itoa_buffered<u32>
   i32.add
   local.set $10
   local.get $8
@@ -15155,7 +15155,7 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -15313,7 +15313,7 @@
     local.get $8
     local.get $9
     local.get $10
-    call $~lib/util/number/dtoa_stream
+    call $~lib/util/number/dtoa_buffered
     i32.add
     local.set $9
     local.get $6
@@ -15351,7 +15351,7 @@
   local.get $8
   local.get $9
   local.get $10
-  call $~lib/util/number/dtoa_stream
+  call $~lib/util/number/dtoa_buffered
   i32.add
   local.set $9
   local.get $7
@@ -16173,7 +16173,7 @@
   i32.const 5296
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa_stream<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16368,7 +16368,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<i8>
+    call $~lib/util/number/itoa_buffered<i8>
     i32.add
     local.set $10
     local.get $7
@@ -16406,7 +16406,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<i8>
+  call $~lib/util/number/itoa_buffered<i8>
   i32.add
   local.set $10
   local.get $8
@@ -16463,7 +16463,7 @@
   i32.const 5296
   call $~lib/array/Array<i8>#join
  )
- (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16622,7 +16622,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<u16>
+    call $~lib/util/number/itoa_buffered<u16>
     i32.add
     local.set $10
     local.get $7
@@ -16660,7 +16660,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<u16>
+  call $~lib/util/number/itoa_buffered<u16>
   i32.add
   local.set $10
   local.get $8
@@ -17051,7 +17051,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17233,7 +17233,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<u64>
+    call $~lib/util/number/itoa_buffered<u64>
     i32.add
     local.set $10
     local.get $7
@@ -17271,7 +17271,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<u64>
+  call $~lib/util/number/itoa_buffered<u64>
   i32.add
   local.set $10
   local.get $8
@@ -17507,7 +17507,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17715,7 +17715,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<i64>
+    call $~lib/util/number/itoa_buffered<i64>
     i32.add
     local.set $10
     local.get $7
@@ -17753,7 +17753,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<i64>
+  call $~lib/util/number/itoa_buffered<i64>
   i32.add
   local.set $10
   local.get $8
@@ -18068,7 +18068,7 @@
   i32.const 5296
   call $~lib/array/Array<~lib/array/Array<i32>>#join
  )
- (func $~lib/util/number/itoa_stream<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -18227,7 +18227,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<u8>
+    call $~lib/util/number/itoa_buffered<u8>
     i32.add
     local.set $10
     local.get $7
@@ -18265,7 +18265,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<u8>
+  call $~lib/util/number/itoa_buffered<u8>
   i32.add
   local.set $10
   local.get $8

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -12,8 +12,9 @@
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_f64 (func (result f64)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
- (type $i32_i32_i64_=>_i32 (func (param i32 i32 i64) (result i32)))
+ (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
+ (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
@@ -23,9 +24,7 @@
  (type $i64_=>_none (func (param i64)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $i32_i32_f64_=>_i32 (func (param i32 i32 f64) (result i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
@@ -13220,32 +13219,26 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 1
   drop
-  local.get $2
+  local.get $1
   i32.const 0
   i32.lt_s
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   if
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
    local.get $0
    i32.const 45
    i32.store16
@@ -13260,50 +13253,50 @@
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 48
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
+   local.get $2
    i32.add
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 4
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
   local.set $6
-  local.get $4
+  local.get $1
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -13394,6 +13387,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<i32>
     i32.add
@@ -13432,6 +13428,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<i32>
   i32.add
@@ -13602,20 +13601,14 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 0
   drop
   i32.const 0
@@ -13624,44 +13617,44 @@
   drop
   i32.const 0
   drop
-  local.get $2
+  local.get $1
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 48
    i32.or
    i32.store16
    i32.const 1
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 4
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
   local.set $6
-  local.get $4
+  local.get $1
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -13752,6 +13745,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<u32>
     i32.add
@@ -13790,6 +13786,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<u32>
   i32.add
@@ -15155,15 +15154,9 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  (local $3 i32)
-  local.get $0
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 f64) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   f64.const 0
   f64.eq
   if
@@ -15179,15 +15172,15 @@
    i32.const 3
    return
   end
-  local.get $2
-  local.get $2
+  local.get $1
+  local.get $1
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $2
-   local.get $2
+   local.get $1
+   local.get $1
    f64.ne
    if
     local.get $0
@@ -15202,11 +15195,11 @@
     i32.const 3
     return
    else
-    local.get $2
+    local.get $1
     f64.const 0
     f64.lt
-    local.set $3
-    local.get $3
+    local.set $2
+    local.get $2
     if
      local.get $0
      i32.const 45
@@ -15223,14 +15216,14 @@
     i64.const 34058970405077102
     i64.store offset=8
     i32.const 8
-    local.get $3
+    local.get $2
     i32.add
     return
    end
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $1
   call $~lib/util/number/dtoa_core
  )
  (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -15312,6 +15305,9 @@
     local.get $9
     local.get $8
     local.get $9
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $10
     call $~lib/util/number/dtoa_buffered
     i32.add
@@ -15350,6 +15346,9 @@
   local.get $9
   local.get $8
   local.get $9
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $10
   call $~lib/util/number/dtoa_buffered
   i32.add
@@ -16173,36 +16172,30 @@
   i32.const 5296
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 1
   drop
-  local.get $2
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
   i32.const 0
   i32.lt_s
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   if
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
    local.get $0
    i32.const 45
    i32.store16
@@ -16217,7 +16210,7 @@
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
@@ -16226,11 +16219,11 @@
   i32.lt_u
   if
    local.get $0
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 24
    i32.shl
    i32.const 24
@@ -16239,44 +16232,44 @@
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
+   local.get $2
    i32.add
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 1
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
+  local.set $6
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
-  local.set $6
-  local.get $4
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -16367,6 +16360,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<i8>
     i32.add
@@ -16405,6 +16401,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<i8>
   i32.add
@@ -16463,20 +16462,14 @@
   i32.const 5296
   call $~lib/array/Array<i8>#join
  )
- (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 0
   drop
   i32.const 0
@@ -16485,14 +16478,14 @@
   drop
   i32.const 0
   drop
-  local.get $2
+  local.get $1
   i32.const 65535
   i32.and
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 65535
    i32.and
    i32.const 48
@@ -16501,36 +16494,36 @@
    i32.const 1
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 2
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   i32.const 65535
   i32.and
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
+  local.set $6
+  local.get $1
   i32.const 65535
   i32.and
-  local.set $6
-  local.get $4
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -16621,6 +16614,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<u16>
     i32.add
@@ -16659,6 +16655,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<u16>
   i32.add
@@ -17051,22 +17050,16 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
+  (local $8 i64)
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 0
   drop
   i32.const 0
@@ -17075,73 +17068,73 @@
   drop
   i32.const 0
   drop
-  local.get $2
+  local.get $1
   i64.const 10
   i64.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 8
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   global.get $~lib/builtins/u32.MAX_VALUE
   i64.extend_i32_u
   i64.le_u
   if
-   local.get $2
+   local.get $1
    i32.wrap_i64
-   local.set $5
+   local.set $4
+   local.get $3
    local.get $4
-   local.get $5
    call $~lib/util/number/decimalCount32
    i32.add
-   local.set $4
+   local.set $3
    local.get $0
-   local.set $8
-   local.get $5
    local.set $7
    local.get $4
    local.set $6
+   local.get $3
+   local.set $5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $8
    local.get $7
    local.get $6
+   local.get $5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $4
-   local.get $2
+   local.get $3
+   local.get $1
    call $~lib/util/number/decimalCount64High
    i32.add
-   local.set $4
+   local.set $3
    local.get $0
-   local.set $7
-   local.get $2
-   local.set $9
-   local.get $4
    local.set $6
+   local.get $1
+   local.set $8
+   local.get $3
+   local.set $5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $9
    local.get $6
+   local.get $8
+   local.get $5
    call $~lib/util/number/utoa64_dec_lut
   end
-  local.get $4
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -17232,6 +17225,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<u64>
     i32.add
@@ -17270,6 +17266,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<u64>
   i32.add
@@ -17507,34 +17506,28 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
+  (local $8 i64)
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 1
   drop
-  local.get $2
+  local.get $1
   i64.const 0
   i64.lt_s
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   if
    i64.const 0
-   local.get $2
+   local.get $1
    i64.sub
-   local.set $2
+   local.set $1
    local.get $0
    i32.const 45
    i32.store16
@@ -17549,79 +17542,79 @@
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   i64.const 10
   i64.lt_u
   if
    local.get $0
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
-   local.get $3
+   local.get $2
    i32.add
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 8
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   global.get $~lib/builtins/u32.MAX_VALUE
   i64.extend_i32_u
   i64.le_u
   if
-   local.get $2
+   local.get $1
    i32.wrap_i64
-   local.set $5
+   local.set $4
+   local.get $3
    local.get $4
-   local.get $5
    call $~lib/util/number/decimalCount32
    i32.add
-   local.set $4
+   local.set $3
    local.get $0
-   local.set $8
-   local.get $5
    local.set $7
    local.get $4
    local.set $6
+   local.get $3
+   local.set $5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $8
    local.get $7
    local.get $6
+   local.get $5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $4
-   local.get $2
+   local.get $3
+   local.get $1
    call $~lib/util/number/decimalCount64High
    i32.add
-   local.set $4
+   local.set $3
    local.get $0
-   local.set $7
-   local.get $2
-   local.set $9
-   local.get $4
    local.set $6
+   local.get $1
+   local.set $8
+   local.get $3
+   local.set $5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $9
    local.get $6
+   local.get $8
+   local.get $5
    call $~lib/util/number/utoa64_dec_lut
   end
-  local.get $4
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -17714,6 +17707,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<i64>
     i32.add
@@ -17752,6 +17748,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<i64>
   i32.add
@@ -18068,20 +18067,14 @@
   i32.const 5296
   call $~lib/array/Array<~lib/array/Array<i32>>#join
  )
- (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 0
   drop
   i32.const 0
@@ -18090,14 +18083,14 @@
   drop
   i32.const 0
   drop
-  local.get $2
+  local.get $1
   i32.const 255
   i32.and
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 255
    i32.and
    i32.const 48
@@ -18106,36 +18099,36 @@
    i32.const 1
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 1
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   i32.const 255
   i32.and
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
+  local.set $6
+  local.get $1
   i32.const 255
   i32.and
-  local.set $6
-  local.get $4
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -18226,6 +18219,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<u8>
     i32.add
@@ -18264,6 +18260,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<u8>
   i32.add

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
@@ -11,13 +11,13 @@
  (type $f32_i32_i32_=>_i32 (func (param f32 i32 i32) (result i32)))
  (type $f64_i32_i32_=>_i32 (func (param f64 i32 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
+ (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
+ (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i64_i64_i32_i32_=>_i64 (func (param i64 i64 i32 i32) (result i64)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i64_i32_i32_=>_none (func (param i64 i32 i32)))
- (type $i32_i32_i64_=>_i32 (func (param i32 i32 i64) (result i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
- (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
@@ -29,8 +29,6 @@
  (type $f32_i32_i32_=>_none (func (param f32 i32 i32)))
  (type $f64_i32_i32_=>_none (func (param f64 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_f64_=>_i32 (func (param i32 i32 f64) (result i32)))
- (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
@@ -17706,31 +17704,26 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
   i32.const 0
   i32.lt_s
-  local.tee $1
+  local.tee $2
   if
    local.get $0
    i32.const 45
    i32.store16
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
@@ -17739,11 +17732,11 @@
   i32.lt_u
   if
    local.get $0
-   local.get $1
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 24
    i32.shl
    i32.const 24
@@ -17751,19 +17744,19 @@
    i32.const 48
    i32.or
    i32.store16
-   local.get $1
+   local.get $2
    i32.const 1
    i32.add
    return
   end
   local.get $2
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
   local.tee $2
   call $~lib/util/number/decimalCount32
-  local.get $1
   i32.add
   local.set $1
   local.get $0
@@ -17900,6 +17893,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.add
@@ -17935,6 +17931,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.add
@@ -18131,21 +18130,16 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 255
   i32.and
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 255
    i32.and
    i32.const 48
@@ -18154,7 +18148,7 @@
    i32.const 1
    return
   end
-  local.get $2
+  local.get $1
   i32.const 255
   i32.and
   local.tee $2
@@ -18220,6 +18214,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.add
@@ -18255,6 +18252,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.add
@@ -18288,31 +18288,26 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<i16> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 16
   i32.shl
   i32.const 16
   i32.shr_s
   i32.const 0
   i32.lt_s
-  local.tee $1
+  local.tee $2
   if
    local.get $0
    i32.const 45
    i32.store16
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
   i32.const 16
   i32.shl
   i32.const 16
@@ -18321,11 +18316,11 @@
   i32.lt_u
   if
    local.get $0
-   local.get $1
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 16
    i32.shl
    i32.const 16
@@ -18333,19 +18328,19 @@
    i32.const 48
    i32.or
    i32.store16
-   local.get $1
+   local.get $2
    i32.const 1
    i32.add
    return
   end
   local.get $2
+  local.get $1
   i32.const 16
   i32.shl
   i32.const 16
   i32.shr_s
   local.tee $2
   call $~lib/util/number/decimalCount32
-  local.get $1
   i32.add
   local.set $1
   local.get $0
@@ -18408,6 +18403,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.const 1
@@ -18445,6 +18443,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 1
@@ -18482,21 +18483,16 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 65535
   i32.and
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 65535
    i32.and
    i32.const 48
@@ -18505,7 +18501,7 @@
    i32.const 1
    return
   end
-  local.get $2
+  local.get $1
   i32.const 65535
   i32.and
   local.tee $2
@@ -18571,6 +18567,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.const 1
@@ -18608,6 +18607,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 1
@@ -18645,49 +18647,44 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 0
   i32.lt_s
-  local.tee $1
+  local.tee $2
   if
    local.get $0
    i32.const 45
    i32.store16
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $1
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 48
    i32.or
    i32.store16
-   local.get $1
+   local.get $2
    i32.const 1
    i32.add
    return
   end
   local.get $0
-  local.get $2
-  local.get $2
-  call $~lib/util/number/decimalCount32
   local.get $1
+  local.get $1
+  call $~lib/util/number/decimalCount32
+  local.get $2
   i32.add
   local.tee $0
   call $~lib/util/number/utoa_dec_simple<u32>
@@ -18747,6 +18744,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.const 2
@@ -18784,6 +18784,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 2
@@ -18821,19 +18824,13 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
+ (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (result i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 48
    i32.or
    i32.store16
@@ -18841,8 +18838,8 @@
    return
   end
   local.get $0
-  local.get $2
-  local.get $2
+  local.get $1
+  local.get $1
   call $~lib/util/number/decimalCount32
   local.tee $0
   call $~lib/util/number/utoa_dec_simple<u32>
@@ -18902,6 +18899,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.const 2
@@ -18939,6 +18939,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 2
@@ -19052,71 +19055,66 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i32)
   (local $3 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  local.get $0
-  i32.add
-  local.set $1
-  local.get $2
   i64.const 0
   i64.lt_s
-  local.tee $0
+  local.tee $2
   if
-   local.get $1
+   local.get $0
    i32.const 45
    i32.store16
    i64.const 0
-   local.get $2
+   local.get $1
    i64.sub
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
   i64.const 10
   i64.lt_u
   if
-   local.get $0
+   local.get $2
    i32.const 1
    i32.shl
-   local.get $1
+   local.get $0
    i32.add
-   local.get $2
+   local.get $1
    i64.const 48
    i64.or
    i64.store16
-   local.get $0
+   local.get $2
    i32.const 1
    i32.add
    return
   end
-  local.get $2
+  local.get $1
   i64.const 4294967295
   i64.le_u
   if
    local.get $2
-   i32.wrap_i64
-   local.tee $3
-   call $~lib/util/number/decimalCount32
-   local.get $0
-   i32.add
-   local.set $0
    local.get $1
-   local.get $3
+   i32.wrap_i64
+   local.tee $2
+   call $~lib/util/number/decimalCount32
+   i32.add
+   local.set $3
    local.get $0
+   local.get $2
+   local.get $3
    call $~lib/util/number/utoa_dec_simple<u32>
   else
-   local.get $1
-   local.get $2
-   local.get $2
-   call $~lib/util/number/decimalCount64High
    local.get $0
+   local.get $1
+   local.get $1
+   call $~lib/util/number/decimalCount64High
+   local.get $2
    i32.add
-   local.tee $0
+   local.tee $3
    call $~lib/util/number/utoa_dec_simple<u64>
   end
-  local.get $0
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -19234,6 +19232,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $7
     i32.const 3
@@ -19271,6 +19272,9 @@
   local.get $8
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $5
   i32.const 3
@@ -19308,48 +19312,43 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i32)
   (local $3 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  local.get $0
-  i32.add
-  local.set $0
-  local.get $2
   i64.const 10
   i64.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
    return
   end
-  local.get $2
+  local.get $1
   i64.const 4294967295
   i64.le_u
   if
-   local.get $2
+   local.get $1
    i32.wrap_i64
    local.tee $3
    call $~lib/util/number/decimalCount32
-   local.set $1
+   local.set $2
    local.get $0
    local.get $3
-   local.get $1
+   local.get $2
    call $~lib/util/number/utoa_dec_simple<u32>
   else
    local.get $0
-   local.get $2
-   local.get $2
+   local.get $1
+   local.get $1
    call $~lib/util/number/decimalCount64High
-   local.tee $1
+   local.tee $2
    call $~lib/util/number/utoa_dec_simple<u64>
   end
-  local.get $1
+  local.get $2
  )
  (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -19444,6 +19443,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $7
     i32.const 3
@@ -19481,6 +19483,9 @@
   local.get $8
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 3
@@ -20499,14 +20504,9 @@
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  local.get $0
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 f64) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   f64.const 0
   f64.eq
   if
@@ -20522,14 +20522,14 @@
    i32.const 3
    return
   end
-  local.get $2
-  local.get $2
+  local.get $1
+  local.get $1
   f64.sub
   f64.const 0
   f64.ne
   if
-   local.get $2
-   local.get $2
+   local.get $1
+   local.get $1
    f64.ne
    if
     local.get $0
@@ -20544,10 +20544,10 @@
     i32.const 3
     return
    else
-    local.get $2
+    local.get $1
     f64.const 0
     f64.lt
-    local.tee $1
+    local.tee $2
     if
      local.get $0
      i32.const 45
@@ -20563,7 +20563,7 @@
     local.get $0
     i64.const 34058970405077102
     i64.store offset=8
-    local.get $1
+    local.get $2
     i32.const 8
     i32.add
     return
@@ -20571,7 +20571,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $1
   call $~lib/util/number/dtoa_core
  )
  (func $~lib/util/string/joinFloatArray<f32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -20629,6 +20629,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.const 2
@@ -20667,6 +20670,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 2
@@ -20759,6 +20765,9 @@
    if
     local.get $1
     local.get $3
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $0
     local.get $6
     i32.const 3
@@ -20796,6 +20805,9 @@
   local.get $7
   local.get $1
   local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $0
   local.get $4
   i32.const 3

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -17706,7 +17706,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_stream<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -17904,7 +17904,7 @@
     local.get $6
     i32.add
     i32.load8_s
-    call $~lib/util/number/itoa_stream<i8>
+    call $~lib/util/number/itoa_buffered<i8>
     local.get $3
     i32.add
     local.set $3
@@ -17939,7 +17939,7 @@
   local.get $4
   i32.add
   i32.load8_s
-  call $~lib/util/number/itoa_stream<i8>
+  call $~lib/util/number/itoa_buffered<i8>
   local.get $3
   i32.add
   local.tee $0
@@ -18131,7 +18131,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -18224,7 +18224,7 @@
     local.get $6
     i32.add
     i32.load8_u
-    call $~lib/util/number/itoa_stream<u8>
+    call $~lib/util/number/itoa_buffered<u8>
     local.get $3
     i32.add
     local.set $3
@@ -18259,7 +18259,7 @@
   local.get $4
   i32.add
   i32.load8_u
-  call $~lib/util/number/itoa_stream<u8>
+  call $~lib/util/number/itoa_buffered<u8>
   local.get $3
   i32.add
   local.tee $0
@@ -18288,7 +18288,7 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -18414,7 +18414,7 @@
     i32.shl
     i32.add
     i32.load16_s
-    call $~lib/util/number/itoa_stream<i16>
+    call $~lib/util/number/itoa_buffered<i16>
     local.get $3
     i32.add
     local.set $3
@@ -18451,7 +18451,7 @@
   i32.shl
   i32.add
   i32.load16_s
-  call $~lib/util/number/itoa_stream<i16>
+  call $~lib/util/number/itoa_buffered<i16>
   local.get $3
   i32.add
   local.tee $0
@@ -18482,7 +18482,7 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -18577,7 +18577,7 @@
     i32.shl
     i32.add
     i32.load16_u
-    call $~lib/util/number/itoa_stream<u16>
+    call $~lib/util/number/itoa_buffered<u16>
     local.get $3
     i32.add
     local.set $3
@@ -18614,7 +18614,7 @@
   i32.shl
   i32.add
   i32.load16_u
-  call $~lib/util/number/itoa_stream<u16>
+  call $~lib/util/number/itoa_buffered<u16>
   local.get $3
   i32.add
   local.tee $0
@@ -18645,7 +18645,7 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -18753,7 +18753,7 @@
     i32.shl
     i32.add
     i32.load
-    call $~lib/util/number/itoa_stream<i32>
+    call $~lib/util/number/itoa_buffered<i32>
     local.get $3
     i32.add
     local.set $3
@@ -18790,7 +18790,7 @@
   i32.shl
   i32.add
   i32.load
-  call $~lib/util/number/itoa_stream<i32>
+  call $~lib/util/number/itoa_buffered<i32>
   local.get $3
   i32.add
   local.tee $0
@@ -18821,7 +18821,7 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -18908,7 +18908,7 @@
     i32.shl
     i32.add
     i32.load
-    call $~lib/util/number/itoa_stream<u32>
+    call $~lib/util/number/itoa_buffered<u32>
     local.get $3
     i32.add
     local.set $3
@@ -18945,7 +18945,7 @@
   i32.shl
   i32.add
   i32.load
-  call $~lib/util/number/itoa_stream<u32>
+  call $~lib/util/number/itoa_buffered<u32>
   local.get $3
   i32.add
   local.tee $0
@@ -19052,7 +19052,7 @@
    br_if $do-continue|0
   end
  )
- (func $~lib/util/number/itoa_stream<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -19240,7 +19240,7 @@
     i32.shl
     i32.add
     i64.load
-    call $~lib/util/number/itoa_stream<i64>
+    call $~lib/util/number/itoa_buffered<i64>
     local.get $3
     i32.add
     local.set $3
@@ -19277,7 +19277,7 @@
   i32.shl
   i32.add
   i64.load
-  call $~lib/util/number/itoa_stream<i64>
+  call $~lib/util/number/itoa_buffered<i64>
   local.get $3
   i32.add
   local.tee $0
@@ -19308,7 +19308,7 @@
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -19450,7 +19450,7 @@
     i32.shl
     i32.add
     i64.load
-    call $~lib/util/number/itoa_stream<u64>
+    call $~lib/util/number/itoa_buffered<u64>
     local.get $3
     i32.add
     local.set $3
@@ -19487,7 +19487,7 @@
   i32.shl
   i32.add
   i64.load
-  call $~lib/util/number/itoa_stream<u64>
+  call $~lib/util/number/itoa_buffered<u64>
   local.get $3
   i32.add
   local.tee $0
@@ -20499,7 +20499,7 @@
   call $~lib/rt/tlsf/checkUsedBlock
   call $~lib/rt/tlsf/freeBlock
  )
- (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -20636,7 +20636,7 @@
     i32.add
     f32.load
     f64.promote_f32
-    call $~lib/util/number/dtoa_stream
+    call $~lib/util/number/dtoa_buffered
     local.get $3
     i32.add
     local.set $3
@@ -20674,7 +20674,7 @@
   i32.add
   f32.load
   f64.promote_f32
-  call $~lib/util/number/dtoa_stream
+  call $~lib/util/number/dtoa_buffered
   local.get $3
   i32.add
   local.tee $0
@@ -20765,7 +20765,7 @@
     i32.shl
     i32.add
     f64.load
-    call $~lib/util/number/dtoa_stream
+    call $~lib/util/number/dtoa_buffered
     local.get $3
     i32.add
     local.set $3
@@ -20802,7 +20802,7 @@
   i32.shl
   i32.add
   f64.load
-  call $~lib/util/number/dtoa_stream
+  call $~lib/util/number/dtoa_buffered
   local.get $3
   i32.add
   local.tee $0

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -32397,7 +32397,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_stream<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32699,7 +32699,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<i8>
+    call $~lib/util/number/itoa_buffered<i8>
     i32.add
     local.set $10
     local.get $7
@@ -32737,7 +32737,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<i8>
+  call $~lib/util/number/itoa_buffered<i8>
   i32.add
   local.set $10
   local.get $8
@@ -33170,7 +33170,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33329,7 +33329,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<u8>
+    call $~lib/util/number/itoa_buffered<u8>
     i32.add
     local.set $10
     local.get $7
@@ -33367,7 +33367,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<u8>
+  call $~lib/util/number/itoa_buffered<u8>
   i32.add
   local.set $10
   local.get $8
@@ -33576,7 +33576,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33771,7 +33771,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<i16>
+    call $~lib/util/number/itoa_buffered<i16>
     i32.add
     local.set $10
     local.get $7
@@ -33809,7 +33809,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<i16>
+  call $~lib/util/number/itoa_buffered<i16>
   i32.add
   local.set $10
   local.get $8
@@ -33926,7 +33926,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34085,7 +34085,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<u16>
+    call $~lib/util/number/itoa_buffered<u16>
     i32.add
     local.set $10
     local.get $7
@@ -34123,7 +34123,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<u16>
+  call $~lib/util/number/itoa_buffered<u16>
   i32.add
   local.set $10
   local.get $8
@@ -34240,7 +34240,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34415,7 +34415,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<i32>
+    call $~lib/util/number/itoa_buffered<i32>
     i32.add
     local.set $10
     local.get $7
@@ -34453,7 +34453,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<i32>
+  call $~lib/util/number/itoa_buffered<i32>
   i32.add
   local.set $10
   local.get $8
@@ -34570,7 +34570,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34721,7 +34721,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<u32>
+    call $~lib/util/number/itoa_buffered<u32>
     i32.add
     local.set $10
     local.get $7
@@ -34759,7 +34759,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<u32>
+  call $~lib/util/number/itoa_buffered<u32>
   i32.add
   local.set $10
   local.get $8
@@ -35237,7 +35237,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35445,7 +35445,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<i64>
+    call $~lib/util/number/itoa_buffered<i64>
     i32.add
     local.set $10
     local.get $7
@@ -35483,7 +35483,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<i64>
+  call $~lib/util/number/itoa_buffered<i64>
   i32.add
   local.set $10
   local.get $8
@@ -35752,7 +35752,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35934,7 +35934,7 @@
     local.get $9
     local.get $10
     local.get $11
-    call $~lib/util/number/itoa_stream<u64>
+    call $~lib/util/number/itoa_buffered<u64>
     i32.add
     local.set $10
     local.get $7
@@ -35972,7 +35972,7 @@
   local.get $9
   local.get $10
   local.get $11
-  call $~lib/util/number/itoa_stream<u64>
+  call $~lib/util/number/itoa_buffered<u64>
   i32.add
   local.set $10
   local.get $8
@@ -37401,7 +37401,7 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -37561,7 +37561,7 @@
     local.get $9
     local.get $10
     f64.promote_f32
-    call $~lib/util/number/dtoa_stream
+    call $~lib/util/number/dtoa_buffered
     i32.add
     local.set $9
     local.get $6
@@ -37600,7 +37600,7 @@
   local.get $9
   local.get $10
   f64.promote_f32
-  call $~lib/util/number/dtoa_stream
+  call $~lib/util/number/dtoa_buffered
   i32.add
   local.set $9
   local.get $7
@@ -37797,7 +37797,7 @@
     local.get $8
     local.get $9
     local.get $10
-    call $~lib/util/number/dtoa_stream
+    call $~lib/util/number/dtoa_buffered
     i32.add
     local.set $9
     local.get $6
@@ -37835,7 +37835,7 @@
   local.get $8
   local.get $9
   local.get $10
-  call $~lib/util/number/dtoa_stream
+  call $~lib/util/number/dtoa_buffered
   i32.add
   local.set $9
   local.get $7

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -28,7 +28,8 @@
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $f32_i32_i32_=>_none (func (param f32 i32 i32)))
  (type $f64_i32_i32_=>_none (func (param f64 i32 i32)))
- (type $i32_i32_i64_=>_i32 (func (param i32 i32 i64) (result i32)))
+ (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
+ (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_i32_f32_=>_f32 (func (param i32 i32 f32) (result f32)))
  (type $f32_i32_i32_=>_f32 (func (param f32 i32 i32) (result f32)))
  (type $i32_i32_f64_=>_f64 (func (param i32 i32 f64) (result f64)))
@@ -40,9 +41,7 @@
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $i32_i32_f64_=>_i32 (func (param i32 i32 f64) (result i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
  (type $f32_f32_=>_f32 (func (param f32 f32) (result f32)))
@@ -32397,36 +32396,30 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 1
   drop
-  local.get $2
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
   i32.const 0
   i32.lt_s
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   if
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
    local.get $0
    i32.const 45
    i32.store16
@@ -32441,7 +32434,7 @@
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
@@ -32450,11 +32443,11 @@
   i32.lt_u
   if
    local.get $0
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 24
    i32.shl
    i32.const 24
@@ -32463,44 +32456,44 @@
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
+   local.get $2
    i32.add
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 1
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
+  local.set $6
+  local.get $1
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
-  local.set $6
-  local.get $4
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -32698,6 +32691,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<i8>
     i32.add
@@ -32736,6 +32732,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<i8>
   i32.add
@@ -33170,20 +33169,14 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 0
   drop
   i32.const 0
@@ -33192,14 +33185,14 @@
   drop
   i32.const 0
   drop
-  local.get $2
+  local.get $1
   i32.const 255
   i32.and
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 255
    i32.and
    i32.const 48
@@ -33208,36 +33201,36 @@
    i32.const 1
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 1
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   i32.const 255
   i32.and
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
+  local.set $6
+  local.get $1
   i32.const 255
   i32.and
-  local.set $6
-  local.get $4
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -33328,6 +33321,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<u8>
     i32.add
@@ -33366,6 +33362,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<u8>
   i32.add
@@ -33576,36 +33575,30 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i16> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 1
   drop
-  local.get $2
+  local.get $1
   i32.const 16
   i32.shl
   i32.const 16
   i32.shr_s
   i32.const 0
   i32.lt_s
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   if
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
    local.get $0
    i32.const 45
    i32.store16
@@ -33620,7 +33613,7 @@
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   i32.const 16
   i32.shl
   i32.const 16
@@ -33629,11 +33622,11 @@
   i32.lt_u
   if
    local.get $0
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 16
    i32.shl
    i32.const 16
@@ -33642,44 +33635,44 @@
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
+   local.get $2
    i32.add
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 2
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   i32.const 16
   i32.shl
   i32.const 16
   i32.shr_s
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
+  local.set $6
+  local.get $1
   i32.const 16
   i32.shl
   i32.const 16
   i32.shr_s
-  local.set $6
-  local.get $4
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -33770,6 +33763,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<i16>
     i32.add
@@ -33808,6 +33804,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<i16>
   i32.add
@@ -33926,20 +33925,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 0
   drop
   i32.const 0
@@ -33948,14 +33941,14 @@
   drop
   i32.const 0
   drop
-  local.get $2
+  local.get $1
   i32.const 65535
   i32.and
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 65535
    i32.and
    i32.const 48
@@ -33964,36 +33957,36 @@
    i32.const 1
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 2
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   i32.const 65535
   i32.and
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
+  local.set $6
+  local.get $1
   i32.const 65535
   i32.and
-  local.set $6
-  local.get $4
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -34084,6 +34077,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<u16>
     i32.add
@@ -34122,6 +34118,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<u16>
   i32.add
@@ -34240,32 +34239,26 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<i32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 1
   drop
-  local.get $2
+  local.get $1
   i32.const 0
   i32.lt_s
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   if
    i32.const 0
-   local.get $2
+   local.get $1
    i32.sub
-   local.set $2
+   local.set $1
    local.get $0
    i32.const 45
    i32.store16
@@ -34280,50 +34273,50 @@
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i32.const 48
    i32.or
    i32.store16
    i32.const 1
-   local.get $3
+   local.get $2
    i32.add
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 4
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
   local.set $6
-  local.get $4
+  local.get $1
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -34414,6 +34407,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<i32>
     i32.add
@@ -34452,6 +34448,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<i32>
   i32.add
@@ -34570,20 +34569,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_buffered<u32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 0
   drop
   i32.const 0
@@ -34592,44 +34585,44 @@
   drop
   i32.const 0
   drop
-  local.get $2
+  local.get $1
   i32.const 10
   i32.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 48
    i32.or
    i32.store16
    i32.const 1
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 4
   i32.const 4
   i32.le_u
   drop
-  local.get $4
-  local.get $2
+  local.get $3
+  local.get $1
   call $~lib/util/number/decimalCount32
   i32.add
-  local.set $4
+  local.set $3
   local.get $0
-  local.set $7
-  local.get $2
   local.set $6
-  local.get $4
+  local.get $1
   local.set $5
+  local.get $3
+  local.set $4
   i32.const 0
   i32.const 1
   i32.ge_s
   drop
-  local.get $7
   local.get $6
   local.get $5
-  call $~lib/util/number/utoa32_dec_lut
   local.get $4
+  call $~lib/util/number/utoa32_dec_lut
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -34720,6 +34713,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<u32>
     i32.add
@@ -34758,6 +34754,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<u32>
   i32.add
@@ -35237,34 +35236,28 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
+  (local $8 i64)
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 1
   drop
-  local.get $2
+  local.get $1
   i64.const 0
   i64.lt_s
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   if
    i64.const 0
-   local.get $2
+   local.get $1
    i64.sub
-   local.set $2
+   local.set $1
    local.get $0
    i32.const 45
    i32.store16
@@ -35279,79 +35272,79 @@
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   i64.const 10
   i64.lt_u
   if
    local.get $0
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $2
+   local.get $1
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
-   local.get $3
+   local.get $2
    i32.add
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 8
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   global.get $~lib/builtins/u32.MAX_VALUE
   i64.extend_i32_u
   i64.le_u
   if
-   local.get $2
+   local.get $1
    i32.wrap_i64
-   local.set $5
+   local.set $4
+   local.get $3
    local.get $4
-   local.get $5
    call $~lib/util/number/decimalCount32
    i32.add
-   local.set $4
+   local.set $3
    local.get $0
-   local.set $8
-   local.get $5
    local.set $7
    local.get $4
    local.set $6
+   local.get $3
+   local.set $5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $8
    local.get $7
    local.get $6
+   local.get $5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $4
-   local.get $2
+   local.get $3
+   local.get $1
    call $~lib/util/number/decimalCount64High
    i32.add
-   local.set $4
+   local.set $3
    local.get $0
-   local.set $7
-   local.get $2
-   local.set $9
-   local.get $4
    local.set $6
+   local.get $1
+   local.set $8
+   local.get $3
+   local.set $5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $9
    local.get $6
+   local.get $8
+   local.get $5
    call $~lib/util/number/utoa64_dec_lut
   end
-  local.get $4
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -35444,6 +35437,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<i64>
     i32.add
@@ -35482,6 +35478,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<i64>
   i32.add
@@ -35752,22 +35751,16 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_buffered<u64> (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  local.get $0
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
+  (local $8 i64)
   i32.const 0
-  local.set $3
+  local.set $2
   i32.const 0
   drop
   i32.const 0
@@ -35776,73 +35769,73 @@
   drop
   i32.const 0
   drop
-  local.get $2
+  local.get $1
   i64.const 10
   i64.lt_u
   if
    local.get $0
-   local.get $2
+   local.get $1
    i64.const 48
    i64.or
    i64.store16
    i32.const 1
    return
   end
-  local.get $3
-  local.set $4
+  local.get $2
+  local.set $3
   i32.const 8
   i32.const 4
   i32.le_u
   drop
-  local.get $2
+  local.get $1
   global.get $~lib/builtins/u32.MAX_VALUE
   i64.extend_i32_u
   i64.le_u
   if
-   local.get $2
+   local.get $1
    i32.wrap_i64
-   local.set $5
+   local.set $4
+   local.get $3
    local.get $4
-   local.get $5
    call $~lib/util/number/decimalCount32
    i32.add
-   local.set $4
+   local.set $3
    local.get $0
-   local.set $8
-   local.get $5
    local.set $7
    local.get $4
    local.set $6
+   local.get $3
+   local.set $5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $8
    local.get $7
    local.get $6
+   local.get $5
    call $~lib/util/number/utoa32_dec_lut
   else
-   local.get $4
-   local.get $2
+   local.get $3
+   local.get $1
    call $~lib/util/number/decimalCount64High
    i32.add
-   local.set $4
+   local.set $3
    local.get $0
-   local.set $7
-   local.get $2
-   local.set $9
-   local.get $4
    local.set $6
+   local.get $1
+   local.set $8
+   local.get $3
+   local.set $5
    i32.const 0
    i32.const 1
    i32.ge_s
    drop
-   local.get $7
-   local.get $9
    local.get $6
+   local.get $8
+   local.get $5
    call $~lib/util/number/utoa64_dec_lut
   end
-  local.get $4
+  local.get $3
  )
  (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -35933,6 +35926,9 @@
     local.get $10
     local.get $9
     local.get $10
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $11
     call $~lib/util/number/itoa_buffered<u64>
     i32.add
@@ -35971,6 +35967,9 @@
   local.get $10
   local.get $9
   local.get $10
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $11
   call $~lib/util/number/itoa_buffered<u64>
   i32.add
@@ -37401,15 +37400,9 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  (local $3 i32)
-  local.get $0
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 f64) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   f64.const 0
   f64.eq
   if
@@ -37425,15 +37418,15 @@
    i32.const 3
    return
   end
-  local.get $2
-  local.get $2
+  local.get $1
+  local.get $1
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $2
-   local.get $2
+   local.get $1
+   local.get $1
    f64.ne
    if
     local.get $0
@@ -37448,11 +37441,11 @@
     i32.const 3
     return
    else
-    local.get $2
+    local.get $1
     f64.const 0
     f64.lt
-    local.set $3
-    local.get $3
+    local.set $2
+    local.get $2
     if
      local.get $0
      i32.const 45
@@ -37469,14 +37462,14 @@
     i64.const 34058970405077102
     i64.store offset=8
     i32.const 8
-    local.get $3
+    local.get $2
     i32.add
     return
    end
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $1
   call $~lib/util/number/dtoa_core
  )
  (func $~lib/util/string/joinFloatArray<f32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -37559,6 +37552,9 @@
     local.get $9
     local.get $8
     local.get $9
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $10
     f64.promote_f32
     call $~lib/util/number/dtoa_buffered
@@ -37598,6 +37594,9 @@
   local.get $9
   local.get $8
   local.get $9
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $10
   f64.promote_f32
   call $~lib/util/number/dtoa_buffered
@@ -37796,6 +37795,9 @@
     local.get $9
     local.get $8
     local.get $9
+    i32.const 1
+    i32.shl
+    i32.add
     local.get $10
     call $~lib/util/number/dtoa_buffered
     i32.add
@@ -37834,6 +37836,9 @@
   local.get $9
   local.get $8
   local.get $9
+  i32.const 1
+  i32.shl
+  i32.add
   local.get $10
   call $~lib/util/number/dtoa_buffered
   i32.add

--- a/tests/compiler/wasi/trace.optimized.wat
+++ b/tests/compiler/wasi/trace.optimized.wat
@@ -1542,7 +1542,7 @@
   local.get $8
   i32.add
  )
- (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   local.get $1
   f64.const 0
@@ -1773,7 +1773,7 @@
    i32.add
    local.tee $6
    local.get $1
-   call $~lib/util/number/dtoa_stream
+   call $~lib/util/number/dtoa_buffered
    local.set $9
    local.get $7
    local.get $6
@@ -1797,7 +1797,7 @@
     local.get $6
     local.get $6
     local.get $2
-    call $~lib/util/number/dtoa_stream
+    call $~lib/util/number/dtoa_buffered
     local.get $6
     call $~lib/string/String.UTF8.encodeUnsafe
     i32.const 1
@@ -1817,7 +1817,7 @@
      local.get $6
      local.get $6
      local.get $3
-     call $~lib/util/number/dtoa_stream
+     call $~lib/util/number/dtoa_buffered
      local.get $6
      call $~lib/string/String.UTF8.encodeUnsafe
      i32.const 1
@@ -1837,7 +1837,7 @@
       local.get $6
       local.get $6
       local.get $4
-      call $~lib/util/number/dtoa_stream
+      call $~lib/util/number/dtoa_buffered
       local.get $6
       call $~lib/string/String.UTF8.encodeUnsafe
       i32.const 1
@@ -1857,7 +1857,7 @@
        local.get $6
        local.get $6
        local.get $5
-       call $~lib/util/number/dtoa_stream
+       call $~lib/util/number/dtoa_buffered
        local.get $6
        call $~lib/string/String.UTF8.encodeUnsafe
        i32.const 1

--- a/tests/compiler/wasi/trace.untouched.wat
+++ b/tests/compiler/wasi/trace.untouched.wat
@@ -5,12 +5,11 @@
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func (param i32 i32 f64 f64 f64 f64 f64)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i32_i32_f64_=>_i32 (func (param i32 i32 f64) (result i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (import "wasi_snapshot_preview1" "fd_write" (func $~lib/bindings/wasi_snapshot_preview1/fd_write (param i32 i32 i32 i32) (result i32)))
  (import "wasi_snapshot_preview1" "proc_exit" (func $~lib/bindings/wasi_snapshot_preview1/proc_exit (param i32)))
  (memory $0 1)
@@ -3186,15 +3185,9 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  (local $3 i32)
-  local.get $0
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 f64) (result i32)
+  (local $2 i32)
   local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $0
-  local.get $2
   f64.const 0
   f64.eq
   if
@@ -3210,15 +3203,15 @@
    i32.const 3
    return
   end
-  local.get $2
-  local.get $2
+  local.get $1
+  local.get $1
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
-   local.get $2
-   local.get $2
+   local.get $1
+   local.get $1
    f64.ne
    if
     local.get $0
@@ -3233,11 +3226,11 @@
     i32.const 3
     return
    else
-    local.get $2
+    local.get $1
     f64.const 0
     f64.lt
-    local.set $3
-    local.get $3
+    local.set $2
+    local.get $2
     if
      local.get $0
      i32.const 45
@@ -3254,14 +3247,14 @@
     i64.const 34058970405077102
     i64.store offset=8
     i32.const 8
-    local.get $3
+    local.get $2
     i32.add
     return
    end
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $1
   call $~lib/util/number/dtoa_core
  )
  (func $~lib/wasi/index/abort (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
@@ -3563,7 +3556,6 @@
    i32.const 1
    local.get $11
    local.get $11
-   i32.const 0
    local.get $2
    call $~lib/util/number/dtoa_buffered
    local.get $11
@@ -3585,7 +3577,6 @@
     i32.const 1
     local.get $11
     local.get $11
-    i32.const 0
     local.get $3
     call $~lib/util/number/dtoa_buffered
     local.get $11
@@ -3607,7 +3598,6 @@
      i32.const 1
      local.get $11
      local.get $11
-     i32.const 0
      local.get $4
      call $~lib/util/number/dtoa_buffered
      local.get $11
@@ -3629,7 +3619,6 @@
       i32.const 1
       local.get $11
       local.get $11
-      i32.const 0
       local.get $5
       call $~lib/util/number/dtoa_buffered
       local.get $11
@@ -3651,7 +3640,6 @@
        i32.const 1
        local.get $11
        local.get $11
-       i32.const 0
        local.get $6
        call $~lib/util/number/dtoa_buffered
        local.get $11

--- a/tests/compiler/wasi/trace.untouched.wat
+++ b/tests/compiler/wasi/trace.untouched.wat
@@ -3186,7 +3186,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa_stream (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_buffered (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -3565,7 +3565,7 @@
    local.get $11
    i32.const 0
    local.get $2
-   call $~lib/util/number/dtoa_stream
+   call $~lib/util/number/dtoa_buffered
    local.get $11
    i32.const 0
    call $~lib/string/String.UTF8.encodeUnsafe
@@ -3587,7 +3587,7 @@
     local.get $11
     i32.const 0
     local.get $3
-    call $~lib/util/number/dtoa_stream
+    call $~lib/util/number/dtoa_buffered
     local.get $11
     i32.const 0
     call $~lib/string/String.UTF8.encodeUnsafe
@@ -3609,7 +3609,7 @@
      local.get $11
      i32.const 0
      local.get $4
-     call $~lib/util/number/dtoa_stream
+     call $~lib/util/number/dtoa_buffered
      local.get $11
      i32.const 0
      call $~lib/string/String.UTF8.encodeUnsafe
@@ -3631,7 +3631,7 @@
       local.get $11
       i32.const 0
       local.get $5
-      call $~lib/util/number/dtoa_stream
+      call $~lib/util/number/dtoa_buffered
       local.get $11
       i32.const 0
       call $~lib/string/String.UTF8.encodeUnsafe
@@ -3653,7 +3653,7 @@
        local.get $11
        i32.const 0
        local.get $6
-       call $~lib/util/number/dtoa_stream
+       call $~lib/util/number/dtoa_buffered
        local.get $11
        i32.const 0
        call $~lib/string/String.UTF8.encodeUnsafe


### PR DESCRIPTION
For better consistency I wanted to do this a long time ago.

Not sure is it breaking changing or not due to this methods usually used internally.

- [x] I've read the contributing guidelines