### PR TITLE
feat(asc): Add options merge algorithm for use by asconfig

### DIFF
--- a/cli/asc.json
+++ b/cli/asc.json
@@ -188,7 +188,8 @@
       " tail-calls          Tail call operations.",
       " multi-value         Multi value types."
     ],
-    "type": "S"
+    "type": "S",
+    "mutuallyExclusive": "disable"
   },
   "disable": {
     "category": "Features",
@@ -198,7 +199,8 @@
       " mutable-globals     Mutable global imports and exports.",
       ""
     ],
-    "type": "S"
+    "type": "S",
+    "mutuallyExclusive": "enable"
   },
   "use": {
     "category": "Features",

--- a/cli/util/options.d.ts
+++ b/cli/util/options.d.ts
@@ -42,7 +42,7 @@ interface Result {
 }
 
 /** Parses the specified command line arguments according to the given configuration. */
-export function parse(argv: string[], config: Config, populateDefaults?: boolean): Result;
+export function parse(argv: string[], config: Config, propagateDefaults?: boolean): Result;
 
 /** Help formatting options. */
 interface HelpOptions {
@@ -57,8 +57,8 @@ interface HelpOptions {
 /** Generates the help text for the specified configuration. */
 export function help(config: Config, options?: HelpOptions): string;
 
+/** Merges two sets of options into one, preferring the current over the parent set. */
+export function merge(config: Config, currentOptions: OptionSet, parentOptions: OptionSet): OptionSet;
+
 /** Populates default values on a parsed options result. */
 export function addDefaults(config: Config, options: OptionSet): OptionSet;
-
-/** Merges two sets of options into one, preferring the newer set. */
-export function merge(config: Config, currentOptions: OptionSet, parentOptions: OptionSet): OptionSet;

--- a/cli/util/options.d.ts
+++ b/cli/util/options.d.ts
@@ -56,4 +56,4 @@ export function help(config: Config, options?: HelpOptions): string;
 export function addDefaults(config: Config, options: { [key: string]: number | string });
 
 /** Merges two sets of options into one, preferring the newer set. */
-export function merge(config: Config, newerOptions: { [key: string]: number | string }, olderOptions: { [key: string]: number | string });
+export function merge(config: Config, currentOptions: { [key: string]: number | string }, parentOptions: { [key: string]: number | string });

--- a/cli/util/options.d.ts
+++ b/cli/util/options.d.ts
@@ -33,13 +33,11 @@ interface Result {
   /** Normal arguments. */
   arguments: string[],
   /** Trailing arguments. */
-  trailing: string[],
-  /** Provided arguments from the cli. */
-  provided: Set<string>
+  trailing: string[]
 }
 
 /** Parses the specified command line arguments according to the given configuration. */
-export function parse(argv: string[], config: Config): Result;
+export function parse(argv: string[], config: Config, populateDefaults?: boolean): Result;
 
 /** Help formatting options. */
 interface HelpOptions {
@@ -53,3 +51,9 @@ interface HelpOptions {
 
 /** Generates the help text for the specified configuration. */
 export function help(config: Config, options?: HelpOptions): string;
+
+/** Populates default values on a parsed options result. */
+export function addDefaults(config: Config, options: { [key: string]: number | string });
+
+/** Merges two sets of options into one, preferring the newer set. */
+export function merge(config: Config, newerOptions: { [key: string]: number | string }, olderOptions: { [key: string]: number | string });

--- a/cli/util/options.d.ts
+++ b/cli/util/options.d.ts
@@ -3,6 +3,11 @@
  * @license Apache-2.0
  */
 
+/** A set of options. */
+export interface OptionSet {
+  [key: string]: number | string
+}
+
 /** Command line option description. */
 export interface OptionDescription {
   /** Textual description. */
@@ -10,7 +15,7 @@ export interface OptionDescription {
   /** Data type. One of (b)oolean [default], (i)nteger, (f)loat or (s)tring. Uppercase means multiple values. */
   type?: "b" | "i" | "f" | "s" | "I" | "F" | "S",
   /** Substituted options, if any. */
-  value?: { [key: string]: number | string },
+  value?: OptionSet,
   /** Short alias, if any. */
   alias?: string
   /** The default value, if any. */
@@ -27,7 +32,7 @@ interface Config {
 /** Parsing result. */
 interface Result {
   /** Parsed options. */
-  options: { [key: string]: number | string },
+  options: OptionSet,
   /** Unknown options. */
   unknown: string[],
   /** Normal arguments. */
@@ -53,7 +58,7 @@ interface HelpOptions {
 export function help(config: Config, options?: HelpOptions): string;
 
 /** Populates default values on a parsed options result. */
-export function addDefaults(config: Config, options: { [key: string]: number | string });
+export function addDefaults(config: Config, options: OptionSet): OptionSet;
 
 /** Merges two sets of options into one, preferring the newer set. */
-export function merge(config: Config, currentOptions: { [key: string]: number | string }, parentOptions: { [key: string]: number | string });
+export function merge(config: Config, currentOptions: OptionSet, parentOptions: OptionSet): OptionSet;

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -160,7 +160,7 @@ function sanitizeValue(value, type) {
       }
       case "S": {
         if (!Array.isArray(value)) value = [ value ];
-        return value.map(v => String(v));
+        return value.map(String);
       }
     }
   }

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -147,12 +147,12 @@ function sanitizeValue(value, type) {
     switch (type) {
       case undefined:
       case "b": return Boolean(value);
-      case "i": return Number(Number(value).toFixed(0)) || 0;
+      case "i": return Math.trunc(value) || 0;
       case "f": return Number(value) || 0;
       case "s": return String(value);
       case "I": {
         if (!Array.isArray(value)) value = [ value ];
-        return value.map(v => Number(Number(v).toFixed(0)) || 0);
+        return value.map(v => Math.trunc(v) || 0);
       }
       case "F": {
         if (!Array.isArray(value)) value = [ value ];

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -16,7 +16,7 @@ const colorsUtil = require("./colors");
 // S    | string array
 
 /** Parses the specified command line arguments according to the given configuration. */
-function parse(argv, config, populateDefaults = true) {
+function parse(argv, config, propagateDefaults = true) {
   var options = {};
   var unknown = [];
   var args = [];
@@ -87,7 +87,7 @@ function parse(argv, config, populateDefaults = true) {
     } else unknown.push(arg);
   }
   while (i < k) trailing.push(argv[i++]); // trailing
-  if (populateDefaults) addDefaults(config, options);
+  if (propagateDefaults) addDefaults(config, options);
 
   return { options, unknown, arguments: args, trailing };
 }
@@ -149,13 +149,9 @@ function merge(config, currentOptions, parentOptions) {
       if (parentOptions[key] != null) {
         // only parent value present
         if (Array.isArray(parentOptions[key])) {
-          if (mutuallyExclusive) {
-            const exclude = currentOptions[mutuallyExclusive];
-            if (exclude) {
-              mergedOptions[key] = parentOptions[key].filter(value => !exclude.includes(value));
-            } else {
-              mergedOptions[key] = parentOptions[key].slice();
-            }
+          let exclude;
+          if (mutuallyExclusive != null && (exclude = currentOptions[mutuallyExclusive])) {
+            mergedOptions[key] = parentOptions[key].filter(value => !exclude.includes(value));
           } else {
             mergedOptions[key] = parentOptions[key].slice();
           }
@@ -173,19 +169,12 @@ function merge(config, currentOptions, parentOptions) {
     } else {
       // both current and parent values present
       if (Array.isArray(currentOptions[key])) {
-        if (mutuallyExclusive) {
-          const exclude = currentOptions[mutuallyExclusive];
-          if (exclude) {
-            mergedOptions[key] = [
-              ...currentOptions[key],
-              ...parentOptions[key].filter(value => !currentOptions[key].includes(value) && !exclude.includes(value))
-            ];
-          } else {
-            mergedOptions[key] = [
-              ...currentOptions[key],
-              ...parentOptions[key].filter(value => !currentOptions[key].includes(value)) // dedup
-            ];
-          }
+        let exclude;
+        if (mutuallyExclusive != null && (exclude = currentOptions[mutuallyExclusive])) {
+          mergedOptions[key] = [
+            ...currentOptions[key],
+            ...parentOptions[key].filter(value => !currentOptions[key].includes(value) && !exclude.includes(value))
+          ];
         } else {
           mergedOptions[key] = [
             ...currentOptions[key],

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -147,16 +147,16 @@ function sanitizeValue(value, type) {
     switch (type) {
       case undefined:
       case "b": return Boolean(value);
-      case "i": return +(+value).toFixed(0) || 0;
-      case "f": return +value || 0;
+      case "i": return Number(Number(value).toFixed(0)) || 0;
+      case "f": return Number(value) || 0;
       case "s": return String(value);
       case "I": {
         if (!Array.isArray(value)) value = [ value ];
-        return value.map(v => +(+v).toFixed(0) || 0);
+        return value.map(v => Number(Number(v).toFixed(0)) || 0);
       }
       case "F": {
         if (!Array.isArray(value)) value = [ value ];
-        return value.map(v => +v || 0);
+        return value.map(v => Number(v) || 0);
       }
       case "S": {
         if (!Array.isArray(value)) value = [ value ];

--- a/tests/cli/options.js
+++ b/tests/cli/options.js
@@ -1,0 +1,49 @@
+const assert = require("assert");
+const optionsUtil = require("../../cli/util/options");
+
+const config = {
+  "enable": {
+    "type": "S",
+    "mutuallyExclusive": "disable"
+  },
+  "disable": {
+    "type": "S",
+    "mutuallyExclusive": "enable"
+  },
+  "other": {
+    "type": "S",
+    "default": ["x"]
+  }
+};
+
+// Present in both should concat
+var merged = optionsUtil.merge(config, { enable: ["a"] }, { enable: ["b"] });
+assert.deepEqual(merged.enable, ["a", "b"]);
+
+merged = optionsUtil.merge(config, { enable: ["a"] }, { enable: ["a", "b"] });
+assert.deepEqual(merged.enable, ["a", "b"]);
+
+// Mutually exclusive should exclude
+merged = optionsUtil.merge(config, { enable: ["a", "b"] }, { disable: ["a", "c"] });
+assert.deepEqual(merged.enable, ["a", "b"]);
+assert.deepEqual(merged.disable, ["c"]);
+
+merged = optionsUtil.merge(config, { disable: ["a", "b"] }, { enable: ["a", "c"] });
+assert.deepEqual(merged.enable, ["c"]);
+assert.deepEqual(merged.disable, ["a", "b"]);
+
+// Populating defaults should work after the fact
+merged = optionsUtil.addDefaults(config, {});
+assert.deepEqual(merged.other, ["x"]);
+
+merged = optionsUtil.addDefaults(config, { other: ["y"] });
+assert.deepEqual(merged.other, ["y"]);
+
+// Complete usage test
+var result = optionsUtil.parse(["--enable", "a", "--disable", "b"], config, false);
+merged = optionsUtil.merge(config, result.options, { enable: ["b", "c"] });
+merged = optionsUtil.merge(config, merged, { disable: ["a", "d"] });
+optionsUtil.addDefaults(config, merged);
+assert.deepEqual(merged.enable, ["a", "c"]);
+assert.deepEqual(merged.disable, ["b", "d"]);
+assert.deepEqual(merged.other, ["x"]);


### PR DESCRIPTION
This is an attempt to solve the reconciliation problems encountered during https://github.com/AssemblyScript/assemblyscript/pull/1238 by extending the existing options parser with a backtracking merge algorithm.

With this, we'd essentially start by parsing command line arguments, obtaining an initial set of options, then merge the project's `asconfig.json` if applicable and continue by merging parent project `asconfig.json`s until we reach the end. Once done, we can add option defaults that we so far omitted.

The options `enable` and `disable` now have an additional `mutuallyExclusive` key indicating that whatever is newer in the respective other equalizes what's older. Does not affect the same level, but only merging a previous level.

There is a basic test in `tests/cli/options.js`, containing the following full usage test:

```js
var result = optionsUtil.parse(["--enable", "a", "--disable", "b"], config, false);
merged = optionsUtil.merge(config, result.options, { enable: ["b", "c"] });
merged = optionsUtil.merge(config, merged, { disable: ["a", "d"] });
optionsUtil.addDefaults(config, merged);
assert.deepEqual(merged.enable, ["a", "c"]);
assert.deepEqual(merged.disable, ["b", "d"]);
assert.deepEqual(merged.other, ["x"]);
```

@jtenner Does this look like it'd help / work in all scenarios?

- [x] I've read the contributing guidelines