### PR TITLE
Do not publish loader when there's no new release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,14 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # On success, semantic-release will update the version and publish,
+      # triggering the postversion script that'll update the loader's version
+      # as well. If nothing was published, the version will still be '0.0.0'.
       run: |
         node node_modules/semantic-release/bin/semantic-release.js --unstable
         cd lib/loader
-        npm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
-        npm publish --access public
+        if [ $(node -pe "require('./package.json').version") != "0.0.0" ]; then
+          npm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
+          npm publish --access public
+        fi
         cd ../..


### PR DESCRIPTION
Turned out that after https://github.com/AssemblyScript/assemblyscript/pull/1358 the loader is always published, even if there isn't a new release. That led to current latest on npm being loader@0.0.0. This PR fixes this by indirectly checking if the main package has been published. Should also unbreak the latest tag at 0 UTC.

- [x] I've read the contributing guidelines