### PR TITLE
fix: Change from "nightly" to "latest" AS version for sdk.js

### DIFF
--- a/lib/sdk/index.js
+++ b/lib/sdk/index.js
@@ -1,6 +1,6 @@
 const BINARYEN_VERSION = "nightly";
 const LONG_VERSION = "latest";
-const ASSEMBLYSCRIPT_VERSION = "nightly";
+const ASSEMBLYSCRIPT_VERSION = "latest";
 
 // AMD/require.js (browser)
 if (typeof define === "function" && define.amd) {

--- a/scripts/build-sdk.js
+++ b/scripts/build-sdk.js
@@ -7,7 +7,7 @@ fs.readFile(path.join(__dirname, "..", "lib", "sdk", "index.js"), "utf8", functi
   data = data
     .replace(/BINARYEN_VERSION = "nightly"/, "BINARYEN_VERSION = " + JSON.stringify(pkg.dependencies.binaryen.version))
     .replace(/LONG_VERSION = "latest"/, "LONG_VERSION = " + JSON.stringify(pkg.dependencies.long.version))
-    .replace(/ASSEMBLYSCRIPT_VERSION = "nightly"/, "ASSEMBLYSCRIPT_VERSION = " + JSON.stringify(pkg.version));
+    .replace(/ASSEMBLYSCRIPT_VERSION = "latest"/, "ASSEMBLYSCRIPT_VERSION = " + JSON.stringify(pkg.version));
   fs.writeFile(path.join(__dirname, "..", "dist", "sdk.js"), data, function(err) {
     if (err) throw err;
   });


### PR DESCRIPTION
- [x] I've read the contributing guidelines