### PR TITLE
Improve pass pipeline

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1632,9 +1632,9 @@ export class Module {
           passes.push("merge-locals");
           passes.push("coalesce-locals");
           passes.push("simplify-locals");
+          passes.push("vacuum");
           passes.push("inlining-optimizing");
           passes.push("precompute-propagate");
-          passes.push("vacuum");
           passes.push("coalesce-locals");
         }
         passes.push("remove-unused-brs");

--- a/src/module.ts
+++ b/src/module.ts
@@ -1530,8 +1530,8 @@ export class Module {
       //   passes.push("post-assemblyscript");
       // }
       passes.push("optimize-instructions");
-      passes.push("inlining");
       passes.push("dce");
+      passes.push("inlining");
       passes.push("remove-unused-brs");
       passes.push("remove-unused-names");
       passes.push("inlining-optimizing");

--- a/src/module.ts
+++ b/src/module.ts
@@ -1530,8 +1530,10 @@ export class Module {
       //   passes.push("post-assemblyscript");
       // }
       passes.push("optimize-instructions");
-      passes.push("dce");
-      passes.push("inlining");
+      if (optimizeLevel >= 3 || shrinkLevel >= 1) {
+        passes.push("dce");
+        passes.push("inlining");
+      }
       passes.push("remove-unused-brs");
       passes.push("remove-unused-names");
       passes.push("inlining-optimizing");

--- a/src/module.ts
+++ b/src/module.ts
@@ -1631,11 +1631,9 @@ export class Module {
           passes.push("vacuum");
           passes.push("merge-locals");
           passes.push("coalesce-locals");
-          passes.push("simplify-locals-nostructure");
-          passes.push("vacuum");
+          passes.push("simplify-locals");
           passes.push("inlining-optimizing");
           passes.push("precompute-propagate");
-          passes.push("simplify-locals");
           passes.push("vacuum");
           passes.push("coalesce-locals");
         }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1635,6 +1635,7 @@ export class Module {
           passes.push("vacuum");
           passes.push("inlining-optimizing");
           passes.push("precompute-propagate");
+          passes.push("vacuum");
           passes.push("coalesce-locals");
         }
         passes.push("remove-unused-brs");

--- a/src/module.ts
+++ b/src/module.ts
@@ -1628,6 +1628,7 @@ export class Module {
           passes.push("directize");
           passes.push("dae-optimizing");
           passes.push("precompute-propagate");
+          passes.push("simplify-locals");
           passes.push("vacuum");
           passes.push("merge-locals");
           passes.push("coalesce-locals");

--- a/src/module.ts
+++ b/src/module.ts
@@ -1622,7 +1622,6 @@ export class Module {
         if (optimizeLevel >= 3) {
           // very expensive, so O3 only
           passes.push("simplify-globals");
-          passes.push("simplify-locals");
           passes.push("vacuum");
           // replace indirect with direct calls again and inline
           passes.push("inlining-optimizing");
@@ -1636,6 +1635,9 @@ export class Module {
           passes.push("vacuum");
           passes.push("inlining-optimizing");
           passes.push("precompute-propagate");
+          passes.push("simplify-locals");
+          passes.push("vacuum");
+          passes.push("coalesce-locals");
         }
         passes.push("remove-unused-brs");
         passes.push("remove-unused-names");

--- a/src/module.ts
+++ b/src/module.ts
@@ -1629,12 +1629,13 @@ export class Module {
           passes.push("simplify-globals");
           passes.push("vacuum");
 
+          passes.push("precompute-propagate");
+          passes.push("vacuum");
+
           // replace indirect with direct calls again and inline
           passes.push("inlining-optimizing");
           passes.push("directize");
           passes.push("dae-optimizing");
-          passes.push("precompute-propagate");
-          passes.push("vacuum");
 
           passes.push("merge-locals");
           passes.push("coalesce-locals");

--- a/src/module.ts
+++ b/src/module.ts
@@ -1622,13 +1622,13 @@ export class Module {
         if (optimizeLevel >= 3) {
           // very expensive, so O3 only
           passes.push("simplify-globals");
+          passes.push("simplify-locals");
           passes.push("vacuum");
           // replace indirect with direct calls again and inline
           passes.push("inlining-optimizing");
           passes.push("directize");
           passes.push("dae-optimizing");
           passes.push("precompute-propagate");
-          passes.push("simplify-locals");
           passes.push("vacuum");
           passes.push("merge-locals");
           passes.push("coalesce-locals");

--- a/src/module.ts
+++ b/src/module.ts
@@ -1512,6 +1512,7 @@ export class Module {
         passes.push("flatten");
         passes.push("simplify-locals-notee-nostructure");
         passes.push("vacuum");
+
         passes.push("code-folding");
         passes.push("flatten");
         passes.push("local-cse");
@@ -1549,11 +1550,13 @@ export class Module {
       }
       passes.push("simplify-locals-nostructure");
       passes.push("vacuum");
+
       passes.push("reorder-locals");
       passes.push("remove-unused-brs");
       passes.push("coalesce-locals");
       passes.push("simplify-locals");
       passes.push("vacuum");
+
       passes.push("reorder-locals");
       passes.push("coalesce-locals");
       passes.push("reorder-locals");
@@ -1576,8 +1579,8 @@ export class Module {
       }
       if (optimizeLevel >= 2 || shrinkLevel >= 1) {
         passes.push("rse");
+        passes.push("vacuum");
       }
-      passes.push("vacuum");
 
       // --- PassRunner::addDefaultGlobalOptimizationPostPasses ---
 
@@ -1623,24 +1626,29 @@ export class Module {
           // very expensive, so O3 only
           passes.push("simplify-globals");
           passes.push("vacuum");
+
           // replace indirect with direct calls again and inline
           passes.push("inlining-optimizing");
           passes.push("directize");
           passes.push("dae-optimizing");
           passes.push("precompute-propagate");
           passes.push("vacuum");
+
           passes.push("merge-locals");
           passes.push("coalesce-locals");
           passes.push("simplify-locals");
           passes.push("vacuum");
+
           passes.push("inlining-optimizing");
           passes.push("precompute-propagate");
           passes.push("vacuum");
+
           passes.push("coalesce-locals");
         }
         passes.push("remove-unused-brs");
         passes.push("remove-unused-names");
         passes.push("vacuum");
+
         passes.push("optimize-instructions");
         passes.push("simplify-globals-optimizing");
       }

--- a/tests/compiler/binary.optimized.wat
+++ b/tests/compiler/binary.optimized.wat
@@ -114,7 +114,7 @@
      local.get $1
      i32.const 8388608
      i32.ge_u
-     if
+     if (result i32)
       local.get $1
       i32.const 8388608
       i32.eq
@@ -122,9 +122,9 @@
       local.get $1
       i32.const 8388608
       i32.sub
-      local.set $1
+     else
+      local.get $1
      end
-     local.get $1
      i32.const 1
      i32.shl
      local.set $1
@@ -261,7 +261,7 @@
      local.get $1
      i64.const 4503599627370496
      i64.ge_u
-     if
+     if (result i64)
       local.get $1
       i64.const 4503599627370496
       i64.eq
@@ -269,9 +269,9 @@
       local.get $1
       i64.const 4503599627370496
       i64.sub
-      local.set $1
+     else
+      local.get $1
      end
-     local.get $1
      i64.const 1
      i64.shl
      local.set $1

--- a/tests/compiler/class-overloading.optimized.wat
+++ b/tests/compiler/class-overloading.optimized.wat
@@ -98,12 +98,11 @@
    local.set $0
   end
   local.get $0
-  i32.eqz
   if (result i32)
+   local.get $0
+  else
    i32.const 3
    call $~lib/rt/stub/__alloc
-  else
-   local.get $0
   end
  )
  (func $~lib/string/String#get:length (param $0 i32) (result i32)

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -287,7 +287,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -307,35 +307,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -345,12 +345,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -358,7 +358,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -377,42 +377,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -427,12 +429,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -442,38 +444,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -491,7 +493,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -500,21 +502,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -541,7 +543,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -1189,14 +1189,14 @@
   global.set $do/ran
   i32.const 0
   local.set $0
-  loop $do-continue|08
+  loop $do-continue|06
    local.get $0
    i32.const 1
    i32.add
    local.tee $0
    i32.const 10
    i32.ne
-   br_if $do-continue|08
+   br_if $do-continue|06
   end
   local.get $0
   i32.const 10

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -1052,19 +1052,19 @@
   i32.const 0
   global.set $do/ran
   i32.const 10
-  local.set $1
+  local.set $0
   loop $do-continue|0
-   local.get $0
-   i32.const 1
-   i32.add
-   local.set $0
    local.get $1
    i32.const 1
+   i32.add
+   local.set $1
+   local.get $0
+   i32.const 1
    i32.sub
-   local.tee $1
+   local.tee $0
    br_if $do-continue|0
   end
-  local.get $1
+  local.get $0
   if
    i32.const 0
    i32.const 1040
@@ -1073,7 +1073,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.ne
   if
@@ -1089,17 +1089,17 @@
   i32.const 0
   global.set $do/ran
   i32.const 10
-  local.set $0
+  local.set $1
   loop $do-continue|00
-   local.get $0
-   local.tee $1
+   local.get $1
+   local.tee $0
    i32.const 1
    i32.sub
-   local.set $0
-   local.get $1
+   local.set $1
+   local.get $0
    br_if $do-continue|00
   end
-  local.get $0
+  local.get $1
   i32.const -1
   i32.ne
   if
@@ -1128,17 +1128,17 @@
   i32.const 0
   global.set $do/ran
   i32.const 0
-  local.set $1
+  local.set $0
   loop $do-continue|01
-   local.get $1
+   local.get $0
    i32.const 1
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 10
    i32.ne
    br_if $do-continue|01
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.ne
   if
@@ -1152,17 +1152,17 @@
   i32.const 1
   global.set $do/ran
   i32.const 0
-  local.set $1
+  local.set $0
   loop $do-continue|02
-   local.get $1
+   local.get $0
    i32.const 1
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 10
    i32.ne
    br_if $do-continue|02
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.ne
   if
@@ -1188,17 +1188,17 @@
   i32.const 0
   global.set $do/ran
   i32.const 0
-  local.set $1
+  local.set $0
   loop $do-continue|08
-   local.get $1
+   local.get $0
    i32.const 1
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 10
    i32.ne
    br_if $do-continue|08
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.ne
   if
@@ -1214,22 +1214,22 @@
   i32.const 0
   global.set $do/ran
   i32.const 0
-  local.set $0
-  i32.const 0
   local.set $1
+  i32.const 0
+  local.set $0
   loop $do-continue|03
-   local.get $0
+   local.get $1
    i32.const 1
    i32.add
-   local.tee $0
+   local.tee $1
    i32.const 10
    i32.ne
    if
     loop $do-continue|1
-     local.get $1
+     local.get $0
      i32.const 1
      i32.add
-     local.tee $1
+     local.tee $0
      i32.const 10
      i32.rem_s
      br_if $do-continue|1
@@ -1237,7 +1237,7 @@
     br $do-continue|03
    end
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.ne
   if
@@ -1248,7 +1248,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 90
   i32.ne
   if
@@ -1264,7 +1264,7 @@
   i32.const 0
   global.set $do/ran
   call $do/Ref#constructor
-  local.set $0
+  local.set $1
   loop $do-continue|04
    local.get $2
    i32.const 1
@@ -1274,20 +1274,20 @@
    i32.eq
    if
     i32.const 0
-    local.set $1
-    local.get $0
+    local.set $0
+    local.get $1
     if
-     local.get $0
+     local.get $1
      call $~lib/rt/pure/__release
     end
    else
     call $do/Ref#constructor
-    local.set $1
-    local.get $0
+    local.set $0
+    local.get $1
     call $~lib/rt/pure/__release
    end
-   local.get $1
-   local.tee $0
+   local.get $0
+   local.tee $1
    br_if $do-continue|04
   end
   local.get $2
@@ -1301,7 +1301,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   if
    i32.const 0
    i32.const 1040
@@ -1312,7 +1312,7 @@
   end
   i32.const 1
   global.set $do/ran
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   global.get $do/ran
   i32.eqz
@@ -1329,7 +1329,7 @@
   i32.const 0
   local.set $2
   call $do/Ref#constructor
-  local.set $0
+  local.set $1
   loop $do-continue|05
    block $do-break|0
     local.get $2
@@ -1339,19 +1339,19 @@
     i32.const 10
     i32.eq
     if
-     local.get $0
+     local.get $1
      if
-      local.get $0
+      local.get $1
       call $~lib/rt/pure/__release
      end
      i32.const 0
-     local.set $0
+     local.set $1
      br $do-break|0
     end
     call $do/Ref#constructor
-    local.tee $1
+    local.tee $0
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $0
     br_if $do-continue|05
    end
   end
@@ -1366,7 +1366,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   if
    i32.const 0
    i32.const 1040
@@ -1377,7 +1377,7 @@
   end
   i32.const 1
   global.set $do/ran
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   global.get $do/ran
   i32.eqz

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1819,27 +1819,27 @@
   (local $4 i32)
   (local $5 i32)
   global.get $~lib/rt/pure/ROOTS
-  local.tee $0
-  local.tee $4
-  local.set $3
+  local.tee $1
+  local.tee $3
+  local.set $4
   global.get $~lib/rt/pure/CUR
-  local.set $1
+  local.set $0
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $4
+   local.get $0
    i32.lt_u
    if
-    local.get $3
+    local.get $4
     i32.load
-    local.tee $2
-    i32.load offset=4
     local.tee $5
+    i32.load offset=4
+    local.tee $2
     i32.const 1879048192
     i32.and
     i32.const 805306368
     i32.eq
     if (result i32)
-     local.get $5
+     local.get $2
      i32.const 268435455
      i32.and
      i32.const 0
@@ -1848,88 +1848,88 @@
      i32.const 0
     end
     if
-     local.get $2
+     local.get $5
      call $~lib/rt/pure/markGray
-     local.get $4
-     local.get $2
+     local.get $3
+     local.get $5
      i32.store
-     local.get $4
+     local.get $3
      i32.const 4
      i32.add
-     local.set $4
+     local.set $3
     else
      i32.const 0
-     local.get $5
+     local.get $2
      i32.const 268435455
      i32.and
      i32.eqz
-     local.get $5
+     local.get $2
      i32.const 1879048192
      i32.and
      select
      if
       global.get $~lib/rt/tlsf/ROOT
-      local.get $2
+      local.get $5
       call $~lib/rt/tlsf/freeBlock
      else
-      local.get $2
       local.get $5
+      local.get $2
       i32.const 2147483647
       i32.and
       i32.store offset=4
      end
     end
-    local.get $3
+    local.get $4
     i32.const 4
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
-  local.get $4
+  local.get $3
   global.set $~lib/rt/pure/CUR
-  local.get $0
-  local.set $1
+  local.get $1
+  local.set $0
   loop $for-loop|1
-   local.get $1
-   local.get $4
+   local.get $0
+   local.get $3
    i32.lt_u
    if
-    local.get $1
+    local.get $0
     i32.load
     call $~lib/rt/pure/scan
-    local.get $1
+    local.get $0
     i32.const 4
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|1
    end
   end
-  local.get $0
-  local.set $1
+  local.get $1
+  local.set $0
   loop $for-loop|2
-   local.get $1
-   local.get $4
+   local.get $0
+   local.get $3
    i32.lt_u
    if
-    local.get $1
+    local.get $0
     i32.load
-    local.tee $5
-    local.get $5
+    local.tee $2
+    local.get $2
     i32.load offset=4
     i32.const 2147483647
     i32.and
     i32.store offset=4
-    local.get $5
+    local.get $2
     call $~lib/rt/pure/collectWhite
-    local.get $1
+    local.get $0
     i32.const 4
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|2
    end
   end
-  local.get $0
+  local.get $1
   global.set $~lib/rt/pure/CUR
  )
  (func $~lib/rt/pure/decrement (param $0 i32)

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -212,7 +212,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -232,35 +232,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -270,12 +270,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -283,7 +283,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -302,42 +302,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -352,12 +354,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -367,38 +369,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -416,7 +418,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -425,21 +427,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -466,7 +468,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -708,22 +710,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -1050,18 +1050,18 @@
   i32.const 0
   global.set $for/ran
   loop $for-loop|0
-   local.get $1
+   local.get $0
    i32.const 10
    i32.lt_s
    if
-    local.get $1
+    local.get $0
     i32.const 1
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|0
    end
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.ne
   if
@@ -1077,20 +1077,20 @@
   i32.const 0
   global.set $for/ran
   i32.const 0
-  local.set $1
+  local.set $0
   loop $for-loop|00
-   local.get $1
+   local.get $0
    i32.const 10
    i32.lt_s
    if
-    local.get $1
+    local.get $0
     i32.const 1
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|00
    end
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.ne
   if
@@ -1106,20 +1106,20 @@
   i32.const 0
   global.set $for/ran
   i32.const 10
-  local.set $1
+  local.set $0
   loop $for-loop|01
-   local.get $1
+   local.get $0
    i32.const 0
    i32.gt_s
    if
-    local.get $1
+    local.get $0
     i32.const 1
     i32.sub
-    local.set $1
+    local.set $0
     br $for-loop|01
    end
   end
-  local.get $1
+  local.get $0
   if
    i32.const 0
    i32.const 1040
@@ -1133,20 +1133,20 @@
   i32.const 0
   global.set $for/ran
   i32.const 0
-  local.set $1
+  local.set $0
   loop $for-loop|02
-   local.get $1
+   local.get $0
    i32.const 10
    i32.ne
    if
-    local.get $1
+    local.get $0
     i32.const 1
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|02
    end
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.ne
   if
@@ -1162,15 +1162,15 @@
   i32.const 0
   global.set $for/ran
   i32.const 10
-  local.set $1
+  local.set $0
   loop $for-loop|04
-   local.get $1
+   local.get $0
    i32.const 1
    i32.sub
-   local.tee $1
+   local.tee $0
    br_if $for-loop|04
   end
-  local.get $1
+  local.get $0
   if
    i32.const 0
    i32.const 1040
@@ -1184,17 +1184,17 @@
   i32.const 0
   global.set $for/ran
   i32.const 0
-  local.set $1
+  local.set $0
   loop $for-loop|06
-   local.get $1
+   local.get $0
    i32.const 1
    i32.add
-   local.tee $1
+   local.tee $0
    i32.const 10
    i32.ne
    br_if $for-loop|06
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.ne
   if
@@ -1214,20 +1214,20 @@
   i32.const 0
   global.set $for/ran
   i32.const 0
-  local.set $1
+  local.set $0
   loop $for-loop|07
-   local.get $1
+   local.get $0
    i32.const 10
    i32.lt_s
    if
-    local.get $1
+    local.get $0
     i32.const 1
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|07
    end
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.ne
   if
@@ -1264,36 +1264,36 @@
   i32.const 0
   global.set $for/ran
   call $for/Ref#constructor
-  local.set $1
+  local.set $0
   loop $for-loop|03
-   local.get $1
+   local.get $0
    if
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.tee $3
+    local.tee $2
     i32.const 10
     i32.eq
     if
      i32.const 0
-     local.set $0
-     local.get $1
+     local.set $1
+     local.get $0
      if
-      local.get $1
+      local.get $0
       call $~lib/rt/pure/__release
      end
     else
      call $for/Ref#constructor
-     local.set $0
-     local.get $1
+     local.set $1
+     local.get $0
      call $~lib/rt/pure/__release
     end
-    local.get $0
-    local.set $1
+    local.get $1
+    local.set $0
     br $for-loop|03
    end
   end
-  local.get $3
+  local.get $2
   i32.const 10
   i32.ne
   if
@@ -1304,7 +1304,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   if
    i32.const 0
    i32.const 1040
@@ -1315,7 +1315,7 @@
   end
   i32.const 1
   global.set $for/ran
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   global.get $for/ran
   i32.eqz
@@ -1331,40 +1331,40 @@
   global.set $for/ran
   call $for/Ref#constructor
   call $for/Ref#constructor
-  local.set $0
+  local.set $1
   call $~lib/rt/pure/__release
   loop $for-loop|05
    block $for-break0
     call $for/Ref#constructor
-    local.tee $1
+    local.tee $0
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $0
     if
-     local.get $2
+     local.get $3
      i32.const 1
      i32.add
-     local.tee $2
+     local.tee $3
      i32.const 10
      i32.eq
      if
-      local.get $0
+      local.get $1
       if
-       local.get $0
+       local.get $1
        call $~lib/rt/pure/__release
       end
       i32.const 0
-      local.set $0
+      local.set $1
       br $for-break0
      end
      call $for/Ref#constructor
-     local.get $0
+     local.get $1
      call $~lib/rt/pure/__release
-     local.set $0
+     local.set $1
      br $for-loop|05
     end
    end
   end
-  local.get $2
+  local.get $3
   i32.const 10
   i32.ne
   if
@@ -1375,7 +1375,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   if
    i32.const 0
    i32.const 1040
@@ -1386,7 +1386,7 @@
   end
   i32.const 1
   global.set $for/ran
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   global.get $for/ran
   i32.eqz

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -284,7 +284,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -304,35 +304,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -342,12 +342,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -355,7 +355,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -374,42 +374,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -424,12 +426,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -439,38 +441,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -488,7 +490,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -497,21 +499,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -538,7 +540,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4

--- a/tests/compiler/implicit-getter-setter.optimized.wat
+++ b/tests/compiler/implicit-getter-setter.optimized.wat
@@ -219,7 +219,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -239,35 +239,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -277,12 +277,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -290,7 +290,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -309,42 +309,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -359,12 +361,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -374,38 +376,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -423,7 +425,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -432,21 +434,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -473,7 +475,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -691,22 +693,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -204,7 +204,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -224,35 +224,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -262,12 +262,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -275,7 +275,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -294,42 +294,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -344,12 +346,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -359,38 +361,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -408,7 +410,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -417,21 +419,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -458,7 +460,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4

--- a/tests/compiler/issues/1225.optimized.wat
+++ b/tests/compiler/issues/1225.optimized.wat
@@ -205,7 +205,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -225,35 +225,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -263,12 +263,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -276,7 +276,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -295,42 +295,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -345,12 +347,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -360,38 +362,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -409,7 +411,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -418,21 +420,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -459,7 +461,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -962,23 +962,21 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $start:logical
+ (func $~start
   (local $0 i32)
-  (local $1 f64)
+  (local $1 i32)
   (local $2 i32)
-  (local $3 f32)
-  (local $4 i32)
-  (local $5 i32)
+  (local $3 i32)
   call $logical/Obj#constructor
-  local.tee $4
-  call $~lib/rt/pure/__retain
   local.tee $2
+  call $~lib/rt/pure/__retain
+  local.tee $0
   if (result i32)
    i32.const 1
   else
    i32.const 0
   end
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__release
   i32.eqz
   if
@@ -990,15 +988,15 @@
    unreachable
   end
   call $logical/Obj#constructor
-  local.tee $2
+  local.tee $0
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $3
   if (result i32)
    i32.const 1
   else
    i32.const 0
   end
-  local.get $5
+  local.get $3
   call $~lib/rt/pure/__release
   i32.eqz
   if
@@ -1009,13 +1007,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
- )
- (func $~start
-  call $start:logical
+  local.get $0
+  call $~lib/rt/pure/__release
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -202,7 +202,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -222,35 +222,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -260,12 +260,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -273,7 +273,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -292,42 +292,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -342,12 +344,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -357,38 +359,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -406,7 +408,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -415,21 +417,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -456,7 +458,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -961,8 +963,8 @@
   end
  )
  (func $start:logical
-  (local $0 f64)
-  (local $1 i32)
+  (local $0 i32)
+  (local $1 f64)
   (local $2 i32)
   (local $3 f32)
   (local $4 i32)
@@ -971,13 +973,13 @@
   local.tee $4
   call $~lib/rt/pure/__retain
   local.tee $2
-  if
+  if (result i32)
    i32.const 1
-   local.set $1
+  else
+   i32.const 0
   end
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $1
   i32.eqz
   if
    i32.const 0

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -963,8 +963,8 @@
   end
  )
  (func $start:logical
-  (local $0 i32)
-  (local $1 f64)
+  (local $0 f64)
+  (local $1 i32)
   (local $2 i32)
   (local $3 f32)
   (local $4 i32)
@@ -973,13 +973,13 @@
   local.tee $4
   call $~lib/rt/pure/__retain
   local.tee $2
-  if
+  if (result i32)
    i32.const 1
-   local.set $0
+  else
+   i32.const 0
   end
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $0
   i32.eqz
   if
    i32.const 0

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
- (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -962,22 +962,24 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start
+ (func $start:logical
   (local $0 i32)
-  (local $1 i32)
+  (local $1 f64)
   (local $2 i32)
-  (local $3 i32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
   call $logical/Obj#constructor
-  local.tee $2
+  local.tee $4
   call $~lib/rt/pure/__retain
-  local.tee $0
-  if (result i32)
+  local.tee $2
+  if
    i32.const 1
-  else
-   i32.const 0
+   local.set $0
   end
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
+  local.get $0
   i32.eqz
   if
    i32.const 0
@@ -988,15 +990,15 @@
    unreachable
   end
   call $logical/Obj#constructor
-  local.tee $0
+  local.tee $2
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $5
   if (result i32)
    i32.const 1
   else
    i32.const 0
   end
-  local.get $3
+  local.get $5
   call $~lib/rt/pure/__release
   i32.eqz
   if
@@ -1007,10 +1009,13 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
+ )
+ (func $~start
+  call $start:logical
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -207,7 +207,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -227,35 +227,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -265,12 +265,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -278,7 +278,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -297,42 +297,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -347,12 +349,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -362,38 +364,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -411,7 +413,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -420,21 +422,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -461,7 +463,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -959,14 +961,13 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.eqz
-  if
+  if (result i32)
+   local.get $0
+  else
    i32.const 4
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
-   local.set $0
   end
-  local.get $0
  )
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -349,8 +349,8 @@
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 i64)
   (local $9 i64)
   (local $10 i32)
   (local $11 i64)
@@ -372,13 +372,13 @@
   i64.sub
   local.tee $12
   i64.and
-  local.set $7
+  local.set $8
   local.get $3
   local.get $10
   i64.extend_i32_s
   i64.shr_u
   i32.wrap_i64
-  local.tee $6
+  local.tee $7
   call $~lib/util/number/decimalCount32
   local.set $4
   loop $while-continue|0
@@ -406,111 +406,111 @@
                 i32.sub
                 br_table $case9|1 $case8|1 $case7|1 $case6|1 $case5|1 $case4|1 $case3|1 $case2|1 $case1|1 $case10|1
                end
-               local.get $6
+               local.get $7
                i32.const 1000000000
                i32.div_u
                local.set $2
-               local.get $6
+               local.get $7
                i32.const 1000000000
                i32.rem_u
-               local.set $6
+               local.set $7
                br $break|1
               end
-              local.get $6
+              local.get $7
               i32.const 100000000
               i32.div_u
               local.set $2
-              local.get $6
+              local.get $7
               i32.const 100000000
               i32.rem_u
-              local.set $6
+              local.set $7
               br $break|1
              end
-             local.get $6
+             local.get $7
              i32.const 10000000
              i32.div_u
              local.set $2
-             local.get $6
+             local.get $7
              i32.const 10000000
              i32.rem_u
-             local.set $6
+             local.set $7
              br $break|1
             end
-            local.get $6
+            local.get $7
             i32.const 1000000
             i32.div_u
             local.set $2
-            local.get $6
+            local.get $7
             i32.const 1000000
             i32.rem_u
-            local.set $6
+            local.set $7
             br $break|1
            end
-           local.get $6
+           local.get $7
            i32.const 100000
            i32.div_u
            local.set $2
-           local.get $6
+           local.get $7
            i32.const 100000
            i32.rem_u
-           local.set $6
+           local.set $7
            br $break|1
           end
-          local.get $6
+          local.get $7
           i32.const 10000
           i32.div_u
           local.set $2
-          local.get $6
+          local.get $7
           i32.const 10000
           i32.rem_u
-          local.set $6
+          local.set $7
           br $break|1
          end
-         local.get $6
+         local.get $7
          i32.const 1000
          i32.div_u
          local.set $2
-         local.get $6
+         local.get $7
          i32.const 1000
          i32.rem_u
-         local.set $6
+         local.set $7
          br $break|1
         end
-        local.get $6
+        local.get $7
         i32.const 100
         i32.div_u
         local.set $2
-        local.get $6
+        local.get $7
         i32.const 100
         i32.rem_u
-        local.set $6
+        local.set $7
         br $break|1
        end
-       local.get $6
+       local.get $7
        i32.const 10
        i32.div_u
        local.set $2
-       local.get $6
+       local.get $7
        i32.const 10
        i32.rem_u
-       local.set $6
+       local.set $7
        br $break|1
       end
-      local.get $6
+      local.get $7
       local.set $2
       i32.const 0
-      local.set $6
+      local.set $7
       br $break|1
      end
      i32.const 0
      local.set $2
     end
     local.get $2
-    local.get $8
+    local.get $6
     i32.or
     if
      local.get $0
-     local.get $8
+     local.get $6
      i32.const 1
      i32.shl
      i32.add
@@ -520,17 +520,17 @@
      i32.const 48
      i32.add
      i32.store16
-     local.get $8
+     local.get $6
      i32.const 1
      i32.add
-     local.set $8
+     local.set $6
     end
     local.get $4
     i32.const 1
     i32.sub
     local.set $4
+    local.get $8
     local.get $7
-    local.get $6
     i64.extend_i32_u
     local.get $10
     i64.extend_i32_s
@@ -555,7 +555,7 @@
      i64.shl
      local.set $3
      local.get $0
-     local.get $8
+     local.get $6
      i32.const 1
      i32.sub
      i32.const 1
@@ -572,11 +572,11 @@
       local.get $1
       local.get $3
       i64.add
-      local.tee $7
+      local.tee $8
       local.get $9
       i64.sub
       i64.gt_u
-      local.get $7
+      local.get $8
       local.get $9
       i64.lt_u
       select
@@ -607,7 +607,7 @@
      local.get $0
      local.get $4
      i32.store16
-     local.get $8
+     local.get $6
      return
     end
     br $while-continue|0
@@ -621,35 +621,35 @@
    i64.const 10
    i64.mul
    local.set $5
-   local.get $7
+   local.get $8
    i64.const 10
    i64.mul
    local.tee $3
    local.get $1
    i64.shr_u
-   local.tee $7
-   local.get $8
+   local.tee $8
+   local.get $6
    i64.extend_i32_s
    i64.or
    i64.const 0
    i64.ne
    if
     local.get $0
-    local.get $8
+    local.get $6
     i32.const 1
     i32.shl
     i32.add
-    local.get $7
+    local.get $8
     i32.wrap_i64
     i32.const 65535
     i32.and
     i32.const 48
     i32.add
     i32.store16
-    local.get $8
+    local.get $6
     i32.const 1
     i32.add
-    local.set $8
+    local.set $6
    end
    local.get $4
    i32.const 1
@@ -658,7 +658,7 @@
    local.get $3
    local.get $12
    i64.and
-   local.tee $7
+   local.tee $8
    local.get $5
    i64.ge_u
    br_if $while-continue|4
@@ -667,7 +667,7 @@
   global.get $~lib/util/number/_K
   i32.add
   global.set $~lib/util/number/_K
-  local.get $7
+  local.get $8
   local.set $1
   local.get $9
   i32.const 0
@@ -681,7 +681,7 @@
   i64.mul
   local.set $3
   local.get $0
-  local.get $8
+  local.get $6
   i32.const 1
   i32.sub
   i32.const 1
@@ -698,11 +698,11 @@
    local.get $1
    local.get $11
    i64.add
-   local.tee $7
+   local.tee $8
    local.get $3
    i64.sub
    i64.gt_u
-   local.get $7
+   local.get $8
    local.get $3
    i64.lt_u
    select
@@ -733,7 +733,7 @@
   local.get $0
   local.get $4
   i32.store16
-  local.get $8
+  local.get $6
  )
  (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -1419,21 +1419,21 @@
   end
   i32.const 56
   call $~lib/rt/stub/__alloc
-  local.tee $1
-  call $~lib/util/number/dtoa_core
   local.tee $0
+  call $~lib/util/number/dtoa_core
+  local.tee $1
   i32.const 28
   i32.ne
-  if
-   local.get $1
+  if (result i32)
    local.get $0
-   call $~lib/string/String#substring
    local.get $1
+   call $~lib/string/String#substring
+   local.get $0
    i32.const 15
    i32.and
    i32.eqz
    i32.const 0
-   local.get $1
+   local.get $0
    select
    i32.eqz
    if
@@ -1444,7 +1444,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $0
    i32.const 16
    i32.sub
    local.tee $2
@@ -1460,7 +1460,7 @@
     unreachable
    end
    global.get $~lib/rt/stub/offset
-   local.get $1
+   local.get $0
    local.get $2
    i32.load
    i32.add
@@ -1469,9 +1469,9 @@
     local.get $2
     global.set $~lib/rt/stub/offset
    end
-   local.set $1
+  else
+   local.get $0
   end
-  local.get $1
   i32.const 2560
   call $~lib/string/String.__eq
   i32.eqz
@@ -1581,11 +1581,11 @@
    unreachable
   end
   global.get $number/a
-  local.tee $1
+  local.tee $0
   i32.const 1
   i32.add
   global.set $number/a
-  local.get $1
+  local.get $0
   call $~lib/number/I32#toString
   i32.const 1360
   call $~lib/string/String.__eq
@@ -1599,11 +1599,11 @@
    unreachable
   end
   global.get $number/a
-  local.tee $1
+  local.tee $0
   i32.const 1
   i32.sub
   global.set $number/a
-  local.get $1
+  local.get $0
   call $~lib/number/I32#toString
   i32.const 2688
   call $~lib/string/String.__eq

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -1812,22 +1812,22 @@
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $1
-  local.tee $0
+  local.get $0
+  local.tee $1
   i32.const 123
   i32.store
-  local.get $1
+  local.get $0
   i32.const 1040
   i32.store offset=4
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $0
   i32.load
   i32.const 123
   i32.ne
@@ -1839,7 +1839,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.load offset=4
   i32.const 1040
   call $~lib/string/String.__eq
@@ -1852,201 +1852,201 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   i32.const 8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $1
+  local.get $0
   i32.const 123
   i32.store
-  local.get $1
+  local.get $0
   block $__inlined_func$~lib/string/String#substring (result i32)
    i32.const 1312
    i32.const 0
    i32.const 1040
    call $~lib/string/String#get:length
-   local.tee $2
-   i32.const 0
-   local.get $2
-   i32.lt_s
-   select
-   local.tee $3
-   i32.const 5
-   local.get $2
-   i32.const 5
-   local.get $2
-   i32.lt_s
-   select
    local.tee $5
-   local.get $3
+   i32.const 0
    local.get $5
+   i32.lt_s
+   select
+   local.tee $4
+   i32.const 5
+   local.get $5
+   i32.const 5
+   local.get $5
+   i32.lt_s
+   select
+   local.tee $2
+   local.get $4
+   local.get $2
    i32.gt_s
    select
    i32.const 1
    i32.shl
-   local.tee $4
-   local.get $3
-   local.get $5
-   local.get $3
-   local.get $5
+   local.tee $3
+   local.get $4
+   local.get $2
+   local.get $4
+   local.get $2
    i32.lt_s
    select
    i32.const 1
    i32.shl
-   local.tee $3
+   local.tee $4
    i32.sub
-   local.tee $5
+   local.tee $2
    i32.eqz
    br_if $__inlined_func$~lib/string/String#substring
    drop
    i32.const 1040
    i32.const 0
-   local.get $4
-   local.get $2
+   local.get $3
+   local.get $5
    i32.const 1
    i32.shl
    i32.eq
-   local.get $3
+   local.get $4
    select
    br_if $__inlined_func$~lib/string/String#substring
    drop
-   local.get $5
+   local.get $2
    i32.const 1
    call $~lib/rt/tlsf/__alloc
-   local.tee $4
-   local.get $3
+   local.tee $3
+   local.get $4
    i32.const 1040
    i32.add
-   local.get $5
+   local.get $2
    call $~lib/memory/memory.copy
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__retain
   end
   i32.store offset=4
-  local.get $1
+  local.get $0
   call $object-literal/testUnmanaged
   i32.const 65
   i32.const 4
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.store
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $1
+  local.get $0
   i64.const 0
   i64.store offset=8
-  local.get $1
+  local.get $0
   i64.const 0
   i64.store offset=16
-  local.get $1
+  local.get $0
   f32.const 0
   f32.store offset=24
-  local.get $1
+  local.get $0
   f64.const 0
   f64.store offset=32
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store8 offset=40
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store8 offset=41
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store16 offset=42
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store16 offset=44
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=48
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=52
-  local.get $1
+  local.get $0
   f64.const 0
   f64.store offset=56
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store8 offset=64
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $1
+  local.get $0
   i64.const 0
   i64.store offset=8
-  local.get $1
+  local.get $0
   i64.const 0
   i64.store offset=16
-  local.get $1
+  local.get $0
   f32.const 0
   f32.store offset=24
-  local.get $1
+  local.get $0
   f64.const 0
   f64.store offset=32
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store8 offset=40
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store8 offset=41
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store16 offset=42
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store16 offset=44
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=48
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store offset=52
-  local.get $1
+  local.get $0
   f64.const 0
   f64.store offset=56
-  local.get $1
+  local.get $0
   i32.const 0
   i32.store8 offset=64
-  local.get $1
+  local.get $0
   call $object-literal/testOmittedTypes
   i32.const 16
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $3
   i32.const 0
   i32.store
-  local.get $4
+  local.get $3
   i32.const 0
   i32.store offset=4
-  local.get $4
+  local.get $3
   f64.const 0
   f64.store offset=8
-  local.get $4
+  local.get $3
   i32.const 0
   i32.store
-  local.get $4
+  local.get $3
   i32.const 1360
   i32.store offset=4
-  local.get $4
+  local.get $3
   f64.const 0
   f64.store offset=8
-  local.get $4
+  local.get $3
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $2
   i32.load
   if
    i32.const 0
@@ -2056,7 +2056,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $2
   i32.load offset=4
   i32.const 1360
   call $~lib/string/String.__eq
@@ -2069,7 +2069,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $2
   f64.load offset=8
   f64.const 0
   f64.ne
@@ -2081,72 +2081,72 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $2
   call $~lib/rt/pure/__release
   i32.const 40
   i32.const 6
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $2
   i32.const 1392
   i32.store
-  local.get $5
+  local.get $2
   i32.const 1424
   i32.store offset=4
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=8
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=12
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=16
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=20
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=24
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=28
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=32
-  local.get $5
+  local.get $2
   i32.const -1
   i32.store offset=36
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=8
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=12
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=16
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=20
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=24
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=28
-  local.get $5
+  local.get $2
   i32.const 0
   i32.store offset=32
-  local.get $5
+  local.get $2
   call $object-literal/testOmittedFoo
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $0
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -211,7 +211,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -231,35 +231,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -269,12 +269,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -282,7 +282,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -301,42 +301,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -351,12 +353,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -366,38 +368,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -415,7 +417,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -424,21 +426,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -465,7 +467,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -683,22 +685,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/rc/local-init.optimized.wat
+++ b/tests/compiler/rc/local-init.optimized.wat
@@ -202,7 +202,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -222,35 +222,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -260,12 +260,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -273,7 +273,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -292,42 +292,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -342,12 +344,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -357,38 +359,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -406,7 +408,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -415,21 +417,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -456,7 +458,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -202,7 +202,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -222,35 +222,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -260,12 +260,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -273,7 +273,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -292,42 +292,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -342,12 +344,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -357,38 +359,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -406,7 +408,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -415,21 +417,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -456,7 +458,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -966,14 +968,14 @@
   global.set $rc/logical-and-mismatch/gloRef
   call $rc/logical-and-mismatch/Ref#constructor
   local.tee $0
-  if
+  if (result i32)
    local.get $0
    call $~lib/rt/pure/__release
    global.get $rc/logical-and-mismatch/gloRef
    call $~lib/rt/pure/__retain
-   local.set $0
+  else
+   local.get $0
   end
-  local.get $0
   call $~lib/rt/pure/__release
   global.get $rc/logical-and-mismatch/gloRef
   local.tee $0
@@ -986,14 +988,22 @@
   call $~lib/rt/pure/__release
   call $rc/logical-and-mismatch/Ref#constructor
   local.tee $0
-  if
+  if (result i32)
    local.get $0
    call $~lib/rt/pure/__release
    call $rc/logical-and-mismatch/Ref#constructor
-   local.set $0
+  else
+   local.get $0
   end
-  local.get $0
   call $~lib/rt/pure/__release
+  global.get $rc/logical-and-mismatch/gloRef
+  local.tee $0
+  if (result i32)
+   global.get $rc/logical-and-mismatch/gloRef
+  else
+   local.get $0
+  end
+  drop
   global.get $rc/logical-and-mismatch/gloRef
   call $~lib/rt/pure/__release
  )

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -997,14 +997,6 @@
   end
   call $~lib/rt/pure/__release
   global.get $rc/logical-and-mismatch/gloRef
-  local.tee $0
-  if (result i32)
-   global.get $rc/logical-and-mismatch/gloRef
-  else
-   local.get $0
-  end
-  drop
-  global.get $rc/logical-and-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
  (func $~lib/rt/pure/decrement (param $0 i32)

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -997,14 +997,6 @@
   end
   call $~lib/rt/pure/__release
   global.get $rc/logical-or-mismatch/gloRef
-  local.tee $0
-  if (result i32)
-   local.get $0
-  else
-   global.get $rc/logical-or-mismatch/gloRef
-  end
-  drop
-  global.get $rc/logical-or-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
  (func $~lib/rt/pure/decrement (param $0 i32)

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -202,7 +202,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -222,35 +222,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -260,12 +260,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -273,7 +273,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -292,42 +292,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -342,12 +344,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -357,38 +359,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -406,7 +408,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -415,21 +417,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -456,7 +458,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -966,15 +968,14 @@
   global.set $rc/logical-or-mismatch/gloRef
   call $rc/logical-or-mismatch/Ref#constructor
   local.tee $0
-  i32.eqz
-  if
+  if (result i32)
+   local.get $0
+  else
    local.get $0
    call $~lib/rt/pure/__release
    global.get $rc/logical-or-mismatch/gloRef
    call $~lib/rt/pure/__retain
-   local.set $0
   end
-  local.get $0
   call $~lib/rt/pure/__release
   global.get $rc/logical-or-mismatch/gloRef
   local.tee $0
@@ -987,15 +988,22 @@
   call $~lib/rt/pure/__release
   call $rc/logical-or-mismatch/Ref#constructor
   local.tee $0
-  i32.eqz
-  if
+  if (result i32)
+   local.get $0
+  else
    local.get $0
    call $~lib/rt/pure/__release
    call $rc/logical-or-mismatch/Ref#constructor
-   local.set $0
   end
-  local.get $0
   call $~lib/rt/pure/__release
+  global.get $rc/logical-or-mismatch/gloRef
+  local.tee $0
+  if (result i32)
+   local.get $0
+  else
+   global.get $rc/logical-or-mismatch/gloRef
+  end
+  drop
   global.get $rc/logical-or-mismatch/gloRef
   call $~lib/rt/pure/__release
  )

--- a/tests/compiler/rc/optimize.optimized.wat
+++ b/tests/compiler/rc/optimize.optimized.wat
@@ -292,7 +292,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -312,35 +312,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -350,12 +350,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -363,7 +363,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -382,42 +382,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -432,12 +434,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -447,38 +449,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -496,7 +498,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -505,21 +507,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -546,7 +548,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -1013,7 +1015,6 @@
   local.get $1
  )
  (func $rc/optimize/OptimizeARC.eliminates.linearChain (param $0 i32)
-  (local $1 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   local.tee $0

--- a/tests/compiler/rc/rereturn.optimized.wat
+++ b/tests/compiler/rc/rereturn.optimized.wat
@@ -205,7 +205,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -225,35 +225,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -263,12 +263,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -276,7 +276,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -295,42 +295,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -345,12 +347,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -360,38 +362,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -409,7 +411,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -418,21 +420,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -459,7 +461,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -677,22 +679,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/rc/ternary-mismatch.optimized.wat
+++ b/tests/compiler/rc/ternary-mismatch.optimized.wat
@@ -204,7 +204,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -224,35 +224,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -262,12 +262,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -275,7 +275,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -294,42 +294,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -344,12 +346,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -359,38 +361,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -408,7 +410,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -417,21 +419,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -458,7 +460,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -112,7 +112,7 @@
   (local $3 i32)
   (local $4 i32)
   i32.const 1040
-  local.set $1
+  local.set $3
   i32.const 8
   local.set $4
   block $~lib/util/memory/memmove|inlined.0
@@ -146,13 +146,13 @@
        i32.const 1
        i32.add
        local.set $0
-       local.get $1
-       local.tee $3
+       local.get $3
+       local.tee $1
        i32.const 1
        i32.add
-       local.set $1
+       local.set $3
        local.get $2
-       local.get $3
+       local.get $1
        i32.load8_u
        i32.store8
        br $while-continue|0
@@ -164,7 +164,7 @@
       i32.ge_u
       if
        local.get $0
-       local.get $1
+       local.get $3
        i64.load
        i64.store
        local.get $4
@@ -175,10 +175,10 @@
        i32.const 8
        i32.add
        local.set $0
-       local.get $1
+       local.get $3
        i32.const 8
        i32.add
-       local.set $1
+       local.set $3
        br $while-continue|1
       end
      end
@@ -191,13 +191,13 @@
       i32.const 1
       i32.add
       local.set $0
-      local.get $1
-      local.tee $3
+      local.get $3
+      local.tee $1
       i32.const 1
       i32.add
-      local.set $1
+      local.set $3
       local.get $2
-      local.get $3
+      local.get $1
       i32.load8_u
       i32.store8
       local.get $4

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -364,8 +364,8 @@
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 i64)
   (local $9 i64)
   (local $10 i32)
   (local $11 i64)
@@ -387,13 +387,13 @@
   i64.sub
   local.tee $12
   i64.and
-  local.set $7
+  local.set $8
   local.get $3
   local.get $10
   i64.extend_i32_s
   i64.shr_u
   i32.wrap_i64
-  local.tee $6
+  local.tee $7
   call $~lib/util/number/decimalCount32
   local.set $4
   loop $while-continue|0
@@ -421,111 +421,111 @@
                 i32.sub
                 br_table $case9|1 $case8|1 $case7|1 $case6|1 $case5|1 $case4|1 $case3|1 $case2|1 $case1|1 $case10|1
                end
-               local.get $6
+               local.get $7
                i32.const 1000000000
                i32.div_u
                local.set $2
-               local.get $6
+               local.get $7
                i32.const 1000000000
                i32.rem_u
-               local.set $6
+               local.set $7
                br $break|1
               end
-              local.get $6
+              local.get $7
               i32.const 100000000
               i32.div_u
               local.set $2
-              local.get $6
+              local.get $7
               i32.const 100000000
               i32.rem_u
-              local.set $6
+              local.set $7
               br $break|1
              end
-             local.get $6
+             local.get $7
              i32.const 10000000
              i32.div_u
              local.set $2
-             local.get $6
+             local.get $7
              i32.const 10000000
              i32.rem_u
-             local.set $6
+             local.set $7
              br $break|1
             end
-            local.get $6
+            local.get $7
             i32.const 1000000
             i32.div_u
             local.set $2
-            local.get $6
+            local.get $7
             i32.const 1000000
             i32.rem_u
-            local.set $6
+            local.set $7
             br $break|1
            end
-           local.get $6
+           local.get $7
            i32.const 100000
            i32.div_u
            local.set $2
-           local.get $6
+           local.get $7
            i32.const 100000
            i32.rem_u
-           local.set $6
+           local.set $7
            br $break|1
           end
-          local.get $6
+          local.get $7
           i32.const 10000
           i32.div_u
           local.set $2
-          local.get $6
+          local.get $7
           i32.const 10000
           i32.rem_u
-          local.set $6
+          local.set $7
           br $break|1
          end
-         local.get $6
+         local.get $7
          i32.const 1000
          i32.div_u
          local.set $2
-         local.get $6
+         local.get $7
          i32.const 1000
          i32.rem_u
-         local.set $6
+         local.set $7
          br $break|1
         end
-        local.get $6
+        local.get $7
         i32.const 100
         i32.div_u
         local.set $2
-        local.get $6
+        local.get $7
         i32.const 100
         i32.rem_u
-        local.set $6
+        local.set $7
         br $break|1
        end
-       local.get $6
+       local.get $7
        i32.const 10
        i32.div_u
        local.set $2
-       local.get $6
+       local.get $7
        i32.const 10
        i32.rem_u
-       local.set $6
+       local.set $7
        br $break|1
       end
-      local.get $6
+      local.get $7
       local.set $2
       i32.const 0
-      local.set $6
+      local.set $7
       br $break|1
      end
      i32.const 0
      local.set $2
     end
     local.get $2
-    local.get $8
+    local.get $6
     i32.or
     if
      local.get $0
-     local.get $8
+     local.get $6
      i32.const 1
      i32.shl
      i32.add
@@ -535,17 +535,17 @@
      i32.const 48
      i32.add
      i32.store16
-     local.get $8
+     local.get $6
      i32.const 1
      i32.add
-     local.set $8
+     local.set $6
     end
     local.get $4
     i32.const 1
     i32.sub
     local.set $4
+    local.get $8
     local.get $7
-    local.get $6
     i64.extend_i32_u
     local.get $10
     i64.extend_i32_s
@@ -570,7 +570,7 @@
      i64.shl
      local.set $3
      local.get $0
-     local.get $8
+     local.get $6
      i32.const 1
      i32.sub
      i32.const 1
@@ -587,11 +587,11 @@
       local.get $1
       local.get $3
       i64.add
-      local.tee $7
+      local.tee $8
       local.get $9
       i64.sub
       i64.gt_u
-      local.get $7
+      local.get $8
       local.get $9
       i64.lt_u
       select
@@ -622,7 +622,7 @@
      local.get $0
      local.get $4
      i32.store16
-     local.get $8
+     local.get $6
      return
     end
     br $while-continue|0
@@ -636,35 +636,35 @@
    i64.const 10
    i64.mul
    local.set $5
-   local.get $7
+   local.get $8
    i64.const 10
    i64.mul
    local.tee $3
    local.get $1
    i64.shr_u
-   local.tee $7
-   local.get $8
+   local.tee $8
+   local.get $6
    i64.extend_i32_s
    i64.or
    i64.const 0
    i64.ne
    if
     local.get $0
-    local.get $8
+    local.get $6
     i32.const 1
     i32.shl
     i32.add
-    local.get $7
+    local.get $8
     i32.wrap_i64
     i32.const 65535
     i32.and
     i32.const 48
     i32.add
     i32.store16
-    local.get $8
+    local.get $6
     i32.const 1
     i32.add
-    local.set $8
+    local.set $6
    end
    local.get $4
    i32.const 1
@@ -673,7 +673,7 @@
    local.get $3
    local.get $12
    i64.and
-   local.tee $7
+   local.tee $8
    local.get $5
    i64.ge_u
    br_if $while-continue|4
@@ -682,7 +682,7 @@
   global.get $~lib/util/number/_K
   i32.add
   global.set $~lib/util/number/_K
-  local.get $7
+  local.get $8
   local.set $1
   local.get $9
   i32.const 0
@@ -696,7 +696,7 @@
   i64.mul
   local.set $3
   local.get $0
-  local.get $8
+  local.get $6
   i32.const 1
   i32.sub
   i32.const 1
@@ -713,11 +713,11 @@
    local.get $1
    local.get $11
    i64.add
-   local.tee $7
+   local.tee $8
    local.get $3
    i64.sub
    i64.gt_u
-   local.get $7
+   local.get $8
    local.get $3
    i64.lt_u
    select
@@ -748,7 +748,7 @@
   local.get $0
   local.get $4
   i32.store16
-  local.get $8
+  local.get $6
  )
  (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -1648,61 +1648,61 @@
  (func $~lib/number/F32#toString (param $0 f32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 f64)
+  (local $3 f64)
+  (local $4 i32)
   block $__inlined_func$~lib/util/number/dtoa
    local.get $0
    f64.promote_f32
-   local.tee $4
+   local.tee $3
    f64.const 0
    f64.eq
    if
     i32.const 1280
-    local.set $2
+    local.set $1
     br $__inlined_func$~lib/util/number/dtoa
    end
-   local.get $4
-   local.get $4
+   local.get $3
+   local.get $3
    f64.sub
    f64.const 0
    f64.ne
    if
-    local.get $4
-    local.get $4
+    local.get $3
+    local.get $3
     f64.ne
     if
      i32.const 1312
-     local.set $2
+     local.set $1
      br $__inlined_func$~lib/util/number/dtoa
     end
     i32.const 1344
     i32.const 1392
-    local.get $4
+    local.get $3
     f64.const 0
     f64.lt
     select
-    local.set $2
+    local.set $1
     br $__inlined_func$~lib/util/number/dtoa
    end
    i32.const 56
    i32.const 1
    call $~lib/rt/stub/__alloc
-   local.tee $2
-   local.get $4
-   call $~lib/util/number/dtoa_core
    local.tee $1
+   local.get $3
+   call $~lib/util/number/dtoa_core
+   local.tee $2
    i32.const 28
    i32.eq
    br_if $__inlined_func$~lib/util/number/dtoa
-   local.get $2
    local.get $1
-   call $~lib/string/String#substring
    local.get $2
+   call $~lib/string/String#substring
+   local.get $1
    i32.const 15
    i32.and
    i32.eqz
    i32.const 0
-   local.get $2
+   local.get $1
    select
    i32.eqz
    if
@@ -1713,10 +1713,10 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $2
+   local.get $1
    i32.const 16
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.load offset=4
    i32.const 1
    i32.ne
@@ -1729,18 +1729,18 @@
     unreachable
    end
    global.get $~lib/rt/stub/offset
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $4
    i32.load
    i32.add
    i32.eq
    if
-    local.get $3
+    local.get $4
     global.set $~lib/rt/stub/offset
    end
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
  )
  (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -1,7 +1,8 @@
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -14,46 +15,34 @@
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/rt/stub/__alloc (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (result i32)
+  (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $0
-  i32.const 1073741808
-  i32.gt_u
-  if
-   unreachable
-  end
+  i32.const 42
+  local.set $1
+  i32.const 2
+  local.set $4
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
+  local.tee $0
+  i32.const 16
+  i32.add
   local.tee $3
-  local.get $0
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $1
-  i32.const 16
-  local.get $1
-  i32.const 16
-  i32.gt_u
-  select
-  local.tee $5
-  i32.add
-  local.tee $1
   memory.size
-  local.tee $4
+  local.tee $2
   i32.const 16
   i32.shl
-  local.tee $2
+  local.tee $5
   i32.gt_u
   if
-   local.get $4
-   local.get $1
    local.get $2
+   local.get $3
+   local.get $5
    i32.sub
    i32.const 65535
    i32.add
@@ -61,16 +50,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $2
-   local.get $4
+   local.tee $5
    local.get $2
+   local.get $5
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $2
+    local.get $5
     memory.grow
     i32.const 0
     i32.lt_s
@@ -79,24 +68,47 @@
     end
    end
   end
-  local.get $1
-  global.set $~lib/rt/stub/offset
   local.get $3
+  global.set $~lib/rt/stub/offset
+  local.get $0
   i32.const 16
   i32.sub
-  local.tee $1
-  local.get $5
+  local.tee $3
+  i32.const 16
   i32.store
-  local.get $1
+  local.get $3
   i32.const 1
   i32.store offset=4
-  local.get $1
+  local.get $3
   i32.const 1
   i32.store offset=8
-  local.get $1
-  local.get $0
-  i32.store offset=12
   local.get $3
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  local.set $3
+  loop $do-continue|0
+   local.get $1
+   i32.const 10
+   i32.div_u
+   local.get $3
+   local.get $4
+   i32.const 1
+   i32.sub
+   local.tee $4
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $1
+   i32.const 10
+   i32.rem_u
+   i32.const 48
+   i32.add
+   i32.store16
+   local.tee $1
+   br_if $do-continue|0
+  end
+  local.get $0
  )
  (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
@@ -184,43 +196,12 @@
  (func $~start
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
   i32.const 1456
   global.set $~lib/rt/stub/offset
   block $__inlined_func$~lib/string/String.__eq (result i32)
-   i32.const 42
-   local.set $1
-   i32.const 2
-   local.set $3
-   i32.const 4
-   call $~lib/rt/stub/__alloc
-   local.tee $0
-   local.set $4
-   loop $do-continue|0
-    local.get $1
-    i32.const 10
-    i32.div_u
-    local.get $4
-    local.get $3
-    i32.const 1
-    i32.sub
-    local.tee $3
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $1
-    i32.const 10
-    i32.rem_u
-    i32.const 48
-    i32.add
-    i32.store16
-    local.tee $1
-    br_if $do-continue|0
-   end
    i32.const 1
-   local.get $0
+   call $~lib/util/number/itoa32
+   local.tee $0
    i32.const 1440
    i32.eq
    br_if $__inlined_func$~lib/string/String.__eq
@@ -233,13 +214,13 @@
     br_if $folding-inner0
     local.get $0
     call $~lib/string/String#get:length
-    local.tee $2
+    local.tee $1
     i32.const 1440
     call $~lib/string/String#get:length
     i32.ne
     br_if $folding-inner0
     local.get $0
-    local.get $2
+    local.get $1
     call $~lib/util/string/compareImpl
     i32.eqz
     br $__inlined_func$~lib/string/String.__eq

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -1,8 +1,7 @@
 (module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
- (type $none_=>_i32 (func (result i32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -15,33 +14,45 @@
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/util/number/itoa32 (result i32)
-  (local $0 i32)
+ (func $~lib/rt/stub/__alloc (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 42
-  local.set $3
-  i32.const 2
-  local.set $5
+  local.get $0
+  i32.const 1073741808
+  i32.gt_u
+  if
+   unreachable
+  end
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $4
-  i32.const 16
+  local.tee $3
+  local.get $0
+  i32.const 15
   i32.add
-  local.tee $0
-  memory.size
+  i32.const -16
+  i32.and
   local.tee $1
+  i32.const 16
+  local.get $1
+  i32.const 16
+  i32.gt_u
+  select
+  local.tee $5
+  i32.add
+  local.tee $1
+  memory.size
+  local.tee $4
   i32.const 16
   i32.shl
   local.tee $2
   i32.gt_u
   if
+   local.get $4
    local.get $1
-   local.get $0
    local.get $2
    i32.sub
    i32.const 65535
@@ -51,7 +62,7 @@
    i32.const 16
    i32.shr_u
    local.tee $2
-   local.get $1
+   local.get $4
    local.get $2
    i32.gt_s
    select
@@ -68,47 +79,24 @@
     end
    end
   end
-  local.get $0
+  local.get $1
   global.set $~lib/rt/stub/offset
-  local.get $4
+  local.get $3
   i32.const 16
   i32.sub
-  local.tee $0
-  i32.const 16
+  local.tee $1
+  local.get $5
   i32.store
-  local.get $0
+  local.get $1
   i32.const 1
   i32.store offset=4
-  local.get $0
+  local.get $1
   i32.const 1
   i32.store offset=8
+  local.get $1
   local.get $0
-  i32.const 4
   i32.store offset=12
-  local.get $4
-  local.set $0
-  loop $do-continue|0
-   local.get $3
-   i32.const 10
-   i32.div_u
-   local.get $0
-   local.get $5
-   i32.const 1
-   i32.sub
-   local.tee $5
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $3
-   i32.const 10
-   i32.rem_u
-   i32.const 48
-   i32.add
-   i32.store16
-   local.tee $3
-   br_if $do-continue|0
-  end
-  local.get $4
+  local.get $3
  )
  (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
@@ -196,12 +184,43 @@
  (func $~start
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   i32.const 1456
   global.set $~lib/rt/stub/offset
   block $__inlined_func$~lib/string/String.__eq (result i32)
-   i32.const 1
-   call $~lib/util/number/itoa32
+   i32.const 42
+   local.set $1
+   i32.const 2
+   local.set $3
+   i32.const 4
+   call $~lib/rt/stub/__alloc
    local.tee $0
+   local.set $4
+   loop $do-continue|0
+    local.get $1
+    i32.const 10
+    i32.div_u
+    local.get $4
+    local.get $3
+    i32.const 1
+    i32.sub
+    local.tee $3
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $1
+    i32.const 10
+    i32.rem_u
+    i32.const 48
+    i32.add
+    i32.store16
+    local.tee $1
+    br_if $do-continue|0
+   end
+   i32.const 1
+   local.get $0
    i32.const 1440
    i32.eq
    br_if $__inlined_func$~lib/string/String.__eq
@@ -214,13 +233,13 @@
     br_if $folding-inner0
     local.get $0
     call $~lib/string/String#get:length
-    local.tee $1
+    local.tee $2
     i32.const 1440
     call $~lib/string/String#get:length
     i32.ne
     br_if $folding-inner0
     local.get $0
-    local.get $1
+    local.get $2
     call $~lib/util/string/compareImpl
     i32.eqz
     br $__inlined_func$~lib/string/String.__eq

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -132,7 +132,6 @@
    i32.sub
    local.set $0
   end
-  local.get $2
   local.get $0
   i32.const 10
   i32.ge_u
@@ -173,6 +172,7 @@
   i32.const 100000
   i32.lt_u
   select
+  local.get $2
   i32.add
   local.tee $3
   i32.const 1

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -225,7 +225,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -245,35 +245,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -283,12 +283,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -296,7 +296,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -315,42 +315,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -365,12 +367,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -380,38 +382,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -429,7 +431,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -438,21 +440,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -479,7 +481,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -697,22 +699,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz
@@ -1334,8 +1335,8 @@
  )
  (func $~lib/util/number/genDigits (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 i64)
   (local $9 i64)
   (local $10 i32)
   (local $11 i64)
@@ -1357,13 +1358,13 @@
   i64.sub
   local.tee $12
   i64.and
-  local.set $7
+  local.set $8
   local.get $3
   local.get $10
   i64.extend_i32_s
   i64.shr_u
   i32.wrap_i64
-  local.tee $6
+  local.tee $7
   call $~lib/util/number/decimalCount32
   local.set $4
   loop $while-continue|0
@@ -1391,111 +1392,111 @@
                 i32.sub
                 br_table $case9|1 $case8|1 $case7|1 $case6|1 $case5|1 $case4|1 $case3|1 $case2|1 $case1|1 $case10|1
                end
-               local.get $6
+               local.get $7
                i32.const 1000000000
                i32.div_u
                local.set $2
-               local.get $6
+               local.get $7
                i32.const 1000000000
                i32.rem_u
-               local.set $6
+               local.set $7
                br $break|1
               end
-              local.get $6
+              local.get $7
               i32.const 100000000
               i32.div_u
               local.set $2
-              local.get $6
+              local.get $7
               i32.const 100000000
               i32.rem_u
-              local.set $6
+              local.set $7
               br $break|1
              end
-             local.get $6
+             local.get $7
              i32.const 10000000
              i32.div_u
              local.set $2
-             local.get $6
+             local.get $7
              i32.const 10000000
              i32.rem_u
-             local.set $6
+             local.set $7
              br $break|1
             end
-            local.get $6
+            local.get $7
             i32.const 1000000
             i32.div_u
             local.set $2
-            local.get $6
+            local.get $7
             i32.const 1000000
             i32.rem_u
-            local.set $6
+            local.set $7
             br $break|1
            end
-           local.get $6
+           local.get $7
            i32.const 100000
            i32.div_u
            local.set $2
-           local.get $6
+           local.get $7
            i32.const 100000
            i32.rem_u
-           local.set $6
+           local.set $7
            br $break|1
           end
-          local.get $6
+          local.get $7
           i32.const 10000
           i32.div_u
           local.set $2
-          local.get $6
+          local.get $7
           i32.const 10000
           i32.rem_u
-          local.set $6
+          local.set $7
           br $break|1
          end
-         local.get $6
+         local.get $7
          i32.const 1000
          i32.div_u
          local.set $2
-         local.get $6
+         local.get $7
          i32.const 1000
          i32.rem_u
-         local.set $6
+         local.set $7
          br $break|1
         end
-        local.get $6
+        local.get $7
         i32.const 100
         i32.div_u
         local.set $2
-        local.get $6
+        local.get $7
         i32.const 100
         i32.rem_u
-        local.set $6
+        local.set $7
         br $break|1
        end
-       local.get $6
+       local.get $7
        i32.const 10
        i32.div_u
        local.set $2
-       local.get $6
+       local.get $7
        i32.const 10
        i32.rem_u
-       local.set $6
+       local.set $7
        br $break|1
       end
-      local.get $6
+      local.get $7
       local.set $2
       i32.const 0
-      local.set $6
+      local.set $7
       br $break|1
      end
      i32.const 0
      local.set $2
     end
     local.get $2
-    local.get $8
+    local.get $6
     i32.or
     if
      local.get $0
-     local.get $8
+     local.get $6
      i32.const 1
      i32.shl
      i32.add
@@ -1505,17 +1506,17 @@
      i32.const 48
      i32.add
      i32.store16
-     local.get $8
+     local.get $6
      i32.const 1
      i32.add
-     local.set $8
+     local.set $6
     end
     local.get $4
     i32.const 1
     i32.sub
     local.set $4
+    local.get $8
     local.get $7
-    local.get $6
     i64.extend_i32_u
     local.get $10
     i64.extend_i32_s
@@ -1540,7 +1541,7 @@
      i64.shl
      local.set $3
      local.get $0
-     local.get $8
+     local.get $6
      i32.const 1
      i32.sub
      i32.const 1
@@ -1557,11 +1558,11 @@
       local.get $1
       local.get $3
       i64.add
-      local.tee $7
+      local.tee $8
       local.get $9
       i64.sub
       i64.gt_u
-      local.get $7
+      local.get $8
       local.get $9
       i64.lt_u
       select
@@ -1592,7 +1593,7 @@
      local.get $0
      local.get $4
      i32.store16
-     local.get $8
+     local.get $6
      return
     end
     br $while-continue|0
@@ -1606,35 +1607,35 @@
    i64.const 10
    i64.mul
    local.set $5
-   local.get $7
+   local.get $8
    i64.const 10
    i64.mul
    local.tee $3
    local.get $1
    i64.shr_u
-   local.tee $7
-   local.get $8
+   local.tee $8
+   local.get $6
    i64.extend_i32_s
    i64.or
    i64.const 0
    i64.ne
    if
     local.get $0
-    local.get $8
+    local.get $6
     i32.const 1
     i32.shl
     i32.add
-    local.get $7
+    local.get $8
     i32.wrap_i64
     i32.const 65535
     i32.and
     i32.const 48
     i32.add
     i32.store16
-    local.get $8
+    local.get $6
     i32.const 1
     i32.add
-    local.set $8
+    local.set $6
    end
    local.get $4
    i32.const 1
@@ -1643,7 +1644,7 @@
    local.get $3
    local.get $12
    i64.and
-   local.tee $7
+   local.tee $8
    local.get $5
    i64.ge_u
    br_if $while-continue|4
@@ -1652,7 +1653,7 @@
   global.get $~lib/util/number/_K
   i32.add
   global.set $~lib/util/number/_K
-  local.get $7
+  local.get $8
   local.set $1
   local.get $9
   i32.const 0
@@ -1666,7 +1667,7 @@
   i64.mul
   local.set $3
   local.get $0
-  local.get $8
+  local.get $6
   i32.const 1
   i32.sub
   i32.const 1
@@ -1683,11 +1684,11 @@
    local.get $1
    local.get $11
    i64.add
-   local.tee $7
+   local.tee $8
    local.get $3
    i64.sub
    i64.gt_u
-   local.get $7
+   local.get $8
    local.get $3
    i64.lt_u
    select
@@ -1718,7 +1719,7 @@
   local.get $0
   local.get $4
   i32.store16
-  local.get $8
+  local.get $6
  )
  (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -137,7 +137,6 @@
    i32.sub
    local.set $0
   end
-  local.get $2
   local.get $0
   i32.const 10
   i32.ge_u
@@ -178,6 +177,7 @@
   i32.const 100000
   i32.lt_u
   select
+  local.get $2
   i32.add
   local.tee $3
   i32.const 1

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -1796,10 +1796,10 @@
   i32.const 12
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
+  local.tee $1
   i32.const 12
   call $~lib/memory/memory.fill
-  local.get $2
+  local.get $1
   local.tee $0
   local.get $3
   i32.load
@@ -1816,7 +1816,7 @@
   local.get $0
   i32.store
   local.get $3
-  local.get $2
+  local.get $1
   i32.store offset=4
   local.get $3
   i32.const 12
@@ -1830,7 +1830,7 @@
   call $~lib/array/Array<i32>#push
   local.get $3
   i32.load offset=12
-  local.tee $2
+  local.tee $1
   i32.const 1
   i32.lt_s
   if
@@ -1843,17 +1843,17 @@
   end
   local.get $3
   i32.load offset=4
-  local.get $2
+  local.get $1
   i32.const 1
   i32.sub
-  local.tee $2
+  local.tee $1
   i32.const 2
   i32.shl
   i32.add
   i32.load
   drop
   local.get $3
-  local.get $2
+  local.get $1
   i32.store offset=12
   local.get $3
   call $~lib/rt/pure/__release
@@ -1876,10 +1876,10 @@
   i32.const 0
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
+  local.tee $1
   i32.const 0
   call $~lib/memory/memory.fill
-  local.get $2
+  local.get $1
   local.tee $0
   local.get $3
   i32.load
@@ -1896,7 +1896,7 @@
   local.get $0
   i32.store
   local.get $3
-  local.get $2
+  local.get $1
   i32.store offset=4
   local.get $3
   i32.const 0
@@ -1906,7 +1906,7 @@
   i32.store offset=12
   local.get $3
   loop $for-loop|0
-   local.get $1
+   local.get $2
    i32.const 10
    i32.lt_s
    if
@@ -1929,10 +1929,10 @@
     i32.const 0
     i32.const 0
     call $~lib/rt/tlsf/__alloc
-    local.tee $2
+    local.tee $1
     i32.const 0
     call $~lib/memory/memory.fill
-    local.get $2
+    local.get $1
     local.tee $0
     local.get $3
     i32.load
@@ -1949,7 +1949,7 @@
     local.get $0
     i32.store
     local.get $3
-    local.get $2
+    local.get $1
     i32.store offset=4
     local.get $3
     i32.const 0
@@ -1967,14 +1967,14 @@
       local.get $3
       local.get $3
       i32.load offset=12
-      local.tee $2
+      local.tee $1
       i32.const 1
       i32.add
       local.tee $5
       call $~lib/array/ensureSize
       local.get $3
       i32.load offset=4
-      local.get $2
+      local.get $1
       i32.const 2
       i32.shl
       i32.add
@@ -1995,10 +1995,10 @@
     end
     local.get $3
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
@@ -2006,12 +2006,12 @@
   i32.const 1360
   i32.const 1392
   call $~lib/string/String.__concat
-  local.tee $1
+  local.tee $2
   call $~lib/rt/pure/__retain
   local.tee $3
   i32.const 1456
   call $~lib/string/String.__concat
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
@@ -2020,7 +2020,7 @@
   i32.const 6
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.store
   i32.const 4
@@ -2032,8 +2032,8 @@
   i32.store
   local.get $3
   local.tee $0
-  local.get $2
-  local.tee $1
+  local.get $1
+  local.tee $2
   i32.load
   local.tee $4
   i32.ne
@@ -2044,63 +2044,63 @@
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $2
   local.get $0
   i32.store
-  local.get $1
+  local.get $2
   local.set $0
   local.get $3
-  local.tee $1
+  local.tee $2
   local.get $0
   i32.load
   local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $2
    local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.tee $1
+  local.tee $2
   local.get $3
   local.tee $0
   i32.load
   local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $2
    local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
-  i32.store
   local.get $2
-  local.tee $1
+  i32.store
+  local.get $1
+  local.tee $2
   local.get $0
   i32.load
   local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $2
    local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $3
-  local.get $2
-  local.tee $1
+  local.get $1
+  local.tee $2
   i32.load
   local.tee $4
   i32.ne
@@ -2111,25 +2111,25 @@
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $2
   local.get $0
   i32.store
-  local.get $2
+  local.get $1
   local.get $3
   i32.load
   local.tee $0
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $2
    local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $3
-  local.get $1
-  i32.store
   local.get $2
+  i32.store
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
@@ -2417,27 +2417,27 @@
   (local $4 i32)
   (local $5 i32)
   global.get $~lib/rt/pure/ROOTS
-  local.tee $0
-  local.tee $4
-  local.set $3
+  local.tee $1
+  local.tee $3
+  local.set $4
   global.get $~lib/rt/pure/CUR
-  local.set $1
+  local.set $0
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $4
+   local.get $0
    i32.lt_u
    if
-    local.get $3
+    local.get $4
     i32.load
-    local.tee $2
-    i32.load offset=4
     local.tee $5
+    i32.load offset=4
+    local.tee $2
     i32.const 1879048192
     i32.and
     i32.const 805306368
     i32.eq
     if (result i32)
-     local.get $5
+     local.get $2
      i32.const 268435455
      i32.and
      i32.const 0
@@ -2446,88 +2446,88 @@
      i32.const 0
     end
     if
-     local.get $2
+     local.get $5
      call $~lib/rt/pure/markGray
-     local.get $4
-     local.get $2
+     local.get $3
+     local.get $5
      i32.store
-     local.get $4
+     local.get $3
      i32.const 4
      i32.add
-     local.set $4
+     local.set $3
     else
      i32.const 0
-     local.get $5
+     local.get $2
      i32.const 268435455
      i32.and
      i32.eqz
-     local.get $5
+     local.get $2
      i32.const 1879048192
      i32.and
      select
      if
       global.get $~lib/rt/tlsf/ROOT
-      local.get $2
+      local.get $5
       call $~lib/rt/tlsf/freeBlock
      else
-      local.get $2
       local.get $5
+      local.get $2
       i32.const 2147483647
       i32.and
       i32.store offset=4
      end
     end
-    local.get $3
+    local.get $4
     i32.const 4
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
-  local.get $4
+  local.get $3
   global.set $~lib/rt/pure/CUR
-  local.get $0
-  local.set $1
+  local.get $1
+  local.set $0
   loop $for-loop|1
-   local.get $1
-   local.get $4
+   local.get $0
+   local.get $3
    i32.lt_u
    if
-    local.get $1
+    local.get $0
     i32.load
     call $~lib/rt/pure/scan
-    local.get $1
+    local.get $0
     i32.const 4
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|1
    end
   end
-  local.get $0
-  local.set $1
+  local.get $1
+  local.set $0
   loop $for-loop|2
-   local.get $1
-   local.get $4
+   local.get $0
+   local.get $3
    i32.lt_u
    if
-    local.get $1
+    local.get $0
     i32.load
-    local.tee $5
-    local.get $5
+    local.tee $2
+    local.get $2
     i32.load offset=4
     i32.const 2147483647
     i32.and
     i32.store offset=4
-    local.get $5
+    local.get $2
     call $~lib/rt/pure/collectWhite
-    local.get $1
+    local.get $0
     i32.const 4
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|2
    end
   end
-  local.get $0
+  local.get $1
   global.set $~lib/rt/pure/CUR
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -229,7 +229,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -249,35 +249,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -287,12 +287,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -300,7 +300,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -319,42 +319,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -369,12 +371,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -384,38 +386,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -433,7 +435,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -442,21 +444,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -483,7 +485,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -725,22 +727,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/retain-return.optimized.wat
+++ b/tests/compiler/retain-return.optimized.wat
@@ -199,7 +199,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -219,35 +219,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -257,12 +257,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -270,7 +270,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -289,42 +289,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -339,12 +341,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -354,38 +356,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -403,7 +405,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -412,21 +414,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -453,7 +455,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -1290,14 +1290,14 @@
    unreachable
   end
   global.get $rt/finalize/expectedWriteIndex
-  local.tee $2
+  local.tee $1
   i32.const 1
   i32.add
   global.set $rt/finalize/expectedWriteIndex
-  local.get $2
-  local.tee $1
-  global.get $rt/finalize/expected
+  local.get $1
   local.tee $2
+  global.get $rt/finalize/expected
+  local.tee $1
   call $~lib/staticarray/StaticArray<usize>#get:length
   i32.ge_u
   if
@@ -1308,8 +1308,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
   local.get $1
+  local.get $2
   i32.const 2
   i32.shl
   i32.add
@@ -1324,10 +1324,10 @@
   i32.const 40
   i32.const 3
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
+  local.tee $0
   i32.const 40
   call $~lib/memory/memory.fill
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__retain
   global.set $rt/finalize/expected
   i32.const 16
@@ -1349,27 +1349,27 @@
   i32.const 0
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $0
+  local.tee $2
   i32.const 0
   call $~lib/memory/memory.fill
-  local.get $0
-  local.tee $2
+  local.get $2
+  local.tee $0
   local.get $3
   i32.load
   local.tee $1
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $0
    local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $3
-  local.get $2
+  local.get $0
   i32.store
   local.get $3
-  local.get $0
+  local.get $2
   i32.store offset=4
   local.get $3
   i32.const 0
@@ -1410,17 +1410,34 @@
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $0
+  local.tee $2
   i32.const 0
   i32.store
   i32.const 4
   i32.const 6
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $0
   i32.const 0
   i32.store
+  local.get $0
+  local.tee $1
   local.get $2
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $2
+  local.tee $3
+  local.get $1
+  i32.store
+  local.get $3
   local.tee $1
   local.get $0
   i32.load
@@ -1437,28 +1454,12 @@
   local.get $1
   i32.store
   local.get $0
-  local.tee $1
-  local.get $2
-  i32.load
-  local.tee $3
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $1
-  i32.store
+  call $rt/finalize/expect
   local.get $2
   call $rt/finalize/expect
-  local.get $0
-  call $rt/finalize/expect
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $0
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
   global.get $rt/finalize/expectedWriteIndex
@@ -1486,9 +1487,9 @@
   global.get $rt/finalize/expected
   call $rt/finalize/expect
   global.get $rt/finalize/expected
-  local.tee $2
+  local.tee $0
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__release
   end
   i32.const 0
@@ -2063,27 +2064,27 @@
   (local $4 i32)
   (local $5 i32)
   global.get $~lib/rt/pure/ROOTS
-  local.tee $0
-  local.tee $4
-  local.set $3
+  local.tee $1
+  local.tee $3
+  local.set $4
   global.get $~lib/rt/pure/CUR
-  local.set $1
+  local.set $0
   loop $for-loop|0
-   local.get $3
-   local.get $1
+   local.get $4
+   local.get $0
    i32.lt_u
    if
-    local.get $3
+    local.get $4
     i32.load
-    local.tee $2
-    i32.load offset=4
     local.tee $5
+    i32.load offset=4
+    local.tee $2
     i32.const 1879048192
     i32.and
     i32.const 805306368
     i32.eq
     if (result i32)
-     local.get $5
+     local.get $2
      i32.const 268435455
      i32.and
      i32.const 0
@@ -2092,87 +2093,87 @@
      i32.const 0
     end
     if
-     local.get $2
+     local.get $5
      call $~lib/rt/pure/markGray
-     local.get $4
-     local.get $2
+     local.get $3
+     local.get $5
      i32.store
-     local.get $4
+     local.get $3
      i32.const 4
      i32.add
-     local.set $4
+     local.set $3
     else
      i32.const 0
-     local.get $5
+     local.get $2
      i32.const 268435455
      i32.and
      i32.eqz
-     local.get $5
+     local.get $2
      i32.const 1879048192
      i32.and
      select
      if
-      local.get $2
+      local.get $5
       call $~lib/rt/pure/finalize
      else
-      local.get $2
       local.get $5
+      local.get $2
       i32.const 2147483647
       i32.and
       i32.store offset=4
      end
     end
-    local.get $3
+    local.get $4
     i32.const 4
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end
-  local.get $4
+  local.get $3
   global.set $~lib/rt/pure/CUR
-  local.get $0
-  local.set $1
+  local.get $1
+  local.set $0
   loop $for-loop|1
-   local.get $1
-   local.get $4
+   local.get $0
+   local.get $3
    i32.lt_u
    if
-    local.get $1
+    local.get $0
     i32.load
     call $~lib/rt/pure/scan
-    local.get $1
+    local.get $0
     i32.const 4
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|1
    end
   end
-  local.get $0
-  local.set $1
+  local.get $1
+  local.set $0
   loop $for-loop|2
-   local.get $1
-   local.get $4
+   local.get $0
+   local.get $3
    i32.lt_u
    if
-    local.get $1
+    local.get $0
     i32.load
-    local.tee $5
-    local.get $5
+    local.tee $2
+    local.get $2
     i32.load offset=4
     i32.const 2147483647
     i32.and
     i32.store offset=4
-    local.get $5
+    local.get $2
     call $~lib/rt/pure/collectWhite
-    local.get $1
+    local.get $0
     i32.const 4
     i32.add
-    local.set $1
+    local.set $0
     br $for-loop|2
    end
   end
-  local.get $0
+  local.get $1
   global.set $~lib/rt/pure/CUR
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -227,7 +227,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -247,35 +247,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -285,12 +285,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -298,7 +298,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -317,42 +317,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -367,12 +369,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -382,38 +384,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -431,7 +433,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -440,21 +442,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -481,7 +483,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -699,22 +701,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz
@@ -1323,12 +1324,11 @@
   i32.const 40
   i32.const 3
   call $~lib/rt/tlsf/__alloc
-  local.tee $0
+  local.tee $2
   i32.const 40
   call $~lib/memory/memory.fill
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__retain
-  local.tee $0
   global.set $rt/finalize/expected
   i32.const 16
   i32.const 4
@@ -1349,27 +1349,27 @@
   i32.const 0
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
+  local.tee $0
   i32.const 0
   call $~lib/memory/memory.fill
-  local.get $2
-  local.tee $0
+  local.get $0
+  local.tee $2
   local.get $3
   i32.load
   local.tee $1
   i32.ne
   if
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $0
+   local.set $2
    local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $3
-  local.get $0
+  local.get $2
   i32.store
   local.get $3
-  local.get $2
+  local.get $0
   i32.store offset=4
   local.get $3
   i32.const 0
@@ -1410,34 +1410,17 @@
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $0
   i32.const 0
   i32.store
   i32.const 4
   i32.const 6
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $0
+  local.tee $2
   i32.const 0
   i32.store
-  local.get $0
-  local.tee $1
   local.get $2
-  i32.load
-  local.tee $3
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.tee $3
-  local.get $1
-  i32.store
-  local.get $3
   local.tee $1
   local.get $0
   i32.load
@@ -1454,12 +1437,28 @@
   local.get $1
   i32.store
   local.get $0
-  call $rt/finalize/expect
+  local.tee $1
+  local.get $2
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $2
+  local.get $1
+  i32.store
   local.get $2
   call $rt/finalize/expect
-  local.get $2
+  local.get $0
+  call $rt/finalize/expect
+  local.get $0
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
   global.get $rt/finalize/expectedWriteIndex
@@ -1487,9 +1486,9 @@
   global.get $rt/finalize/expected
   call $rt/finalize/expect
   global.get $rt/finalize/expected
-  local.tee $0
+  local.tee $2
   if
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__release
   end
   i32.const 0

--- a/tests/compiler/runtime-full.optimized.wat
+++ b/tests/compiler/runtime-full.optimized.wat
@@ -205,7 +205,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -225,35 +225,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -263,12 +263,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -276,7 +276,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -295,42 +295,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -345,12 +347,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -360,38 +362,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -409,7 +411,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -418,21 +420,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -459,7 +461,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -677,22 +679,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -257,7 +257,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -277,35 +277,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -315,12 +315,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -328,7 +328,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -347,42 +347,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -397,12 +399,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -412,38 +414,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -461,7 +463,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -470,21 +472,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -511,7 +513,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -729,22 +731,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -8669,16 +8669,17 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  local.get $2
+  i32.const 6352
   call $~lib/rt/pure/__retain
-  local.set $6
+  local.set $8
   local.get $1
   i32.const 1
   i32.sub
@@ -8686,7 +8687,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $6
+   local.get $8
    call $~lib/rt/pure/__release
    i32.const 6112
    return
@@ -8696,36 +8697,36 @@
   if
    local.get $0
    i32.load
-   local.tee $3
+   local.tee $2
    if
-    local.get $3
+    local.get $2
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $2
    end
-   local.get $6
+   local.get $8
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__release
    i32.const 8320
    i32.const 6112
-   local.get $3
+   local.get $2
    select
    return
   end
   i32.const 6112
   local.set $1
-  local.get $6
+  local.get $8
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $5
   loop $for-loop|0
-   local.get $3
+   local.get $2
    local.get $7
    i32.lt_s
    if
     local.get $4
-    local.tee $2
+    local.tee $3
     local.get $0
-    local.get $3
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -8736,101 +8737,97 @@
      local.get $4
      call $~lib/rt/pure/__retain
      local.set $4
-     local.get $2
+     local.get $3
      call $~lib/rt/pure/__release
     end
     local.get $4
     if
      local.get $1
-     local.tee $5
+     local.get $1
      i32.const 8320
      call $~lib/string/String.__concat
-     local.tee $1
-     local.tee $2
-     local.get $5
+     local.tee $6
+     local.tee $3
      i32.ne
      if
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__retain
-      local.set $2
-      local.get $5
+      local.set $3
+      local.get $1
       call $~lib/rt/pure/__release
      end
-     local.get $1
+     local.get $6
      call $~lib/rt/pure/__release
-     local.get $2
+     local.get $3
      local.set $1
     end
-    local.get $8
+    local.get $5
     if
      local.get $1
-     local.tee $2
-     local.get $6
+     local.tee $3
+     local.get $8
      call $~lib/string/String.__concat
-     local.tee $5
+     local.tee $6
      local.tee $1
-     local.get $2
+     local.get $3
      i32.ne
      if
       local.get $1
       call $~lib/rt/pure/__retain
       local.set $1
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__release
      end
-     local.get $5
+     local.get $6
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
   local.get $4
-  local.tee $3
   local.get $0
   local.get $7
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $3
   i32.ne
   if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
    local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $2
-  local.tee $0
+  local.get $3
   if
    local.get $1
-   local.tee $2
+   local.get $1
    i32.const 8320
    call $~lib/string/String.__concat
-   local.tee $3
+   local.tee $0
    local.tee $4
-   local.get $2
    i32.ne
    if
     local.get $4
     call $~lib/rt/pure/__retain
     local.set $4
-    local.get $2
+    local.get $1
     call $~lib/rt/pure/__release
    end
-   local.get $3
+   local.get $0
    call $~lib/rt/pure/__release
    local.get $4
    local.set $1
   end
-  local.get $6
+  local.get $8
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -8839,7 +8836,6 @@
   i32.load offset=4
   local.get $0
   i32.load offset=12
-  i32.const 6352
   call $~lib/util/string/joinReferenceArray<std/array/Ref | null>
   i32.const 6352
   call $~lib/rt/pure/__release
@@ -10229,7 +10225,8 @@
   i32.const 6352
   call $~lib/array/Array<u32>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10237,60 +10234,60 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  local.get $2
+  i32.const 6352
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $9
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $6
+  local.tee $8
   i32.const 0
   i32.lt_s
   if
-   local.get $5
+   local.get $9
    call $~lib/rt/pure/__release
    i32.const 6112
    return
   end
-  local.get $6
+  local.get $8
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $3
+   local.tee $2
    if
-    local.get $3
+    local.get $2
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $2
    end
-   local.get $3
+   local.get $2
    if (result i32)
-    local.get $3
+    local.get $2
     i32.const 6352
     call $~lib/array/Array<u32>#join
    else
     i32.const 6112
    end
-   local.get $5
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6112
   local.set $1
-  local.get $5
+  local.get $9
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $6
   loop $for-loop|0
-   local.get $3
-   local.get $6
+   local.get $2
+   local.get $8
    i32.lt_s
    if
     local.get $4
-    local.tee $2
+    local.tee $3
     local.get $0
-    local.get $3
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -10301,7 +10298,7 @@
      local.get $4
      call $~lib/rt/pure/__retain
      local.set $4
-     local.get $2
+     local.get $3
      call $~lib/rt/pure/__release
     end
     local.get $4
@@ -10309,82 +10306,82 @@
      local.get $4
      i32.const 6352
      call $~lib/array/Array<u32>#join
-     local.tee $2
+     local.tee $3
      local.get $1
-     local.get $2
+     local.get $1
+     local.get $3
      call $~lib/string/String.__concat
-     local.tee $9
-     local.tee $2
-     local.get $1
+     local.tee $5
+     local.tee $3
      i32.ne
      if
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__retain
-      local.set $2
+      local.set $3
       local.get $1
       call $~lib/rt/pure/__release
      end
      call $~lib/rt/pure/__release
-     local.get $9
+     local.get $5
      call $~lib/rt/pure/__release
-     local.get $2
+     local.get $3
      local.set $1
     end
-    local.get $8
+    local.get $6
     if
      local.get $1
-     local.tee $2
-     local.get $5
+     local.tee $3
+     local.get $9
      call $~lib/string/String.__concat
      local.tee $7
      local.tee $1
-     local.get $2
+     local.get $3
      i32.ne
      if
       local.get $1
       call $~lib/rt/pure/__retain
       local.set $1
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__release
      end
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $for-loop|0
    end
   end
+  local.get $4
   local.get $0
-  local.get $6
+  local.get $8
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
-  local.get $4
+  local.tee $3
   i32.ne
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $3
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $3
   if
-   local.get $2
+   local.get $3
    i32.const 6352
    call $~lib/array/Array<u32>#join
    local.tee $0
+   local.get $1
    local.get $1
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
    local.tee $4
-   local.get $1
    i32.ne
    if
     local.get $4
@@ -10399,9 +10396,9 @@
    local.get $4
    local.set $1
   end
-  local.get $5
+  local.get $9
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -10410,7 +10407,6 @@
   i32.load offset=4
   local.get $0
   i32.load offset=12
-  i32.const 6352
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>
   i32.const 6352
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6613,80 +6613,6 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $std/array/createRandomString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  i32.const 6112
-  local.set $1
-  loop $for-loop|0
-   local.get $4
-   local.get $0
-   i32.lt_s
-   if
-    local.get $1
-    block $__inlined_func$~lib/string/String#charAt (result i32)
-     i32.const 6112
-     call $~lib/math/NativeMath.random
-     i32.const 5136
-     call $~lib/string/String#get:length
-     f64.convert_i32_s
-     f64.mul
-     f64.floor
-     i32.trunc_f64_s
-     local.tee $3
-     i32.const 5136
-     call $~lib/string/String#get:length
-     i32.ge_u
-     br_if $__inlined_func$~lib/string/String#charAt
-     drop
-     i32.const 2
-     i32.const 1
-     call $~lib/rt/tlsf/__alloc
-     local.tee $2
-     local.get $3
-     i32.const 1
-     i32.shl
-     i32.const 5136
-     i32.add
-     i32.load16_u
-     i32.store16
-     local.get $2
-     call $~lib/rt/pure/__retain
-    end
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $5
-    local.set $2
-    local.get $5
-    local.get $1
-    local.tee $3
-    i32.ne
-    if
-     local.get $2
-     call $~lib/rt/pure/__retain
-     local.set $2
-     local.get $3
-     call $~lib/rt/pure/__release
-    end
-    local.get $2
-    local.set $1
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $5
-    call $~lib/rt/pure/__release
-    local.get $4
-    i32.const 1
-    i32.add
-    local.set $4
-    br $for-loop|0
-   end
-  end
-  local.get $1
- )
  (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -10974,51 +10900,52 @@
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $0
   i32.eqz
   if
    i32.const 12
    i32.const 2
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
+  local.tee $1
   i32.const 0
   i32.store
-  local.get $2
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $2
+  local.get $0
   i32.const 0
   i32.store offset=8
   i32.const 1
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
+  local.tee $2
   i32.const 0
   i32.const 1
   call $~lib/memory/memory.fill
-  local.get $1
-  local.tee $0
   local.get $2
+  local.tee $0
+  local.get $1
   i32.load
-  local.tee $7
+  local.tee $4
   i32.ne
   if
    local.get $0
    call $~lib/rt/pure/__retain
    local.set $0
-   local.get $7
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $0
   i32.store
-  local.get $2
   local.get $1
-  i32.store offset=4
   local.get $2
+  i32.store offset=4
+  local.get $1
   i32.const 1
   i32.store offset=8
   global.get $std/array/arr
@@ -11033,7 +10960,7 @@
    unreachable
   end
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 0
@@ -11102,7 +11029,7 @@
   i32.const 1600
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $3
   call $std/array/isArraysEqual<u8>
   i32.eqz
   if
@@ -11126,7 +11053,7 @@
   i32.const 1632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $4
   call $std/array/isArraysEqual<u8>
   i32.eqz
   if
@@ -11150,7 +11077,7 @@
   i32.const 1664
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $9
   call $std/array/isArraysEqual<u8>
   i32.eqz
   if
@@ -11167,11 +11094,11 @@
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $12
+  local.get $9
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -11242,7 +11169,7 @@
   i32.const 1840
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $3
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11267,7 +11194,7 @@
   i32.const 1888
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $4
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11292,7 +11219,7 @@
   i32.const 1936
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $9
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11310,11 +11237,11 @@
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $12
+  local.get $9
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.load offset=12
@@ -11654,7 +11581,7 @@
   i32.const 2032
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $4
   call $~lib/array/Array<i32>#concat
   call $~lib/rt/pure/__release
   global.get $std/array/arr
@@ -11857,10 +11784,10 @@
   local.get $2
   global.get $std/array/arr
   call $~lib/array/Array<i32>#concat
-  local.set $4
+  local.set $3
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $3
   i32.load offset=12
   i32.const 3
   i32.ne
@@ -11884,9 +11811,9 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $3
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -11908,7 +11835,7 @@
   i32.const 2112
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $3
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11934,14 +11861,14 @@
   i32.const 3
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $7
+  local.tee $4
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2208
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $9
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11966,14 +11893,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $6
+  local.tee $15
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2304
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $23
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11998,14 +11925,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $9
+  local.tee $6
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2400
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $8
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12030,14 +11957,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $8
+  local.tee $7
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2496
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12062,14 +11989,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $14
+  local.tee $12
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2592
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $13
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12101,7 +12028,7 @@
   i32.const 2688
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12126,14 +12053,14 @@
   i32.const -2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $18
+  local.tee $17
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $18
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12158,14 +12085,14 @@
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $16
+  local.tee $14
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2880
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $20
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12183,21 +12110,22 @@
   i32.const 2928
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
+  local.set $0
   local.get $1
   call $~lib/rt/pure/__release
-  local.tee $1
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const -2
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $20
+  local.tee $19
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2976
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $21
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12215,15 +12143,15 @@
   i32.const 3024
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.const -4
   i32.const -3
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $23
+  local.tee $22
   i32.const 5
   i32.const 2
   i32.const 3
@@ -12248,15 +12176,15 @@
   i32.const 3120
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $0
+  local.tee $1
   i32.const 5
   i32.const 2
   i32.const 3
@@ -12275,53 +12203,53 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $4
-  call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $5
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $23
+  call $~lib/rt/pure/__release
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $12
+  call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $14
-  call $~lib/rt/pure/__release
-  local.get $15
-  call $~lib/rt/pure/__release
   local.get $28
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $16
-  call $~lib/rt/pure/__release
-  local.get $21
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $20
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $19
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $22
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
@@ -12904,7 +12832,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $1
-  local.set $7
+  local.set $4
   i32.const 0
   local.set $0
   block $__inlined_func$~lib/array/Array<f32>#indexOf
@@ -12923,15 +12851,15 @@
     local.set $0
     br $__inlined_func$~lib/array/Array<f32>#indexOf
    end
-   local.get $7
+   local.get $4
    i32.load offset=4
-   local.set $4
+   local.set $3
    loop $while-continue|0
     local.get $0
     local.get $2
     i32.lt_s
     if
-     local.get $4
+     local.get $3
      local.get $0
      i32.const 2
      i32.shl
@@ -12968,16 +12896,16 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $2
-  local.set $12
+  local.set $9
   i32.const 0
   local.set $0
   block $__inlined_func$~lib/array/Array<f64>#indexOf
    local.get $2
    i32.load offset=12
-   local.tee $4
+   local.tee $3
    if (result i32)
     i32.const 0
-    local.get $4
+    local.get $3
     i32.ge_s
    else
     i32.const 1
@@ -12987,15 +12915,15 @@
     local.set $0
     br $__inlined_func$~lib/array/Array<f64>#indexOf
    end
-   local.get $12
+   local.get $9
    i32.load offset=4
-   local.set $7
+   local.set $4
    loop $while-continue|019
     local.get $0
-    local.get $4
+    local.get $3
     i32.lt_s
     if
-     local.get $7
+     local.get $4
      local.get $0
      i32.const 3
      i32.shl
@@ -13177,10 +13105,10 @@
    call $~lib/rt/pure/__retain
    local.tee $2
    i32.load offset=12
-   local.tee $4
+   local.tee $3
    if (result i32)
     i32.const 0
-    local.get $4
+    local.get $3
     i32.ge_s
    else
     i32.const 1
@@ -13189,14 +13117,14 @@
    drop
    local.get $2
    i32.load offset=4
-   local.set $12
+   local.set $9
    loop $while-continue|020
     local.get $0
-    local.get $4
+    local.get $3
     i32.lt_s
     if
      i32.const 1
-     local.get $12
+     local.get $9
      local.get $0
      i32.const 2
      i32.shl
@@ -13242,28 +13170,28 @@
    i32.const 3312
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $4
+   local.tee $3
    i32.load offset=12
-   local.tee $7
+   local.tee $4
    if (result i32)
     i32.const 0
-    local.get $7
+    local.get $4
     i32.ge_s
    else
     i32.const 1
    end
    br_if $__inlined_func$~lib/array/Array<f64>#includes
    drop
-   local.get $4
+   local.get $3
    i32.load offset=4
-   local.set $6
+   local.set $15
    loop $while-continue|021
     local.get $0
-    local.get $7
+    local.get $4
     i32.lt_s
     if
      i32.const 1
-     local.get $6
+     local.get $15
      local.get $0
      i32.const 3
      i32.shl
@@ -13356,7 +13284,7 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $3
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -13368,14 +13296,14 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $6
+  local.tee $3
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 3392
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $4
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13394,7 +13322,7 @@
   i32.const 3440
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $6
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13419,14 +13347,14 @@
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $10
+  local.tee $8
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 3504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $7
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13445,7 +13373,7 @@
   i32.const 3520
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13470,14 +13398,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $14
+  local.tee $12
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 3616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $13
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13496,7 +13424,7 @@
   i32.const 3648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13514,21 +13442,21 @@
   i32.const 3680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
+  local.set $2
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#splice
-  local.tee $18
+  local.tee $17
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 3728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $18
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13540,14 +13468,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 3760
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $14
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13565,20 +13493,21 @@
   i32.const 3792
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.get $0
+  local.set $0
+  local.get $2
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.get $0
   i32.const 0
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $21
+  local.tee $20
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 3840
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13597,7 +13526,7 @@
   i32.const 3872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $21
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13621,7 +13550,7 @@
   i32.const -1
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $23
+  local.tee $22
   i32.const 1
   i32.const 2
   i32.const 3
@@ -14070,7 +13999,7 @@
   local.tee $1
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#splice
-  local.tee $7
+  local.tee $15
   i32.load offset=12
   if
    i32.const 0
@@ -14096,7 +14025,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $9
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -14120,13 +14049,13 @@
   i32.store offset=16
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $9
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#splice
-  local.set $12
-  local.get $7
+  local.set $23
+  local.get $15
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $23
   i32.load offset=12
   i32.const 2
   i32.ne
@@ -14138,7 +14067,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $12
+  local.get $23
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $55
@@ -14153,7 +14082,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $12
+  local.get $23
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $56
@@ -14168,7 +14097,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $9
   i32.load offset=12
   i32.const 3
   i32.ne
@@ -14180,7 +14109,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $9
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $57
@@ -14195,7 +14124,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $9
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $58
@@ -14210,7 +14139,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $9
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $59
@@ -14231,7 +14160,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $15
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -14244,7 +14173,7 @@
   i32.const 2
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $7
+  local.get $15
   call $~lib/array/Array<std/array/Ref | null>#splice
   local.tee $28
   i32.load offset=12
@@ -14283,7 +14212,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $15
   i32.load offset=12
   i32.const 2
   i32.ne
@@ -14295,7 +14224,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $15
   i32.const 0
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $60
@@ -14307,7 +14236,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $15
   i32.const 1
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $1
@@ -14334,37 +14263,37 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $6
-  call $~lib/rt/pure/__release
-  local.get $5
-  call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $10
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $12
+  call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $14
-  call $~lib/rt/pure/__release
-  local.get $15
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $16
-  call $~lib/rt/pure/__release
-  local.get $21
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $20
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $19
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $22
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
@@ -14914,17 +14843,17 @@
    unreachable
   end
   loop $for-loop|0
-   local.get $3
+   local.get $5
    i32.const 100
    i32.lt_s
    if
     global.get $std/array/arr
     call $~lib/array/Array<i32>#pop
     drop
-    local.get $3
+    local.get $5
     i32.const 1
     i32.add
-    local.set $3
+    local.set $5
     br $for-loop|0
    end
   end
@@ -14957,7 +14886,7 @@
   call $~lib/rt/pure/__retain
   local.tee $1
   i32.load offset=4
-  local.set $6
+  local.set $4
   loop $for-loop|039
    local.get $0
    local.get $3
@@ -14978,13 +14907,13 @@
     i32.load offset=4
     i32.add
     i32.load
-    local.set $9
+    local.set $6
     i32.const 3
     global.set $~argumentsLength
+    local.get $4
     local.get $5
-    local.get $6
     i32.add
-    local.get $9
+    local.get $6
     f32.convert_i32_s
     f32.store
     local.get $0
@@ -15619,7 +15548,7 @@
   i32.const 5376
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $18
   call $std/array/isArraysEqual<f32>
   i32.eqz
   if
@@ -15705,7 +15634,7 @@
   i32.const 5504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $14
   call $std/array/isArraysEqual<f64>
   i32.eqz
   if
@@ -15736,7 +15665,7 @@
   i32.const 5632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $20
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15754,21 +15683,21 @@
   i32.const 5680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
+  local.set $4
   i32.const 0
   global.set $~argumentsLength
-  local.get $6
+  local.get $4
   i32.const 0
   call $~lib/array/Array<u32>#sort@varargs
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $4
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 5728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15786,7 +15715,7 @@
   i32.const 5776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $17
+  local.set $16
   i32.const 1
   i32.const 2
   i32.const 3
@@ -15800,14 +15729,14 @@
   i32.const 5824
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $6
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 5856
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $10
+  local.set $8
   i32.const 4
   i32.const 2
   i32.const 3
@@ -15817,20 +15746,20 @@
   local.set $2
   i32.const 64
   call $std/array/createReverseOrderedArray
-  local.set $8
+  local.set $7
   i32.const 128
   call $std/array/createReverseOrderedArray
-  local.set $13
+  local.set $10
   i32.const 1024
   call $std/array/createReverseOrderedArray
-  local.set $14
+  local.set $12
   i32.const 10000
   call $std/array/createReverseOrderedArray
-  local.set $15
+  local.set $13
   i32.const 512
   call $std/array/createRandomOrderedArray
-  local.set $18
-  local.get $17
+  local.set $17
+  local.get $16
   call $std/array/assertSortedDefault<i32>
   local.get $5
   call $std/array/assertSortedDefault<i32>
@@ -15841,7 +15770,7 @@
   i32.const 5920
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $21
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15853,16 +15782,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $6
   call $std/array/assertSortedDefault<i32>
-  local.get $9
+  local.get $6
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 5952
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15874,9 +15803,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $10
+  local.get $8
   call $std/array/assertSortedDefault<i32>
-  local.get $10
+  local.get $8
   local.get $2
   i32.const 0
   call $std/array/isArraysEqual<u32>
@@ -15889,9 +15818,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $7
   call $std/array/assertSortedDefault<i32>
-  local.get $8
+  local.get $7
   local.get $2
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15904,9 +15833,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $13
+  local.get $10
   call $std/array/assertSortedDefault<i32>
-  local.get $13
+  local.get $10
   local.get $2
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15919,9 +15848,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $14
+  local.get $12
   call $std/array/assertSortedDefault<i32>
-  local.get $14
+  local.get $12
   local.get $2
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15934,9 +15863,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $15
+  local.get $13
   call $std/array/assertSortedDefault<i32>
-  local.get $15
+  local.get $13
   local.get $2
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15949,47 +15878,47 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $18
+  local.get $17
   call $std/array/assertSortedDefault<i32>
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $18
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $21
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
   local.get $20
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $19
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $12
+  call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $17
   call $~lib/rt/pure/__release
-  local.get $15
-  call $~lib/rt/pure/__release
-  local.get $18
+  local.get $21
   call $~lib/rt/pure/__release
   local.get $22
-  call $~lib/rt/pure/__release
-  local.get $23
   call $~lib/rt/pure/__release
   i32.const 64
   call $std/array/createRandomOrderedArray
@@ -16031,73 +15960,73 @@
   i32.const 6128
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
+  local.set $5
   i32.const 7
   i32.const 2
   i32.const 15
   i32.const 6176
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $8
   i32.const 1
   global.set $~argumentsLength
   block $__inlined_func$std/array/isSorted<~lib/string/String | null> (result i32)
    i32.const 1
-   local.set $2
-   local.get $1
+   local.set $0
+   local.get $5
    call $~lib/rt/pure/__retain
-   local.tee $9
+   local.tee $4
    i32.const 55
    call $~lib/array/Array<~lib/array/Array<i32>>#sort
-   local.tee $10
+   local.tee $6
    call $~lib/rt/pure/__retain
-   local.tee $0
+   local.tee $1
    i32.load offset=12
-   local.set $8
+   local.set $7
    loop $for-loop|00
-    local.get $2
-    local.get $8
+    local.get $0
+    local.get $7
     i32.lt_s
     if
+     local.get $1
      local.get $0
-     local.get $2
      i32.const 1
      i32.sub
      call $~lib/array/Array<std/array/Ref | null>#__get
-     local.set $3
+     local.set $2
+     local.get $1
      local.get $0
-     local.get $2
      call $~lib/array/Array<std/array/Ref | null>#__get
-     local.set $6
+     local.set $3
      i32.const 2
      global.set $~argumentsLength
+     local.get $2
      local.get $3
-     local.get $6
      call $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0
      i32.const 0
      i32.gt_s
      if
-      local.get $0
+      local.get $1
+      call $~lib/rt/pure/__release
+      local.get $2
       call $~lib/rt/pure/__release
       local.get $3
-      call $~lib/rt/pure/__release
-      local.get $6
       call $~lib/rt/pure/__release
       i32.const 0
       br $__inlined_func$std/array/isSorted<~lib/string/String | null>
      end
+     local.get $2
+     call $~lib/rt/pure/__release
      local.get $3
      call $~lib/rt/pure/__release
-     local.get $6
-     call $~lib/rt/pure/__release
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $for-loop|00
     end
    end
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
    i32.const 1
   end
@@ -16110,12 +16039,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $10
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $4
   call $~lib/rt/pure/__release
-  local.get $1
   local.get $5
+  local.get $8
   call $std/array/isArraysEqual<~lib/string/String | null>
   i32.eqz
   if
@@ -16131,24 +16060,91 @@
   i32.const 0
   i32.const 400
   call $~lib/array/Array<~lib/string/String>#constructor
-  local.set $2
+  local.set $1
   loop $for-loop|06
    local.get $0
    i32.const 400
    i32.lt_s
    if
-    local.get $2
     local.get $0
+    local.set $3
     call $~lib/math/NativeMath.random
     f64.const 32
     f64.mul
     i32.trunc_f64_s
-    call $std/array/createRandomString
-    local.tee $3
-    call $~lib/array/Array<~lib/array/Array<i32>>#__set
+    local.set $7
+    i32.const 0
+    local.set $6
+    i32.const 6112
+    local.set $0
+    loop $for-loop|01
+     local.get $6
+     local.get $7
+     i32.lt_s
+     if
+      block $__inlined_func$~lib/string/String#charAt (result i32)
+       i32.const 6112
+       call $~lib/math/NativeMath.random
+       i32.const 5136
+       call $~lib/string/String#get:length
+       f64.convert_i32_s
+       f64.mul
+       f64.floor
+       i32.trunc_f64_s
+       local.tee $2
+       i32.const 5136
+       call $~lib/string/String#get:length
+       i32.ge_u
+       br_if $__inlined_func$~lib/string/String#charAt
+       drop
+       i32.const 2
+       i32.const 1
+       call $~lib/rt/tlsf/__alloc
+       local.tee $4
+       local.get $2
+       i32.const 1
+       i32.shl
+       i32.const 5136
+       i32.add
+       i32.load16_u
+       i32.store16
+       local.get $4
+       call $~lib/rt/pure/__retain
+      end
+      local.set $2
+      local.get $0
+      local.tee $4
+      local.get $0
+      local.get $2
+      call $~lib/string/String.__concat
+      local.tee $10
+      local.tee $0
+      i32.ne
+      if
+       local.get $0
+       call $~lib/rt/pure/__retain
+       local.set $0
+       local.get $4
+       call $~lib/rt/pure/__release
+      end
+      local.get $2
+      call $~lib/rt/pure/__release
+      local.get $10
+      call $~lib/rt/pure/__release
+      local.get $6
+      i32.const 1
+      i32.add
+      local.set $6
+      br $for-loop|01
+     end
+    end
+    local.get $1
     local.get $3
-    call $~lib/rt/pure/__release
     local.get $0
+    call $~lib/array/Array<~lib/array/Array<i32>>#__set
+    local.get $0
+    call $~lib/rt/pure/__release
+    local.get $3
     i32.const 1
     i32.add
     local.set $0
@@ -16157,14 +16153,14 @@
   end
   i32.const 1
   global.set $~argumentsLength
-  local.get $2
+  local.get $1
   i32.const 56
   call $std/array/assertSorted<~lib/array/Array<i32>>
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 2
   i32.const 0
@@ -16198,10 +16194,10 @@
   i32.const 6432
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $6
   i32.const 6112
   call $~lib/array/Array<i32>#join
-  local.tee $10
+  local.tee $8
   i32.const 6784
   call $~lib/string/String.__eq
   i32.eqz
@@ -16219,10 +16215,10 @@
   i32.const 6816
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $7
   i32.const 6848
   call $~lib/array/Array<u32>#join
-  local.tee $13
+  local.tee $10
   i32.const 6784
   call $~lib/string/String.__eq
   i32.eqz
@@ -16240,10 +16236,10 @@
   i32.const 6880
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $12
   i32.const 6912
   call $~lib/array/Array<i32>#join
-  local.tee $15
+  local.tee $13
   i32.const 6944
   call $~lib/string/String.__eq
   i32.eqz
@@ -16287,10 +16283,10 @@
   i32.const 8288
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $16
   i32.const 6112
   call $~lib/array/Array<~lib/string/String | null>#join
-  local.tee $18
+  local.tee $17
   i32.const 8256
   call $~lib/string/String.__eq
   i32.eqz
@@ -16308,7 +16304,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $4
   i32.load offset=4
   local.tee $5
   i32.const 0
@@ -16321,9 +16317,9 @@
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $6
+  local.get $4
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $19
+  local.tee $18
   i32.const 8368
   call $~lib/string/String.__eq
   i32.eqz
@@ -16343,17 +16339,17 @@
   call $~lib/rt/pure/__retain
   local.tee $5
   i32.load offset=4
-  local.tee $16
+  local.tee $14
   i32.const 0
   call $std/array/Ref#constructor
   i32.store
-  local.get $16
+  local.get $14
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=4
   local.get $5
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $16
+  local.tee $14
   i32.const 8448
   call $~lib/string/String.__eq
   i32.eqz
@@ -16369,33 +16365,33 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $10
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $12
+  call $~lib/rt/pure/__release
   local.get $13
-  call $~lib/rt/pure/__release
-  local.get $14
-  call $~lib/rt/pure/__release
-  local.get $15
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
   local.get $17
+  call $~lib/rt/pure/__release
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $14
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 2
@@ -16410,7 +16406,7 @@
   i32.const 8544
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
+  local.set $4
   i32.const 2
   i32.const 2
   i32.const 3
@@ -16424,7 +16420,7 @@
   i32.const 8608
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $6
   local.get $3
   i32.const 6352
   call $~lib/array/Array<i32>#join
@@ -16441,11 +16437,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $4
   i32.const 6352
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $23
+  local.set $22
   local.get $0
   i32.const 8256
   call $~lib/string/String.__eq
@@ -16475,7 +16471,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $6
   i32.const 6352
   call $~lib/array/Array<i32>#join
   local.tee $0
@@ -16498,15 +16494,15 @@
   i32.const 8704
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $8
   i32.load offset=4
-  local.get $10
+  local.get $8
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i8>
-  local.set $8
+  local.set $7
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $7
   i32.const 8736
   call $~lib/string/String.__eq
   i32.eqz
@@ -16524,15 +16520,15 @@
   i32.const 8768
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $10
   i32.load offset=4
-  local.get $13
+  local.get $10
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u16>
-  local.set $14
+  local.set $12
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $12
   i32.const 8800
   call $~lib/string/String.__eq
   i32.eqz
@@ -16550,15 +16546,15 @@
   i32.const 8848
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $13
   i32.load offset=4
-  local.get $15
+  local.get $13
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u64>
-  local.set $17
+  local.set $16
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $16
   i32.const 8896
   call $~lib/string/String.__eq
   i32.eqz
@@ -16576,15 +16572,15 @@
   i32.const 8960
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $17
   i32.load offset=4
-  local.get $18
+  local.get $17
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i64>
-  local.set $19
+  local.set $18
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $18
   i32.const 9008
   call $~lib/string/String.__eq
   i32.eqz
@@ -16671,10 +16667,10 @@
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>
-  local.set $16
+  local.set $14
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $14
   i32.const 9408
   call $~lib/string/String.__eq
   i32.eqz
@@ -16715,10 +16711,10 @@
   local.get $1
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>
-  local.set $21
+  local.set $20
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $21
+  local.get $20
   i32.const 9408
   call $~lib/string/String.__eq
   i32.eqz
@@ -16760,10 +16756,10 @@
   local.get $2
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>
-  local.set $20
+  local.set $19
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $19
   i32.const 8256
   call $~lib/string/String.__eq
   i32.eqz
@@ -16777,34 +16773,34 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $6
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $22
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $12
   call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $14
-  call $~lib/rt/pure/__release
-  local.get $15
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
-  call $~lib/rt/pure/__release
-  local.get $19
   call $~lib/rt/pure/__release
   local.get $29
   call $~lib/rt/pure/__release
@@ -16814,11 +16810,11 @@
   call $~lib/rt/pure/__release
   local.get $32
   call $~lib/rt/pure/__release
-  local.get $16
-  call $~lib/rt/pure/__release
-  local.get $21
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $20
+  call $~lib/rt/pure/__release
+  local.get $19
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   call $~lib/rt/pure/__release
@@ -16864,7 +16860,7 @@
   i32.store offset=12
   local.get $5
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $9
+  local.tee $6
   i32.load offset=12
   i32.const 10
   i32.ne
@@ -16881,7 +16877,7 @@
    i32.const 10
    i32.lt_s
    if
-    local.get $9
+    local.get $6
     local.get $11
     call $~lib/array/Array<u32>#__get
     local.get $11
@@ -16907,9 +16903,9 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $8
   i32.load offset=4
-  local.tee $11
+  local.tee $3
   i32.const 1
   i32.const 2
   i32.const 15
@@ -16917,7 +16913,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $11
+  local.get $3
   i32.const 3
   i32.const 2
   i32.const 15
@@ -16925,7 +16921,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $11
+  local.get $3
   i32.const 3
   i32.const 2
   i32.const 15
@@ -16933,7 +16929,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=8
-  local.get $11
+  local.get $3
   i32.const 1
   i32.const 2
   i32.const 15
@@ -16941,7 +16937,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=12
-  local.get $10
+  local.get $8
   call $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#flat
   local.set $3
   i32.const 8
@@ -16950,7 +16946,7 @@
   i32.const 10016
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
+  local.set $4
   local.get $3
   i32.load offset=12
   i32.const 8
@@ -16967,18 +16963,18 @@
   local.set $11
   loop $for-loop|2
    local.get $11
-   local.get $6
+   local.get $4
    i32.load offset=12
    i32.lt_s
    if
     local.get $3
     local.get $11
     call $~lib/array/Array<std/array/Ref | null>#__get
-    local.tee $8
-    local.get $6
+    local.tee $7
+    local.get $4
     local.get $11
     call $~lib/array/Array<std/array/Ref | null>#__get
-    local.tee $13
+    local.tee $10
     call $~lib/string/String.__eq
     i32.eqz
     if
@@ -16989,9 +16985,9 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $8
+    local.get $7
     call $~lib/rt/pure/__release
-    local.get $13
+    local.get $10
     call $~lib/rt/pure/__release
     local.get $11
     i32.const 1
@@ -17008,7 +17004,7 @@
   call $~lib/rt/pure/__retain
   local.tee $11
   i32.load offset=4
-  local.tee $8
+  local.tee $7
   i32.const 0
   i32.const 2
   i32.const 3
@@ -17016,7 +17012,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $8
+  local.get $7
   i32.const 0
   i32.const 2
   i32.const 3
@@ -17026,7 +17022,7 @@
   i32.store offset=4
   local.get $11
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $8
+  local.tee $7
   i32.load offset=12
   if
    i32.const 0
@@ -17038,13 +17034,13 @@
   end
   local.get $11
   call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
   local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
+  call $~lib/rt/pure/__release
+  local.get $23
+  call $~lib/rt/pure/__release
+  local.get $15
   call $~lib/rt/pure/__release
   local.get $28
   call $~lib/rt/pure/__release
@@ -17056,13 +17052,13 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<u32>#constructor (param $0 i32) (param $1 i32) (result i32)

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -532,7 +532,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -552,35 +552,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -590,12 +590,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -603,7 +603,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -622,42 +622,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -672,12 +674,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -687,38 +689,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -736,7 +738,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -745,21 +747,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -786,7 +788,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -1028,22 +1030,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz
@@ -8510,22 +8511,22 @@
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $3
    if
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $3
    end
-   local.get $4
+   local.get $3
    if (result i32)
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
    else
     i32.const 6112
    end
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
@@ -8535,30 +8536,30 @@
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $4
+   local.get $3
    local.get $6
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
-     local.set $3
+     local.set $4
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
      local.tee $2
      local.get $1
@@ -8601,10 +8602,10 @@
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $3
     i32.const 1
     i32.add
-    local.set $4
+    local.set $3
     br $for-loop|0
    end
   end
@@ -8615,13 +8616,13 @@
   i32.add
   i32.load
   local.tee $2
-  local.get $3
+  local.get $4
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -8633,20 +8634,20 @@
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
-   local.tee $3
+   local.tee $4
    local.get $1
    i32.ne
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $4
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $4
    local.set $1
   end
   local.get $5
@@ -8695,19 +8696,19 @@
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $3
    if
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $3
    end
    local.get $6
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 8320
    i32.const 6112
-   local.get $4
+   local.get $3
    select
    return
   end
@@ -8717,28 +8718,28 @@
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $4
+   local.get $3
    local.get $7
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
-     local.set $3
+     local.set $4
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
      local.get $1
      local.tee $5
@@ -8780,15 +8781,15 @@
      local.get $5
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $3
     i32.const 1
     i32.add
-    local.set $4
+    local.set $3
     br $for-loop|0
    end
   end
-  local.get $3
-  local.tee $4
+  local.get $4
+  local.tee $3
   local.get $0
   local.get $7
   i32.const 2
@@ -8801,7 +8802,7 @@
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -8811,20 +8812,20 @@
    local.tee $2
    i32.const 8320
    call $~lib/string/String.__concat
-   local.tee $4
    local.tee $3
+   local.tee $4
    local.get $2
    i32.ne
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $4
     local.get $2
     call $~lib/rt/pure/__release
    end
-   local.get $4
-   call $~lib/rt/pure/__release
    local.get $3
+   call $~lib/rt/pure/__release
+   local.get $4
    local.set $1
   end
   local.get $6
@@ -9732,15 +9733,15 @@
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $3
    if
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $3
    end
-   local.get $4
+   local.get $3
    if (result i32)
-    local.get $4
+    local.get $3
     i32.const 6352
     call $~lib/array/Array<i32>#join
    else
@@ -9748,7 +9749,7 @@
    end
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
@@ -9758,30 +9759,30 @@
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $4
+   local.get $3
    local.get $6
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
-     local.set $3
+     local.set $4
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
-     local.get $3
+     local.get $4
      i32.const 6352
      call $~lib/array/Array<i32>#join
      local.tee $2
@@ -9825,14 +9826,14 @@
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $3
     i32.const 1
     i32.add
-    local.set $4
+    local.set $3
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
   local.get $0
   local.get $6
   i32.const 2
@@ -9845,7 +9846,7 @@
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -9859,19 +9860,19 @@
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
-   local.tee $3
+   local.tee $4
    i32.ne
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $4
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $4
    local.set $1
   end
   local.get $5
@@ -10075,15 +10076,15 @@
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $3
    if
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $3
    end
-   local.get $4
+   local.get $3
    if (result i32)
-    local.get $4
+    local.get $3
     i32.const 6352
     call $~lib/array/Array<u8>#join
    else
@@ -10091,7 +10092,7 @@
    end
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
@@ -10101,30 +10102,30 @@
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $4
+   local.get $3
    local.get $6
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
-     local.set $3
+     local.set $4
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
-     local.get $3
+     local.get $4
      i32.const 6352
      call $~lib/array/Array<u8>#join
      local.tee $2
@@ -10168,14 +10169,14 @@
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $3
     i32.const 1
     i32.add
-    local.set $4
+    local.set $3
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
   local.get $0
   local.get $6
   i32.const 2
@@ -10188,7 +10189,7 @@
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -10202,19 +10203,19 @@
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
-   local.tee $3
+   local.tee $4
    i32.ne
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $4
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $4
    local.set $1
   end
   local.get $5
@@ -10256,15 +10257,15 @@
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $3
    if
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $3
    end
-   local.get $4
+   local.get $3
    if (result i32)
-    local.get $4
+    local.get $3
     i32.const 6352
     call $~lib/array/Array<u32>#join
    else
@@ -10272,7 +10273,7 @@
    end
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
@@ -10282,30 +10283,30 @@
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $4
+   local.get $3
    local.get $6
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
-     local.set $3
+     local.set $4
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
-     local.get $3
+     local.get $4
      i32.const 6352
      call $~lib/array/Array<u32>#join
      local.tee $2
@@ -10349,10 +10350,10 @@
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $3
     i32.const 1
     i32.add
-    local.set $4
+    local.set $3
     br $for-loop|0
    end
   end
@@ -10363,13 +10364,13 @@
   i32.add
   i32.load
   local.tee $2
-  local.get $3
+  local.get $4
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -10382,20 +10383,20 @@
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
-   local.tee $3
+   local.tee $4
    local.get $1
    i32.ne
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $4
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $4
    local.set $1
   end
   local.get $5
@@ -10443,22 +10444,22 @@
   if
    local.get $0
    i32.load
-   local.tee $4
+   local.tee $3
    if
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $3
    end
-   local.get $4
+   local.get $3
    if (result i32)
-    local.get $4
+    local.get $3
     call $~lib/array/Array<~lib/array/Array<u32>>#toString
    else
     i32.const 6112
    end
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
@@ -10468,32 +10469,32 @@
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $4
+   local.get $3
    local.get $6
    i32.lt_s
    if
-    local.get $3
+    local.get $4
     local.tee $2
     local.get $0
-    local.get $4
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
-     local.set $3
+     local.set $4
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
      local.get $1
      local.get $1
-     local.get $3
+     local.get $4
      call $~lib/array/Array<~lib/array/Array<u32>>#toString
      local.tee $7
      call $~lib/string/String.__concat
@@ -10534,14 +10535,14 @@
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $3
     i32.const 1
     i32.add
-    local.set $4
+    local.set $3
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
   local.get $0
   local.get $6
   i32.const 2
@@ -10554,7 +10555,7 @@
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -10565,21 +10566,21 @@
    call $~lib/array/Array<~lib/array/Array<u32>>#toString
    local.tee $0
    call $~lib/string/String.__concat
-   local.tee $4
    local.tee $3
+   local.tee $4
    i32.ne
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $4
     local.get $1
     call $~lib/rt/pure/__release
    end
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $4
-   call $~lib/rt/pure/__release
    local.get $3
+   call $~lib/rt/pure/__release
+   local.get $4
    local.set $1
   end
   local.get $5
@@ -10602,12 +10603,12 @@
   i32.load offset=4
   local.set $6
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -10619,72 +10620,72 @@
     else
      i32.const 0
     end
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $1
+    local.set $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   i32.const 2
   i32.shl
-  local.tee $1
+  local.tee $2
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.set $3
+  local.set $4
   i32.const 16
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   local.tee $0
-  local.get $2
+  local.get $3
   i32.store offset=12
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
   local.get $0
-  local.get $3
+  local.get $4
   i32.store offset=4
   local.get $0
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__retain
   i32.store
   i32.const 0
-  local.set $1
+  local.set $2
   loop $for-loop|1
-   local.get $1
+   local.get $2
    local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $2
+    local.tee $3
     if
+     local.get $1
+     local.get $4
+     i32.add
      local.get $3
-     local.get $4
-     i32.add
-     local.get $2
      i32.load offset=4
-     local.get $2
+     local.get $3
      i32.load offset=8
-     local.tee $2
+     local.tee $3
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $4
+     local.get $1
+     local.get $3
      i32.add
-     local.set $4
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|1
    end
   end
@@ -10706,12 +10707,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $6
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -10723,98 +10724,98 @@
     else
      i32.const 0
     end
-    local.get $2
+    local.get $3
     i32.add
-    local.set $2
-    local.get $1
+    local.set $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $3
   i32.const 2
   i32.shl
-  local.tee $1
+  local.tee $2
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $0
   i32.const 16
   i32.const 15
   call $~lib/rt/tlsf/__alloc
-  local.tee $3
-  local.get $2
+  local.tee $4
+  local.get $3
   i32.store offset=12
-  local.get $3
-  local.get $1
+  local.get $4
+  local.get $2
   i32.store offset=8
-  local.get $3
+  local.get $4
   local.get $0
   i32.store offset=4
-  local.get $3
+  local.get $4
   local.get $0
   call $~lib/rt/pure/__retain
   i32.store
   i32.const 0
-  local.set $1
+  local.set $2
   loop $for-loop|1
-   local.get $1
+   local.get $2
    local.get $6
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $4
+    local.tee $5
     if
      local.get $0
-     local.get $5
+     local.get $1
      i32.add
-     local.get $4
+     local.get $5
      i32.load offset=4
-     local.get $4
+     local.get $5
      i32.load offset=8
-     local.tee $4
+     local.tee $5
      call $~lib/memory/memory.copy
-     local.get $4
+     local.get $1
      local.get $5
      i32.add
-     local.set $5
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|1
    end
   end
   i32.const 0
-  local.set $1
+  local.set $2
   loop $for-loop|2
-   local.get $1
    local.get $2
+   local.get $3
    i32.lt_s
    if
     local.get $0
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
     call $~lib/rt/pure/__retain
     drop
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|2
    end
   end
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__retain
  )
  (func $start:std/array
@@ -10899,34 +10900,35 @@
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $0
   i32.eqz
   if
    i32.const 12
    i32.const 2
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
+  local.tee $1
   i32.const 0
   i32.store
-  local.get $2
+  local.get $0
   i32.const 0
   i32.store offset=4
-  local.get $2
+  local.get $0
   i32.const 0
   i32.store offset=8
   i32.const 1
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
+  local.tee $2
   i32.const 0
   i32.const 1
   call $~lib/memory/memory.fill
-  local.get $1
-  local.tee $0
   local.get $2
+  local.tee $0
+  local.get $1
   i32.load
   local.tee $4
   i32.ne
@@ -10937,13 +10939,13 @@
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $0
   i32.store
-  local.get $2
   local.get $1
-  i32.store offset=4
   local.get $2
+  i32.store offset=4
+  local.get $1
   i32.const 1
   i32.store offset=8
   global.get $std/array/arr
@@ -10958,7 +10960,7 @@
    unreachable
   end
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 0
@@ -15970,7 +15972,7 @@
   global.set $~argumentsLength
   block $__inlined_func$std/array/isSorted<~lib/string/String | null> (result i32)
    i32.const 1
-   local.set $2
+   local.set $0
    local.get $5
    call $~lib/rt/pure/__retain
    local.tee $4
@@ -15978,53 +15980,53 @@
    call $~lib/array/Array<~lib/array/Array<i32>>#sort
    local.tee $6
    call $~lib/rt/pure/__retain
-   local.tee $0
+   local.tee $1
    i32.load offset=12
    local.set $7
    loop $for-loop|00
-    local.get $2
+    local.get $0
     local.get $7
     i32.lt_s
     if
+     local.get $1
      local.get $0
-     local.get $2
      i32.const 1
      i32.sub
      call $~lib/array/Array<std/array/Ref | null>#__get
-     local.set $1
+     local.set $2
+     local.get $1
      local.get $0
-     local.get $2
      call $~lib/array/Array<std/array/Ref | null>#__get
      local.set $3
      i32.const 2
      global.set $~argumentsLength
-     local.get $1
+     local.get $2
      local.get $3
      call $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0
      i32.const 0
      i32.gt_s
      if
-      local.get $0
-      call $~lib/rt/pure/__release
       local.get $1
+      call $~lib/rt/pure/__release
+      local.get $2
       call $~lib/rt/pure/__release
       local.get $3
       call $~lib/rt/pure/__release
       i32.const 0
       br $__inlined_func$std/array/isSorted<~lib/string/String | null>
      end
-     local.get $1
+     local.get $2
      call $~lib/rt/pure/__release
      local.get $3
      call $~lib/rt/pure/__release
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $for-loop|00
     end
    end
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
    i32.const 1
   end

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6613,6 +6613,80 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
+ (func $std/array/createRandomString (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  i32.const 6112
+  local.set $1
+  loop $for-loop|0
+   local.get $4
+   local.get $0
+   i32.lt_s
+   if
+    local.get $1
+    block $__inlined_func$~lib/string/String#charAt (result i32)
+     i32.const 6112
+     call $~lib/math/NativeMath.random
+     i32.const 5136
+     call $~lib/string/String#get:length
+     f64.convert_i32_s
+     f64.mul
+     f64.floor
+     i32.trunc_f64_s
+     local.tee $3
+     i32.const 5136
+     call $~lib/string/String#get:length
+     i32.ge_u
+     br_if $__inlined_func$~lib/string/String#charAt
+     drop
+     i32.const 2
+     i32.const 1
+     call $~lib/rt/tlsf/__alloc
+     local.tee $2
+     local.get $3
+     i32.const 1
+     i32.shl
+     i32.const 5136
+     i32.add
+     i32.load16_u
+     i32.store16
+     local.get $2
+     call $~lib/rt/pure/__retain
+    end
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $5
+    local.set $2
+    local.get $5
+    local.get $1
+    local.tee $3
+    i32.ne
+    if
+     local.get $2
+     call $~lib/rt/pure/__retain
+     local.set $2
+     local.get $3
+     call $~lib/rt/pure/__release
+    end
+    local.get $2
+    local.set $1
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $5
+    call $~lib/rt/pure/__release
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
+    br $for-loop|0
+   end
+  end
+  local.get $1
+ )
  (func $~lib/string/String#substring (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -10929,13 +11003,13 @@
   local.tee $0
   local.get $2
   i32.load
-  local.tee $4
+  local.tee $7
   i32.ne
   if
    local.get $0
    call $~lib/rt/pure/__retain
    local.set $0
-   local.get $4
+   local.get $7
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -11028,7 +11102,7 @@
   i32.const 1600
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $4
   call $std/array/isArraysEqual<u8>
   i32.eqz
   if
@@ -11052,7 +11126,7 @@
   i32.const 1632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $7
   call $std/array/isArraysEqual<u8>
   i32.eqz
   if
@@ -11076,7 +11150,7 @@
   i32.const 1664
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $12
   call $std/array/isArraysEqual<u8>
   i32.eqz
   if
@@ -11093,11 +11167,11 @@
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $12
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -11168,7 +11242,7 @@
   i32.const 1840
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $4
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11193,7 +11267,7 @@
   i32.const 1888
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $7
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11218,7 +11292,7 @@
   i32.const 1936
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $12
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11236,11 +11310,11 @@
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $12
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   i32.load offset=12
@@ -11580,7 +11654,7 @@
   i32.const 2032
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $7
   call $~lib/array/Array<i32>#concat
   call $~lib/rt/pure/__release
   global.get $std/array/arr
@@ -11783,10 +11857,10 @@
   local.get $2
   global.get $std/array/arr
   call $~lib/array/Array<i32>#concat
-  local.set $3
+  local.set $4
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   i32.load offset=12
   i32.const 3
   i32.ne
@@ -11810,9 +11884,9 @@
   end
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -11834,7 +11908,7 @@
   i32.const 2112
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $4
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11860,14 +11934,14 @@
   i32.const 3
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $4
+  local.tee $7
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2208
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $12
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11892,14 +11966,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $15
+  local.tee $6
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2304
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $5
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11924,14 +11998,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $6
+  local.tee $9
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2400
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11956,14 +12030,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $7
+  local.tee $8
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2496
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $13
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -11988,14 +12062,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $12
+  local.tee $14
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2592
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $15
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12027,7 +12101,7 @@
   i32.const 2688
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $17
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12052,14 +12126,14 @@
   i32.const -2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $17
+  local.tee $18
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12084,14 +12158,14 @@
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $14
+  local.tee $16
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2880
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $21
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12109,22 +12183,21 @@
   i32.const 2928
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $0
+  local.tee $1
   i32.const -4
   i32.const -3
   i32.const -2
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $19
+  local.tee $20
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 2976
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12142,15 +12215,15 @@
   i32.const 3024
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $22
+  local.tee $23
   i32.const 5
   i32.const 2
   i32.const 3
@@ -12175,15 +12248,15 @@
   i32.const 3120
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.const -4
   i32.const -3
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $1
+  local.tee $0
   i32.const 5
   i32.const 2
   i32.const 3
@@ -12202,53 +12275,53 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $4
-  call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $15
-  call $~lib/rt/pure/__release
-  local.get $23
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $8
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
+  local.get $12
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $9
+  call $~lib/rt/pure/__release
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $28
+  local.get $14
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $28
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $14
-  call $~lib/rt/pure/__release
-  local.get $20
-  call $~lib/rt/pure/__release
   local.get $19
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $21
   call $~lib/rt/pure/__release
+  local.get $20
+  call $~lib/rt/pure/__release
   local.get $22
+  call $~lib/rt/pure/__release
+  local.get $23
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
@@ -12831,7 +12904,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $1
-  local.set $4
+  local.set $7
   i32.const 0
   local.set $0
   block $__inlined_func$~lib/array/Array<f32>#indexOf
@@ -12850,15 +12923,15 @@
     local.set $0
     br $__inlined_func$~lib/array/Array<f32>#indexOf
    end
-   local.get $4
+   local.get $7
    i32.load offset=4
-   local.set $3
+   local.set $4
    loop $while-continue|0
     local.get $0
     local.get $2
     i32.lt_s
     if
-     local.get $3
+     local.get $4
      local.get $0
      i32.const 2
      i32.shl
@@ -12895,16 +12968,16 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $2
-  local.set $9
+  local.set $12
   i32.const 0
   local.set $0
   block $__inlined_func$~lib/array/Array<f64>#indexOf
    local.get $2
    i32.load offset=12
-   local.tee $3
+   local.tee $4
    if (result i32)
     i32.const 0
-    local.get $3
+    local.get $4
     i32.ge_s
    else
     i32.const 1
@@ -12914,15 +12987,15 @@
     local.set $0
     br $__inlined_func$~lib/array/Array<f64>#indexOf
    end
-   local.get $9
+   local.get $12
    i32.load offset=4
-   local.set $4
+   local.set $7
    loop $while-continue|019
     local.get $0
-    local.get $3
+    local.get $4
     i32.lt_s
     if
-     local.get $4
+     local.get $7
      local.get $0
      i32.const 3
      i32.shl
@@ -13104,10 +13177,10 @@
    call $~lib/rt/pure/__retain
    local.tee $2
    i32.load offset=12
-   local.tee $3
+   local.tee $4
    if (result i32)
     i32.const 0
-    local.get $3
+    local.get $4
     i32.ge_s
    else
     i32.const 1
@@ -13116,14 +13189,14 @@
    drop
    local.get $2
    i32.load offset=4
-   local.set $9
+   local.set $12
    loop $while-continue|020
     local.get $0
-    local.get $3
+    local.get $4
     i32.lt_s
     if
      i32.const 1
-     local.get $9
+     local.get $12
      local.get $0
      i32.const 2
      i32.shl
@@ -13169,28 +13242,28 @@
    i32.const 3312
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $3
-   i32.load offset=12
    local.tee $4
+   i32.load offset=12
+   local.tee $7
    if (result i32)
     i32.const 0
-    local.get $4
+    local.get $7
     i32.ge_s
    else
     i32.const 1
    end
    br_if $__inlined_func$~lib/array/Array<f64>#includes
    drop
-   local.get $3
+   local.get $4
    i32.load offset=4
-   local.set $15
+   local.set $6
    loop $while-continue|021
     local.get $0
-    local.get $4
+    local.get $7
     i32.lt_s
     if
      i32.const 1
-     local.get $15
+     local.get $6
      local.get $0
      i32.const 3
      i32.shl
@@ -13283,7 +13356,7 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 2
@@ -13295,14 +13368,14 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $3
+  local.tee $6
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 3392
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $5
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13321,7 +13394,7 @@
   i32.const 3440
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $9
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13346,14 +13419,14 @@
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $8
+  local.tee $10
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 3504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $8
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13372,7 +13445,7 @@
   i32.const 3520
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $13
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13397,14 +13470,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $12
+  local.tee $14
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 3616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $15
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13423,7 +13496,7 @@
   i32.const 3648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $17
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13441,21 +13514,21 @@
   i32.const 3680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $0
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#splice
-  local.tee $17
+  local.tee $18
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 3728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13467,14 +13540,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $0
   i32.const 3
   i32.const 2
   i32.const 3
   i32.const 3760
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13492,21 +13565,20 @@
   i32.const 3792
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $2
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $20
+  local.tee $21
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 3840
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $20
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13525,7 +13597,7 @@
   i32.const 3872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13549,7 +13621,7 @@
   i32.const -1
   i32.const 2147483647
   call $~lib/array/Array<i32>#splice
-  local.tee $22
+  local.tee $23
   i32.const 1
   i32.const 2
   i32.const 3
@@ -13998,7 +14070,7 @@
   local.tee $1
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#splice
-  local.tee $15
+  local.tee $7
   i32.load offset=12
   if
    i32.const 0
@@ -14024,7 +14096,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $4
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -14048,13 +14120,13 @@
   i32.store offset=16
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $4
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#splice
-  local.set $23
-  local.get $15
+  local.set $12
+  local.get $7
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $12
   i32.load offset=12
   i32.const 2
   i32.ne
@@ -14066,7 +14138,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
+  local.get $12
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $55
@@ -14081,7 +14153,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
+  local.get $12
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $56
@@ -14096,7 +14168,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $4
   i32.load offset=12
   i32.const 3
   i32.ne
@@ -14108,7 +14180,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $4
   i32.const 0
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $57
@@ -14123,7 +14195,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $4
   i32.const 1
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $58
@@ -14138,7 +14210,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $4
   i32.const 2
   call $~lib/array/Array<std/array/Ref>#__get
   local.tee $59
@@ -14159,7 +14231,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $7
   i32.load offset=4
   local.tee $0
   i32.const 1
@@ -14172,7 +14244,7 @@
   i32.const 2
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $15
+  local.get $7
   call $~lib/array/Array<std/array/Ref | null>#splice
   local.tee $28
   i32.load offset=12
@@ -14211,7 +14283,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $15
+  local.get $7
   i32.load offset=12
   i32.const 2
   i32.ne
@@ -14223,7 +14295,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $15
+  local.get $7
   i32.const 0
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $60
@@ -14235,7 +14307,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $15
+  local.get $7
   i32.const 1
   call $~lib/array/Array<std/array/Ref | null>#__get
   local.tee $1
@@ -14262,37 +14334,37 @@
   end
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $5
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__release
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $15
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $14
-  call $~lib/rt/pure/__release
-  local.get $20
-  call $~lib/rt/pure/__release
   local.get $19
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $21
   call $~lib/rt/pure/__release
+  local.get $20
+  call $~lib/rt/pure/__release
   local.get $22
+  call $~lib/rt/pure/__release
+  local.get $23
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
@@ -14842,17 +14914,17 @@
    unreachable
   end
   loop $for-loop|0
-   local.get $5
+   local.get $3
    i32.const 100
    i32.lt_s
    if
     global.get $std/array/arr
     call $~lib/array/Array<i32>#pop
     drop
-    local.get $5
+    local.get $3
     i32.const 1
     i32.add
-    local.set $5
+    local.set $3
     br $for-loop|0
    end
   end
@@ -14885,7 +14957,7 @@
   call $~lib/rt/pure/__retain
   local.tee $1
   i32.load offset=4
-  local.set $4
+  local.set $6
   loop $for-loop|039
    local.get $0
    local.get $3
@@ -14906,13 +14978,13 @@
     i32.load offset=4
     i32.add
     i32.load
-    local.set $6
+    local.set $9
     i32.const 3
     global.set $~argumentsLength
-    local.get $4
     local.get $5
-    i32.add
     local.get $6
+    i32.add
+    local.get $9
     f32.convert_i32_s
     f32.store
     local.get $0
@@ -15547,7 +15619,7 @@
   i32.const 5376
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $19
   call $std/array/isArraysEqual<f32>
   i32.eqz
   if
@@ -15633,7 +15705,7 @@
   i32.const 5504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $16
   call $std/array/isArraysEqual<f64>
   i32.eqz
   if
@@ -15664,7 +15736,7 @@
   i32.const 5632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $21
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15682,21 +15754,21 @@
   i32.const 5680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $4
+  local.set $6
   i32.const 0
   global.set $~argumentsLength
-  local.get $4
+  local.get $6
   i32.const 0
   call $~lib/array/Array<u32>#sort@varargs
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $6
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 5728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $20
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15714,7 +15786,7 @@
   i32.const 5776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $16
+  local.set $17
   i32.const 1
   i32.const 2
   i32.const 3
@@ -15728,14 +15800,14 @@
   i32.const 5824
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
+  local.set $9
   i32.const 4
   i32.const 2
   i32.const 3
   i32.const 5856
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $10
   i32.const 4
   i32.const 2
   i32.const 3
@@ -15745,20 +15817,20 @@
   local.set $2
   i32.const 64
   call $std/array/createReverseOrderedArray
-  local.set $7
+  local.set $8
   i32.const 128
   call $std/array/createReverseOrderedArray
-  local.set $10
+  local.set $13
   i32.const 1024
   call $std/array/createReverseOrderedArray
-  local.set $12
+  local.set $14
   i32.const 10000
   call $std/array/createReverseOrderedArray
-  local.set $13
+  local.set $15
   i32.const 512
   call $std/array/createRandomOrderedArray
-  local.set $17
-  local.get $16
+  local.set $18
+  local.get $17
   call $std/array/assertSortedDefault<i32>
   local.get $5
   call $std/array/assertSortedDefault<i32>
@@ -15769,7 +15841,7 @@
   i32.const 5920
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15781,16 +15853,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $9
   call $std/array/assertSortedDefault<i32>
-  local.get $6
+  local.get $9
   i32.const 2
   i32.const 2
   i32.const 3
   i32.const 5952
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $23
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15802,9 +15874,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $10
   call $std/array/assertSortedDefault<i32>
-  local.get $8
+  local.get $10
   local.get $2
   i32.const 0
   call $std/array/isArraysEqual<u32>
@@ -15817,9 +15889,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $8
   call $std/array/assertSortedDefault<i32>
-  local.get $7
+  local.get $8
   local.get $2
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15832,9 +15904,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $10
+  local.get $13
   call $std/array/assertSortedDefault<i32>
-  local.get $10
+  local.get $13
   local.get $2
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15847,9 +15919,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $12
+  local.get $14
   call $std/array/assertSortedDefault<i32>
-  local.get $12
+  local.get $14
   local.get $2
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15862,9 +15934,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $13
+  local.get $15
   call $std/array/assertSortedDefault<i32>
-  local.get $13
+  local.get $15
   local.get $2
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15877,47 +15949,47 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $17
+  local.get $18
   call $std/array/assertSortedDefault<i32>
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $20
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
-  local.get $16
-  call $~lib/rt/pure/__release
-  local.get $5
+  local.get $21
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $13
+  local.get $20
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
-  local.get $21
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $9
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $13
+  call $~lib/rt/pure/__release
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $18
   call $~lib/rt/pure/__release
   local.get $22
+  call $~lib/rt/pure/__release
+  local.get $23
   call $~lib/rt/pure/__release
   i32.const 64
   call $std/array/createRandomOrderedArray
@@ -15959,32 +16031,32 @@
   i32.const 6128
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $1
   i32.const 7
   i32.const 2
   i32.const 15
   i32.const 6176
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $5
   i32.const 1
   global.set $~argumentsLength
   block $__inlined_func$std/array/isSorted<~lib/string/String | null> (result i32)
    i32.const 1
    local.set $2
-   local.get $5
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.tee $4
+   local.tee $9
    i32.const 55
    call $~lib/array/Array<~lib/array/Array<i32>>#sort
-   local.tee $6
+   local.tee $10
    call $~lib/rt/pure/__retain
    local.tee $0
    i32.load offset=12
-   local.set $7
+   local.set $8
    loop $for-loop|00
     local.get $2
-    local.get $7
+    local.get $8
     i32.lt_s
     if
      local.get $0
@@ -15992,31 +16064,31 @@
      i32.const 1
      i32.sub
      call $~lib/array/Array<std/array/Ref | null>#__get
-     local.set $1
+     local.set $3
      local.get $0
      local.get $2
      call $~lib/array/Array<std/array/Ref | null>#__get
-     local.set $3
+     local.set $6
      i32.const 2
      global.set $~argumentsLength
-     local.get $1
      local.get $3
+     local.get $6
      call $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0
      i32.const 0
      i32.gt_s
      if
       local.get $0
       call $~lib/rt/pure/__release
-      local.get $1
-      call $~lib/rt/pure/__release
       local.get $3
+      call $~lib/rt/pure/__release
+      local.get $6
       call $~lib/rt/pure/__release
       i32.const 0
       br $__inlined_func$std/array/isSorted<~lib/string/String | null>
      end
-     local.get $1
-     call $~lib/rt/pure/__release
      local.get $3
+     call $~lib/rt/pure/__release
+     local.get $6
      call $~lib/rt/pure/__release
      local.get $2
      i32.const 1
@@ -16038,12 +16110,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $9
   call $~lib/rt/pure/__release
+  local.get $1
   local.get $5
-  local.get $8
   call $std/array/isArraysEqual<~lib/string/String | null>
   i32.eqz
   if
@@ -16059,91 +16131,24 @@
   i32.const 0
   i32.const 400
   call $~lib/array/Array<~lib/string/String>#constructor
-  local.set $1
+  local.set $2
   loop $for-loop|06
    local.get $0
    i32.const 400
    i32.lt_s
    if
+    local.get $2
     local.get $0
-    local.set $3
     call $~lib/math/NativeMath.random
     f64.const 32
     f64.mul
     i32.trunc_f64_s
-    local.set $7
-    i32.const 0
-    local.set $6
-    i32.const 6112
-    local.set $0
-    loop $for-loop|01
-     local.get $6
-     local.get $7
-     i32.lt_s
-     if
-      block $__inlined_func$~lib/string/String#charAt (result i32)
-       i32.const 6112
-       call $~lib/math/NativeMath.random
-       i32.const 5136
-       call $~lib/string/String#get:length
-       f64.convert_i32_s
-       f64.mul
-       f64.floor
-       i32.trunc_f64_s
-       local.tee $2
-       i32.const 5136
-       call $~lib/string/String#get:length
-       i32.ge_u
-       br_if $__inlined_func$~lib/string/String#charAt
-       drop
-       i32.const 2
-       i32.const 1
-       call $~lib/rt/tlsf/__alloc
-       local.tee $4
-       local.get $2
-       i32.const 1
-       i32.shl
-       i32.const 5136
-       i32.add
-       i32.load16_u
-       i32.store16
-       local.get $4
-       call $~lib/rt/pure/__retain
-      end
-      local.set $2
-      local.get $0
-      local.tee $4
-      local.get $0
-      local.get $2
-      call $~lib/string/String.__concat
-      local.tee $10
-      local.tee $0
-      i32.ne
-      if
-       local.get $0
-       call $~lib/rt/pure/__retain
-       local.set $0
-       local.get $4
-       call $~lib/rt/pure/__release
-      end
-      local.get $2
-      call $~lib/rt/pure/__release
-      local.get $10
-      call $~lib/rt/pure/__release
-      local.get $6
-      i32.const 1
-      i32.add
-      local.set $6
-      br $for-loop|01
-     end
-    end
-    local.get $1
-    local.get $3
-    local.get $0
+    call $std/array/createRandomString
+    local.tee $3
     call $~lib/array/Array<~lib/array/Array<i32>>#__set
-    local.get $0
-    call $~lib/rt/pure/__release
     local.get $3
+    call $~lib/rt/pure/__release
+    local.get $0
     i32.const 1
     i32.add
     local.set $0
@@ -16152,14 +16157,14 @@
   end
   i32.const 1
   global.set $~argumentsLength
-  local.get $1
+  local.get $2
   i32.const 56
   call $std/array/assertSorted<~lib/array/Array<i32>>
+  local.get $1
+  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   i32.const 2
   i32.const 0
@@ -16193,10 +16198,10 @@
   i32.const 6432
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $6
+  local.tee $9
   i32.const 6112
   call $~lib/array/Array<i32>#join
-  local.tee $8
+  local.tee $10
   i32.const 6784
   call $~lib/string/String.__eq
   i32.eqz
@@ -16214,10 +16219,10 @@
   i32.const 6816
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $8
   i32.const 6848
   call $~lib/array/Array<u32>#join
-  local.tee $10
+  local.tee $13
   i32.const 6784
   call $~lib/string/String.__eq
   i32.eqz
@@ -16235,10 +16240,10 @@
   i32.const 6880
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $14
   i32.const 6912
   call $~lib/array/Array<i32>#join
-  local.tee $13
+  local.tee $15
   i32.const 6944
   call $~lib/string/String.__eq
   i32.eqz
@@ -16282,10 +16287,10 @@
   i32.const 8288
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $17
   i32.const 6112
   call $~lib/array/Array<~lib/string/String | null>#join
-  local.tee $17
+  local.tee $18
   i32.const 8256
   call $~lib/string/String.__eq
   i32.eqz
@@ -16303,7 +16308,7 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $4
+  local.tee $6
   i32.load offset=4
   local.tee $5
   i32.const 0
@@ -16316,9 +16321,9 @@
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=8
-  local.get $4
+  local.get $6
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $18
+  local.tee $19
   i32.const 8368
   call $~lib/string/String.__eq
   i32.eqz
@@ -16338,17 +16343,17 @@
   call $~lib/rt/pure/__retain
   local.tee $5
   i32.load offset=4
-  local.tee $14
+  local.tee $16
   i32.const 0
   call $std/array/Ref#constructor
   i32.store
-  local.get $14
+  local.get $16
   i32.const 0
   call $std/array/Ref#constructor
   i32.store offset=4
   local.get $5
   call $~lib/array/Array<std/array/Ref | null>#join
-  local.tee $14
+  local.tee $16
   i32.const 8448
   call $~lib/string/String.__eq
   i32.eqz
@@ -16364,33 +16369,33 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $7
+  local.get $9
   call $~lib/rt/pure/__release
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $13
+  call $~lib/rt/pure/__release
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $15
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $16
-  call $~lib/rt/pure/__release
   local.get $17
-  call $~lib/rt/pure/__release
-  local.get $4
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $19
+  call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $16
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 2
@@ -16405,7 +16410,7 @@
   i32.const 8544
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $4
+  local.set $6
   i32.const 2
   i32.const 2
   i32.const 3
@@ -16419,7 +16424,7 @@
   i32.const 8608
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $6
+  local.set $9
   local.get $3
   i32.const 6352
   call $~lib/array/Array<i32>#join
@@ -16436,11 +16441,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $6
   i32.const 6352
   call $~lib/array/Array<i32>#join
   local.tee $0
-  local.set $22
+  local.set $23
   local.get $0
   i32.const 8256
   call $~lib/string/String.__eq
@@ -16470,7 +16475,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $9
   i32.const 6352
   call $~lib/array/Array<i32>#join
   local.tee $0
@@ -16493,15 +16498,15 @@
   i32.const 8704
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $10
   i32.load offset=4
-  local.get $8
+  local.get $10
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i8>
-  local.set $7
+  local.set $8
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $8
   i32.const 8736
   call $~lib/string/String.__eq
   i32.eqz
@@ -16519,15 +16524,15 @@
   i32.const 8768
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $13
   i32.load offset=4
-  local.get $10
+  local.get $13
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u16>
-  local.set $12
+  local.set $14
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $14
   i32.const 8800
   call $~lib/string/String.__eq
   i32.eqz
@@ -16545,15 +16550,15 @@
   i32.const 8848
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $15
   i32.load offset=4
-  local.get $13
+  local.get $15
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<u64>
-  local.set $16
+  local.set $17
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $17
   i32.const 8896
   call $~lib/string/String.__eq
   i32.eqz
@@ -16571,15 +16576,15 @@
   i32.const 8960
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $18
   i32.load offset=4
-  local.get $17
+  local.get $18
   i32.load offset=12
   call $~lib/util/string/joinIntegerArray<i64>
-  local.set $18
+  local.set $19
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $19
   i32.const 9008
   call $~lib/string/String.__eq
   i32.eqz
@@ -16666,10 +16671,10 @@
   local.get $0
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>
-  local.set $14
+  local.set $16
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $16
   i32.const 9408
   call $~lib/string/String.__eq
   i32.eqz
@@ -16710,10 +16715,10 @@
   local.get $1
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>
-  local.set $20
+  local.set $21
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $21
   i32.const 9408
   call $~lib/string/String.__eq
   i32.eqz
@@ -16755,10 +16760,10 @@
   local.get $2
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>
-  local.set $19
+  local.set $20
   i32.const 6352
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $20
   i32.const 8256
   call $~lib/string/String.__eq
   i32.eqz
@@ -16772,34 +16777,34 @@
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $9
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $23
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $15
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
   local.get $18
+  call $~lib/rt/pure/__release
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $29
   call $~lib/rt/pure/__release
@@ -16809,11 +16814,11 @@
   call $~lib/rt/pure/__release
   local.get $32
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $21
   call $~lib/rt/pure/__release
   local.get $20
-  call $~lib/rt/pure/__release
-  local.get $19
   call $~lib/rt/pure/__release
   global.get $std/array/arr
   call $~lib/rt/pure/__release
@@ -16859,7 +16864,7 @@
   i32.store offset=12
   local.get $5
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $6
+  local.tee $9
   i32.load offset=12
   i32.const 10
   i32.ne
@@ -16876,7 +16881,7 @@
    i32.const 10
    i32.lt_s
    if
-    local.get $6
+    local.get $9
     local.get $11
     call $~lib/array/Array<u32>#__get
     local.get $11
@@ -16902,9 +16907,9 @@
   i32.const 0
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $10
   i32.load offset=4
-  local.tee $3
+  local.tee $11
   i32.const 1
   i32.const 2
   i32.const 15
@@ -16912,7 +16917,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $3
+  local.get $11
   i32.const 3
   i32.const 2
   i32.const 15
@@ -16920,7 +16925,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $3
+  local.get $11
   i32.const 3
   i32.const 2
   i32.const 15
@@ -16928,7 +16933,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=8
-  local.get $3
+  local.get $11
   i32.const 1
   i32.const 2
   i32.const 15
@@ -16936,7 +16941,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store offset=12
-  local.get $8
+  local.get $10
   call $~lib/array/Array<~lib/array/Array<~lib/string/String | null>>#flat
   local.set $3
   i32.const 8
@@ -16945,7 +16950,7 @@
   i32.const 10016
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $4
+  local.set $6
   local.get $3
   i32.load offset=12
   i32.const 8
@@ -16962,18 +16967,18 @@
   local.set $11
   loop $for-loop|2
    local.get $11
-   local.get $4
+   local.get $6
    i32.load offset=12
    i32.lt_s
    if
     local.get $3
     local.get $11
     call $~lib/array/Array<std/array/Ref | null>#__get
-    local.tee $7
-    local.get $4
+    local.tee $8
+    local.get $6
     local.get $11
     call $~lib/array/Array<std/array/Ref | null>#__get
-    local.tee $10
+    local.tee $13
     call $~lib/string/String.__eq
     i32.eqz
     if
@@ -16984,9 +16989,9 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $7
+    local.get $8
     call $~lib/rt/pure/__release
-    local.get $10
+    local.get $13
     call $~lib/rt/pure/__release
     local.get $11
     i32.const 1
@@ -17003,7 +17008,7 @@
   call $~lib/rt/pure/__retain
   local.tee $11
   i32.load offset=4
-  local.tee $7
+  local.tee $8
   i32.const 0
   i32.const 2
   i32.const 3
@@ -17011,7 +17016,7 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $7
+  local.get $8
   i32.const 0
   i32.const 2
   i32.const 3
@@ -17021,7 +17026,7 @@
   i32.store offset=4
   local.get $11
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
-  local.tee $7
+  local.tee $8
   i32.load offset=12
   if
    i32.const 0
@@ -17033,13 +17038,13 @@
   end
   local.get $11
   call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $12
+  call $~lib/rt/pure/__release
   local.get $7
-  call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $23
-  call $~lib/rt/pure/__release
-  local.get $15
   call $~lib/rt/pure/__release
   local.get $28
   call $~lib/rt/pure/__release
@@ -17051,13 +17056,13 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $9
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $6
   call $~lib/rt/pure/__release
  )
  (func $~lib/array/Array<u32>#constructor (param $0 i32) (param $1 i32) (result i32)

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -1603,16 +1603,16 @@
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $5
   i32.const 0
   i32.store
-  local.get $3
+  local.get $5
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $5
   i32.const 0
   i32.store offset=12
   local.get $0
@@ -1632,37 +1632,37 @@
   local.tee $4
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
+  local.tee $2
   i32.const 0
   local.get $4
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $5
   i32.load
-  local.tee $5
+  local.tee $3
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
+  local.get $5
   local.get $1
+  i32.store
+  local.get $5
+  local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $5
   local.get $4
   i32.store offset=8
-  local.get $3
+  local.get $5
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $5
  )
  (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (param $0 i32) (result i32)
   local.get $0
@@ -4135,66 +4135,66 @@
  (func $~lib/util/sort/insertionSort<f32> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f32)
+  (local $4 i32)
   (local $5 f32)
-  (local $6 i32)
+  (local $6 f32)
   loop $for-loop|0
-   local.get $6
+   local.get $4
    local.get $1
    i32.lt_s
    if
     local.get $0
-    local.get $6
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     f32.load
     local.set $5
-    local.get $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $2
     loop $while-continue|1
-     local.get $3
+     local.get $2
      i32.const 0
      i32.ge_s
      if
       block $while-break|1
        local.get $0
-       local.get $3
+       local.get $2
        i32.const 2
        i32.shl
        i32.add
        f32.load
-       local.set $4
+       local.set $6
        i32.const 2
        global.set $~argumentsLength
        local.get $5
-       local.get $4
+       local.get $6
        call $~lib/util/sort/COMPARATOR<f32>~anonymous|0
        i32.const 0
        i32.ge_s
        br_if $while-break|1
-       local.get $3
-       local.tee $2
+       local.get $2
+       local.tee $3
        i32.const 1
        i32.sub
-       local.set $3
+       local.set $2
        local.get $0
-       local.get $2
+       local.get $3
        i32.const 1
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $6
        f32.store
        br $while-continue|1
       end
      end
     end
     local.get $0
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
     i32.const 2
@@ -4202,10 +4202,10 @@
     i32.add
     local.get $5
     f32.store
-    local.get $6
+    local.get $4
     i32.const 1
     i32.add
-    local.set $6
+    local.set $4
     br $for-loop|0
    end
   end
@@ -4578,66 +4578,66 @@
  (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f64)
+  (local $4 i32)
   (local $5 f64)
-  (local $6 i32)
+  (local $6 f64)
   loop $for-loop|0
-   local.get $6
+   local.get $4
    local.get $1
    i32.lt_s
    if
     local.get $0
-    local.get $6
+    local.get $4
     i32.const 3
     i32.shl
     i32.add
     f64.load
     local.set $5
-    local.get $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $2
     loop $while-continue|1
-     local.get $3
+     local.get $2
      i32.const 0
      i32.ge_s
      if
       block $while-break|1
        local.get $0
-       local.get $3
+       local.get $2
        i32.const 3
        i32.shl
        i32.add
        f64.load
-       local.set $4
+       local.set $6
        i32.const 2
        global.set $~argumentsLength
        local.get $5
-       local.get $4
+       local.get $6
        call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
        i32.const 0
        i32.ge_s
        br_if $while-break|1
-       local.get $3
-       local.tee $2
+       local.get $2
+       local.tee $3
        i32.const 1
        i32.sub
-       local.set $3
+       local.set $2
        local.get $0
-       local.get $2
+       local.get $3
        i32.const 1
        i32.add
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $6
        f64.store
        br $while-continue|1
       end
      end
     end
     local.get $0
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
     i32.const 3
@@ -4645,10 +4645,10 @@
     i32.add
     local.get $5
     f64.store
-    local.get $6
+    local.get $4
     i32.const 1
     i32.add
-    local.set $6
+    local.set $4
     br $for-loop|0
    end
   end
@@ -5046,63 +5046,63 @@
   (local $6 i32)
   (local $7 i32)
   loop $for-loop|0
-   local.get $7
+   local.get $5
    local.get $1
    i32.lt_s
    if
     local.get $0
-    local.get $7
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
     i32.load
     local.set $6
-    local.get $7
+    local.get $5
     i32.const 1
     i32.sub
-    local.set $4
+    local.set $3
     loop $while-continue|1
-     local.get $4
+     local.get $3
      i32.const 0
      i32.ge_s
      if
       block $while-break|1
        local.get $0
-       local.get $4
+       local.get $3
        i32.const 2
        i32.shl
        i32.add
        i32.load
-       local.set $5
+       local.set $7
        i32.const 2
        global.set $~argumentsLength
        local.get $6
-       local.get $5
+       local.get $7
        local.get $2
        call_indirect (type $i32_i32_=>_i32)
        i32.const 0
        i32.ge_s
        br_if $while-break|1
-       local.get $4
-       local.tee $3
+       local.get $3
+       local.tee $4
        i32.const 1
        i32.sub
-       local.set $4
+       local.set $3
        local.get $0
-       local.get $3
+       local.get $4
        i32.const 1
        i32.add
        i32.const 2
        i32.shl
        i32.add
-       local.get $5
+       local.get $7
        i32.store
        br $while-continue|1
       end
      end
     end
     local.get $0
-    local.get $4
+    local.get $3
     i32.const 1
     i32.add
     i32.const 2
@@ -5110,10 +5110,10 @@
     i32.add
     local.get $6
     i32.store
-    local.get $7
+    local.get $5
     i32.const 1
     i32.add
-    local.set $7
+    local.set $5
     br $for-loop|0
    end
   end
@@ -5385,7 +5385,7 @@
   (local $4 i32)
   local.get $0
   i32.load offset=12
-  local.tee $3
+  local.tee $2
   i32.const 1
   i32.le_s
   if
@@ -5396,48 +5396,48 @@
   local.get $0
   i32.load offset=4
   local.set $4
-  local.get $3
+  local.get $2
   i32.const 2
   i32.eq
   if
    local.get $4
    i32.load offset=4
-   local.set $3
+   local.set $2
    local.get $4
    i32.load
-   local.set $2
+   local.set $3
    i32.const 2
    global.set $~argumentsLength
-   local.get $3
    local.get $2
+   local.get $3
    local.get $1
    call_indirect (type $i32_i32_=>_i32)
    i32.const 0
    i32.lt_s
    if
     local.get $4
-    local.get $2
+    local.get $3
     i32.store offset=4
     local.get $4
-    local.get $3
+    local.get $2
     i32.store
    end
    local.get $0
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $3
-  local.tee $2
+  local.get $2
+  local.tee $3
   i32.const 256
   i32.lt_s
   if
    local.get $4
-   local.get $2
+   local.get $3
    local.get $1
    call $~lib/util/sort/insertionSort<i32>
   else
    local.get $4
-   local.get $2
+   local.get $3
    local.get $1
    call $~lib/util/sort/weakHeapSort<i32>
   end
@@ -5723,49 +5723,49 @@
   i32.const 12
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $4
   i32.const 0
   i32.store
-  local.get $2
+  local.get $4
   i32.const 0
   i32.store offset=4
-  local.get $2
+  local.get $4
   i32.const 0
   i32.store offset=8
-  local.get $2
+  local.get $4
   i32.const 0
   i32.store offset=12
   i32.const 8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.const 8
   call $~lib/memory/memory.fill
-  local.get $0
-  local.set $1
-  local.get $0
-  local.get $2
+  local.get $1
+  local.set $0
+  local.get $1
+  local.get $4
   i32.load
-  local.tee $4
+  local.tee $2
   i32.ne
   if
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
+   local.set $0
+   local.get $2
    call $~lib/rt/pure/__release
   end
-  local.get $2
-  local.get $1
-  i32.store
-  local.get $2
+  local.get $4
   local.get $0
+  i32.store
+  local.get $4
+  local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $4
   i32.const 8
   i32.store offset=8
-  local.get $2
+  local.get $4
   i32.const 2
   i32.store offset=12
   loop $for-loop|0
@@ -5775,17 +5775,17 @@
    if
     i32.const 1
     call $~lib/array/Array<i32>#constructor
-    local.tee $0
+    local.tee $1
     i32.const 0
     i32.const 1
     local.get $3
     i32.sub
     call $~lib/array/Array<i32>#__set
-    local.get $2
+    local.get $4
     local.get $3
-    local.get $0
+    local.get $1
     call $~lib/array/Array<~lib/array/Array<i32>>#__set
-    local.get $0
+    local.get $1
     call $~lib/rt/pure/__release
     local.get $3
     i32.const 1
@@ -5794,7 +5794,7 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $4
  )
  (func $start:std/array~anonymous|47 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -6056,49 +6056,49 @@
   i32.const 14
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $4
   i32.const 0
   i32.store
-  local.get $2
+  local.get $4
   i32.const 0
   i32.store offset=4
-  local.get $2
+  local.get $4
   i32.const 0
   i32.store offset=8
-  local.get $2
+  local.get $4
   i32.const 0
   i32.store offset=12
   i32.const 2048
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.const 2048
   call $~lib/memory/memory.fill
-  local.get $0
-  local.set $1
-  local.get $0
-  local.get $2
+  local.get $1
+  local.set $0
+  local.get $1
+  local.get $4
   i32.load
-  local.tee $4
+  local.tee $2
   i32.ne
   if
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
+   local.set $0
+   local.get $2
    call $~lib/rt/pure/__release
   end
-  local.get $2
-  local.get $1
-  i32.store
-  local.get $2
+  local.get $4
   local.get $0
+  i32.store
+  local.get $4
+  local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $4
   i32.const 2048
   i32.store offset=8
-  local.get $2
+  local.get $4
   i32.const 512
   i32.store offset=12
   loop $for-loop|0
@@ -6110,16 +6110,16 @@
     i32.const 13
     call $~lib/rt/tlsf/__alloc
     call $~lib/rt/pure/__retain
-    local.tee $0
+    local.tee $1
     i32.const 511
     local.get $3
     i32.sub
     i32.store
-    local.get $2
+    local.get $4
     local.get $3
-    local.get $0
+    local.get $1
     call $~lib/array/Array<~lib/array/Array<i32>>#__set
-    local.get $0
+    local.get $1
     call $~lib/rt/pure/__release
     local.get $3
     i32.const 1
@@ -6128,7 +6128,7 @@
     br $for-loop|0
    end
   end
-  local.get $2
+  local.get $4
  )
  (func $start:std/array~anonymous|48 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -6505,35 +6505,35 @@
   local.get $1
   i32.const 2
   i32.shl
-  local.tee $5
+  local.tee $4
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $3
+  local.tee $2
   i32.const 0
-  local.get $5
+  local.get $4
   call $~lib/memory/memory.fill
-  local.get $3
-  local.set $2
-  local.get $3
+  local.get $2
+  local.set $3
+  local.get $2
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $5
   i32.ne
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $4
+   local.set $3
+   local.get $5
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $2
+  local.get $3
   i32.store
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $4
   i32.store offset=8
   local.get $0
   local.get $1
@@ -6702,7 +6702,7 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
@@ -6711,7 +6711,7 @@
    i32.const 6112
    return
   end
-  local.get $5
+  local.get $4
   i32.eqz
   if
    i32.const 6288
@@ -6724,10 +6724,10 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $5
+  local.get $4
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $6
+  local.tee $5
   i32.const 5
   i32.add
   i32.mul
@@ -6739,22 +6739,22 @@
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $4
+  local.set $1
   loop $for-loop|1
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.lt_s
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.add
     i32.load8_u
     local.tee $9
     i32.eqz
     i32.const 4
     i32.add
-    local.set $1
-    local.get $4
+    local.set $7
+    local.get $1
     local.get $2
     i32.const 1
     i32.shl
@@ -6763,57 +6763,55 @@
     i32.const 6320
     local.get $9
     select
-    local.get $1
+    local.get $7
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $1
     local.get $2
+    local.get $7
     i32.add
-    local.set $1
-    local.get $6
+    local.set $2
+    local.get $5
     if
-     local.get $4
      local.get $1
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $6
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $1
-     local.get $6
+     local.get $2
+     local.get $5
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $1
-    local.set $2
-    local.get $7
+    local.get $6
     i32.const 1
     i32.add
-    local.set $7
+    local.set $6
     br $for-loop|1
    end
   end
   local.get $0
-  local.get $5
+  local.get $4
   i32.add
   i32.load8_u
-  local.tee $1
+  local.tee $4
   i32.eqz
   i32.const 4
   i32.add
   local.set $0
-  local.get $4
+  local.get $1
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   i32.const 6288
   i32.const 6320
-  local.get $1
+  local.get $4
   select
   local.get $0
   i32.const 1
@@ -6826,18 +6824,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $4
+   local.get $1
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $1
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $1
  )
  (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
@@ -8312,14 +8310,13 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
   i32.const 7072
   call $~lib/rt/pure/__retain
   local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $6
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
@@ -8328,7 +8325,7 @@
    i32.const 6112
    return
   end
-  local.get $6
+  local.get $5
   i32.eqz
   if
    block $__inlined_func$~lib/util/number/dtoa
@@ -8395,34 +8392,34 @@
    local.get $0
    return
   end
-  local.get $6
+  local.get $5
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $7
+  local.tee $6
   i32.const 28
   i32.add
   i32.mul
   i32.const 28
   i32.add
-  local.tee $9
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $1
   loop $for-loop|0
-   local.get $8
-   local.get $6
+   local.get $7
+   local.get $5
    i32.lt_s
    if
-    local.get $5
+    local.get $1
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $8
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
@@ -8430,41 +8427,39 @@
     call $~lib/util/number/dtoa_buffered
     local.get $2
     i32.add
-    local.set $1
-    local.get $7
+    local.set $2
+    local.get $6
     if
-     local.get $5
      local.get $1
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $7
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $1
-     local.get $7
+     local.get $2
+     local.get $6
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $1
-    local.set $2
-    local.get $8
+    local.get $7
     i32.const 1
     i32.add
-    local.set $8
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $9
-  local.get $5
+  local.get $8
+  local.get $1
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 3
   i32.shl
   i32.add
@@ -8475,18 +8470,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $5
+   local.get $1
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $1
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $1
  )
  (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -8917,14 +8912,13 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
   local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
@@ -8933,7 +8927,7 @@
    i32.const 6112
    return
   end
-  local.get $5
+  local.get $4
   i32.eqz
   if
    local.get $0
@@ -8943,74 +8937,72 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $5
+  local.get $4
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $6
+  local.tee $5
   i32.const 11
   i32.add
   i32.mul
   i32.const 11
   i32.add
-  local.tee $8
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $4
+  local.set $1
   loop $for-loop|0
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.lt_s
    if
-    local.get $4
+    local.get $1
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $7
+    local.get $6
     i32.add
     i32.load8_s
     call $~lib/util/number/itoa_buffered<i8>
     local.get $2
     i32.add
-    local.set $1
-    local.get $6
+    local.set $2
+    local.get $5
     if
-     local.get $4
      local.get $1
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $6
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $1
-     local.get $6
+     local.get $2
+     local.get $5
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $1
-    local.set $2
-    local.get $7
+    local.get $6
     i32.const 1
     i32.add
-    local.set $7
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $8
-  local.get $4
+  local.get $7
+  local.get $1
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   local.get $0
-  local.get $5
+  local.get $4
   i32.add
   i32.load8_s
   call $~lib/util/number/itoa_buffered<i8>
@@ -9019,18 +9011,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $4
+   local.get $1
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $1
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $1
  )
  (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -9069,14 +9061,13 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
   local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
@@ -9085,7 +9076,7 @@
    i32.const 6112
    return
   end
-  local.get $5
+  local.get $4
   i32.eqz
   if
    local.get $0
@@ -9095,34 +9086,34 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $5
+  local.get $4
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $6
+  local.tee $5
   i32.const 10
   i32.add
   i32.mul
   i32.const 10
   i32.add
-  local.tee $8
+  local.tee $7
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $4
+  local.set $1
   loop $for-loop|0
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.lt_s
    if
-    local.get $4
+    local.get $1
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 1
     i32.shl
     i32.add
@@ -9130,41 +9121,39 @@
     call $~lib/util/number/itoa_buffered<u16>
     local.get $2
     i32.add
-    local.set $1
-    local.get $6
+    local.set $2
+    local.get $5
     if
-     local.get $4
      local.get $1
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $6
+     local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $1
-     local.get $6
+     local.get $2
+     local.get $5
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $1
-    local.set $2
-    local.get $7
+    local.get $6
     i32.const 1
     i32.add
-    local.set $7
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $8
-  local.get $4
+  local.get $7
+  local.get $1
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   local.get $0
-  local.get $5
+  local.get $4
   i32.const 1
   i32.shl
   i32.add
@@ -9175,18 +9164,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $4
+   local.get $1
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $1
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $1
  )
  (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
@@ -9306,18 +9295,17 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i64)
+  (local $5 i64)
+  (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
   local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
@@ -9326,22 +9314,22 @@
    i32.const 6112
    return
   end
-  local.get $5
+  local.get $4
   i32.eqz
   if
    block $__inlined_func$~lib/util/number/utoa64 (result i32)
     i32.const 6656
     local.get $0
     i64.load
-    local.tee $6
+    local.tee $5
     i64.eqz
     br_if $__inlined_func$~lib/util/number/utoa64
     drop
-    local.get $6
+    local.get $5
     i64.const 4294967295
     i64.le_u
     if
-     local.get $6
+     local.get $5
      i32.wrap_i64
      local.tee $1
      call $~lib/util/number/decimalCount32
@@ -9355,7 +9343,7 @@
      local.get $2
      call $~lib/util/number/utoa_dec_simple<u32>
     else
-     local.get $6
+     local.get $5
      call $~lib/util/number/decimalCount64High
      local.tee $1
      i32.const 1
@@ -9363,7 +9351,7 @@
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $0
-     local.get $6
+     local.get $5
      local.get $1
      call $~lib/util/number/utoa_dec_simple<u64>
     end
@@ -9374,34 +9362,34 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $5
+  local.get $4
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $7
+  local.tee $6
   i32.const 20
   i32.add
   i32.mul
   i32.const 20
   i32.add
-  local.tee $9
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $4
+  local.set $1
   loop $for-loop|0
-   local.get $8
-   local.get $5
+   local.get $7
+   local.get $4
    i32.lt_s
    if
-    local.get $4
+    local.get $1
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $8
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
@@ -9409,41 +9397,39 @@
     call $~lib/util/number/itoa_buffered<u64>
     local.get $2
     i32.add
-    local.set $1
-    local.get $7
+    local.set $2
+    local.get $6
     if
-     local.get $4
      local.get $1
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $7
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $1
-     local.get $7
+     local.get $2
+     local.get $6
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $1
-    local.set $2
-    local.get $8
+    local.get $7
     i32.const 1
     i32.add
-    local.set $8
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $9
-  local.get $4
+  local.get $8
+  local.get $1
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   local.get $0
-  local.get $5
+  local.get $4
   i32.const 3
   i32.shl
   i32.add
@@ -9454,18 +9440,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $4
+   local.get $1
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $1
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $1
  )
  (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i64) (result i32)
   (local $2 i32)
@@ -9530,206 +9516,12 @@
  )
  (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i64)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  i32.const 6352
-  call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  i32.const 1
-  i32.sub
-  local.tee $6
-  i32.const 0
-  i32.lt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 6112
-   return
-  end
-  local.get $6
-  i32.eqz
-  if
-   block $__inlined_func$~lib/util/number/itoa64 (result i32)
-    i32.const 6656
-    local.get $0
-    i64.load
-    i32.wrap_i64
-    i64.extend_i32_s
-    local.tee $4
-    i64.eqz
-    br_if $__inlined_func$~lib/util/number/itoa64
-    drop
-    local.get $4
-    i64.const 63
-    i64.shr_u
-    i32.wrap_i64
-    local.tee $0
-    if
-     i64.const 0
-     local.get $4
-     i64.sub
-     local.set $4
-    end
-    local.get $4
-    i64.const 4294967295
-    i64.le_u
-    if
-     local.get $4
-     i32.wrap_i64
-     local.tee $2
-     call $~lib/util/number/decimalCount32
-     local.get $0
-     i32.add
-     local.tee $3
-     i32.const 1
-     i32.shl
-     i32.const 1
-     call $~lib/rt/tlsf/__alloc
-     local.tee $1
-     local.get $2
-     local.get $3
-     call $~lib/util/number/utoa_dec_simple<u32>
-    else
-     local.get $4
-     call $~lib/util/number/decimalCount64High
-     local.get $0
-     i32.add
-     local.tee $2
-     i32.const 1
-     i32.shl
-     i32.const 1
-     call $~lib/rt/tlsf/__alloc
-     local.tee $1
-     local.get $4
-     local.get $2
-     call $~lib/util/number/utoa_dec_simple<u64>
-    end
-    local.get $0
-    if
-     local.get $1
-     i32.const 45
-     i32.store16
-    end
-    local.get $1
-    call $~lib/rt/pure/__retain
-   end
-   local.get $5
-   call $~lib/rt/pure/__release
-   return
-  end
-  local.get $6
-  local.get $5
-  call $~lib/string/String#get:length
-  local.tee $7
-  i32.const 21
-  i32.add
-  i32.mul
-  i32.const 21
-  i32.add
-  local.tee $9
-  i32.const 1
-  i32.shl
-  i32.const 1
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.set $3
-  loop $for-loop|0
-   local.get $8
-   local.get $6
-   i32.lt_s
-   if
-    local.get $3
-    local.get $2
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $0
-    local.get $8
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    call $~lib/util/number/itoa_buffered<i64>
-    local.get $2
-    i32.add
-    local.set $1
-    local.get $7
-    if
-     local.get $3
-     local.get $1
-     i32.const 1
-     i32.shl
-     i32.add
-     local.get $5
-     local.get $7
-     i32.const 1
-     i32.shl
-     call $~lib/memory/memory.copy
-     local.get $1
-     local.get $7
-     i32.add
-     local.set $1
-    end
-    local.get $1
-    local.set $2
-    local.get $8
-    i32.const 1
-    i32.add
-    local.set $8
-    br $for-loop|0
-   end
-  end
-  local.get $9
-  local.get $3
-  local.get $2
-  i32.const 1
-  i32.shl
-  i32.add
-  local.get $0
-  local.get $6
-  i32.const 3
-  i32.shl
-  i32.add
-  i64.load
-  call $~lib/util/number/itoa_buffered<i64>
-  local.get $2
-  i32.add
-  local.tee $0
-  i32.gt_s
-  if
-   local.get $3
-   local.get $0
-   call $~lib/string/String#substring
-   local.get $5
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
-   return
-  end
-  local.get $5
-  call $~lib/rt/pure/__release
-  local.get $3
- )
- (func $~lib/array/Array<~lib/string/String | null>#toString (param $0 i32) (result i32)
-  local.get $0
-  i32.const 6352
-  call $~lib/array/Array<~lib/string/String | null>#join
- )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
+  (local $3 i64)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
   local.set $4
@@ -9748,127 +9540,318 @@
   local.get $5
   i32.eqz
   if
+   block $__inlined_func$~lib/util/number/itoa64 (result i32)
+    i32.const 6656
+    local.get $0
+    i64.load
+    i32.wrap_i64
+    i64.extend_i32_s
+    local.tee $3
+    i64.eqz
+    br_if $__inlined_func$~lib/util/number/itoa64
+    drop
+    local.get $3
+    i64.const 63
+    i64.shr_u
+    i32.wrap_i64
+    local.tee $0
+    if
+     i64.const 0
+     local.get $3
+     i64.sub
+     local.set $3
+    end
+    local.get $3
+    i64.const 4294967295
+    i64.le_u
+    if
+     local.get $3
+     i32.wrap_i64
+     local.tee $2
+     call $~lib/util/number/decimalCount32
+     local.get $0
+     i32.add
+     local.tee $5
+     i32.const 1
+     i32.shl
+     i32.const 1
+     call $~lib/rt/tlsf/__alloc
+     local.tee $1
+     local.get $2
+     local.get $5
+     call $~lib/util/number/utoa_dec_simple<u32>
+    else
+     local.get $3
+     call $~lib/util/number/decimalCount64High
+     local.get $0
+     i32.add
+     local.tee $2
+     i32.const 1
+     i32.shl
+     i32.const 1
+     call $~lib/rt/tlsf/__alloc
+     local.tee $1
+     local.get $3
+     local.get $2
+     call $~lib/util/number/utoa_dec_simple<u64>
+    end
+    local.get $0
+    if
+     local.get $1
+     i32.const 45
+     i32.store16
+    end
+    local.get $1
+    call $~lib/rt/pure/__retain
+   end
+   local.get $4
+   call $~lib/rt/pure/__release
+   return
+  end
+  local.get $5
+  local.get $4
+  call $~lib/string/String#get:length
+  local.tee $6
+  i32.const 21
+  i32.add
+  i32.mul
+  i32.const 21
+  i32.add
+  local.tee $8
+  i32.const 1
+  i32.shl
+  i32.const 1
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.set $1
+  loop $for-loop|0
+   local.get $7
+   local.get $5
+   i32.lt_s
+   if
+    local.get $1
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $0
+    local.get $7
+    i32.const 3
+    i32.shl
+    i32.add
+    i64.load
+    call $~lib/util/number/itoa_buffered<i64>
+    local.get $2
+    i32.add
+    local.set $2
+    local.get $6
+    if
+     local.get $1
+     local.get $2
+     i32.const 1
+     i32.shl
+     i32.add
+     local.get $4
+     local.get $6
+     i32.const 1
+     i32.shl
+     call $~lib/memory/memory.copy
+     local.get $2
+     local.get $6
+     i32.add
+     local.set $2
+    end
+    local.get $7
+    i32.const 1
+    i32.add
+    local.set $7
+    br $for-loop|0
+   end
+  end
+  local.get $8
+  local.get $1
+  local.get $2
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $0
+  local.get $5
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+  call $~lib/util/number/itoa_buffered<i64>
+  local.get $2
+  i32.add
+  local.tee $0
+  i32.gt_s
+  if
+   local.get $1
+   local.get $0
+   call $~lib/string/String#substring
+   local.get $4
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   return
+  end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $1
+ )
+ (func $~lib/array/Array<~lib/string/String | null>#toString (param $0 i32) (result i32)
+  local.get $0
+  i32.const 6352
+  call $~lib/array/Array<~lib/string/String | null>#join
+ )
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  i32.const 6352
+  call $~lib/rt/pure/__retain
+  local.set $9
+  local.get $1
+  i32.const 1
+  i32.sub
+  local.tee $8
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $9
+   call $~lib/rt/pure/__release
+   i32.const 6112
+   return
+  end
+  local.get $8
+  i32.eqz
+  if
    local.get $0
    i32.load
-   local.tee $0
+   local.tee $2
    if
-    local.get $0
+    local.get $2
     call $~lib/rt/pure/__retain
-    local.set $0
+    local.set $2
    end
-   local.get $0
+   local.get $2
    if (result i32)
-    local.get $0
+    local.get $2
     i32.const 6352
     call $~lib/array/Array<i32>#join
    else
     i32.const 6112
    end
-   local.get $4
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6112
   local.set $1
-  local.get $4
+  local.get $9
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $6
   loop $for-loop|0
-   local.get $6
-   local.get $5
+   local.get $2
+   local.get $8
    i32.lt_s
    if
-    local.get $3
-    local.tee $2
+    local.get $4
+    local.tee $3
     local.get $0
-    local.get $6
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
-     local.set $3
-     local.get $2
+     local.set $4
+     local.get $3
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
-     local.get $3
+     local.get $4
      i32.const 6352
      call $~lib/array/Array<i32>#join
-     local.tee $2
+     local.tee $3
      local.get $1
      local.get $1
-     local.get $2
+     local.get $3
      call $~lib/string/String.__concat
-     local.tee $9
-     local.tee $2
+     local.tee $5
+     local.tee $3
      i32.ne
      if
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__retain
-      local.set $2
+      local.set $3
       local.get $1
       call $~lib/rt/pure/__release
      end
      call $~lib/rt/pure/__release
-     local.get $9
+     local.get $5
      call $~lib/rt/pure/__release
-     local.get $2
+     local.get $3
      local.set $1
     end
-    local.get $8
+    local.get $6
     if
      local.get $1
-     local.tee $2
-     local.get $4
+     local.tee $3
+     local.get $9
      call $~lib/string/String.__concat
      local.tee $7
      local.tee $1
-     local.get $2
+     local.get $3
      i32.ne
      if
       local.get $1
       call $~lib/rt/pure/__retain
       local.set $1
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__release
      end
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $6
+    local.get $2
     i32.const 1
     i32.add
-    local.set $6
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
   local.get $0
-  local.get $5
+  local.get $8
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $3
   i32.ne
   if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
    local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $3
   if
-   local.get $2
+   local.get $3
    i32.const 6352
    call $~lib/array/Array<i32>#join
    local.tee $0
@@ -9877,24 +9860,24 @@
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
-   local.tee $3
+   local.tee $4
    i32.ne
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $4
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $4
    local.set $1
   end
-  local.get $4
+  local.get $9
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -10075,143 +10058,143 @@
   (local $9 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
-  local.set $4
+  local.set $9
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $8
   i32.const 0
   i32.lt_s
   if
-   local.get $4
+   local.get $9
    call $~lib/rt/pure/__release
    i32.const 6112
    return
   end
-  local.get $5
+  local.get $8
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $0
+   local.tee $2
    if
-    local.get $0
+    local.get $2
     call $~lib/rt/pure/__retain
-    local.set $0
+    local.set $2
    end
-   local.get $0
+   local.get $2
    if (result i32)
-    local.get $0
+    local.get $2
     i32.const 6352
     call $~lib/array/Array<u8>#join
    else
     i32.const 6112
    end
-   local.get $4
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6112
   local.set $1
-  local.get $4
+  local.get $9
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $6
   loop $for-loop|0
-   local.get $6
-   local.get $5
+   local.get $2
+   local.get $8
    i32.lt_s
    if
-    local.get $3
-    local.tee $2
+    local.get $4
+    local.tee $3
     local.get $0
-    local.get $6
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
-     local.set $3
-     local.get $2
+     local.set $4
+     local.get $3
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
-     local.get $3
+     local.get $4
      i32.const 6352
      call $~lib/array/Array<u8>#join
-     local.tee $2
+     local.tee $3
      local.get $1
      local.get $1
-     local.get $2
+     local.get $3
      call $~lib/string/String.__concat
-     local.tee $9
-     local.tee $2
+     local.tee $5
+     local.tee $3
      i32.ne
      if
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__retain
-      local.set $2
+      local.set $3
       local.get $1
       call $~lib/rt/pure/__release
      end
      call $~lib/rt/pure/__release
-     local.get $9
+     local.get $5
      call $~lib/rt/pure/__release
-     local.get $2
+     local.get $3
      local.set $1
     end
-    local.get $8
+    local.get $6
     if
      local.get $1
-     local.tee $2
-     local.get $4
+     local.tee $3
+     local.get $9
      call $~lib/string/String.__concat
      local.tee $7
      local.tee $1
-     local.get $2
+     local.get $3
      i32.ne
      if
       local.get $1
       call $~lib/rt/pure/__retain
       local.set $1
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__release
      end
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $6
+    local.get $2
     i32.const 1
     i32.add
-    local.set $6
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
   local.get $0
-  local.get $5
+  local.get $8
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $3
   i32.ne
   if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
    local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $3
   if
-   local.get $2
+   local.get $3
    i32.const 6352
    call $~lib/array/Array<u8>#join
    local.tee $0
@@ -10220,24 +10203,24 @@
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
-   local.tee $3
+   local.tee $4
    i32.ne
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $4
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $4
    local.set $1
   end
-  local.get $4
+  local.get $9
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -10443,166 +10426,166 @@
   (local $9 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
-  local.set $4
+  local.set $9
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $8
   i32.const 0
   i32.lt_s
   if
-   local.get $4
+   local.get $9
    call $~lib/rt/pure/__release
    i32.const 6112
    return
   end
-  local.get $5
+  local.get $8
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $0
+   local.tee $2
    if
-    local.get $0
+    local.get $2
     call $~lib/rt/pure/__retain
-    local.set $0
+    local.set $2
    end
-   local.get $0
+   local.get $2
    if (result i32)
-    local.get $0
+    local.get $2
     call $~lib/array/Array<~lib/array/Array<u32>>#toString
    else
     i32.const 6112
    end
-   local.get $4
+   local.get $9
    call $~lib/rt/pure/__release
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6112
   local.set $1
-  local.get $4
+  local.get $9
   call $~lib/string/String#get:length
-  local.set $8
+  local.set $6
   loop $for-loop|0
-   local.get $6
-   local.get $5
+   local.get $2
+   local.get $8
    i32.lt_s
    if
-    local.get $3
-    local.tee $2
+    local.get $4
+    local.tee $3
     local.get $0
-    local.get $6
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
-     local.set $3
-     local.get $2
+     local.set $4
+     local.get $3
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
      local.get $1
      local.get $1
-     local.get $3
+     local.get $4
      call $~lib/array/Array<~lib/array/Array<u32>>#toString
      local.tee $7
      call $~lib/string/String.__concat
-     local.tee $9
-     local.tee $2
+     local.tee $5
+     local.tee $3
      i32.ne
      if
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__retain
-      local.set $2
+      local.set $3
       local.get $1
       call $~lib/rt/pure/__release
      end
      local.get $7
      call $~lib/rt/pure/__release
-     local.get $9
+     local.get $5
      call $~lib/rt/pure/__release
-     local.get $2
+     local.get $3
      local.set $1
     end
-    local.get $8
+    local.get $6
     if
      local.get $1
-     local.tee $2
-     local.get $4
+     local.tee $3
+     local.get $9
      call $~lib/string/String.__concat
      local.tee $7
      local.tee $1
-     local.get $2
+     local.get $3
      i32.ne
      if
       local.get $1
       call $~lib/rt/pure/__retain
       local.set $1
-      local.get $2
+      local.get $3
       call $~lib/rt/pure/__release
      end
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $6
+    local.get $2
     i32.const 1
     i32.add
-    local.set $6
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $3
+  local.get $4
   local.get $0
-  local.get $5
+  local.get $8
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $3
   i32.ne
   if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
    local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $3
   if
    local.get $1
    local.get $1
-   local.get $2
+   local.get $3
    call $~lib/array/Array<~lib/array/Array<u32>>#toString
    local.tee $0
    call $~lib/string/String.__concat
-   local.tee $5
-   local.tee $3
+   local.tee $2
+   local.tee $4
    i32.ne
    if
-    local.get $3
+    local.get $4
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $4
     local.get $1
     call $~lib/rt/pure/__release
    end
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $5
+   local.get $2
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $4
    local.set $1
   end
-  local.get $4
+  local.get $9
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -10917,35 +10900,34 @@
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $0
+  local.tee $2
   i32.eqz
   if
    i32.const 12
    i32.const 2
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
-   local.set $0
+   local.set $2
   end
-  local.get $0
-  local.tee $1
+  local.get $2
   i32.const 0
   i32.store
-  local.get $0
+  local.get $2
   i32.const 0
   i32.store offset=4
-  local.get $0
+  local.get $2
   i32.const 0
   i32.store offset=8
   i32.const 1
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.const 1
   call $~lib/memory/memory.fill
-  local.get $2
-  local.tee $0
   local.get $1
+  local.tee $0
+  local.get $2
   i32.load
   local.tee $4
   i32.ne
@@ -10956,13 +10938,13 @@
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $2
   local.get $0
   i32.store
-  local.get $1
   local.get $2
-  i32.store offset=4
   local.get $1
+  i32.store offset=4
+  local.get $2
   i32.const 1
   i32.store offset=8
   global.get $std/array/arr
@@ -10977,7 +10959,7 @@
    unreachable
   end
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   i32.const 5
   i32.const 0
@@ -12127,9 +12109,10 @@
   i32.const 2928
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
+  local.set $0
   local.get $1
   call $~lib/rt/pure/__release
-  local.tee $1
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const -2
@@ -12159,10 +12142,10 @@
   i32.const 3024
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.const -4
   i32.const -3
   i32.const -1
@@ -12192,15 +12175,15 @@
   i32.const 3120
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $0
+  local.tee $1
   i32.const 5
   i32.const 2
   i32.const 3
@@ -12219,7 +12202,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -12265,7 +12248,7 @@
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
@@ -13458,10 +13441,10 @@
   i32.const 3680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
+  local.set $2
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#splice
@@ -13484,7 +13467,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $2
   i32.const 3
   i32.const 2
   i32.const 3
@@ -13509,9 +13492,10 @@
   i32.const 3792
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.get $0
+  local.set $0
+  local.get $2
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.get $0
   i32.const 0
   i32.const 1
   call $~lib/array/Array<i32>#splice
@@ -15987,7 +15971,7 @@
   global.set $~argumentsLength
   block $__inlined_func$std/array/isSorted<~lib/string/String | null> (result i32)
    i32.const 1
-   local.set $0
+   local.set $2
    local.get $5
    call $~lib/rt/pure/__retain
    local.tee $4
@@ -15995,53 +15979,53 @@
    call $~lib/array/Array<~lib/array/Array<i32>>#sort
    local.tee $6
    call $~lib/rt/pure/__retain
-   local.tee $1
+   local.tee $0
    i32.load offset=12
    local.set $7
    loop $for-loop|00
-    local.get $0
+    local.get $2
     local.get $7
     i32.lt_s
     if
-     local.get $1
      local.get $0
+     local.get $2
      i32.const 1
      i32.sub
      call $~lib/array/Array<std/array/Ref | null>#__get
-     local.set $2
-     local.get $1
+     local.set $1
      local.get $0
+     local.get $2
      call $~lib/array/Array<std/array/Ref | null>#__get
      local.set $3
      i32.const 2
      global.set $~argumentsLength
-     local.get $2
+     local.get $1
      local.get $3
      call $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0
      i32.const 0
      i32.gt_s
      if
-      local.get $1
+      local.get $0
       call $~lib/rt/pure/__release
-      local.get $2
+      local.get $1
       call $~lib/rt/pure/__release
       local.get $3
       call $~lib/rt/pure/__release
       i32.const 0
       br $__inlined_func$std/array/isSorted<~lib/string/String | null>
      end
-     local.get $2
+     local.get $1
      call $~lib/rt/pure/__release
      local.get $3
      call $~lib/rt/pure/__release
-     local.get $0
+     local.get $2
      i32.const 1
      i32.add
-     local.set $0
+     local.set $2
      br $for-loop|00
     end
    end
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
    i32.const 1
   end
@@ -16092,7 +16076,7 @@
     local.set $6
     i32.const 6112
     local.set $0
-    loop $for-loop|02
+    loop $for-loop|01
      local.get $6
      local.get $7
      i32.lt_s
@@ -16150,7 +16134,7 @@
       i32.const 1
       i32.add
       local.set $6
-      br $for-loop|02
+      br $for-loop|01
      end
     end
     local.get $1
@@ -17116,35 +17100,35 @@
   local.get $1
   i32.const 2
   i32.shl
-  local.tee $5
+  local.tee $4
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $3
+  local.tee $2
   i32.const 0
-  local.get $5
+  local.get $4
   call $~lib/memory/memory.fill
-  local.get $3
-  local.set $2
-  local.get $3
+  local.get $2
+  local.set $3
+  local.get $2
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $5
   i32.ne
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $4
+   local.set $3
+   local.get $5
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $2
+  local.get $3
   i32.store
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $4
   i32.store offset=8
   local.get $0
   local.get $1
@@ -17491,29 +17475,29 @@
   local.get $1
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $3
+  local.tee $2
   i32.const 0
   local.get $1
   call $~lib/memory/memory.fill
-  local.get $3
-  local.set $2
-  local.get $3
+  local.get $2
+  local.set $3
+  local.get $2
   local.get $0
   i32.load
   local.tee $4
   i32.ne
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $3
    local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $2
+  local.get $3
   i32.store
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=4
   local.get $0
   local.get $1

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -6702,7 +6702,7 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
@@ -6711,7 +6711,7 @@
    i32.const 6112
    return
   end
-  local.get $4
+  local.get $5
   i32.eqz
   if
    i32.const 6288
@@ -6724,10 +6724,10 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $4
+  local.get $5
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $5
+  local.tee $6
   i32.const 5
   i32.add
   i32.mul
@@ -6739,22 +6739,22 @@
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $1
+  local.set $4
   loop $for-loop|1
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.lt_s
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.add
     i32.load8_u
     local.tee $9
     i32.eqz
     i32.const 4
     i32.add
-    local.set $7
-    local.get $1
+    local.set $1
+    local.get $4
     local.get $2
     i32.const 1
     i32.shl
@@ -6763,55 +6763,57 @@
     i32.const 6320
     local.get $9
     select
-    local.get $7
+    local.get $1
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
+    local.get $1
     local.get $2
-    local.get $7
     i32.add
-    local.set $2
-    local.get $5
+    local.set $1
+    local.get $6
     if
+     local.get $4
      local.get $1
-     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $5
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $5
+     local.get $1
+     local.get $6
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $6
+    local.get $1
+    local.set $2
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|1
    end
   end
   local.get $0
-  local.get $4
+  local.get $5
   i32.add
   i32.load8_u
-  local.tee $4
+  local.tee $1
   i32.eqz
   i32.const 4
   i32.add
   local.set $0
-  local.get $1
+  local.get $4
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   i32.const 6288
   i32.const 6320
-  local.get $4
+  local.get $1
   select
   local.get $0
   i32.const 1
@@ -6824,18 +6826,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $1
+   local.get $4
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $4
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $4
  )
  (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
@@ -8310,13 +8312,14 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   i32.const 7072
   call $~lib/rt/pure/__retain
   local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $5
+  local.tee $6
   i32.const 0
   i32.lt_s
   if
@@ -8325,7 +8328,7 @@
    i32.const 6112
    return
   end
-  local.get $5
+  local.get $6
   i32.eqz
   if
    block $__inlined_func$~lib/util/number/dtoa
@@ -8392,34 +8395,34 @@
    local.get $0
    return
   end
-  local.get $5
+  local.get $6
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $6
+  local.tee $7
   i32.const 28
   i32.add
   i32.mul
   i32.const 28
   i32.add
-  local.tee $8
+  local.tee $9
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $1
+  local.set $5
   loop $for-loop|0
-   local.get $7
-   local.get $5
+   local.get $8
+   local.get $6
    i32.lt_s
    if
-    local.get $1
+    local.get $5
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 3
     i32.shl
     i32.add
@@ -8427,39 +8430,41 @@
     call $~lib/util/number/dtoa_buffered
     local.get $2
     i32.add
-    local.set $2
-    local.get $6
+    local.set $1
+    local.get $7
     if
+     local.get $5
      local.get $1
-     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $6
+     local.get $1
+     local.get $7
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $7
+    local.get $1
+    local.set $2
+    local.get $8
     i32.const 1
     i32.add
-    local.set $7
+    local.set $8
     br $for-loop|0
    end
   end
-  local.get $8
-  local.get $1
+  local.get $9
+  local.get $5
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   local.get $0
-  local.get $5
+  local.get $6
   i32.const 3
   i32.shl
   i32.add
@@ -8470,18 +8475,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $1
+   local.get $5
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $5
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $5
  )
  (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -8912,13 +8917,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
   local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
@@ -8927,7 +8933,7 @@
    i32.const 6112
    return
   end
-  local.get $4
+  local.get $5
   i32.eqz
   if
    local.get $0
@@ -8937,72 +8943,74 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $4
+  local.get $5
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $5
+  local.tee $6
   i32.const 11
   i32.add
   i32.mul
   i32.const 11
   i32.add
-  local.tee $7
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $1
+  local.set $4
   loop $for-loop|0
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.lt_s
    if
-    local.get $1
+    local.get $4
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $6
+    local.get $7
     i32.add
     i32.load8_s
     call $~lib/util/number/itoa_buffered<i8>
     local.get $2
     i32.add
-    local.set $2
-    local.get $5
+    local.set $1
+    local.get $6
     if
+     local.get $4
      local.get $1
-     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $5
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $5
+     local.get $1
+     local.get $6
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $6
+    local.get $1
+    local.set $2
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $1
+  local.get $8
+  local.get $4
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   local.get $0
-  local.get $4
+  local.get $5
   i32.add
   i32.load8_s
   call $~lib/util/number/itoa_buffered<i8>
@@ -9011,18 +9019,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $1
+   local.get $4
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $4
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $4
  )
  (func $~lib/util/number/itoa_buffered<u16> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -9061,13 +9069,14 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
   local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
@@ -9076,7 +9085,7 @@
    i32.const 6112
    return
   end
-  local.get $4
+  local.get $5
   i32.eqz
   if
    local.get $0
@@ -9086,34 +9095,34 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $4
+  local.get $5
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $5
+  local.tee $6
   i32.const 10
   i32.add
   i32.mul
   i32.const 10
   i32.add
-  local.tee $7
+  local.tee $8
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $1
+  local.set $4
   loop $for-loop|0
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.lt_s
    if
-    local.get $1
+    local.get $4
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 1
     i32.shl
     i32.add
@@ -9121,39 +9130,41 @@
     call $~lib/util/number/itoa_buffered<u16>
     local.get $2
     i32.add
-    local.set $2
-    local.get $5
+    local.set $1
+    local.get $6
     if
+     local.get $4
      local.get $1
-     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $5
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $5
+     local.get $1
+     local.get $6
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $6
+    local.get $1
+    local.set $2
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $7
-  local.get $1
+  local.get $8
+  local.get $4
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   local.get $0
-  local.get $4
+  local.get $5
   i32.const 1
   i32.shl
   i32.add
@@ -9164,18 +9175,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $1
+   local.get $4
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $4
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $4
  )
  (func $~lib/util/number/decimalCount64High (param $0 i64) (result i32)
   local.get $0
@@ -9295,17 +9306,18 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i64)
-  (local $6 i32)
+  (local $5 i32)
+  (local $6 i64)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
   local.set $3
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
@@ -9314,22 +9326,22 @@
    i32.const 6112
    return
   end
-  local.get $4
+  local.get $5
   i32.eqz
   if
    block $__inlined_func$~lib/util/number/utoa64 (result i32)
     i32.const 6656
     local.get $0
     i64.load
-    local.tee $5
+    local.tee $6
     i64.eqz
     br_if $__inlined_func$~lib/util/number/utoa64
     drop
-    local.get $5
+    local.get $6
     i64.const 4294967295
     i64.le_u
     if
-     local.get $5
+     local.get $6
      i32.wrap_i64
      local.tee $1
      call $~lib/util/number/decimalCount32
@@ -9343,7 +9355,7 @@
      local.get $2
      call $~lib/util/number/utoa_dec_simple<u32>
     else
-     local.get $5
+     local.get $6
      call $~lib/util/number/decimalCount64High
      local.tee $1
      i32.const 1
@@ -9351,7 +9363,7 @@
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $0
-     local.get $5
+     local.get $6
      local.get $1
      call $~lib/util/number/utoa_dec_simple<u64>
     end
@@ -9362,34 +9374,34 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $4
+  local.get $5
   local.get $3
   call $~lib/string/String#get:length
-  local.tee $6
+  local.tee $7
   i32.const 20
   i32.add
   i32.mul
   i32.const 20
   i32.add
-  local.tee $8
+  local.tee $9
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $1
+  local.set $4
   loop $for-loop|0
-   local.get $7
-   local.get $4
+   local.get $8
+   local.get $5
    i32.lt_s
    if
-    local.get $1
+    local.get $4
     local.get $2
     i32.const 1
     i32.shl
     i32.add
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 3
     i32.shl
     i32.add
@@ -9397,39 +9409,41 @@
     call $~lib/util/number/itoa_buffered<u64>
     local.get $2
     i32.add
-    local.set $2
-    local.get $6
+    local.set $1
+    local.get $7
     if
+     local.get $4
      local.get $1
-     local.get $2
      i32.const 1
      i32.shl
      i32.add
      local.get $3
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $2
-     local.get $6
+     local.get $1
+     local.get $7
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $7
+    local.get $1
+    local.set $2
+    local.get $8
     i32.const 1
     i32.add
-    local.set $7
+    local.set $8
     br $for-loop|0
    end
   end
-  local.get $8
-  local.get $1
+  local.get $9
+  local.get $4
   local.get $2
   i32.const 1
   i32.shl
   i32.add
   local.get $0
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.add
@@ -9440,18 +9454,18 @@
   local.tee $0
   i32.gt_s
   if
-   local.get $1
+   local.get $4
    local.get $0
    call $~lib/string/String#substring
    local.get $3
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $4
    call $~lib/rt/pure/__release
    return
   end
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $4
  )
  (func $~lib/util/number/itoa_buffered<i64> (param $0 i32) (param $1 i64) (result i32)
   (local $2 i32)
@@ -9516,198 +9530,8 @@
  )
  (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (local $3 i64)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  i32.const 6352
-  call $~lib/rt/pure/__retain
-  local.set $4
-  local.get $1
-  i32.const 1
-  i32.sub
-  local.tee $5
-  i32.const 0
-  i32.lt_s
-  if
-   local.get $4
-   call $~lib/rt/pure/__release
-   i32.const 6112
-   return
-  end
-  local.get $5
-  i32.eqz
-  if
-   block $__inlined_func$~lib/util/number/itoa64 (result i32)
-    i32.const 6656
-    local.get $0
-    i64.load
-    i32.wrap_i64
-    i64.extend_i32_s
-    local.tee $3
-    i64.eqz
-    br_if $__inlined_func$~lib/util/number/itoa64
-    drop
-    local.get $3
-    i64.const 63
-    i64.shr_u
-    i32.wrap_i64
-    local.tee $0
-    if
-     i64.const 0
-     local.get $3
-     i64.sub
-     local.set $3
-    end
-    local.get $3
-    i64.const 4294967295
-    i64.le_u
-    if
-     local.get $3
-     i32.wrap_i64
-     local.tee $2
-     call $~lib/util/number/decimalCount32
-     local.get $0
-     i32.add
-     local.tee $5
-     i32.const 1
-     i32.shl
-     i32.const 1
-     call $~lib/rt/tlsf/__alloc
-     local.tee $1
-     local.get $2
-     local.get $5
-     call $~lib/util/number/utoa_dec_simple<u32>
-    else
-     local.get $3
-     call $~lib/util/number/decimalCount64High
-     local.get $0
-     i32.add
-     local.tee $2
-     i32.const 1
-     i32.shl
-     i32.const 1
-     call $~lib/rt/tlsf/__alloc
-     local.tee $1
-     local.get $3
-     local.get $2
-     call $~lib/util/number/utoa_dec_simple<u64>
-    end
-    local.get $0
-    if
-     local.get $1
-     i32.const 45
-     i32.store16
-    end
-    local.get $1
-    call $~lib/rt/pure/__retain
-   end
-   local.get $4
-   call $~lib/rt/pure/__release
-   return
-  end
-  local.get $5
-  local.get $4
-  call $~lib/string/String#get:length
-  local.tee $6
-  i32.const 21
-  i32.add
-  i32.mul
-  i32.const 21
-  i32.add
-  local.tee $8
-  i32.const 1
-  i32.shl
-  i32.const 1
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.set $1
-  loop $for-loop|0
-   local.get $7
-   local.get $5
-   i32.lt_s
-   if
-    local.get $1
-    local.get $2
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $0
-    local.get $7
-    i32.const 3
-    i32.shl
-    i32.add
-    i64.load
-    call $~lib/util/number/itoa_buffered<i64>
-    local.get $2
-    i32.add
-    local.set $2
-    local.get $6
-    if
-     local.get $1
-     local.get $2
-     i32.const 1
-     i32.shl
-     i32.add
-     local.get $4
-     local.get $6
-     i32.const 1
-     i32.shl
-     call $~lib/memory/memory.copy
-     local.get $2
-     local.get $6
-     i32.add
-     local.set $2
-    end
-    local.get $7
-    i32.const 1
-    i32.add
-    local.set $7
-    br $for-loop|0
-   end
-  end
-  local.get $8
-  local.get $1
-  local.get $2
-  i32.const 1
-  i32.shl
-  i32.add
-  local.get $0
-  local.get $5
-  i32.const 3
-  i32.shl
-  i32.add
-  i64.load
-  call $~lib/util/number/itoa_buffered<i64>
-  local.get $2
-  i32.add
-  local.tee $0
-  i32.gt_s
-  if
-   local.get $1
-   local.get $0
-   call $~lib/string/String#substring
-   local.get $4
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   return
-  end
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $1
- )
- (func $~lib/array/Array<~lib/string/String | null>#toString (param $0 i32) (result i32)
-  local.get $0
-  i32.const 6352
-  call $~lib/array/Array<~lib/string/String | null>#join
- )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
+  (local $4 i64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -9731,58 +9555,251 @@
   local.get $6
   i32.eqz
   if
-   local.get $0
-   i32.load
-   local.tee $3
+   block $__inlined_func$~lib/util/number/itoa64 (result i32)
+    i32.const 6656
+    local.get $0
+    i64.load
+    i32.wrap_i64
+    i64.extend_i32_s
+    local.tee $4
+    i64.eqz
+    br_if $__inlined_func$~lib/util/number/itoa64
+    drop
+    local.get $4
+    i64.const 63
+    i64.shr_u
+    i32.wrap_i64
+    local.tee $0
+    if
+     i64.const 0
+     local.get $4
+     i64.sub
+     local.set $4
+    end
+    local.get $4
+    i64.const 4294967295
+    i64.le_u
+    if
+     local.get $4
+     i32.wrap_i64
+     local.tee $2
+     call $~lib/util/number/decimalCount32
+     local.get $0
+     i32.add
+     local.tee $3
+     i32.const 1
+     i32.shl
+     i32.const 1
+     call $~lib/rt/tlsf/__alloc
+     local.tee $1
+     local.get $2
+     local.get $3
+     call $~lib/util/number/utoa_dec_simple<u32>
+    else
+     local.get $4
+     call $~lib/util/number/decimalCount64High
+     local.get $0
+     i32.add
+     local.tee $2
+     i32.const 1
+     i32.shl
+     i32.const 1
+     call $~lib/rt/tlsf/__alloc
+     local.tee $1
+     local.get $4
+     local.get $2
+     call $~lib/util/number/utoa_dec_simple<u64>
+    end
+    local.get $0
+    if
+     local.get $1
+     i32.const 45
+     i32.store16
+    end
+    local.get $1
+    call $~lib/rt/pure/__retain
+   end
+   local.get $5
+   call $~lib/rt/pure/__release
+   return
+  end
+  local.get $6
+  local.get $5
+  call $~lib/string/String#get:length
+  local.tee $7
+  i32.const 21
+  i32.add
+  i32.mul
+  i32.const 21
+  i32.add
+  local.tee $9
+  i32.const 1
+  i32.shl
+  i32.const 1
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.set $3
+  loop $for-loop|0
+   local.get $8
+   local.get $6
+   i32.lt_s
    if
     local.get $3
-    call $~lib/rt/pure/__retain
-    local.set $3
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $0
+    local.get $8
+    i32.const 3
+    i32.shl
+    i32.add
+    i64.load
+    call $~lib/util/number/itoa_buffered<i64>
+    local.get $2
+    i32.add
+    local.set $1
+    local.get $7
+    if
+     local.get $3
+     local.get $1
+     i32.const 1
+     i32.shl
+     i32.add
+     local.get $5
+     local.get $7
+     i32.const 1
+     i32.shl
+     call $~lib/memory/memory.copy
+     local.get $1
+     local.get $7
+     i32.add
+     local.set $1
+    end
+    local.get $1
+    local.set $2
+    local.get $8
+    i32.const 1
+    i32.add
+    local.set $8
+    br $for-loop|0
    end
+  end
+  local.get $9
+  local.get $3
+  local.get $2
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $0
+  local.get $6
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+  call $~lib/util/number/itoa_buffered<i64>
+  local.get $2
+  i32.add
+  local.tee $0
+  i32.gt_s
+  if
    local.get $3
-   if (result i32)
-    local.get $3
-    i32.const 6352
-    call $~lib/array/Array<i32>#join
-   else
-    i32.const 6112
-   end
+   local.get $0
+   call $~lib/string/String#substring
    local.get $5
    call $~lib/rt/pure/__release
    local.get $3
    call $~lib/rt/pure/__release
    return
   end
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $3
+ )
+ (func $~lib/array/Array<~lib/string/String | null>#toString (param $0 i32) (result i32)
+  local.get $0
+  i32.const 6352
+  call $~lib/array/Array<~lib/string/String | null>#join
+ )
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  i32.const 6352
+  call $~lib/rt/pure/__retain
+  local.set $4
+  local.get $1
+  i32.const 1
+  i32.sub
+  local.tee $5
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $4
+   call $~lib/rt/pure/__release
+   i32.const 6112
+   return
+  end
+  local.get $5
+  i32.eqz
+  if
+   local.get $0
+   i32.load
+   local.tee $0
+   if
+    local.get $0
+    call $~lib/rt/pure/__retain
+    local.set $0
+   end
+   local.get $0
+   if (result i32)
+    local.get $0
+    i32.const 6352
+    call $~lib/array/Array<i32>#join
+   else
+    i32.const 6112
+   end
+   local.get $4
+   call $~lib/rt/pure/__release
+   local.get $0
+   call $~lib/rt/pure/__release
+   return
+  end
   i32.const 6112
   local.set $1
-  local.get $5
+  local.get $4
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $3
    local.get $6
+   local.get $5
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     local.tee $2
     local.get $0
-    local.get $3
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $4
+    local.tee $3
     i32.ne
     if
-     local.get $4
+     local.get $3
      call $~lib/rt/pure/__retain
-     local.set $4
+     local.set $3
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $3
     if
-     local.get $4
+     local.get $3
      i32.const 6352
      call $~lib/array/Array<i32>#join
      local.tee $2
@@ -9810,7 +9827,7 @@
     if
      local.get $1
      local.tee $2
-     local.get $5
+     local.get $4
      call $~lib/string/String.__concat
      local.tee $7
      local.tee $1
@@ -9826,16 +9843,16 @@
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $6
     i32.const 1
     i32.add
-    local.set $3
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $4
+  local.get $3
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -9846,7 +9863,7 @@
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -9860,22 +9877,22 @@
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
-   local.tee $4
+   local.tee $3
    i32.ne
    if
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $3
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $3
    local.set $1
   end
-  local.get $5
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -10058,74 +10075,74 @@
   (local $9 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $4
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $6
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__release
    i32.const 6112
    return
   end
-  local.get $6
+  local.get $5
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $3
+   local.tee $0
    if
-    local.get $3
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $0
    end
-   local.get $3
+   local.get $0
    if (result i32)
-    local.get $3
+    local.get $0
     i32.const 6352
     call $~lib/array/Array<u8>#join
    else
     i32.const 6112
    end
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $0
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6112
   local.set $1
-  local.get $5
+  local.get $4
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $3
    local.get $6
+   local.get $5
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     local.tee $2
     local.get $0
-    local.get $3
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $4
+    local.tee $3
     i32.ne
     if
-     local.get $4
+     local.get $3
      call $~lib/rt/pure/__retain
-     local.set $4
+     local.set $3
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $3
     if
-     local.get $4
+     local.get $3
      i32.const 6352
      call $~lib/array/Array<u8>#join
      local.tee $2
@@ -10153,7 +10170,7 @@
     if
      local.get $1
      local.tee $2
-     local.get $5
+     local.get $4
      call $~lib/string/String.__concat
      local.tee $7
      local.tee $1
@@ -10169,16 +10186,16 @@
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $6
     i32.const 1
     i32.add
-    local.set $3
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $4
+  local.get $3
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -10189,7 +10206,7 @@
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -10203,22 +10220,22 @@
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
-   local.tee $4
+   local.tee $3
    i32.ne
    if
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $3
     local.get $1
     call $~lib/rt/pure/__release
    end
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $3
    local.set $1
   end
-  local.get $5
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -10426,75 +10443,75 @@
   (local $9 i32)
   i32.const 6352
   call $~lib/rt/pure/__retain
-  local.set $5
+  local.set $4
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $6
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__release
    i32.const 6112
    return
   end
-  local.get $6
+  local.get $5
   i32.eqz
   if
    local.get $0
    i32.load
-   local.tee $3
+   local.tee $0
    if
-    local.get $3
+    local.get $0
     call $~lib/rt/pure/__retain
-    local.set $3
+    local.set $0
    end
-   local.get $3
+   local.get $0
    if (result i32)
-    local.get $3
+    local.get $0
     call $~lib/array/Array<~lib/array/Array<u32>>#toString
    else
     i32.const 6112
    end
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $0
    call $~lib/rt/pure/__release
    return
   end
   i32.const 6112
   local.set $1
-  local.get $5
+  local.get $4
   call $~lib/string/String#get:length
   local.set $8
   loop $for-loop|0
-   local.get $3
    local.get $6
+   local.get $5
    i32.lt_s
    if
-    local.get $4
+    local.get $3
     local.tee $2
     local.get $0
-    local.get $3
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $4
+    local.tee $3
     i32.ne
     if
-     local.get $4
+     local.get $3
      call $~lib/rt/pure/__retain
-     local.set $4
+     local.set $3
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $4
+    local.get $3
     if
      local.get $1
      local.get $1
-     local.get $4
+     local.get $3
      call $~lib/array/Array<~lib/array/Array<u32>>#toString
      local.tee $7
      call $~lib/string/String.__concat
@@ -10519,7 +10536,7 @@
     if
      local.get $1
      local.tee $2
-     local.get $5
+     local.get $4
      call $~lib/string/String.__concat
      local.tee $7
      local.tee $1
@@ -10535,16 +10552,16 @@
      local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $6
     i32.const 1
     i32.add
-    local.set $3
+    local.set $6
     br $for-loop|0
    end
   end
-  local.get $4
+  local.get $3
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -10555,7 +10572,7 @@
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
   local.get $2
@@ -10566,24 +10583,24 @@
    call $~lib/array/Array<~lib/array/Array<u32>>#toString
    local.tee $0
    call $~lib/string/String.__concat
+   local.tee $5
    local.tee $3
-   local.tee $4
    i32.ne
    if
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
-    local.set $4
+    local.set $3
     local.get $1
     call $~lib/rt/pure/__release
    end
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $5
    call $~lib/rt/pure/__release
-   local.get $4
+   local.get $3
    local.set $1
   end
-  local.get $5
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -12110,10 +12127,9 @@
   i32.const 2928
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $0
+  local.tee $1
   i32.const -4
   i32.const -3
   i32.const -2
@@ -12143,10 +12159,10 @@
   i32.const 3024
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const -1
@@ -12176,15 +12192,15 @@
   i32.const 3120
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.const -4
   i32.const -3
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $1
+  local.tee $0
   i32.const 5
   i32.const 2
   i32.const 3
@@ -12203,7 +12219,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -12249,7 +12265,7 @@
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
@@ -13442,10 +13458,10 @@
   i32.const 3680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $0
   local.get $1
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $0
   i32.const 2
   i32.const 2
   call $~lib/array/Array<i32>#splice
@@ -13468,7 +13484,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $0
   i32.const 3
   i32.const 2
   i32.const 3
@@ -13493,10 +13509,9 @@
   i32.const 3792
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $2
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/array/Array<i32>#splice
@@ -16077,7 +16092,7 @@
     local.set $6
     i32.const 6112
     local.set $0
-    loop $for-loop|01
+    loop $for-loop|02
      local.get $6
      local.get $7
      i32.lt_s
@@ -16135,7 +16150,7 @@
       i32.const 1
       i32.add
       local.set $6
-      br $for-loop|01
+      br $for-loop|02
      end
     end
     local.get $1

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1586,12 +1586,12 @@
   i32.const 8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
+  local.tee $0
   i32.const 8
   call $~lib/memory/memory.fill
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $2
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1605,11 +1605,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $2
   i32.const 0
   i32.const 1073741808
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.tee $0
+  local.tee $1
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1623,8 +1623,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  local.get $9
+  local.get $1
+  local.get $2
   i32.eq
   if
    i32.const 0
@@ -1634,13 +1634,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $2
   i32.const 1
   i32.const 1073741808
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1654,13 +1654,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $2
   i32.const -1
   i32.const 1073741808
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1674,13 +1674,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $2
   i32.const 1
   i32.const 3
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1694,13 +1694,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $2
   i32.const 1
   i32.const -1
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1714,14 +1714,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $2
   i32.const -3
   i32.const -1
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1735,14 +1735,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $2
   i32.const -4
   i32.const 42
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1756,14 +1756,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
+  local.get $2
   i32.const 42
   i32.const 1073741808
   call $~lib/arraybuffer/ArrayBuffer#slice
-  local.set $7
-  local.get $0
+  local.set $4
+  local.get $1
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $4
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1775,7 +1775,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $4
   i32.eqz
   if
    i32.const 0
@@ -1785,12 +1785,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  block $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null> (result i32)
-   i32.const 0
-   call $~lib/rt/pure/__release
-   i32.const 0
-   br $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null>
-  end
+  i32.const 0
+  call $~lib/rt/pure/__release
+  i32.const 0
   if
    i32.const 0
    i32.const 1312
@@ -1827,32 +1824,32 @@
   call $~lib/rt/pure/__retain
   i32.const 0
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.set $6
+  local.set $5
   i32.const 16
   i32.const 3
   call $~lib/rt/tlsf/__alloc
-  local.set $1
+  local.set $0
   i32.const 8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $0
+  local.tee $1
   i32.const 1376
   i32.const 8
   call $~lib/memory/memory.copy
-  local.get $1
   local.get $0
+  local.get $1
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $1
   local.get $0
-  i32.store offset=4
   local.get $1
+  i32.store offset=4
+  local.get $0
   i32.const 8
   i32.store offset=8
-  local.get $1
+  local.get $0
   i32.const 2
   i32.store offset=12
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__retain
   i32.const 12
   i32.const 9
@@ -1860,35 +1857,35 @@
   call $~lib/rt/pure/__retain
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.set $4
-  local.get $6
+  local.set $7
+  local.get $5
   i32.load
-  local.tee $0
+  local.tee $1
   i32.const 16
   i32.sub
   i32.load offset=12
-  local.tee $1
-  local.set $3
+  local.tee $0
+  local.set $8
   i32.const 12
   i32.const 15
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $3
   i32.const 0
   i32.store
-  local.get $8
+  local.get $3
   i32.const 0
   i32.store offset=4
-  local.get $8
+  local.get $3
   i32.const 0
   i32.store offset=8
-  local.get $1
+  local.get $0
   i32.const 1073741808
   i32.gt_u
-  local.get $1
   local.get $0
+  local.get $1
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $0
   i32.const 16
   i32.sub
   i32.load offset=12
@@ -1902,41 +1899,41 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.set $0
-  local.get $1
-  local.get $8
+  local.get $0
+  local.set $1
+  local.get $0
+  local.get $3
   i32.load
-  local.tee $2
+  local.tee $9
   i32.ne
   if
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $0
-   local.get $2
+   local.set $1
+   local.get $9
    call $~lib/rt/pure/__release
   end
-  local.get $8
-  local.get $0
-  i32.store
-  local.get $8
-  local.get $1
-  i32.store offset=4
-  local.get $8
   local.get $3
-  i32.store offset=8
   local.get $1
+  i32.store
+  local.get $3
+  local.get $0
+  i32.store offset=4
+  local.get $3
+  local.get $8
+  i32.store offset=8
+  local.get $0
   call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
+  local.get $2
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $5
+  call $~lib/rt/pure/__release
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $3
   call $~lib/rt/pure/__release
  )
  (func $~start

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1785,9 +1785,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  call $~lib/rt/pure/__release
-  i32.const 0
+  block $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null> (result i32)
+   i32.const 0
+   call $~lib/rt/pure/__release
+   i32.const 0
+   br $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null>
+  end
   if
    i32.const 0
    i32.const 1312

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -219,7 +219,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -239,35 +239,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -277,12 +277,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -290,7 +290,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -309,42 +309,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -359,12 +361,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -374,38 +376,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -423,7 +425,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -432,21 +434,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -473,7 +475,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -691,22 +693,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1785,12 +1785,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  block $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null> (result i32)
-   i32.const 0
-   call $~lib/rt/pure/__release
-   i32.const 0
-   br $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array | null>
-  end
+  i32.const 0
+  call $~lib/rt/pure/__release
+  i32.const 0
   if
    i32.const 0
    i32.const 1312

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -1136,10 +1136,11 @@
   i32.const 8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
+  local.tee $1
   i32.const 0
   i32.store8
-  local.get $2
+  local.get $1
+  local.tee $2
   i32.const 4
   i32.add
   i32.const 0
@@ -1163,24 +1164,22 @@
   i32.const 0
   i32.store8 offset=4
   local.get $2
-  local.set $1
-  local.get $2
   local.get $0
   i32.load
   local.tee $3
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $2
    local.get $3
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $1
   i32.store offset=4
   local.get $0
   i32.const 8

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -227,7 +227,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -247,35 +247,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -285,12 +285,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -298,7 +298,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -317,42 +317,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -367,12 +369,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -382,38 +384,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -431,7 +433,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -440,21 +442,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -481,7 +483,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -699,22 +701,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz
@@ -1139,30 +1140,31 @@
   i32.const 0
   i32.store8
   local.get $2
-  local.tee $1
   i32.const 4
   i32.add
   i32.const 0
   i32.store8 offset=3
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store8 offset=1
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store8 offset=2
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store8 offset=6
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store8 offset=5
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store8 offset=3
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store8 offset=4
-  local.get $1
+  local.get $2
+  local.set $1
+  local.get $2
   local.get $0
   i32.load
   local.tee $3
@@ -1439,13 +1441,12 @@
   i32.load16_s
   local.set $0
   local.get $2
-  i32.eqz
-  if
+  if (result i32)
+   local.get $0
+  else
    local.get $0
    call $~lib/polyfills/bswap<i16>
-   local.set $0
   end
-  local.get $0
  )
  (func $~lib/dataview/DataView#getInt32 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
@@ -1473,13 +1474,12 @@
   i32.load
   local.set $0
   local.get $2
-  i32.eqz
-  if
+  if (result i32)
+   local.get $0
+  else
    local.get $0
    call $~lib/polyfills/bswap<u32>
-   local.set $0
   end
-  local.get $0
  )
  (func $~lib/dataview/DataView#getInt64 (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
@@ -1563,13 +1563,12 @@
   i32.load16_u
   local.set $0
   local.get $2
-  i32.eqz
-  if
+  if (result i32)
+   local.get $0
+  else
    local.get $0
    call $~lib/polyfills/bswap<u16>
-   local.set $0
   end
-  local.get $0
  )
  (func $~lib/dataview/DataView#getUint32 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
@@ -1597,13 +1596,12 @@
   i32.load
   local.set $0
   local.get $2
-  i32.eqz
-  if
+  if (result i32)
+   local.get $0
+  else
    local.get $0
    call $~lib/polyfills/bswap<u32>
-   local.set $0
   end
-  local.get $0
  )
  (func $~lib/dataview/DataView#getUint64 (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1379,55 +1379,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i32.load8_s
      i32.store8
-     local.get $2
      local.get $3
+     local.get $2
      i32.load offset=4
      i32.store offset=4
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i32.load8_s
      call $~lib/util/hash/hash8
      local.get $1
@@ -1435,64 +1435,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=8
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 12
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 12
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -1500,7 +1500,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<i8,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -2075,8 +2075,8 @@
   local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $5
-  local.set $8
+  local.tee $7
+  local.set $4
   i32.const 16
   i32.const 4
   call $~lib/rt/tlsf/__alloc
@@ -2093,7 +2093,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $8
+  local.get $4
   i32.const 1073741808
   i32.gt_u
   if
@@ -2104,49 +2104,49 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $3
-  local.get $8
+  local.tee $2
+  local.get $4
   call $~lib/memory/memory.fill
-  local.get $3
-  local.set $2
-  local.get $3
+  local.get $2
+  local.set $3
+  local.get $2
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $8
   i32.ne
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $4
+   local.set $3
+   local.get $8
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $2
+  local.get $3
   i32.store
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=4
   local.get $0
-  local.get $8
+  local.get $4
   i32.store offset=8
   local.get $0
-  local.get $8
+  local.get $4
   i32.store offset=12
   loop $for-loop|0
-   local.get $7
    local.get $5
+   local.get $7
    i32.lt_s
    if
     local.get $6
-    local.get $7
+    local.get $5
     i32.const 12
     i32.mul
     i32.add
-    local.tee $3
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
@@ -2154,7 +2154,7 @@
     if
      local.get $0
      local.get $1
-     local.get $3
+     local.get $2
      i32.load8_s
      call $~lib/array/Array<i8>#__set
      local.get $1
@@ -2162,10 +2162,10 @@
      i32.add
      local.set $1
     end
-    local.get $7
+    local.get $5
     i32.const 1
     i32.add
-    local.set $7
+    local.set $5
     br $for-loop|0
    end
   end
@@ -2184,16 +2184,16 @@
   i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $5
   i32.const 0
   i32.store
-  local.get $3
+  local.get $5
   i32.const 0
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
   i32.store offset=8
-  local.get $3
+  local.get $5
   i32.const 0
   i32.store offset=12
   local.get $0
@@ -2213,36 +2213,36 @@
   local.tee $4
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
+  local.tee $2
   local.get $4
   call $~lib/memory/memory.fill
-  local.get $1
-  local.set $2
-  local.get $1
-  local.get $3
+  local.get $2
+  local.set $1
+  local.get $2
+  local.get $5
   i32.load
-  local.tee $5
+  local.tee $3
   i32.ne
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $5
+   local.set $1
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $2
-  i32.store
-  local.get $3
+  local.get $5
   local.get $1
+  i32.store
+  local.get $5
+  local.get $2
   i32.store offset=4
-  local.get $3
+  local.get $5
   local.get $4
   i32.store offset=8
-  local.get $3
+  local.get $5
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $5
  )
  (func $~lib/array/Array<i32>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -2406,55 +2406,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i32.load8_s
      i32.store8
-     local.get $2
      local.get $3
+     local.get $2
      i32.load8_s offset=1
      i32.store8 offset=1
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i32.load8_s
      call $~lib/util/hash/hash8
      local.get $1
@@ -2462,64 +2462,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=4
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 8
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 8
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -2527,7 +2527,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<i8,i8>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -2751,55 +2751,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i32.load
      i32.store
-     local.get $2
      local.get $3
+     local.get $2
      i32.load offset=4
      i32.store offset=4
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i32.load
      call $~lib/util/hash/hash32
      local.get $1
@@ -2807,64 +2807,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=8
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 12
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 12
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -2872,7 +2872,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<i32,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -3611,55 +3611,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i32.load8_u
      i32.store8
-     local.get $2
      local.get $3
+     local.get $2
      i32.load offset=4
      i32.store offset=4
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i32.load8_u
      call $~lib/util/hash/hash8
      local.get $1
@@ -3667,64 +3667,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=8
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 12
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 12
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -3732,7 +3732,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<u8,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -3867,8 +3867,8 @@
   local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $5
-  local.set $8
+  local.tee $7
+  local.set $4
   i32.const 16
   i32.const 9
   call $~lib/rt/tlsf/__alloc
@@ -3885,7 +3885,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $8
+  local.get $4
   i32.const 1073741808
   i32.gt_u
   if
@@ -3896,49 +3896,49 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $3
-  local.get $8
+  local.tee $2
+  local.get $4
   call $~lib/memory/memory.fill
-  local.get $3
-  local.set $2
-  local.get $3
+  local.get $2
+  local.set $3
+  local.get $2
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $8
   i32.ne
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $4
+   local.set $3
+   local.get $8
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $2
+  local.get $3
   i32.store
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=4
   local.get $0
-  local.get $8
+  local.get $4
   i32.store offset=8
   local.get $0
-  local.get $8
+  local.get $4
   i32.store offset=12
   loop $for-loop|0
-   local.get $7
    local.get $5
+   local.get $7
    i32.lt_s
    if
     local.get $6
-    local.get $7
+    local.get $5
     i32.const 12
     i32.mul
     i32.add
-    local.tee $3
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
@@ -3946,7 +3946,7 @@
     if
      local.get $0
      local.get $1
-     local.get $3
+     local.get $2
      i32.load8_u
      call $~lib/array/Array<i8>#__set
      local.get $1
@@ -3954,10 +3954,10 @@
      i32.add
      local.set $1
     end
-    local.get $7
+    local.get $5
     i32.const 1
     i32.add
-    local.set $7
+    local.set $5
     br $for-loop|0
    end
   end
@@ -3977,55 +3977,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i32.load8_u
      i32.store8
-     local.get $2
      local.get $3
+     local.get $2
      i32.load8_u offset=1
      i32.store8 offset=1
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i32.load8_u
      call $~lib/util/hash/hash8
      local.get $1
@@ -4033,64 +4033,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=4
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 8
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 8
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -4098,7 +4098,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<u8,u8>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -4881,55 +4881,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i32.load16_s
      i32.store16
-     local.get $2
      local.get $3
+     local.get $2
      i32.load offset=4
      i32.store offset=4
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i32.load16_s
      call $~lib/util/hash/hash16
      local.get $1
@@ -4937,64 +4937,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=8
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 12
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 12
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -5002,7 +5002,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<i16,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -5305,55 +5305,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i32.load16_s
      i32.store16
-     local.get $2
      local.get $3
+     local.get $2
      i32.load16_s offset=2
      i32.store16 offset=2
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i32.load16_s
      call $~lib/util/hash/hash16
      local.get $1
@@ -5361,64 +5361,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=4
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 8
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 8
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -5426,7 +5426,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<i16,i16>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -5643,28 +5643,28 @@
   i32.const 11
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $7
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
-  local.get $2
+  local.get $7
   i32.const 3
   i32.store offset=4
-  local.get $2
+  local.get $7
   i32.const 48
   call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
-  local.get $2
+  local.get $7
   i32.const 4
   i32.store offset=12
-  local.get $2
+  local.get $7
   i32.const 0
   i32.store offset=16
-  local.get $2
+  local.get $7
   i32.const 0
   i32.store offset=20
   loop $for-loop|1
-   local.get $3
+   local.get $6
    i32.const 16
    i32.shl
    i32.const 16
@@ -5672,8 +5672,8 @@
    i32.const 100
    i32.lt_s
    if
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<i16,i32>#has
     if
      i32.const 0
@@ -5683,9 +5683,9 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
-    local.get $3
+    local.get $7
+    local.get $6
+    local.get $6
     i32.const 16
     i32.shl
     i32.const 16
@@ -5694,8 +5694,8 @@
     i32.add
     call $~lib/map/Map<i16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -5706,10 +5706,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<i16,i32>#get
-    local.get $3
+    local.get $6
     i32.const 16
     i32.shl
     i32.const 16
@@ -5725,14 +5725,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $6
     i32.const 1
     i32.add
-    local.set $3
+    local.set $6
     br $for-loop|1
    end
   end
-  local.get $2
+  local.get $7
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -5745,9 +5745,9 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $6
   loop $for-loop|3
-   local.get $3
+   local.get $6
    i32.const 16
    i32.shl
    i32.const 16
@@ -5755,8 +5755,8 @@
    i32.const 100
    i32.lt_s
    if
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -5767,10 +5767,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<i16,i32>#get
-    local.get $3
+    local.get $6
     i32.const 16
     i32.shl
     i32.const 16
@@ -5786,9 +5786,9 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
-    local.get $3
+    local.get $7
+    local.get $6
+    local.get $6
     i32.const 16
     i32.shl
     i32.const 16
@@ -5797,8 +5797,8 @@
     i32.add
     call $~lib/map/Map<i16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -5809,10 +5809,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<i16,i32>#get
-    local.get $3
+    local.get $6
     i32.const 16
     i32.shl
     i32.const 16
@@ -5828,14 +5828,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $6
     i32.const 1
     i32.add
-    local.set $3
+    local.set $6
     br $for-loop|3
    end
   end
-  local.get $2
+  local.get $7
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -5847,47 +5847,47 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $7
   call $~lib/map/Map<i16,i32>#keys
-  local.set $4
-  local.get $2
+  local.set $5
+  local.get $7
   call $~lib/map/Map<i8,i32>#values
-  local.set $6
+  local.set $3
   i32.const 24
   i32.const 13
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $6
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
-  local.get $3
+  local.get $6
   i32.const 3
   i32.store offset=4
-  local.get $3
+  local.get $6
   i32.const 32
   call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
-  local.get $3
+  local.get $6
   i32.const 4
   i32.store offset=12
-  local.get $3
+  local.get $6
   i32.const 0
   i32.store offset=16
-  local.get $3
+  local.get $6
   i32.const 0
   i32.store offset=20
   call $~lib/map/Map<i32,i32>#constructor
-  local.set $5
+  local.set $4
   loop $for-loop|4
-   local.get $0
-   local.get $4
+   local.get $1
+   local.get $5
    i32.load offset=12
    i32.lt_s
    if
-    local.get $0
-    local.tee $1
-    local.get $4
+    local.get $1
+    local.tee $0
+    local.get $5
     i32.load offset=12
     i32.ge_u
     if
@@ -5898,20 +5898,20 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $5
     i32.load offset=4
-    local.get $1
+    local.get $0
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s
-    local.set $0
-    local.get $6
-    local.get $1
-    call $~lib/array/Array<i32>#__get
-    local.set $7
-    local.get $2
+    local.set $1
+    local.get $3
     local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $2
+    local.get $7
+    local.get $1
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -5922,8 +5922,8 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
     local.get $7
+    local.get $2
     i32.const 20
     i32.sub
     call $~lib/map/Map<i16,i32>#has
@@ -5936,27 +5936,27 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
-    local.get $0
-    local.get $0
+    local.get $6
+    local.get $1
+    local.get $1
     call $~lib/map/Map<i16,i16>#set
     call $~lib/rt/pure/__release
-    local.get $5
-    local.get $7
+    local.get $4
+    local.get $2
     i32.const 20
     i32.sub
-    local.tee $0
-    local.get $0
+    local.tee $1
+    local.get $1
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $0
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     br $for-loop|4
    end
   end
-  local.get $3
+  local.get $6
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -5968,7 +5968,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -5981,9 +5981,9 @@
    unreachable
   end
   i32.const 0
-  local.set $0
+  local.set $1
   loop $for-loop|6
-   local.get $0
+   local.get $1
    i32.const 16
    i32.shl
    i32.const 16
@@ -5991,8 +5991,8 @@
    i32.const 50
    i32.lt_s
    if
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -6003,10 +6003,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<i16,i32>#get
-    local.get $0
+    local.get $1
     i32.const 16
     i32.shl
     i32.const 16
@@ -6022,11 +6022,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<i16,i32>#delete
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<i16,i32>#has
     if
      i32.const 0
@@ -6036,14 +6036,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $1
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     br $for-loop|6
    end
   end
-  local.get $2
+  local.get $7
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -6056,9 +6056,9 @@
    unreachable
   end
   i32.const 0
-  local.set $0
+  local.set $1
   loop $for-loop|8
-   local.get $0
+   local.get $1
    i32.const 16
    i32.shl
    i32.const 16
@@ -6066,8 +6066,8 @@
    i32.const 50
    i32.lt_s
    if
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<i16,i32>#has
     if
      i32.const 0
@@ -6077,9 +6077,9 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $0
-    local.get $0
+    local.get $7
+    local.get $1
+    local.get $1
     i32.const 16
     i32.shl
     i32.const 16
@@ -6088,8 +6088,8 @@
     i32.add
     call $~lib/map/Map<i16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
@@ -6100,11 +6100,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<i16,i32>#delete
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<i16,i32>#has
     if
      i32.const 0
@@ -6114,14 +6114,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $1
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     br $for-loop|8
    end
   end
-  local.get $2
+  local.get $7
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -6133,9 +6133,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $7
   call $~lib/map/Map<i8,i32>#clear
-  local.get $2
+  local.get $7
   i32.load offset=20
   if
    i32.const 0
@@ -6145,15 +6145,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<u16,i32>#has (param $0 i32) (param $1 i32) (result i32)
@@ -6178,55 +6178,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i32.load16_u
      i32.store16
-     local.get $2
      local.get $3
+     local.get $2
      i32.load offset=4
      i32.store offset=4
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i32.load16_u
      call $~lib/util/hash/hash16
      local.get $1
@@ -6234,64 +6234,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=8
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 12
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 12
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -6299,7 +6299,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<u16,i32>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -6548,55 +6548,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i32.load16_u
      i32.store16
-     local.get $2
      local.get $3
+     local.get $2
      i32.load16_u offset=2
      i32.store16 offset=2
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i32.load16_u
      call $~lib/util/hash/hash16
      local.get $1
@@ -6604,64 +6604,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=4
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 8
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 8
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -6669,7 +6669,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<u16,u16>#set (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -6882,35 +6882,35 @@
   i32.const 14
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $7
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
-  local.get $2
+  local.get $7
   i32.const 3
   i32.store offset=4
-  local.get $2
+  local.get $7
   i32.const 48
   call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
-  local.get $2
+  local.get $7
   i32.const 4
   i32.store offset=12
-  local.get $2
+  local.get $7
   i32.const 0
   i32.store offset=16
-  local.get $2
+  local.get $7
   i32.const 0
   i32.store offset=20
   loop $for-loop|1
-   local.get $3
+   local.get $6
    i32.const 65535
    i32.and
    i32.const 100
    i32.lt_u
    if
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<u16,i32>#has
     if
      i32.const 0
@@ -6920,17 +6920,17 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
-    local.get $3
+    local.get $7
+    local.get $6
+    local.get $6
     i32.const 65535
     i32.and
     i32.const 10
     i32.add
     call $~lib/map/Map<u16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -6941,10 +6941,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<u16,i32>#get
-    local.get $3
+    local.get $6
     i32.const 65535
     i32.and
     i32.const 10
@@ -6958,14 +6958,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $6
     i32.const 1
     i32.add
-    local.set $3
+    local.set $6
     br $for-loop|1
    end
   end
-  local.get $2
+  local.get $7
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -6978,16 +6978,16 @@
    unreachable
   end
   i32.const 0
-  local.set $3
+  local.set $6
   loop $for-loop|3
-   local.get $3
+   local.get $6
    i32.const 65535
    i32.and
    i32.const 100
    i32.lt_u
    if
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -6998,10 +6998,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<u16,i32>#get
-    local.get $3
+    local.get $6
     i32.const 65535
     i32.and
     i32.const 10
@@ -7015,17 +7015,17 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
-    local.get $3
+    local.get $7
+    local.get $6
+    local.get $6
     i32.const 65535
     i32.and
     i32.const 20
     i32.add
     call $~lib/map/Map<u16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -7036,10 +7036,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $3
+    local.get $7
+    local.get $6
     call $~lib/map/Map<u16,i32>#get
-    local.get $3
+    local.get $6
     i32.const 65535
     i32.and
     i32.const 20
@@ -7053,14 +7053,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $6
     i32.const 1
     i32.add
-    local.set $3
+    local.set $6
     br $for-loop|3
    end
   end
-  local.get $2
+  local.get $7
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -7072,47 +7072,47 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $7
   call $~lib/map/Map<u16,i32>#keys
-  local.set $4
-  local.get $2
+  local.set $5
+  local.get $7
   call $~lib/map/Map<i8,i32>#values
-  local.set $6
+  local.set $3
   i32.const 24
   i32.const 16
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $6
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store
-  local.get $3
+  local.get $6
   i32.const 3
   i32.store offset=4
-  local.get $3
+  local.get $6
   i32.const 32
   call $~lib/arraybuffer/ArrayBuffer#constructor
   i32.store offset=8
-  local.get $3
+  local.get $6
   i32.const 4
   i32.store offset=12
-  local.get $3
+  local.get $6
   i32.const 0
   i32.store offset=16
-  local.get $3
+  local.get $6
   i32.const 0
   i32.store offset=20
   call $~lib/map/Map<i32,i32>#constructor
-  local.set $5
+  local.set $4
   loop $for-loop|4
-   local.get $0
-   local.get $4
+   local.get $1
+   local.get $5
    i32.load offset=12
    i32.lt_s
    if
-    local.get $0
-    local.tee $1
-    local.get $4
+    local.get $1
+    local.tee $0
+    local.get $5
     i32.load offset=12
     i32.ge_u
     if
@@ -7123,20 +7123,20 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $4
+    local.get $5
     i32.load offset=4
-    local.get $1
+    local.get $0
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u
-    local.set $0
-    local.get $6
-    local.get $1
-    call $~lib/array/Array<i32>#__get
-    local.set $7
-    local.get $2
+    local.set $1
+    local.get $3
     local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $2
+    local.get $7
+    local.get $1
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -7147,8 +7147,8 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
     local.get $7
+    local.get $2
     i32.const 20
     i32.sub
     call $~lib/map/Map<u16,i32>#has
@@ -7161,27 +7161,27 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
-    local.get $0
-    local.get $0
+    local.get $6
+    local.get $1
+    local.get $1
     call $~lib/map/Map<u16,u16>#set
     call $~lib/rt/pure/__release
-    local.get $5
-    local.get $7
+    local.get $4
+    local.get $2
     i32.const 20
     i32.sub
-    local.tee $0
-    local.get $0
+    local.tee $1
+    local.get $1
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $1
+    local.get $0
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     br $for-loop|4
    end
   end
-  local.get $3
+  local.get $6
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -7193,7 +7193,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -7206,16 +7206,16 @@
    unreachable
   end
   i32.const 0
-  local.set $0
+  local.set $1
   loop $for-loop|6
-   local.get $0
+   local.get $1
    i32.const 65535
    i32.and
    i32.const 50
    i32.lt_u
    if
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -7226,10 +7226,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<u16,i32>#get
-    local.get $0
+    local.get $1
     i32.const 65535
     i32.and
     i32.const 20
@@ -7243,11 +7243,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<u16,i32>#delete
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<u16,i32>#has
     if
      i32.const 0
@@ -7257,14 +7257,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $1
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     br $for-loop|6
    end
   end
-  local.get $2
+  local.get $7
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -7277,16 +7277,16 @@
    unreachable
   end
   i32.const 0
-  local.set $0
+  local.set $1
   loop $for-loop|8
-   local.get $0
+   local.get $1
    i32.const 65535
    i32.and
    i32.const 50
    i32.lt_u
    if
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<u16,i32>#has
     if
      i32.const 0
@@ -7296,17 +7296,17 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $0
-    local.get $0
+    local.get $7
+    local.get $1
+    local.get $1
     i32.const 65535
     i32.and
     i32.const 10
     i32.add
     call $~lib/map/Map<u16,i32>#set
     call $~lib/rt/pure/__release
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
@@ -7317,11 +7317,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<u16,i32>#delete
-    local.get $2
-    local.get $0
+    local.get $7
+    local.get $1
     call $~lib/map/Map<u16,i32>#has
     if
      i32.const 0
@@ -7331,14 +7331,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $1
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     br $for-loop|8
    end
   end
-  local.get $2
+  local.get $7
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -7350,9 +7350,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $7
   call $~lib/map/Map<i8,i32>#clear
-  local.get $2
+  local.get $7
   i32.load offset=20
   if
    i32.const 0
@@ -7362,15 +7362,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<i32,i32>#has (param $0 i32) (param $1 i32) (result i32)
@@ -8631,55 +8631,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 4
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 4
   i32.shl
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i64.load
      i64.store
-     local.get $2
      local.get $3
+     local.get $2
      i32.load offset=8
      i32.store offset=8
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i64.load
      call $~lib/util/hash/hash64
      local.get $1
@@ -8687,64 +8687,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=12
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 16
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 16
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -8752,7 +8752,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<i64,i32>#set (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
@@ -9120,55 +9120,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 24
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 24
   i32.mul
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=16
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      i64.load
      i64.store
-     local.get $2
      local.get $3
+     local.get $2
      i64.load offset=8
      i64.store offset=8
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      i64.load
      call $~lib/util/hash/hash64
      local.get $1
@@ -9176,64 +9176,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=16
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 24
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 24
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -9241,7 +9241,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<i64,i64>#set (param $0 i32) (param $1 i64) (param $2 i64) (result i32)
@@ -10593,55 +10593,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      f32.load
      f32.store
-     local.get $2
      local.get $3
+     local.get $2
      i32.load offset=4
      i32.store offset=4
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      f32.load
      i32.reinterpret_f32
      call $~lib/util/hash/hash32
@@ -10650,64 +10650,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=8
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 12
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 12
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -10715,7 +10715,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<f32,i32>#set (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
@@ -10996,55 +10996,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      f32.load
      f32.store
-     local.get $2
      local.get $3
+     local.get $2
      f32.load offset=4
      f32.store offset=4
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      f32.load
      i32.reinterpret_f32
      call $~lib/util/hash/hash32
@@ -11053,64 +11053,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=8
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 12
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 12
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -11118,7 +11118,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<f32,f32>#set (param $0 i32) (param $1 f32) (param $2 f32) (result i32)
@@ -11829,55 +11829,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 4
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 4
   i32.shl
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      f64.load
      f64.store
-     local.get $2
      local.get $3
+     local.get $2
      i32.load offset=8
      i32.store offset=8
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      f64.load
      i64.reinterpret_f64
      call $~lib/util/hash/hash64
@@ -11886,64 +11886,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=12
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 16
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 16
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -11951,7 +11951,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<f64,i32>#set (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
@@ -12232,55 +12232,55 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $4
+  local.tee $5
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
-  local.get $4
+  local.get $5
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 24
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $0
   i32.load offset=16
   i32.const 24
   i32.mul
   i32.add
-  local.set $7
-  local.get $4
-  local.set $2
+  local.set $8
+  local.get $5
+  local.set $3
   loop $while-continue|0
-   local.get $5
-   local.get $7
+   local.get $4
+   local.get $8
    i32.ne
    if
-    local.get $5
-    local.tee $3
+    local.get $4
+    local.tee $2
     i32.load offset=16
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $3
+     local.get $2
      f64.load
      f64.store
-     local.get $2
      local.get $3
+     local.get $2
      f64.load offset=8
      f64.store offset=8
-     local.get $2
-     local.get $6
      local.get $3
+     local.get $6
+     local.get $2
      f64.load
      i64.reinterpret_f64
      call $~lib/util/hash/hash64
@@ -12289,64 +12289,64 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $3
+     local.tee $2
      i32.load
      i32.store offset=16
+     local.get $2
      local.get $3
-     local.get $2
      i32.store
-     local.get $2
+     local.get $3
      i32.const 24
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $5
+    local.get $4
     i32.const 24
     i32.add
-    local.set $5
+    local.set $4
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $5
+  local.tee $4
   local.get $0
-  local.tee $3
-  i32.load
   local.tee $2
+  i32.load
+  local.tee $3
   i32.ne
   if
-   local.get $5
+   local.get $4
    call $~lib/rt/pure/__retain
-   local.set $5
-   local.get $2
+   local.set $4
+   local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $3
-  local.get $5
+  local.get $2
+  local.get $4
   i32.store
-  local.get $3
+  local.get $2
   local.get $1
   i32.store offset=4
-  local.get $3
+  local.get $2
   local.set $1
-  local.get $4
-  local.tee $3
+  local.get $5
+  local.tee $2
   local.get $1
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $5
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $3
+  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
@@ -12354,7 +12354,7 @@
   i32.store offset=16
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<f64,f64>#set (param $0 i32) (param $1 f64) (param $2 f64) (result i32)

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -226,7 +226,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -246,35 +246,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -284,12 +284,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -297,7 +297,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -316,42 +316,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -366,12 +368,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -381,38 +383,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -430,7 +432,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -439,21 +441,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -480,7 +482,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -722,22 +724,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz
@@ -1303,7 +1304,6 @@
   call $~lib/memory/memory.fill
   local.get $1
   call $~lib/rt/pure/__retain
-  local.tee $0
  )
  (func $~lib/util/hash/hash8 (param $0 i32) (result i32)
   local.get $0
@@ -1389,45 +1389,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i32.load8_s
      i32.store8
-     local.get $5
      local.get $2
+     local.get $3
      i32.load offset=4
      i32.store offset=4
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i32.load8_s
      call $~lib/util/hash/hash8
      local.get $1
@@ -1435,29 +1435,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=8
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 12
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 12
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -1467,32 +1488,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -2075,8 +2075,8 @@
   local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $3
+  local.tee $5
+  local.set $8
   i32.const 16
   i32.const 4
   call $~lib/rt/tlsf/__alloc
@@ -2093,7 +2093,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $3
+  local.get $8
   i32.const 1073741808
   i32.gt_u
   if
@@ -2104,73 +2104,73 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $3
+  local.tee $3
+  local.get $8
   call $~lib/memory/memory.fill
-  local.get $1
+  local.get $3
   local.set $2
-  local.get $1
+  local.get $3
   local.get $0
   i32.load
-  local.tee $8
+  local.tee $4
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $8
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
   local.get $2
   i32.store
   local.get $0
-  local.get $1
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $3
+  local.get $8
   i32.store offset=8
   local.get $0
-  local.get $3
+  local.get $8
   i32.store offset=12
   loop $for-loop|0
-   local.get $5
    local.get $7
+   local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $5
+    local.get $7
     i32.const 12
     i32.mul
     i32.add
-    local.tee $1
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $4
      local.get $1
+     local.get $3
      i32.load8_s
      call $~lib/array/Array<i8>#__set
-     local.get $4
+     local.get $1
      i32.const 1
      i32.add
-     local.set $4
+     local.set $1
     end
-    local.get $5
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $4
+  local.get $1
   call $~lib/array/Array<i8>#set:length
   local.get $0
  )
@@ -2416,45 +2416,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i32.load8_s
      i32.store8
-     local.get $5
      local.get $2
+     local.get $3
      i32.load8_s offset=1
      i32.store8 offset=1
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i32.load8_s
      call $~lib/util/hash/hash8
      local.get $1
@@ -2462,29 +2462,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 8
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 8
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -2494,32 +2515,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -2761,45 +2761,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i32.load
      i32.store
-     local.get $5
      local.get $2
+     local.get $3
      i32.load offset=4
      i32.store offset=4
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i32.load
      call $~lib/util/hash/hash32
      local.get $1
@@ -2807,29 +2807,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=8
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 12
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 12
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -2839,32 +2860,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -3621,45 +3621,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i32.load8_u
      i32.store8
-     local.get $5
      local.get $2
+     local.get $3
      i32.load offset=4
      i32.store offset=4
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i32.load8_u
      call $~lib/util/hash/hash8
      local.get $1
@@ -3667,29 +3667,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=8
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 12
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 12
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -3699,32 +3720,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -3867,8 +3867,8 @@
   local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $3
+  local.tee $5
+  local.set $8
   i32.const 16
   i32.const 9
   call $~lib/rt/tlsf/__alloc
@@ -3885,7 +3885,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $3
+  local.get $8
   i32.const 1073741808
   i32.gt_u
   if
@@ -3896,73 +3896,73 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $3
+  local.tee $3
+  local.get $8
   call $~lib/memory/memory.fill
-  local.get $1
+  local.get $3
   local.set $2
-  local.get $1
+  local.get $3
   local.get $0
   i32.load
-  local.tee $8
+  local.tee $4
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $8
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
   local.get $2
   i32.store
   local.get $0
-  local.get $1
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $3
+  local.get $8
   i32.store offset=8
   local.get $0
-  local.get $3
+  local.get $8
   i32.store offset=12
   loop $for-loop|0
-   local.get $5
    local.get $7
+   local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $5
+    local.get $7
     i32.const 12
     i32.mul
     i32.add
-    local.tee $1
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $4
      local.get $1
+     local.get $3
      i32.load8_u
      call $~lib/array/Array<i8>#__set
-     local.get $4
+     local.get $1
      i32.const 1
      i32.add
-     local.set $4
+     local.set $1
     end
-    local.get $5
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $4
+  local.get $1
   call $~lib/array/Array<i8>#set:length
   local.get $0
  )
@@ -3987,45 +3987,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i32.load8_u
      i32.store8
-     local.get $5
      local.get $2
+     local.get $3
      i32.load8_u offset=1
      i32.store8 offset=1
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i32.load8_u
      call $~lib/util/hash/hash8
      local.get $1
@@ -4033,29 +4033,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 8
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 8
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -4065,32 +4086,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -4891,45 +4891,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i32.load16_s
      i32.store16
-     local.get $5
      local.get $2
+     local.get $3
      i32.load offset=4
      i32.store offset=4
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i32.load16_s
      call $~lib/util/hash/hash16
      local.get $1
@@ -4937,29 +4937,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=8
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 12
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 12
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -4969,32 +4990,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -5189,11 +5189,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 12
   call $~lib/rt/tlsf/__alloc
@@ -5210,7 +5210,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 536870904
   i32.gt_u
   if
@@ -5221,76 +5221,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 1
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 12
     i32.mul
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i32.load16_s
      call $~lib/array/Array<i16>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i16>#set:length
   local.get $0
  )
@@ -5315,45 +5315,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i32.load16_s
      i32.store16
-     local.get $5
      local.get $2
+     local.get $3
      i32.load16_s offset=2
      i32.store16 offset=2
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i32.load16_s
      call $~lib/util/hash/hash16
      local.get $1
@@ -5361,29 +5361,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 8
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 8
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -5393,32 +5414,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -6188,45 +6188,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i32.load16_u
      i32.store16
-     local.get $5
      local.get $2
+     local.get $3
      i32.load offset=4
      i32.store offset=4
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i32.load16_u
      call $~lib/util/hash/hash16
      local.get $1
@@ -6234,29 +6234,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=8
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 12
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 12
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -6266,32 +6287,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -6432,11 +6432,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 15
   call $~lib/rt/tlsf/__alloc
@@ -6453,7 +6453,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 536870904
   i32.gt_u
   if
@@ -6464,76 +6464,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 1
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 12
     i32.mul
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i32.load16_u
      call $~lib/array/Array<i16>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i16>#set:length
   local.get $0
  )
@@ -6558,45 +6558,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i32.load16_u
      i32.store16
-     local.get $5
      local.get $2
+     local.get $3
      i32.load16_u offset=2
      i32.store16 offset=2
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i32.load16_u
      call $~lib/util/hash/hash16
      local.get $1
@@ -6604,29 +6604,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 8
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 8
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -6636,32 +6657,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -7470,14 +7470,14 @@
   (local $6 i32)
   (local $7 i32)
   call $~lib/map/Map<i32,i32>#constructor
-  local.set $0
+  local.set $1
   loop $for-loop|0
-   local.get $1
+   local.get $2
    i32.const 100
    i32.lt_s
    if
-    local.get $0
     local.get $1
+    local.get $2
     call $~lib/map/Map<i32,i32>#has
     if
      i32.const 0
@@ -7487,15 +7487,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
     local.get $1
-    local.get $1
+    local.get $2
+    local.get $2
     i32.const 10
     i32.add
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $0
     local.get $1
+    local.get $2
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     if
@@ -7506,10 +7506,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
     local.get $1
+    local.get $2
     call $~lib/map/Map<i32,i32>#get
-    local.get $1
+    local.get $2
     i32.const 10
     i32.add
     i32.ne
@@ -7521,14 +7521,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $0
+  local.get $1
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -7541,14 +7541,14 @@
    unreachable
   end
   i32.const 0
-  local.set $1
+  local.set $2
   loop $for-loop|1
-   local.get $1
+   local.get $2
    i32.const 100
    i32.lt_s
    if
-    local.get $0
     local.get $1
+    local.get $2
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     if
@@ -7559,10 +7559,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
     local.get $1
+    local.get $2
     call $~lib/map/Map<i32,i32>#get
-    local.get $1
+    local.get $2
     i32.const 10
     i32.add
     i32.ne
@@ -7574,15 +7574,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
     local.get $1
-    local.get $1
+    local.get $2
+    local.get $2
     i32.const 20
     i32.add
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $0
     local.get $1
+    local.get $2
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     if
@@ -7593,10 +7593,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
     local.get $1
+    local.get $2
     call $~lib/map/Map<i32,i32>#get
-    local.get $1
+    local.get $2
     i32.const 20
     i32.add
     i32.ne
@@ -7608,14 +7608,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|1
    end
   end
-  local.get $0
+  local.get $1
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -7627,14 +7627,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   local.set $5
-  local.get $0
+  local.get $1
   i32.load offset=16
   local.tee $6
   call $~lib/array/Array<i32>#constructor
-  local.set $1
+  local.set $2
   loop $for-loop|01
    local.get $4
    local.get $6
@@ -7651,15 +7651,15 @@
     i32.and
     i32.eqz
     if
-     local.get $1
-     local.get $3
+     local.get $2
+     local.get $0
      local.get $7
      i32.load
      call $~lib/array/Array<i32>#__set
-     local.get $3
+     local.get $0
      i32.const 1
      i32.add
-     local.set $3
+     local.set $0
     end
     local.get $4
     i32.const 1
@@ -7668,31 +7668,31 @@
     br $for-loop|01
    end
   end
-  local.get $1
-  local.get $3
-  call $~lib/array/Array<i32>#set:length
+  local.get $2
   local.get $0
+  call $~lib/array/Array<i32>#set:length
+  local.get $1
   call $~lib/map/Map<i8,i32>#values
   local.set $6
   call $~lib/map/Map<i32,i32>#constructor
-  local.set $3
+  local.set $0
   call $~lib/map/Map<i32,i32>#constructor
   local.set $4
   loop $for-loop|2
+   local.get $3
    local.get $2
-   local.get $1
    i32.load offset=12
    i32.lt_s
    if
-    local.get $1
     local.get $2
+    local.get $3
     call $~lib/array/Array<i32>#__get
     local.set $5
     local.get $6
-    local.get $2
+    local.get $3
     call $~lib/array/Array<i32>#__get
     local.set $7
-    local.get $0
+    local.get $1
     local.get $5
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
@@ -7704,7 +7704,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
+    local.get $1
     local.get $7
     i32.const 20
     i32.sub
@@ -7718,7 +7718,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $3
+    local.get $0
     local.get $5
     local.get $5
     call $~lib/map/Map<i32,i32>#set
@@ -7731,14 +7731,14 @@
     local.get $5
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|2
    end
   end
-  local.get $3
+  local.get $0
   i32.load offset=20
   i32.const 100
   i32.ne
@@ -7763,14 +7763,14 @@
    unreachable
   end
   i32.const 0
-  local.set $2
+  local.set $3
   loop $for-loop|3
-   local.get $2
+   local.get $3
    i32.const 50
    i32.lt_s
    if
-    local.get $0
-    local.get $2
+    local.get $1
+    local.get $3
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     if
@@ -7781,10 +7781,10 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $2
+    local.get $1
+    local.get $3
     call $~lib/map/Map<i32,i32>#get
-    local.get $2
+    local.get $3
     i32.const 20
     i32.add
     i32.ne
@@ -7796,11 +7796,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $2
+    local.get $1
+    local.get $3
     call $~lib/map/Map<i32,i32>#delete
-    local.get $0
-    local.get $2
+    local.get $1
+    local.get $3
     call $~lib/map/Map<i32,i32>#has
     if
      i32.const 0
@@ -7810,14 +7810,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|3
    end
   end
-  local.get $0
+  local.get $1
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -7830,14 +7830,14 @@
    unreachable
   end
   i32.const 0
-  local.set $2
+  local.set $3
   loop $for-loop|4
-   local.get $2
+   local.get $3
    i32.const 50
    i32.lt_s
    if
-    local.get $0
-    local.get $2
+    local.get $1
+    local.get $3
     call $~lib/map/Map<i32,i32>#has
     if
      i32.const 0
@@ -7847,15 +7847,15 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $2
-    local.get $2
+    local.get $1
+    local.get $3
+    local.get $3
     i32.const 10
     i32.add
     call $~lib/map/Map<i32,i32>#set
     call $~lib/rt/pure/__release
-    local.get $0
-    local.get $2
+    local.get $1
+    local.get $3
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     if
@@ -7866,11 +7866,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $0
-    local.get $2
+    local.get $1
+    local.get $3
     call $~lib/map/Map<i32,i32>#delete
-    local.get $0
-    local.get $2
+    local.get $1
+    local.get $3
     call $~lib/map/Map<i32,i32>#has
     if
      i32.const 0
@@ -7880,14 +7880,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $for-loop|4
    end
   end
-  local.get $0
+  local.get $1
   i32.load offset=20
   i32.const 50
   i32.ne
@@ -7899,9 +7899,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/map/Map<i8,i32>#clear
-  local.get $0
+  local.get $1
   i32.load offset=20
   if
    i32.const 0
@@ -7911,15 +7911,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $~lib/map/Map<u32,i32>#keys (param $0 i32) (result i32)
@@ -7934,11 +7934,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 18
   call $~lib/rt/tlsf/__alloc
@@ -7955,7 +7955,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 268435452
   i32.gt_u
   if
@@ -7966,76 +7966,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 2
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 12
     i32.mul
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i32.load
      call $~lib/array/Array<i32>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
@@ -8641,45 +8641,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 4
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 4
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i64.load
      i64.store
-     local.get $5
      local.get $2
+     local.get $3
      i32.load offset=8
      i32.store offset=8
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i64.load
      call $~lib/util/hash/hash64
      local.get $1
@@ -8687,29 +8687,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=12
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 16
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 16
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -8719,32 +8740,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -8931,11 +8931,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 21
   call $~lib/rt/tlsf/__alloc
@@ -8952,7 +8952,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 134217726
   i32.gt_u
   if
@@ -8963,76 +8963,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 3
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 4
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i64.load
      call $~lib/array/Array<i64>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )
@@ -9130,45 +9130,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 24
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 24
   i32.mul
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=16
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      i64.load
      i64.store
-     local.get $5
      local.get $2
+     local.get $3
      i64.load offset=8
      i64.store offset=8
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      i64.load
      call $~lib/util/hash/hash64
      local.get $1
@@ -9176,29 +9176,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=16
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 24
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 24
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -9208,32 +9229,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -9953,11 +9953,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 24
   call $~lib/rt/tlsf/__alloc
@@ -9974,7 +9974,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 134217726
   i32.gt_u
   if
@@ -9985,76 +9985,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 3
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 4
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i64.load
      call $~lib/array/Array<i64>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )
@@ -10603,45 +10603,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      f32.load
      f32.store
-     local.get $5
      local.get $2
+     local.get $3
      i32.load offset=4
      i32.store offset=4
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      f32.load
      i32.reinterpret_f32
      call $~lib/util/hash/hash32
@@ -10650,29 +10650,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=8
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 12
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 12
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -10682,32 +10703,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -10837,8 +10837,8 @@
  (func $~lib/map/Map<f32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 f32)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 f32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -10847,11 +10847,11 @@
   (local $10 i32)
   local.get $0
   i32.load offset=8
-  local.set $5
+  local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $8
-  local.set $7
+  local.tee $9
+  local.set $8
   i32.const 16
   i32.const 27
   call $~lib/rt/tlsf/__alloc
@@ -10868,7 +10868,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $8
+  local.get $9
   i32.const 268435452
   i32.gt_u
   if
@@ -10879,66 +10879,66 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $8
   i32.const 2
   i32.shl
-  local.tee $6
+  local.tee $7
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $6
+  local.tee $3
+  local.get $7
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $5
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
+   local.set $2
+   local.get $5
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=8
   local.get $0
-  local.get $7
+  local.get $8
   i32.store offset=12
   loop $for-loop|0
+   local.get $10
    local.get $9
-   local.get $8
    i32.lt_s
    if
-    local.get $5
-    local.get $9
+    local.get $6
+    local.get $10
     i32.const 12
     i32.mul
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
+     local.get $3
      f32.load
-     local.set $3
-     local.get $10
+     local.set $4
+     local.get $1
      local.get $0
      i32.load offset=12
      i32.ge_u
      if
-      local.get $10
+      local.get $1
       i32.const 0
       i32.lt_s
       if
@@ -10950,38 +10950,38 @@
        unreachable
       end
       local.get $0
-      local.get $10
+      local.get $1
       i32.const 1
       i32.add
-      local.tee $2
+      local.tee $3
       i32.const 2
       call $~lib/array/ensureSize
       local.get $0
-      local.get $2
+      local.get $3
       i32.store offset=12
      end
      local.get $0
      i32.load offset=4
-     local.get $10
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
-     local.get $3
+     local.get $4
      f32.store
-     local.get $10
+     local.get $1
      i32.const 1
      i32.add
-     local.set $10
+     local.set $1
     end
-    local.get $9
+    local.get $10
     i32.const 1
     i32.add
-    local.set $9
+    local.set $10
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $10
+  local.get $1
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
@@ -11006,45 +11006,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 12
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 12
   i32.mul
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      f32.load
      f32.store
-     local.get $5
      local.get $2
+     local.get $3
      f32.load offset=4
      f32.store offset=4
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      f32.load
      i32.reinterpret_f32
      call $~lib/util/hash/hash32
@@ -11053,29 +11053,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=8
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 12
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 12
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -11085,32 +11106,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -11839,45 +11839,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 4
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 4
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      f64.load
      f64.store
-     local.get $5
      local.get $2
+     local.get $3
      i32.load offset=8
      i32.store offset=8
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      f64.load
      i64.reinterpret_f64
      call $~lib/util/hash/hash64
@@ -11886,29 +11886,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=12
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 16
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 16
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -11918,32 +11939,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
@@ -12073,8 +12073,8 @@
  (func $~lib/map/Map<f64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 f64)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 f64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -12083,11 +12083,11 @@
   (local $10 i32)
   local.get $0
   i32.load offset=8
-  local.set $5
+  local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $8
-  local.set $7
+  local.tee $9
+  local.set $8
   i32.const 16
   i32.const 30
   call $~lib/rt/tlsf/__alloc
@@ -12104,7 +12104,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $8
+  local.get $9
   i32.const 134217726
   i32.gt_u
   if
@@ -12115,66 +12115,66 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $8
   i32.const 3
   i32.shl
-  local.tee $6
+  local.tee $7
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $6
+  local.tee $3
+  local.get $7
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $5
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
+   local.set $2
+   local.get $5
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=8
   local.get $0
-  local.get $7
+  local.get $8
   i32.store offset=12
   loop $for-loop|0
+   local.get $10
    local.get $9
-   local.get $8
    i32.lt_s
    if
-    local.get $5
-    local.get $9
+    local.get $6
+    local.get $10
     i32.const 4
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=12
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
+     local.get $3
      f64.load
-     local.set $3
-     local.get $10
+     local.set $4
+     local.get $1
      local.get $0
      i32.load offset=12
      i32.ge_u
      if
-      local.get $10
+      local.get $1
       i32.const 0
       i32.lt_s
       if
@@ -12186,38 +12186,38 @@
        unreachable
       end
       local.get $0
-      local.get $10
+      local.get $1
       i32.const 1
       i32.add
-      local.tee $2
+      local.tee $3
       i32.const 3
       call $~lib/array/ensureSize
       local.get $0
-      local.get $2
+      local.get $3
       i32.store offset=12
      end
      local.get $0
      i32.load offset=4
-     local.get $10
+     local.get $1
      i32.const 3
      i32.shl
      i32.add
-     local.get $3
+     local.get $4
      f64.store
-     local.get $10
+     local.get $1
      i32.const 1
      i32.add
-     local.set $10
+     local.set $1
     end
-    local.get $9
+    local.get $10
     i32.const 1
     i32.add
-    local.set $9
+    local.set $10
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $10
+  local.get $1
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )
@@ -12242,45 +12242,45 @@
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 24
   i32.mul
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 24
   i32.mul
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
-  local.set $5
+  local.set $2
   loop $while-continue|0
-   local.get $3
-   local.get $8
+   local.get $5
+   local.get $7
    i32.ne
    if
-    local.get $3
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=16
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $5
      local.get $2
+     local.get $3
      f64.load
      f64.store
-     local.get $5
      local.get $2
+     local.get $3
      f64.load offset=8
      f64.store offset=8
-     local.get $5
-     local.get $6
      local.get $2
+     local.get $6
+     local.get $3
      f64.load
      i64.reinterpret_f64
      call $~lib/util/hash/hash64
@@ -12289,29 +12289,50 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=16
+     local.get $3
      local.get $2
-     local.get $5
      i32.store
-     local.get $5
+     local.get $2
      i32.const 24
      i32.add
-     local.set $5
+     local.set $2
     end
-    local.get $3
+    local.get $5
     i32.const 24
     i32.add
-    local.set $3
+    local.set $5
     br $while-continue|0
    end
   end
   local.get $6
-  local.tee $3
+  local.tee $5
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
+  local.tee $2
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $5
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
   local.tee $5
   i32.ne
   if
@@ -12321,32 +12342,11 @@
    local.get $5
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
   local.get $3
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $4
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $2
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -842,31 +842,31 @@
  )
  (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
   (local $1 f64)
-  (local $2 i32)
+  (local $2 f64)
   (local $3 i32)
-  (local $4 f64)
-  (local $5 i64)
-  (local $6 f64)
+  (local $4 i32)
+  (local $5 f64)
+  (local $6 i64)
   (local $7 f64)
   i32.const 1
-  local.set $3
+  local.set $4
   local.get $0
   i64.reinterpret_f64
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $2
+  local.tee $3
   i32.const 1071284858
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $2
+   local.get $3
    i32.const 31
    i32.shr_u
   end
   if
-   local.get $2
+   local.get $3
    i32.const -1074790400
    i32.ge_u
    if
@@ -886,7 +886,7 @@
     f64.div
     return
    end
-   local.get $2
+   local.get $3
    i32.const 1
    i32.shl
    i32.const 2034237440
@@ -895,19 +895,17 @@
     local.get $0
     return
    end
-   local.get $2
+   local.get $3
    i32.const -1076707644
    i32.le_u
-   if (result f64)
+   if
     i32.const 0
-    local.set $3
+    local.set $4
     local.get $0
-   else
-    f64.const 0
+    local.set $1
    end
-   local.set $1
   else
-   local.get $2
+   local.get $3
    i32.const 2146435072
    i32.ge_u
    if
@@ -915,29 +913,29 @@
     return
    end
   end
-  local.get $3
+  local.get $4
   if
    f64.const 1
    local.get $0
    f64.add
    i64.reinterpret_f64
-   local.tee $5
+   local.tee $6
    i64.const 32
    i64.shr_u
    i32.wrap_i64
    i32.const 614242
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 20
    i32.shr_u
    i32.const 1023
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 54
    i32.lt_s
-   if (result f64)
+   if
     f64.const 1
-    local.get $5
+    local.get $6
     f64.reinterpret_i64
     local.tee $1
     local.get $0
@@ -948,20 +946,18 @@
     f64.const 1
     f64.sub
     f64.sub
-    local.get $3
+    local.get $4
     i32.const 2
     i32.ge_s
     select
     local.get $1
     f64.div
-   else
-    f64.const 0
+    local.set $2
    end
-   local.set $6
-   local.get $5
+   local.get $6
    i64.const 4294967295
    i64.and
-   local.get $2
+   local.get $3
    i32.const 1048575
    i32.and
    i32.const 1072079006
@@ -980,20 +976,20 @@
   local.get $1
   f64.add
   f64.div
-  local.tee $4
-  local.get $4
+  local.tee $5
+  local.get $5
   f64.mul
   local.tee $7
   local.get $7
   f64.mul
   local.set $0
-  local.get $4
+  local.get $5
   f64.const 0.5
   local.get $1
   f64.mul
   local.get $1
   f64.mul
-  local.tee $4
+  local.tee $5
   local.get $7
   f64.const 0.6666666666666735
   local.get $0
@@ -1023,15 +1019,15 @@
   f64.add
   f64.add
   f64.mul
-  local.get $3
+  local.get $4
   f64.convert_i32_s
   local.tee $0
   f64.const 1.9082149292705877e-10
   f64.mul
-  local.get $6
+  local.get $2
   f64.add
   f64.add
-  local.get $4
+  local.get $5
   f64.sub
   local.get $1
   f64.add
@@ -1278,27 +1274,27 @@
  )
  (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
   (local $1 f32)
-  (local $2 i32)
+  (local $2 f32)
   (local $3 i32)
-  (local $4 f32)
+  (local $4 i32)
   (local $5 f32)
   (local $6 f32)
   i32.const 1
-  local.set $3
+  local.set $4
   local.get $0
   i32.reinterpret_f32
-  local.tee $2
+  local.tee $3
   i32.const 1054086096
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $2
+   local.get $3
    i32.const 31
    i32.shr_u
   end
   if
-   local.get $2
+   local.get $3
    i32.const -1082130432
    i32.ge_u
    if
@@ -1318,7 +1314,7 @@
     f32.div
     return
    end
-   local.get $2
+   local.get $3
    i32.const 1
    i32.shl
    i32.const 1728053248
@@ -1327,19 +1323,17 @@
     local.get $0
     return
    end
-   local.get $2
+   local.get $3
    i32.const -1097468391
    i32.le_u
-   if (result f32)
+   if
     i32.const 0
-    local.set $3
+    local.set $4
     local.get $0
-   else
-    f32.const 0
+    local.set $1
    end
-   local.set $1
   else
-   local.get $2
+   local.get $3
    i32.const 2139095040
    i32.ge_u
    if
@@ -1347,7 +1341,7 @@
     return
    end
   end
-  local.get $3
+  local.get $4
   if
    f32.const 1
    local.get $0
@@ -1356,15 +1350,15 @@
    i32.reinterpret_f32
    i32.const 4913933
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 23
    i32.shr_u
    i32.const 127
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 25
    i32.lt_s
-   if (result f32)
+   if
     f32.const 1
     local.get $1
     local.get $0
@@ -1375,17 +1369,15 @@
     f32.const 1
     f32.sub
     f32.sub
-    local.get $3
+    local.get $4
     i32.const 2
     i32.ge_s
     select
     local.get $1
     f32.div
-   else
-    f32.const 0
+    local.set $2
    end
-   local.set $5
-   local.get $2
+   local.get $3
    i32.const 8388607
    i32.and
    i32.const 1060439283
@@ -1400,20 +1392,20 @@
   local.get $1
   f32.add
   f32.div
-  local.tee $4
-  local.get $4
+  local.tee $5
+  local.get $5
   f32.mul
   local.tee $6
   local.get $6
   f32.mul
   local.set $0
-  local.get $4
+  local.get $5
   f32.const 0.5
   local.get $1
   f32.mul
   local.get $1
   f32.mul
-  local.tee $4
+  local.tee $5
   local.get $6
   f32.const 0.6666666269302368
   local.get $0
@@ -1431,15 +1423,15 @@
   f32.add
   f32.add
   f32.mul
-  local.get $3
+  local.get $4
   f32.convert_i32_s
   local.tee $0
   f32.const 9.05800061445916e-06
   f32.mul
+  local.get $2
+  f32.add
+  f32.add
   local.get $5
-  f32.add
-  f32.add
-  local.get $4
   f32.sub
   local.get $1
   f32.add
@@ -2590,12 +2582,13 @@
   call $std/math/check<f32>
  )
  (func $~lib/math/NativeMath.atan2 (param $0 f64) (param $1 f64) (result f64)
-  (local $2 i32)
+  (local $2 f64)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i64)
-  (local $6 i32)
+  (local $5 i32)
+  (local $6 i64)
   (local $7 i32)
+  (local $8 i32)
   i32.const 1
   local.get $0
   local.get $0
@@ -2612,24 +2605,24 @@
   end
   local.get $0
   i64.reinterpret_f64
-  local.tee $5
-  i64.const 32
-  i64.shr_u
-  i32.wrap_i64
-  local.set $6
-  local.get $5
-  i32.wrap_i64
-  local.get $1
-  i64.reinterpret_f64
-  local.tee $5
+  local.tee $6
   i64.const 32
   i64.shr_u
   i32.wrap_i64
   local.set $7
-  local.get $5
+  local.get $6
   i32.wrap_i64
-  local.tee $4
-  local.get $7
+  local.get $1
+  i64.reinterpret_f64
+  local.tee $6
+  i64.const 32
+  i64.shr_u
+  i32.wrap_i64
+  local.set $8
+  local.get $6
+  i32.wrap_i64
+  local.tee $5
+  local.get $8
   i32.const 1072693248
   i32.sub
   i32.or
@@ -2639,24 +2632,24 @@
    call $~lib/math/NativeMath.atan
    return
   end
-  local.get $7
+  local.get $8
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
-  local.get $6
+  local.get $7
   i32.const 31
   i32.shr_u
   i32.or
-  local.set $3
+  local.set $4
+  local.get $8
+  i32.const 2147483647
+  i32.and
+  local.set $8
   local.get $7
   i32.const 2147483647
   i32.and
-  local.set $7
-  local.get $6
-  i32.const 2147483647
-  i32.and
-  local.tee $6
+  local.tee $7
   i32.or
   i32.eqz
   if
@@ -2664,11 +2657,11 @@
     block $case3|0
      block $case2|0
       block $case1|0
-       local.get $3
+       local.get $4
        i32.eqz
        br_if $case1|0
        block $tablify|0
-        local.get $3
+        local.get $4
         i32.const 1
         i32.sub
         br_table $case1|0 $case2|0 $case3|0 $tablify|0
@@ -2686,98 +2679,97 @@
    end
   end
   block $folding-inner0
-   local.get $4
-   local.get $7
+   local.get $5
+   local.get $8
    i32.or
    i32.eqz
    br_if $folding-inner0
-   local.get $7
+   local.get $8
    i32.const 2146435072
    i32.eq
    if
     f64.const 2.356194490192345
     f64.const 0.7853981633974483
-    local.get $3
+    local.get $4
     i32.const 2
     i32.and
     select
     f64.const 3.141592653589793
     f64.const 0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.and
     select
-    local.get $6
+    local.get $7
     i32.const 2146435072
     i32.eq
     select
     local.tee $0
     f64.neg
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 1
     i32.and
     select
     return
    end
    i32.const 1
-   local.get $6
+   local.get $7
    i32.const 2146435072
    i32.eq
-   local.get $7
+   local.get $8
    i32.const 67108864
    i32.add
-   local.get $6
+   local.get $7
    i32.lt_u
    select
    br_if $folding-inner0
-   local.get $6
+   local.get $7
    i32.const 67108864
    i32.add
-   local.get $7
+   local.get $8
    i32.lt_u
    i32.const 0
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    select
-   if (result f64)
-    f64.const 0
-   else
+   i32.eqz
+   if
     local.get $0
     local.get $1
     f64.div
     f64.abs
     call $~lib/math/NativeMath.atan
+    local.set $2
    end
-   local.set $0
    block $break|1
     block $case3|1
      block $case2|1
       block $case1|1
-       local.get $3
-       local.tee $2
+       local.get $4
+       local.tee $3
        if
-        local.get $2
+        local.get $3
         i32.const 1
         i32.sub
         br_table $case1|1 $case2|1 $case3|1 $break|1
        end
-       local.get $0
+       local.get $2
        return
       end
-      local.get $0
+      local.get $2
       f64.neg
       return
      end
      f64.const 3.141592653589793
-     local.get $0
+     local.get $2
      f64.const 1.2246467991473532e-16
      f64.sub
      f64.sub
      return
     end
-    local.get $0
+    local.get $2
     f64.const 1.2246467991473532e-16
     f64.sub
     f64.const 3.141592653589793
@@ -2788,7 +2780,7 @@
   end
   f64.const -1.5707963267948966
   f64.const 1.5707963267948966
-  local.get $3
+  local.get $4
   i32.const 1
   i32.and
   select
@@ -2812,9 +2804,10 @@
   end
  )
  (func $~lib/math/NativeMathf.atan2 (param $0 f32) (param $1 f32) (result f32)
-  (local $2 i32)
+  (local $2 f32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   i32.const 1
   local.get $0
   local.get $0
@@ -2831,10 +2824,10 @@
   end
   local.get $0
   i32.reinterpret_f32
-  local.set $2
+  local.set $3
   local.get $1
   i32.reinterpret_f32
-  local.tee $4
+  local.tee $5
   i32.const 1065353216
   i32.eq
   if
@@ -2842,42 +2835,42 @@
    call $~lib/math/NativeMathf.atan
    return
   end
-  local.get $4
+  local.get $5
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
-  local.get $2
+  local.get $3
   i32.const 31
   i32.shr_u
   i32.or
-  local.set $3
-  local.get $4
-  i32.const 2147483647
-  i32.and
   local.set $4
-  local.get $2
+  local.get $5
   i32.const 2147483647
   i32.and
-  local.tee $2
+  local.set $5
+  local.get $3
+  i32.const 2147483647
+  i32.and
+  local.tee $3
   i32.eqz
   if
    block $break|0
     block $case3|0
      block $case2|0
-      local.get $3
+      local.get $4
       i32.eqz
-      local.get $3
+      local.get $4
       i32.const 1
       i32.eq
       i32.or
       i32.eqz
       if
-       local.get $3
+       local.get $4
        i32.const 2
        i32.eq
        br_if $case2|0
-       local.get $3
+       local.get $4
        i32.const 3
        i32.eq
        br_if $case3|0
@@ -2894,26 +2887,26 @@
    end
   end
   block $folding-inner0
-   local.get $4
+   local.get $5
    i32.eqz
    br_if $folding-inner0
-   local.get $4
+   local.get $5
    i32.const 2139095040
    i32.eq
    if
     f32.const 2.356194496154785
     f32.const 0.7853981852531433
-    local.get $3
+    local.get $4
     i32.const 2
     i32.and
     select
     f32.const 3.1415927410125732
     f32.const 0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.and
     select
-    local.get $2
+    local.get $3
     i32.const 2139095040
     i32.eq
     select
@@ -2921,70 +2914,69 @@
     local.get $0
     f32.neg
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 1
     i32.and
     select
     return
    end
    i32.const 1
-   local.get $2
+   local.get $3
    i32.const 2139095040
    i32.eq
-   local.get $4
+   local.get $5
    i32.const 218103808
    i32.add
-   local.get $2
+   local.get $3
    i32.lt_u
    select
    br_if $folding-inner0
-   local.get $2
+   local.get $3
    i32.const 218103808
    i32.add
-   local.get $4
+   local.get $5
    i32.lt_u
    i32.const 0
-   local.get $3
+   local.get $4
    i32.const 2
    i32.and
    select
-   if (result f32)
-    f32.const 0
-   else
+   i32.eqz
+   if
     local.get $0
     local.get $1
     f32.div
     f32.abs
     call $~lib/math/NativeMathf.atan
+    local.set $2
    end
-   local.set $0
    block $break|1
     block $case3|1
      block $case2|1
       block $case1|1
-       local.get $3
-       local.tee $2
+       local.get $4
+       local.tee $3
        if
-        local.get $2
+        local.get $3
         i32.const 1
         i32.sub
         br_table $case1|1 $case2|1 $case3|1 $break|1
        end
-       local.get $0
+       local.get $2
        return
       end
-      local.get $0
+      local.get $2
       f32.neg
       return
      end
      f32.const 3.1415927410125732
-     local.get $0
+     local.get $2
      f32.const -8.742277657347586e-08
      f32.sub
      f32.sub
      return
     end
-    local.get $0
+    local.get $2
     f32.const -8.742277657347586e-08
     f32.sub
     f32.const 3.1415927410125732
@@ -2995,7 +2987,7 @@
   end
   f32.const -1.5707963705062866
   f32.const 1.5707963705062866
-  local.get $3
+  local.get $4
   i32.const 1
   i32.and
   select
@@ -5557,7 +5549,7 @@
   i64.const 52
   i64.shr_u
   i32.wrap_i64
-  local.tee $10
+  local.tee $6
   i32.const 2047
   i32.eq
   if
@@ -5574,7 +5566,7 @@
   i64.const 52
   i64.shr_u
   i32.wrap_i64
-  local.tee $6
+  local.tee $10
   i32.const 2047
   i32.eq
   select
@@ -5582,8 +5574,8 @@
    local.get $0
    return
   end
-  local.get $6
   local.get $10
+  local.get $6
   i32.sub
   i32.const 64
   i32.gt_s
@@ -5594,13 +5586,13 @@
    return
   end
   f64.const 1
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $10
   i32.const 1533
   i32.gt_s
   if (result f64)
    f64.const 5260135901548373507240989e186
-   local.set $7
+   local.set $9
    local.get $1
    f64.const 1.90109156629516e-211
    f64.mul
@@ -5609,12 +5601,12 @@
    f64.const 1.90109156629516e-211
    f64.mul
   else
-   local.get $10
+   local.get $6
    i32.const 573
    i32.lt_s
    if (result f64)
     f64.const 1.90109156629516e-211
-    local.set $7
+    local.set $9
     local.get $1
     f64.const 5260135901548373507240989e186
     f64.mul
@@ -5632,26 +5624,26 @@
   local.get $1
   f64.const 134217729
   f64.mul
-  local.tee $5
+  local.tee $11
   f64.sub
-  local.get $5
+  local.get $11
   f64.add
   local.tee $8
   f64.sub
-  local.set $11
+  local.set $5
   local.get $0
   local.get $0
   local.get $0
   f64.const 134217729
   f64.mul
-  local.tee $5
+  local.tee $11
   f64.sub
-  local.get $5
+  local.get $11
   f64.add
-  local.tee $9
+  local.tee $7
   f64.sub
-  local.set $5
-  local.get $7
+  local.set $11
+  local.get $9
   local.get $8
   local.get $8
   f64.mul
@@ -5663,13 +5655,13 @@
   f64.const 2
   local.get $8
   f64.mul
-  local.get $11
+  local.get $5
   f64.add
-  local.get $11
+  local.get $5
   f64.mul
   f64.add
-  local.get $9
-  local.get $9
+  local.get $7
+  local.get $7
   f64.mul
   local.get $0
   local.get $0
@@ -5677,11 +5669,11 @@
   local.tee $0
   f64.sub
   f64.const 2
-  local.get $9
+  local.get $7
   f64.mul
-  local.get $5
+  local.get $11
   f64.add
-  local.get $5
+  local.get $11
   f64.mul
   f64.add
   f64.add
@@ -7088,14 +7080,14 @@
  )
  (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
-  (local $3 f64)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 f64)
-  (local $7 i32)
+  (local $3 i32)
+  (local $4 f64)
+  (local $5 f64)
+  (local $6 i32)
+  (local $7 f64)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f64)
+  (local $10 i32)
   (local $11 i32)
   (local $12 f64)
   (local $13 i64)
@@ -7170,17 +7162,17 @@
   local.tee $15
   i32.const 2147483647
   i32.and
-  local.set $4
+  local.set $6
   local.get $1
   i64.reinterpret_f64
   local.tee $13
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $7
+  local.tee $8
   i32.const 2147483647
   i32.and
-  local.tee $8
+  local.tee $9
   local.get $13
   i32.wrap_i64
   local.tee $19
@@ -7193,22 +7185,22 @@
   i32.const 1
   local.get $19
   i32.const 0
-  local.get $8
+  local.get $9
   i32.const 2146435072
   i32.eq
   select
   i32.const 1
-  local.get $8
+  local.get $9
   i32.const 2146435072
   i32.gt_s
   i32.const 1
   local.get $18
   i32.const 0
-  local.get $4
+  local.get $6
   i32.const 2146435072
   i32.eq
   select
-  local.get $4
+  local.get $6
   i32.const 2146435072
   i32.gt_s
   select
@@ -7223,47 +7215,47 @@
   local.get $15
   i32.const 0
   i32.lt_s
-  if (result i32)
-   local.get $8
+  if
+   local.get $9
    i32.const 1128267776
    i32.ge_s
    if (result i32)
     i32.const 2
    else
-    local.get $8
+    local.get $9
     i32.const 1072693248
     i32.ge_s
     if (result i32)
      i32.const 52
      i32.const 20
-     local.get $8
+     local.get $9
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $9
+     local.tee $10
      i32.const 20
      i32.gt_s
-     local.tee $5
+     local.tee $3
      select
-     local.get $9
+     local.get $10
      i32.sub
      local.set $11
      i32.const 2
      local.get $19
-     local.get $8
-     local.get $5
+     local.get $9
+     local.get $3
      select
-     local.tee $5
+     local.tee $3
      local.get $11
      i32.shr_u
-     local.tee $9
+     local.tee $10
      i32.const 1
      i32.and
      i32.sub
      i32.const 0
-     local.get $5
-     local.get $9
+     local.get $3
+     local.get $10
      local.get $11
      i32.shl
      i32.eq
@@ -7272,30 +7264,28 @@
      i32.const 0
     end
    end
-  else
-   i32.const 0
+   local.set $3
   end
-  local.set $5
   local.get $19
   i32.eqz
   if
-   local.get $8
+   local.get $9
    i32.const 2146435072
    i32.eq
    if
     local.get $18
-    local.get $4
+    local.get $6
     i32.const 1072693248
     i32.sub
     i32.or
     if
-     local.get $4
+     local.get $6
      i32.const 1072693248
      i32.ge_s
      if
       local.get $1
       f64.const 0
-      local.get $7
+      local.get $8
       i32.const 0
       i32.ge_s
       select
@@ -7304,7 +7294,7 @@
       local.get $1
       f64.neg
       f64.const 0
-      local.get $7
+      local.get $8
       i32.const 0
       i32.lt_s
       select
@@ -7317,11 +7307,11 @@
     end
     unreachable
    end
-   local.get $8
+   local.get $9
    i32.const 1072693248
    i32.eq
    if
-    local.get $7
+    local.get $8
     i32.const 0
     i32.ge_s
     if
@@ -7333,7 +7323,7 @@
     f64.div
     return
    end
-   local.get $7
+   local.get $8
    i32.const 1073741824
    i32.eq
    if
@@ -7342,7 +7332,7 @@
     f64.mul
     return
    end
-   local.get $7
+   local.get $8
    i32.const 1071644672
    i32.eq
    if
@@ -7358,67 +7348,69 @@
   end
   local.get $0
   f64.abs
-  local.set $3
+  local.set $5
   local.get $18
   i32.eqz
   if
    i32.const 1
-   local.get $4
+   local.get $6
    i32.const 1072693248
    i32.eq
-   local.get $4
+   local.get $6
    i32.const 2146435072
    i32.eq
    i32.const 1
-   local.get $4
+   local.get $6
    select
    select
    if
     f64.const 1
-    local.get $3
+    local.get $5
     f64.div
-    local.get $3
-    local.get $7
+    local.get $5
+    local.get $8
     i32.const 0
     i32.lt_s
     select
-    local.set $3
+    local.set $5
     local.get $15
     i32.const 0
     i32.lt_s
     if (result f64)
-     local.get $5
-     local.get $4
+     local.get $3
+     local.get $6
      i32.const 1072693248
      i32.sub
      i32.or
      if (result f64)
-      local.get $3
-      f64.neg
-      local.get $3
       local.get $5
+      f64.neg
+      local.get $5
+      local.get $3
       i32.const 1
       i32.eq
       select
      else
-      local.get $3
-      local.get $3
+      local.get $5
+      local.get $5
       f64.sub
       local.tee $0
       local.get $0
       f64.div
      end
     else
-     local.get $3
+     local.get $5
     end
     return
    end
   end
+  f64.const 1
+  local.set $4
   local.get $15
   i32.const 0
   i32.lt_s
-  if (result f64)
-   local.get $5
+  if
+   local.get $3
    i32.eqz
    if
     local.get $0
@@ -7431,94 +7423,92 @@
    end
    f64.const -1
    f64.const 1
-   local.get $5
+   local.get $3
    i32.const 1
    i32.eq
    select
-  else
-   f64.const 1
+   local.set $4
   end
-  local.set $10
-  local.get $8
+  local.get $9
   i32.const 1105199104
   i32.gt_s
   if (result f64)
-   local.get $8
+   local.get $9
    i32.const 1139802112
    i32.gt_s
    if
-    local.get $4
+    local.get $6
     i32.const 1072693247
     i32.le_s
     if
      f64.const inf
      f64.const 0
-     local.get $7
+     local.get $8
      i32.const 0
      i32.lt_s
      select
      return
     end
-    local.get $4
+    local.get $6
     i32.const 1072693248
     i32.ge_s
     if
      f64.const inf
      f64.const 0
-     local.get $7
+     local.get $8
      i32.const 0
      i32.gt_s
      select
      return
     end
    end
-   local.get $4
+   local.get $6
    i32.const 1072693247
    i32.lt_s
    if
-    local.get $10
+    local.get $4
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
-    local.get $10
+    local.get $4
     f64.const 1e-300
     f64.mul
     f64.const 1e-300
     f64.mul
-    local.get $7
+    local.get $8
     i32.const 0
     i32.lt_s
     select
     return
    end
-   local.get $4
+   local.get $6
    i32.const 1072693248
    i32.gt_s
    if
-    local.get $10
+    local.get $4
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
-    local.get $10
+    local.get $4
     f64.const 1e-300
     f64.mul
     f64.const 1e-300
     f64.mul
-    local.get $7
+    local.get $8
     i32.const 0
     i32.gt_s
     select
     return
    end
    f64.const 1.4426950216293335
-   local.get $3
+   local.get $5
    f64.const 1
    f64.sub
    local.tee $0
    f64.mul
-   local.tee $3
+   local.tee $5
    local.get $0
    f64.const 1.9259629911266175e-08
    f64.mul
@@ -7544,86 +7534,86 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $6
+   local.set $7
    local.get $0
-   local.get $6
-   local.get $3
+   local.get $7
+   local.get $5
    f64.sub
    f64.sub
   else
-   local.get $4
+   local.get $6
    i32.const 1048576
    i32.lt_s
    if (result i32)
-    local.get $3
+    local.get $5
     f64.const 9007199254740992
     f64.mul
-    local.tee $3
+    local.tee $5
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.set $4
+    local.set $6
     i32.const -53
    else
     i32.const 0
    end
-   local.get $4
+   local.get $6
    i32.const 20
    i32.shr_s
    i32.const 1023
    i32.sub
    i32.add
-   local.set $7
-   local.get $4
+   local.set $8
+   local.get $6
    i32.const 1048575
    i32.and
-   local.tee $5
+   local.tee $3
    i32.const 1072693248
    i32.or
-   local.set $4
-   local.get $5
+   local.set $6
+   local.get $3
    i32.const 235662
    i32.gt_s
    if
-    local.get $5
+    local.get $3
     i32.const 767610
     i32.lt_s
     if
      i32.const 1
      local.set $16
     else
-     local.get $7
+     local.get $8
      i32.const 1
      i32.add
-     local.set $7
-     local.get $4
+     local.set $8
+     local.get $6
      i32.const -1048576
      i32.add
-     local.set $4
+     local.set $6
     end
    end
    f64.const 0.9617967009544373
-   local.get $3
+   local.get $5
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
-   local.get $4
+   local.get $6
    i64.extend_i32_s
    i64.const 32
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.tee $6
+   local.tee $7
    f64.const 1.5
    f64.const 1
    local.get $16
    select
    local.tee $2
    f64.sub
-   local.tee $3
+   local.tee $5
    f64.const 1
-   local.get $6
+   local.get $7
    local.get $2
    f64.add
    f64.div
@@ -7670,9 +7660,9 @@
    f64.add
    f64.mul
    local.get $0
-   local.get $3
+   local.get $5
    local.get $14
-   local.get $4
+   local.get $6
    i32.const 1
    i32.shr_s
    i32.const 536870912
@@ -7691,7 +7681,7 @@
    f64.mul
    f64.sub
    local.get $14
-   local.get $6
+   local.get $7
    local.get $0
    local.get $2
    f64.sub
@@ -7711,14 +7701,14 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.tee $6
+   local.tee $7
    f64.mul
-   local.tee $3
+   local.tee $5
    local.get $2
-   local.get $6
+   local.get $7
    f64.mul
    local.get $0
-   local.get $6
+   local.get $7
    f64.const 3
    f64.sub
    local.get $20
@@ -7741,7 +7731,7 @@
    f64.mul
    local.get $0
    local.get $2
-   local.get $3
+   local.get $5
    f64.sub
    f64.sub
    f64.const 0.9617966939259756
@@ -7758,9 +7748,9 @@
    f64.const 0
    local.get $16
    select
-   local.tee $3
+   local.tee $5
    f64.add
-   local.get $7
+   local.get $8
    f64.convert_i32_s
    local.tee $0
    f64.add
@@ -7768,18 +7758,18 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $6
+   local.set $7
    local.get $2
-   local.get $6
+   local.get $7
    local.get $0
    f64.sub
-   local.get $3
+   local.get $5
    f64.sub
    local.get $20
    f64.sub
    f64.sub
   end
-  local.set $3
+  local.set $5
   local.get $1
   local.get $1
   i64.reinterpret_f64
@@ -7788,15 +7778,15 @@
   f64.reinterpret_i64
   local.tee $0
   f64.sub
-  local.get $6
+  local.get $7
   f64.mul
   local.get $1
-  local.get $3
+  local.get $5
   f64.mul
   f64.add
   local.tee $1
   local.get $0
-  local.get $6
+  local.get $7
   f64.mul
   local.tee $2
   f64.add
@@ -7804,7 +7794,7 @@
   i64.reinterpret_f64
   local.tee $13
   i32.wrap_i64
-  local.set $5
+  local.set $3
   block $folding-inner1
    block $folding-inner0
     local.get $13
@@ -7815,7 +7805,7 @@
     i32.const 1083179008
     i32.ge_s
     if
-     local.get $5
+     local.get $3
      local.get $11
      i32.const 1083179008
      i32.sub
@@ -7836,7 +7826,7 @@
      i32.const 1083231232
      i32.ge_s
      i32.const 0
-     local.get $5
+     local.get $3
      local.get $11
      i32.const -1064252416
      i32.sub
@@ -7853,39 +7843,39 @@
     local.get $11
     i32.const 2147483647
     i32.and
-    local.tee $9
+    local.tee $10
     i32.const 20
     i32.shr_s
     i32.const 1023
     i32.sub
-    local.set $5
+    local.set $3
     i32.const 0
-    local.set $7
+    local.set $8
     local.get $1
-    local.get $9
+    local.get $10
     i32.const 1071644672
     i32.gt_s
     if
      i32.const 1048575
      local.get $11
      i32.const 1048576
-     local.get $5
+     local.get $3
      i32.const 1
      i32.add
      i32.shr_s
      i32.add
-     local.tee $9
+     local.tee $10
      i32.const 2147483647
      i32.and
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $5
+     local.tee $3
      i32.shr_s
      i32.const -1
      i32.xor
-     local.get $9
+     local.get $10
      i32.and
      i64.extend_i32_s
      i64.const 32
@@ -7893,23 +7883,23 @@
      f64.reinterpret_i64
      local.set $0
      i32.const 0
-     local.get $9
+     local.get $10
      i32.const 1048575
      i32.and
      i32.const 1048576
      i32.or
      i32.const 20
-     local.get $5
+     local.get $3
      i32.sub
      i32.shr_s
-     local.tee $7
+     local.tee $8
      i32.sub
-     local.get $7
+     local.get $8
      local.get $11
      i32.const 0
      i32.lt_s
      select
-     local.set $7
+     local.set $8
      local.get $2
      local.get $0
      f64.sub
@@ -7924,7 +7914,7 @@
     local.tee $0
     f64.const 0.6931471824645996
     f64.mul
-    local.tee $3
+    local.tee $5
     local.get $1
     local.get $0
     local.get $2
@@ -7942,7 +7932,7 @@
     local.get $2
     f64.mul
     local.set $0
-    local.get $10
+    local.get $4
     f64.const 1
     local.get $2
     local.get $2
@@ -7974,7 +7964,7 @@
     f64.div
     local.get $1
     local.get $2
-    local.get $3
+    local.get $5
     f64.sub
     f64.sub
     local.tee $0
@@ -7991,25 +7981,25 @@
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.get $7
+    local.get $8
     i32.const 20
     i32.shl
     i32.add
-    local.tee $5
+    local.tee $3
     i32.const 20
     i32.shr_s
     i32.const 0
     i32.le_s
     if (result f64)
      local.get $0
-     local.get $7
+     local.get $8
      call $~lib/math/NativeMath.scalbn
     else
      local.get $0
      i64.reinterpret_f64
      i64.const 4294967295
      i64.and
-     local.get $5
+     local.get $3
      i64.extend_i32_s
      i64.const 32
      i64.shl
@@ -8019,14 +8009,14 @@
     f64.mul
     return
    end
-   local.get $10
+   local.get $4
    f64.const 1.e+300
    f64.mul
    f64.const 1.e+300
    f64.mul
    return
   end
-  local.get $10
+  local.get $4
   f64.const 1e-300
   f64.mul
   f64.const 1e-300
@@ -8758,10 +8748,10 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 f32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
+  (local $8 i32)
   (local $9 i32)
   local.get $0
   i32.reinterpret_f32
@@ -8770,26 +8760,26 @@
   i32.shr_u
   i32.const 255
   i32.and
-  local.set $4
+  local.set $9
   local.get $1
   i32.reinterpret_f32
-  local.tee $7
+  local.tee $6
   i32.const 23
   i32.shr_u
   i32.const 255
   i32.and
-  local.set $5
+  local.set $8
   local.get $2
   local.set $3
   i32.const 1
   local.get $1
   local.get $1
   f32.ne
-  local.get $4
+  local.get $9
   i32.const 255
   i32.eq
   i32.const 1
-  local.get $7
+  local.get $6
   i32.const 1
   i32.shl
   select
@@ -8814,8 +8804,8 @@
   local.get $3
   i32.const 31
   i32.shr_u
-  local.set $9
-  local.get $4
+  local.set $4
+  local.get $9
   if (result i32)
    local.get $3
    i32.const 8388607
@@ -8825,45 +8815,45 @@
   else
    local.get $3
    i32.const 1
-   local.get $4
+   local.get $9
    local.get $3
    i32.const 9
    i32.shl
    i32.clz
    i32.sub
-   local.tee $4
+   local.tee $9
    i32.sub
    i32.shl
   end
   local.set $2
-  local.get $5
+  local.get $8
   if (result i32)
-   local.get $7
+   local.get $6
    i32.const 8388607
    i32.and
    i32.const 8388608
    i32.or
   else
-   local.get $7
+   local.get $6
    i32.const 1
-   local.get $5
-   local.get $7
+   local.get $8
+   local.get $6
    i32.const 9
    i32.shl
    i32.clz
    i32.sub
-   local.tee $5
+   local.tee $8
    i32.sub
    i32.shl
   end
   local.set $3
   block $do-break|0
-   local.get $4
-   local.get $5
+   local.get $9
+   local.get $8
    i32.lt_s
    if
-    local.get $5
-    local.get $4
+    local.get $8
+    local.get $9
     i32.const 1
     i32.add
     i32.eq
@@ -8872,18 +8862,18 @@
     return
    end
    loop $while-continue|1
-    local.get $4
-    local.get $5
+    local.get $9
+    local.get $8
     i32.gt_s
     if
      local.get $2
      local.get $3
      i32.ge_u
      if (result i32)
-      local.get $6
+      local.get $7
       i32.const 1
       i32.add
-      local.set $6
+      local.set $7
       local.get $2
       local.get $3
       i32.sub
@@ -8893,14 +8883,14 @@
      i32.const 1
      i32.shl
      local.set $2
-     local.get $6
+     local.get $7
      i32.const 1
      i32.shl
-     local.set $6
-     local.get $4
+     local.set $7
+     local.get $9
      i32.const 1
      i32.sub
-     local.set $4
+     local.set $9
      br $while-continue|1
     end
    end
@@ -8908,10 +8898,10 @@
    local.get $3
    i32.ge_u
    if
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     local.get $2
     local.get $3
     i32.sub
@@ -8919,36 +8909,36 @@
    end
    local.get $2
    if
-    local.get $4
+    local.get $9
     local.get $2
     i32.const 8
     i32.shl
     i32.clz
     local.tee $3
     i32.sub
-    local.set $4
+    local.set $9
     local.get $2
     local.get $3
     i32.shl
     local.set $2
    else
     i32.const -30
-    local.set $4
+    local.set $9
    end
   end
   local.get $2
   i32.const 8388608
   i32.sub
-  local.get $4
+  local.get $9
   i32.const 23
   i32.shl
   i32.or
   local.get $2
   i32.const 1
-  local.get $4
+  local.get $9
   i32.sub
   i32.shr_u
-  local.get $4
+  local.get $9
   i32.const 0
   i32.gt_s
   select
@@ -8956,7 +8946,7 @@
   local.tee $0
   local.get $0
   f32.add
-  local.set $8
+  local.set $5
   local.get $0
   local.get $1
   f32.abs
@@ -8965,27 +8955,27 @@
   local.get $0
   i32.const 1
   i32.const 1
-  local.get $6
+  local.get $7
   i32.const 1
   i32.and
   i32.const 0
-  local.get $8
+  local.get $5
   local.get $1
   f32.eq
   select
-  local.get $8
+  local.get $5
   local.get $1
   f32.gt
   select
   i32.const 0
-  local.get $5
-  local.get $4
+  local.get $8
+  local.get $9
   i32.const 1
   i32.add
   i32.eq
   select
-  local.get $4
-  local.get $5
+  local.get $8
+  local.get $9
   i32.eq
   select
   select
@@ -8993,7 +8983,7 @@
   local.get $0
   f32.neg
   local.get $0
-  local.get $9
+  local.get $4
   select
  )
  (func $std/math/test_remf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
@@ -10438,40 +10428,39 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_tanh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
-  (local $3 i32)
-  (local $4 f64)
-  (local $5 i64)
+ (func $~lib/math/NativeMath.tanh (param $0 f64) (result f64)
+  (local $1 f64)
+  (local $2 i32)
+  (local $3 i64)
   local.get $0
-  local.tee $4
   i64.reinterpret_f64
   i64.const 9223372036854775807
   i64.and
-  local.tee $5
+  local.tee $3
   f64.reinterpret_i64
-  local.set $0
-  local.get $5
+  local.set $1
+  local.get $3
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $3
+  local.tee $2
   i32.const 1071748074
   i32.gt_u
-  if
-   local.get $3
+  if (result f64)
+   local.get $2
    i32.const 1077149696
    i32.gt_u
    if (result f64)
     f64.const 1
     f64.const 0
-    local.get $0
+    local.get $1
     f64.div
     f64.sub
    else
     f64.const 1
     f64.const 2
     f64.const 2
-    local.get $0
+    local.get $1
     f64.mul
     call $~lib/math/NativeMath.expm1
     f64.const 2
@@ -10479,49 +10468,51 @@
     f64.div
     f64.sub
    end
-   local.set $0
   else
-   local.get $3
+   local.get $2
    i32.const 1070618798
    i32.gt_u
-   if
+   if (result f64)
     f64.const 2
-    local.get $0
+    local.get $1
     f64.mul
     call $~lib/math/NativeMath.expm1
-    local.tee $0
-    local.get $0
+    local.tee $1
+    local.get $1
     f64.const 2
     f64.add
     f64.div
-    local.set $0
    else
-    local.get $3
+    local.get $2
     i32.const 1048576
     i32.ge_u
-    if
+    if (result f64)
      f64.const -2
-     local.get $0
+     local.get $1
      f64.mul
      call $~lib/math/NativeMath.expm1
-     local.tee $0
+     local.tee $1
      f64.neg
-     local.get $0
+     local.get $1
      f64.const 2
      f64.add
      f64.div
-     local.set $0
+    else
+     local.get $1
     end
    end
   end
   local.get $0
-  local.get $4
   f64.copysign
+ )
+ (func $std/math/test_tanh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+  local.get $0
+  call $~lib/math/NativeMath.tanh
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $4
+   local.get $0
    call $~lib/bindings/Math/tanh
    local.get $1
    local.get $2
@@ -10630,8 +10621,8 @@
  )
  (func $~lib/math/NativeMath.sincos (param $0 f64)
   (local $1 f64)
-  (local $2 i64)
-  (local $3 f64)
+  (local $2 f64)
+  (local $3 i64)
   (local $4 f64)
   (local $5 i32)
   (local $6 i32)
@@ -10640,7 +10631,7 @@
   (local $9 f64)
   local.get $0
   i64.reinterpret_f64
-  local.tee $2
+  local.tee $3
   i64.const 32
   i64.shr_u
   i32.wrap_i64
@@ -10669,27 +10660,27 @@
    local.get $0
    local.get $0
    f64.mul
-   local.tee $3
+   local.tee $2
    local.get $0
    f64.mul
    f64.const -0.16666666666666632
-   local.get $3
+   local.get $2
    f64.const 0.00833333333332249
-   local.get $3
+   local.get $2
    f64.const -1.984126982985795e-04
-   local.get $3
+   local.get $2
    f64.const 2.7557313707070068e-06
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.get $3
-   local.get $3
-   local.get $3
+   local.get $2
+   local.get $2
+   local.get $2
    f64.mul
    f64.mul
    f64.const -2.5050760253406863e-08
-   local.get $3
+   local.get $2
    f64.const 1.58969099521155e-10
    f64.mul
    f64.add
@@ -10705,7 +10696,7 @@
    local.get $0
    local.get $0
    f64.mul
-   local.tee $3
+   local.tee $2
    f64.mul
    local.tee $4
    f64.sub
@@ -10715,28 +10706,28 @@
    f64.sub
    local.get $4
    f64.sub
-   local.get $3
-   local.get $3
+   local.get $2
+   local.get $2
    f64.const 0.0416666666666666
-   local.get $3
+   local.get $2
    f64.const -0.001388888888887411
-   local.get $3
+   local.get $2
    f64.const 2.480158728947673e-05
    f64.mul
    f64.add
    f64.mul
    f64.add
    f64.mul
-   local.get $3
-   local.get $3
+   local.get $2
+   local.get $2
    f64.mul
    local.tee $4
    local.get $4
    f64.mul
    f64.const -2.7557314351390663e-07
-   local.get $3
+   local.get $2
    f64.const 2.087572321298175e-09
-   local.get $3
+   local.get $2
    f64.const -1.1359647557788195e-11
    f64.mul
    f64.add
@@ -10768,7 +10759,7 @@
    return
   end
   block $~lib/math/rempio2|inlined.3 (result i32)
-   local.get $2
+   local.get $3
    i64.const 32
    i64.shr_u
    i32.wrap_i64
@@ -10787,12 +10778,12 @@
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.tee $3
+    local.tee $2
     f64.const 1.5707963267341256
     f64.mul
     f64.sub
     local.tee $0
-    local.get $3
+    local.get $2
     f64.const 6.077100506506192e-11
     f64.mul
     local.tee $4
@@ -10810,12 +10801,12 @@
     i32.const 16
     i32.gt_u
     if
-     local.get $3
+     local.get $2
      f64.const 2.0222662487959506e-21
      f64.mul
      local.get $0
      local.get $0
-     local.get $3
+     local.get $2
      f64.const 6.077100506303966e-11
      f64.mul
      local.tee $4
@@ -10843,12 +10834,12 @@
      i32.const 49
      i32.gt_u
      if (result f64)
-      local.get $3
+      local.get $2
       f64.const 8.4784276603689e-32
       f64.mul
       local.get $0
       local.get $0
-      local.get $3
+      local.get $2
       f64.const 2.0222662487111665e-21
       f64.mul
       local.tee $4
@@ -10875,12 +10866,12 @@
     local.get $4
     f64.sub
     global.set $~lib/math/rempio2_y1
-    local.get $3
+    local.get $2
     i32.trunc_f64_s
     br $~lib/math/rempio2|inlined.3
    end
    i32.const 0
-   local.get $2
+   local.get $3
    call $~lib/math/pio2_large_quot
    local.tee $5
    i32.sub
@@ -10896,14 +10887,14 @@
   local.tee $0
   local.get $4
   f64.mul
-  local.set $3
+  local.set $2
   local.get $4
   local.get $0
   f64.const 0.5
   global.get $~lib/math/rempio2_y1
   local.tee $1
   f64.mul
-  local.get $3
+  local.get $2
   f64.const 0.00833333333332249
   local.get $0
   f64.const -1.984126982985795e-04
@@ -10930,7 +10921,7 @@
   f64.mul
   local.get $1
   f64.sub
-  local.get $3
+  local.get $2
   f64.const -0.16666666666666632
   f64.mul
   f64.sub
@@ -10942,7 +10933,7 @@
   local.get $4
   local.get $4
   f64.mul
-  local.tee $3
+  local.tee $2
   f64.mul
   local.tee $7
   f64.sub
@@ -10952,28 +10943,28 @@
   f64.sub
   local.get $7
   f64.sub
-  local.get $3
-  local.get $3
+  local.get $2
+  local.get $2
   f64.const 0.0416666666666666
-  local.get $3
+  local.get $2
   f64.const -0.001388888888887411
-  local.get $3
+  local.get $2
   f64.const 2.480158728947673e-05
   f64.mul
   f64.add
   f64.mul
   f64.add
   f64.mul
-  local.get $3
-  local.get $3
+  local.get $2
+  local.get $2
   f64.mul
   local.tee $7
   local.get $7
   f64.mul
   f64.const -2.7557314351390663e-07
-  local.get $3
+  local.get $2
   f64.const 2.087572321298175e-09
-  local.get $3
+  local.get $2
   f64.const -1.1359647557788195e-11
   f64.mul
   f64.add
@@ -10988,7 +10979,7 @@
   f64.sub
   f64.add
   f64.add
-  local.tee $3
+  local.tee $2
   local.set $4
   local.get $6
   i32.const 1
@@ -10997,7 +10988,7 @@
    local.get $8
    f64.neg
    local.set $4
-   local.get $3
+   local.get $2
    local.set $0
   end
   local.get $6

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -842,31 +842,31 @@
  )
  (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
   (local $1 f64)
-  (local $2 f64)
+  (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 f64)
-  (local $6 i64)
+  (local $4 f64)
+  (local $5 i64)
+  (local $6 f64)
   (local $7 f64)
   i32.const 1
-  local.set $4
+  local.set $3
   local.get $0
   i64.reinterpret_f64
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $3
+  local.tee $2
   i32.const 1071284858
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $3
+   local.get $2
    i32.const 31
    i32.shr_u
   end
   if
-   local.get $3
+   local.get $2
    i32.const -1074790400
    i32.ge_u
    if
@@ -886,7 +886,7 @@
     f64.div
     return
    end
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.const 2034237440
@@ -895,19 +895,19 @@
     local.get $0
     return
    end
-   local.get $3
+   local.get $2
    i32.const -1076707644
    i32.le_u
    if (result f64)
     i32.const 0
-    local.set $4
+    local.set $3
     local.get $0
    else
     f64.const 0
    end
    local.set $1
   else
-   local.get $3
+   local.get $2
    i32.const 2146435072
    i32.ge_u
    if
@@ -915,29 +915,29 @@
     return
    end
   end
-  local.get $4
+  local.get $3
   if
    f64.const 1
    local.get $0
    f64.add
    i64.reinterpret_f64
-   local.tee $6
+   local.tee $5
    i64.const 32
    i64.shr_u
    i32.wrap_i64
    i32.const 614242
    i32.add
-   local.tee $3
+   local.tee $2
    i32.const 20
    i32.shr_u
    i32.const 1023
    i32.sub
-   local.tee $4
+   local.tee $3
    i32.const 54
    i32.lt_s
    if (result f64)
     f64.const 1
-    local.get $6
+    local.get $5
     f64.reinterpret_i64
     local.tee $1
     local.get $0
@@ -948,7 +948,7 @@
     f64.const 1
     f64.sub
     f64.sub
-    local.get $4
+    local.get $3
     i32.const 2
     i32.ge_s
     select
@@ -957,11 +957,11 @@
    else
     f64.const 0
    end
-   local.set $2
-   local.get $6
+   local.set $6
+   local.get $5
    i64.const 4294967295
    i64.and
-   local.get $3
+   local.get $2
    i32.const 1048575
    i32.and
    i32.const 1072079006
@@ -980,20 +980,20 @@
   local.get $1
   f64.add
   f64.div
-  local.tee $5
-  local.get $5
+  local.tee $4
+  local.get $4
   f64.mul
   local.tee $7
   local.get $7
   f64.mul
   local.set $0
-  local.get $5
+  local.get $4
   f64.const 0.5
   local.get $1
   f64.mul
   local.get $1
   f64.mul
-  local.tee $5
+  local.tee $4
   local.get $7
   f64.const 0.6666666666666735
   local.get $0
@@ -1023,15 +1023,15 @@
   f64.add
   f64.add
   f64.mul
-  local.get $4
+  local.get $3
   f64.convert_i32_s
   local.tee $0
   f64.const 1.9082149292705877e-10
   f64.mul
-  local.get $2
+  local.get $6
   f64.add
   f64.add
-  local.get $5
+  local.get $4
   f64.sub
   local.get $1
   f64.add
@@ -1278,27 +1278,27 @@
  )
  (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
   (local $1 f32)
-  (local $2 f32)
+  (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
+  (local $4 f32)
   (local $5 f32)
   (local $6 f32)
   i32.const 1
-  local.set $4
+  local.set $3
   local.get $0
   i32.reinterpret_f32
-  local.tee $3
+  local.tee $2
   i32.const 1054086096
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $3
+   local.get $2
    i32.const 31
    i32.shr_u
   end
   if
-   local.get $3
+   local.get $2
    i32.const -1082130432
    i32.ge_u
    if
@@ -1318,7 +1318,7 @@
     f32.div
     return
    end
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.const 1728053248
@@ -1327,19 +1327,19 @@
     local.get $0
     return
    end
-   local.get $3
+   local.get $2
    i32.const -1097468391
    i32.le_u
    if (result f32)
     i32.const 0
-    local.set $4
+    local.set $3
     local.get $0
    else
     f32.const 0
    end
    local.set $1
   else
-   local.get $3
+   local.get $2
    i32.const 2139095040
    i32.ge_u
    if
@@ -1347,7 +1347,7 @@
     return
    end
   end
-  local.get $4
+  local.get $3
   if
    f32.const 1
    local.get $0
@@ -1356,12 +1356,12 @@
    i32.reinterpret_f32
    i32.const 4913933
    i32.add
-   local.tee $3
+   local.tee $2
    i32.const 23
    i32.shr_u
    i32.const 127
    i32.sub
-   local.tee $4
+   local.tee $3
    i32.const 25
    i32.lt_s
    if (result f32)
@@ -1375,7 +1375,7 @@
     f32.const 1
     f32.sub
     f32.sub
-    local.get $4
+    local.get $3
     i32.const 2
     i32.ge_s
     select
@@ -1384,8 +1384,8 @@
    else
     f32.const 0
    end
-   local.set $2
-   local.get $3
+   local.set $5
+   local.get $2
    i32.const 8388607
    i32.and
    i32.const 1060439283
@@ -1400,20 +1400,20 @@
   local.get $1
   f32.add
   f32.div
-  local.tee $5
-  local.get $5
+  local.tee $4
+  local.get $4
   f32.mul
   local.tee $6
   local.get $6
   f32.mul
   local.set $0
-  local.get $5
+  local.get $4
   f32.const 0.5
   local.get $1
   f32.mul
   local.get $1
   f32.mul
-  local.tee $5
+  local.tee $4
   local.get $6
   f32.const 0.6666666269302368
   local.get $0
@@ -1431,15 +1431,15 @@
   f32.add
   f32.add
   f32.mul
-  local.get $4
+  local.get $3
   f32.convert_i32_s
   local.tee $0
   f32.const 9.05800061445916e-06
   f32.mul
-  local.get $2
-  f32.add
-  f32.add
   local.get $5
+  f32.add
+  f32.add
+  local.get $4
   f32.sub
   local.get $1
   f32.add
@@ -2592,11 +2592,10 @@
  (func $~lib/math/NativeMath.atan2 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f64)
-  (local $5 i32)
+  (local $4 i32)
+  (local $5 i64)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
   i32.const 1
   local.get $0
   local.get $0
@@ -2613,24 +2612,24 @@
   end
   local.get $0
   i64.reinterpret_f64
-  local.tee $7
+  local.tee $5
   i64.const 32
   i64.shr_u
   i32.wrap_i64
   local.set $6
-  local.get $7
+  local.get $5
   i32.wrap_i64
   local.get $1
   i64.reinterpret_f64
-  local.tee $7
+  local.tee $5
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $5
-  local.get $7
-  i32.wrap_i64
-  local.tee $8
+  local.set $7
   local.get $5
+  i32.wrap_i64
+  local.tee $4
+  local.get $7
   i32.const 1072693248
   i32.sub
   i32.or
@@ -2640,7 +2639,7 @@
    call $~lib/math/NativeMath.atan
    return
   end
-  local.get $5
+  local.get $7
   i32.const 30
   i32.shr_u
   i32.const 2
@@ -2649,11 +2648,11 @@
   i32.const 31
   i32.shr_u
   i32.or
-  local.set $2
-  local.get $5
+  local.set $3
+  local.get $7
   i32.const 2147483647
   i32.and
-  local.set $5
+  local.set $7
   local.get $6
   i32.const 2147483647
   i32.and
@@ -2665,11 +2664,11 @@
     block $case3|0
      block $case2|0
       block $case1|0
-       local.get $2
+       local.get $3
        i32.eqz
        br_if $case1|0
        block $tablify|0
-        local.get $2
+        local.get $3
         i32.const 1
         i32.sub
         br_table $case1|0 $case2|0 $case3|0 $tablify|0
@@ -2687,24 +2686,24 @@
    end
   end
   block $folding-inner0
-   local.get $5
-   local.get $8
+   local.get $4
+   local.get $7
    i32.or
    i32.eqz
    br_if $folding-inner0
-   local.get $5
+   local.get $7
    i32.const 2146435072
    i32.eq
    if
     f64.const 2.356194490192345
     f64.const 0.7853981633974483
-    local.get $2
+    local.get $3
     i32.const 2
     i32.and
     select
     f64.const 3.141592653589793
     f64.const 0
-    local.get $2
+    local.get $3
     i32.const 2
     i32.and
     select
@@ -2715,7 +2714,7 @@
     local.tee $0
     f64.neg
     local.get $0
-    local.get $2
+    local.get $3
     i32.const 1
     i32.and
     select
@@ -2725,7 +2724,7 @@
    local.get $6
    i32.const 2146435072
    i32.eq
-   local.get $5
+   local.get $7
    i32.const 67108864
    i32.add
    local.get $6
@@ -2735,10 +2734,10 @@
    local.get $6
    i32.const 67108864
    i32.add
-   local.get $5
+   local.get $7
    i32.lt_u
    i32.const 0
-   local.get $2
+   local.get $3
    i32.const 2
    i32.and
    select
@@ -2751,34 +2750,34 @@
     f64.abs
     call $~lib/math/NativeMath.atan
    end
-   local.set $4
+   local.set $0
    block $break|1
     block $case3|1
      block $case2|1
       block $case1|1
-       local.get $2
-       local.tee $3
+       local.get $3
+       local.tee $2
        if
-        local.get $3
+        local.get $2
         i32.const 1
         i32.sub
         br_table $case1|1 $case2|1 $case3|1 $break|1
        end
-       local.get $4
+       local.get $0
        return
       end
-      local.get $4
+      local.get $0
       f64.neg
       return
      end
      f64.const 3.141592653589793
-     local.get $4
+     local.get $0
      f64.const 1.2246467991473532e-16
      f64.sub
      f64.sub
      return
     end
-    local.get $4
+    local.get $0
     f64.const 1.2246467991473532e-16
     f64.sub
     f64.const 3.141592653589793
@@ -2789,7 +2788,7 @@
   end
   f64.const -1.5707963267948966
   f64.const 1.5707963267948966
-  local.get $2
+  local.get $3
   i32.const 1
   i32.and
   select
@@ -2815,8 +2814,7 @@
  (func $~lib/math/NativeMathf.atan2 (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f32)
-  (local $5 i32)
+  (local $4 i32)
   i32.const 1
   local.get $0
   local.get $0
@@ -2833,10 +2831,10 @@
   end
   local.get $0
   i32.reinterpret_f32
-  local.set $3
+  local.set $2
   local.get $1
   i32.reinterpret_f32
-  local.tee $5
+  local.tee $4
   i32.const 1065353216
   i32.eq
   if
@@ -2844,42 +2842,42 @@
    call $~lib/math/NativeMathf.atan
    return
   end
-  local.get $5
+  local.get $4
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
-  local.get $3
+  local.get $2
   i32.const 31
   i32.shr_u
   i32.or
-  local.set $2
-  local.get $5
+  local.set $3
+  local.get $4
   i32.const 2147483647
   i32.and
-  local.set $5
-  local.get $3
+  local.set $4
+  local.get $2
   i32.const 2147483647
   i32.and
-  local.tee $3
+  local.tee $2
   i32.eqz
   if
    block $break|0
     block $case3|0
      block $case2|0
-      local.get $2
+      local.get $3
       i32.eqz
-      local.get $2
+      local.get $3
       i32.const 1
       i32.eq
       i32.or
       i32.eqz
       if
-       local.get $2
+       local.get $3
        i32.const 2
        i32.eq
        br_if $case2|0
-       local.get $2
+       local.get $3
        i32.const 3
        i32.eq
        br_if $case3|0
@@ -2896,26 +2894,26 @@
    end
   end
   block $folding-inner0
-   local.get $5
+   local.get $4
    i32.eqz
    br_if $folding-inner0
-   local.get $5
+   local.get $4
    i32.const 2139095040
    i32.eq
    if
     f32.const 2.356194496154785
     f32.const 0.7853981852531433
-    local.get $2
+    local.get $3
     i32.const 2
     i32.and
     select
     f32.const 3.1415927410125732
     f32.const 0
-    local.get $2
+    local.get $3
     i32.const 2
     i32.and
     select
-    local.get $3
+    local.get $2
     i32.const 2139095040
     i32.eq
     select
@@ -2923,30 +2921,30 @@
     local.get $0
     f32.neg
     local.get $0
-    local.get $2
+    local.get $3
     i32.const 1
     i32.and
     select
     return
    end
    i32.const 1
-   local.get $3
+   local.get $2
    i32.const 2139095040
    i32.eq
-   local.get $5
+   local.get $4
    i32.const 218103808
    i32.add
-   local.get $3
+   local.get $2
    i32.lt_u
    select
    br_if $folding-inner0
-   local.get $3
+   local.get $2
    i32.const 218103808
    i32.add
-   local.get $5
+   local.get $4
    i32.lt_u
    i32.const 0
-   local.get $2
+   local.get $3
    i32.const 2
    i32.and
    select
@@ -2959,34 +2957,34 @@
     f32.abs
     call $~lib/math/NativeMathf.atan
    end
-   local.set $4
+   local.set $0
    block $break|1
     block $case3|1
      block $case2|1
       block $case1|1
-       local.get $2
-       local.tee $3
+       local.get $3
+       local.tee $2
        if
-        local.get $3
+        local.get $2
         i32.const 1
         i32.sub
         br_table $case1|1 $case2|1 $case3|1 $break|1
        end
-       local.get $4
+       local.get $0
        return
       end
-      local.get $4
+      local.get $0
       f32.neg
       return
      end
      f32.const 3.1415927410125732
-     local.get $4
+     local.get $0
      f32.const -8.742277657347586e-08
      f32.sub
      f32.sub
      return
     end
-    local.get $4
+    local.get $0
     f32.const -8.742277657347586e-08
     f32.sub
     f32.const 3.1415927410125732
@@ -2997,7 +2995,7 @@
   end
   f32.const -1.5707963705062866
   f32.const 1.5707963705062866
-  local.get $2
+  local.get $3
   i32.const 1
   i32.and
   select
@@ -7092,12 +7090,12 @@
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
-  (local $5 f64)
-  (local $6 i32)
-  (local $7 f64)
+  (local $5 i32)
+  (local $6 f64)
+  (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
+  (local $10 f64)
   (local $11 i32)
   (local $12 f64)
   (local $13 i64)
@@ -7172,17 +7170,17 @@
   local.tee $15
   i32.const 2147483647
   i32.and
-  local.set $6
+  local.set $4
   local.get $1
   i64.reinterpret_f64
   local.tee $13
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $8
+  local.tee $7
   i32.const 2147483647
   i32.and
-  local.tee $9
+  local.tee $8
   local.get $13
   i32.wrap_i64
   local.tee $19
@@ -7195,22 +7193,22 @@
   i32.const 1
   local.get $19
   i32.const 0
-  local.get $9
+  local.get $8
   i32.const 2146435072
   i32.eq
   select
   i32.const 1
-  local.get $9
+  local.get $8
   i32.const 2146435072
   i32.gt_s
   i32.const 1
   local.get $18
   i32.const 0
-  local.get $6
+  local.get $4
   i32.const 2146435072
   i32.eq
   select
-  local.get $6
+  local.get $4
   i32.const 2146435072
   i32.gt_s
   select
@@ -7226,46 +7224,46 @@
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $9
+   local.get $8
    i32.const 1128267776
    i32.ge_s
    if (result i32)
     i32.const 2
    else
-    local.get $9
+    local.get $8
     i32.const 1072693248
     i32.ge_s
     if (result i32)
      i32.const 52
      i32.const 20
-     local.get $9
+     local.get $8
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $10
+     local.tee $9
      i32.const 20
      i32.gt_s
-     local.tee $4
+     local.tee $5
      select
-     local.get $10
+     local.get $9
      i32.sub
      local.set $11
      i32.const 2
      local.get $19
-     local.get $9
-     local.get $4
+     local.get $8
+     local.get $5
      select
-     local.tee $4
+     local.tee $5
      local.get $11
      i32.shr_u
-     local.tee $10
+     local.tee $9
      i32.const 1
      i32.and
      i32.sub
      i32.const 0
-     local.get $4
-     local.get $10
+     local.get $5
+     local.get $9
      local.get $11
      i32.shl
      i32.eq
@@ -7277,27 +7275,27 @@
   else
    i32.const 0
   end
-  local.set $4
+  local.set $5
   local.get $19
   i32.eqz
   if
-   local.get $9
+   local.get $8
    i32.const 2146435072
    i32.eq
    if
     local.get $18
-    local.get $6
+    local.get $4
     i32.const 1072693248
     i32.sub
     i32.or
     if
-     local.get $6
+     local.get $4
      i32.const 1072693248
      i32.ge_s
      if
       local.get $1
       f64.const 0
-      local.get $8
+      local.get $7
       i32.const 0
       i32.ge_s
       select
@@ -7306,7 +7304,7 @@
       local.get $1
       f64.neg
       f64.const 0
-      local.get $8
+      local.get $7
       i32.const 0
       i32.lt_s
       select
@@ -7319,11 +7317,11 @@
     end
     unreachable
    end
-   local.get $9
+   local.get $8
    i32.const 1072693248
    i32.eq
    if
-    local.get $8
+    local.get $7
     i32.const 0
     i32.ge_s
     if
@@ -7335,7 +7333,7 @@
     f64.div
     return
    end
-   local.get $8
+   local.get $7
    i32.const 1073741824
    i32.eq
    if
@@ -7344,7 +7342,7 @@
     f64.mul
     return
    end
-   local.get $8
+   local.get $7
    i32.const 1071644672
    i32.eq
    if
@@ -7360,69 +7358,67 @@
   end
   local.get $0
   f64.abs
-  local.set $5
+  local.set $3
   local.get $18
   i32.eqz
   if
    i32.const 1
-   local.get $6
+   local.get $4
    i32.const 1072693248
    i32.eq
-   local.get $6
+   local.get $4
    i32.const 2146435072
    i32.eq
    i32.const 1
-   local.get $6
+   local.get $4
    select
    select
    if
     f64.const 1
-    local.get $5
+    local.get $3
     f64.div
-    local.get $5
-    local.get $8
+    local.get $3
+    local.get $7
     i32.const 0
     i32.lt_s
     select
-    local.set $5
+    local.set $3
     local.get $15
     i32.const 0
     i32.lt_s
     if (result f64)
+     local.get $5
      local.get $4
-     local.get $6
      i32.const 1072693248
      i32.sub
      i32.or
      if (result f64)
-      local.get $5
+      local.get $3
       f64.neg
+      local.get $3
       local.get $5
-      local.get $4
       i32.const 1
       i32.eq
       select
      else
-      local.get $5
-      local.get $5
+      local.get $3
+      local.get $3
       f64.sub
       local.tee $0
       local.get $0
       f64.div
      end
     else
-     local.get $5
+     local.get $3
     end
     return
    end
   end
-  f64.const 1
-  local.set $3
   local.get $15
   i32.const 0
   i32.lt_s
   if (result f64)
-   local.get $4
+   local.get $5
    i32.eqz
    if
     local.get $0
@@ -7435,94 +7431,94 @@
    end
    f64.const -1
    f64.const 1
-   local.get $4
+   local.get $5
    i32.const 1
    i32.eq
    select
   else
    f64.const 1
   end
-  local.set $3
-  local.get $9
+  local.set $10
+  local.get $8
   i32.const 1105199104
   i32.gt_s
   if (result f64)
-   local.get $9
+   local.get $8
    i32.const 1139802112
    i32.gt_s
    if
-    local.get $6
+    local.get $4
     i32.const 1072693247
     i32.le_s
     if
      f64.const inf
      f64.const 0
-     local.get $8
+     local.get $7
      i32.const 0
      i32.lt_s
      select
      return
     end
-    local.get $6
+    local.get $4
     i32.const 1072693248
     i32.ge_s
     if
      f64.const inf
      f64.const 0
-     local.get $8
+     local.get $7
      i32.const 0
      i32.gt_s
      select
      return
     end
    end
-   local.get $6
+   local.get $4
    i32.const 1072693247
    i32.lt_s
    if
-    local.get $3
+    local.get $10
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
-    local.get $3
+    local.get $10
     f64.const 1e-300
     f64.mul
     f64.const 1e-300
     f64.mul
-    local.get $8
+    local.get $7
     i32.const 0
     i32.lt_s
     select
     return
    end
-   local.get $6
+   local.get $4
    i32.const 1072693248
    i32.gt_s
    if
-    local.get $3
+    local.get $10
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
-    local.get $3
+    local.get $10
     f64.const 1e-300
     f64.mul
     f64.const 1e-300
     f64.mul
-    local.get $8
+    local.get $7
     i32.const 0
     i32.gt_s
     select
     return
    end
    f64.const 1.4426950216293335
-   local.get $5
+   local.get $3
    f64.const 1
    f64.sub
    local.tee $0
    f64.mul
-   local.tee $5
+   local.tee $3
    local.get $0
    f64.const 1.9259629911266175e-08
    f64.mul
@@ -7548,86 +7544,86 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $7
+   local.set $6
    local.get $0
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $3
    f64.sub
    f64.sub
   else
-   local.get $6
+   local.get $4
    i32.const 1048576
    i32.lt_s
    if (result i32)
-    local.get $5
+    local.get $3
     f64.const 9007199254740992
     f64.mul
-    local.tee $5
+    local.tee $3
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.set $6
+    local.set $4
     i32.const -53
    else
     i32.const 0
    end
-   local.get $6
+   local.get $4
    i32.const 20
    i32.shr_s
    i32.const 1023
    i32.sub
    i32.add
-   local.set $8
-   local.get $6
+   local.set $7
+   local.get $4
    i32.const 1048575
    i32.and
-   local.tee $4
+   local.tee $5
    i32.const 1072693248
    i32.or
-   local.set $6
-   local.get $4
+   local.set $4
+   local.get $5
    i32.const 235662
    i32.gt_s
    if
-    local.get $4
+    local.get $5
     i32.const 767610
     i32.lt_s
     if
      i32.const 1
      local.set $16
     else
-     local.get $8
+     local.get $7
      i32.const 1
      i32.add
-     local.set $8
-     local.get $6
+     local.set $7
+     local.get $4
      i32.const -1048576
      i32.add
-     local.set $6
+     local.set $4
     end
    end
    f64.const 0.9617967009544373
-   local.get $5
+   local.get $3
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
-   local.get $6
+   local.get $4
    i64.extend_i32_s
    i64.const 32
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.tee $7
+   local.tee $6
    f64.const 1.5
    f64.const 1
    local.get $16
    select
    local.tee $2
    f64.sub
-   local.tee $5
+   local.tee $3
    f64.const 1
-   local.get $7
+   local.get $6
    local.get $2
    f64.add
    f64.div
@@ -7674,9 +7670,9 @@
    f64.add
    f64.mul
    local.get $0
-   local.get $5
+   local.get $3
    local.get $14
-   local.get $6
+   local.get $4
    i32.const 1
    i32.shr_s
    i32.const 536870912
@@ -7695,7 +7691,7 @@
    f64.mul
    f64.sub
    local.get $14
-   local.get $7
+   local.get $6
    local.get $0
    local.get $2
    f64.sub
@@ -7715,14 +7711,14 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.tee $7
+   local.tee $6
    f64.mul
-   local.tee $5
+   local.tee $3
    local.get $2
-   local.get $7
+   local.get $6
    f64.mul
    local.get $0
-   local.get $7
+   local.get $6
    f64.const 3
    f64.sub
    local.get $20
@@ -7745,7 +7741,7 @@
    f64.mul
    local.get $0
    local.get $2
-   local.get $5
+   local.get $3
    f64.sub
    f64.sub
    f64.const 0.9617966939259756
@@ -7762,9 +7758,9 @@
    f64.const 0
    local.get $16
    select
-   local.tee $5
+   local.tee $3
    f64.add
-   local.get $8
+   local.get $7
    f64.convert_i32_s
    local.tee $0
    f64.add
@@ -7772,18 +7768,18 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $7
+   local.set $6
    local.get $2
-   local.get $7
+   local.get $6
    local.get $0
    f64.sub
-   local.get $5
+   local.get $3
    f64.sub
    local.get $20
    f64.sub
    f64.sub
   end
-  local.set $5
+  local.set $3
   local.get $1
   local.get $1
   i64.reinterpret_f64
@@ -7792,15 +7788,15 @@
   f64.reinterpret_i64
   local.tee $0
   f64.sub
-  local.get $7
+  local.get $6
   f64.mul
   local.get $1
-  local.get $5
+  local.get $3
   f64.mul
   f64.add
   local.tee $1
   local.get $0
-  local.get $7
+  local.get $6
   f64.mul
   local.tee $2
   f64.add
@@ -7808,7 +7804,7 @@
   i64.reinterpret_f64
   local.tee $13
   i32.wrap_i64
-  local.set $4
+  local.set $5
   block $folding-inner1
    block $folding-inner0
     local.get $13
@@ -7819,7 +7815,7 @@
     i32.const 1083179008
     i32.ge_s
     if
-     local.get $4
+     local.get $5
      local.get $11
      i32.const 1083179008
      i32.sub
@@ -7840,7 +7836,7 @@
      i32.const 1083231232
      i32.ge_s
      i32.const 0
-     local.get $4
+     local.get $5
      local.get $11
      i32.const -1064252416
      i32.sub
@@ -7857,39 +7853,39 @@
     local.get $11
     i32.const 2147483647
     i32.and
-    local.tee $10
+    local.tee $9
     i32.const 20
     i32.shr_s
     i32.const 1023
     i32.sub
-    local.set $4
+    local.set $5
     i32.const 0
-    local.set $8
+    local.set $7
     local.get $1
-    local.get $10
+    local.get $9
     i32.const 1071644672
     i32.gt_s
     if
      i32.const 1048575
      local.get $11
      i32.const 1048576
-     local.get $4
+     local.get $5
      i32.const 1
      i32.add
      i32.shr_s
      i32.add
-     local.tee $10
+     local.tee $9
      i32.const 2147483647
      i32.and
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $4
+     local.tee $5
      i32.shr_s
      i32.const -1
      i32.xor
-     local.get $10
+     local.get $9
      i32.and
      i64.extend_i32_s
      i64.const 32
@@ -7897,23 +7893,23 @@
      f64.reinterpret_i64
      local.set $0
      i32.const 0
-     local.get $10
+     local.get $9
      i32.const 1048575
      i32.and
      i32.const 1048576
      i32.or
      i32.const 20
-     local.get $4
+     local.get $5
      i32.sub
      i32.shr_s
-     local.tee $8
+     local.tee $7
      i32.sub
-     local.get $8
+     local.get $7
      local.get $11
      i32.const 0
      i32.lt_s
      select
-     local.set $8
+     local.set $7
      local.get $2
      local.get $0
      f64.sub
@@ -7928,7 +7924,7 @@
     local.tee $0
     f64.const 0.6931471824645996
     f64.mul
-    local.tee $5
+    local.tee $3
     local.get $1
     local.get $0
     local.get $2
@@ -7946,7 +7942,7 @@
     local.get $2
     f64.mul
     local.set $0
-    local.get $3
+    local.get $10
     f64.const 1
     local.get $2
     local.get $2
@@ -7978,7 +7974,7 @@
     f64.div
     local.get $1
     local.get $2
-    local.get $5
+    local.get $3
     f64.sub
     f64.sub
     local.tee $0
@@ -7995,25 +7991,25 @@
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.get $8
+    local.get $7
     i32.const 20
     i32.shl
     i32.add
-    local.tee $4
+    local.tee $5
     i32.const 20
     i32.shr_s
     i32.const 0
     i32.le_s
     if (result f64)
      local.get $0
-     local.get $8
+     local.get $7
      call $~lib/math/NativeMath.scalbn
     else
      local.get $0
      i64.reinterpret_f64
      i64.const 4294967295
      i64.and
-     local.get $4
+     local.get $5
      i64.extend_i32_s
      i64.const 32
      i64.shl
@@ -8023,14 +8019,14 @@
     f64.mul
     return
    end
-   local.get $3
+   local.get $10
    f64.const 1.e+300
    f64.mul
    f64.const 1.e+300
    f64.mul
    return
   end
-  local.get $3
+  local.get $10
   f64.const 1e-300
   f64.mul
   f64.const 1e-300

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -842,31 +842,31 @@
  )
  (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
   (local $1 f64)
-  (local $2 f64)
+  (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 f64)
-  (local $6 i64)
+  (local $4 f64)
+  (local $5 i64)
+  (local $6 f64)
   (local $7 f64)
   i32.const 1
-  local.set $4
+  local.set $3
   local.get $0
   i64.reinterpret_f64
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $3
+  local.tee $2
   i32.const 1071284858
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $3
+   local.get $2
    i32.const 31
    i32.shr_u
   end
   if
-   local.get $3
+   local.get $2
    i32.const -1074790400
    i32.ge_u
    if
@@ -886,7 +886,7 @@
     f64.div
     return
    end
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.const 2034237440
@@ -895,17 +895,19 @@
     local.get $0
     return
    end
-   local.get $3
+   local.get $2
    i32.const -1076707644
    i32.le_u
-   if
+   if (result f64)
     i32.const 0
-    local.set $4
+    local.set $3
     local.get $0
-    local.set $1
+   else
+    f64.const 0
    end
+   local.set $1
   else
-   local.get $3
+   local.get $2
    i32.const 2146435072
    i32.ge_u
    if
@@ -913,29 +915,29 @@
     return
    end
   end
-  local.get $4
+  local.get $3
   if
    f64.const 1
    local.get $0
    f64.add
    i64.reinterpret_f64
-   local.tee $6
+   local.tee $5
    i64.const 32
    i64.shr_u
    i32.wrap_i64
    i32.const 614242
    i32.add
-   local.tee $3
+   local.tee $2
    i32.const 20
    i32.shr_u
    i32.const 1023
    i32.sub
-   local.tee $4
+   local.tee $3
    i32.const 54
    i32.lt_s
-   if
+   if (result f64)
     f64.const 1
-    local.get $6
+    local.get $5
     f64.reinterpret_i64
     local.tee $1
     local.get $0
@@ -946,18 +948,20 @@
     f64.const 1
     f64.sub
     f64.sub
-    local.get $4
+    local.get $3
     i32.const 2
     i32.ge_s
     select
     local.get $1
     f64.div
-    local.set $2
+   else
+    f64.const 0
    end
-   local.get $6
+   local.set $6
+   local.get $5
    i64.const 4294967295
    i64.and
-   local.get $3
+   local.get $2
    i32.const 1048575
    i32.and
    i32.const 1072079006
@@ -976,20 +980,20 @@
   local.get $1
   f64.add
   f64.div
-  local.tee $5
-  local.get $5
+  local.tee $4
+  local.get $4
   f64.mul
   local.tee $7
   local.get $7
   f64.mul
   local.set $0
-  local.get $5
+  local.get $4
   f64.const 0.5
   local.get $1
   f64.mul
   local.get $1
   f64.mul
-  local.tee $5
+  local.tee $4
   local.get $7
   f64.const 0.6666666666666735
   local.get $0
@@ -1019,15 +1023,15 @@
   f64.add
   f64.add
   f64.mul
-  local.get $4
+  local.get $3
   f64.convert_i32_s
   local.tee $0
   f64.const 1.9082149292705877e-10
   f64.mul
-  local.get $2
+  local.get $6
   f64.add
   f64.add
-  local.get $5
+  local.get $4
   f64.sub
   local.get $1
   f64.add
@@ -1274,27 +1278,27 @@
  )
  (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
   (local $1 f32)
-  (local $2 f32)
+  (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
+  (local $4 f32)
   (local $5 f32)
   (local $6 f32)
   i32.const 1
-  local.set $4
+  local.set $3
   local.get $0
   i32.reinterpret_f32
-  local.tee $3
+  local.tee $2
   i32.const 1054086096
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $3
+   local.get $2
    i32.const 31
    i32.shr_u
   end
   if
-   local.get $3
+   local.get $2
    i32.const -1082130432
    i32.ge_u
    if
@@ -1314,7 +1318,7 @@
     f32.div
     return
    end
-   local.get $3
+   local.get $2
    i32.const 1
    i32.shl
    i32.const 1728053248
@@ -1323,17 +1327,19 @@
     local.get $0
     return
    end
-   local.get $3
+   local.get $2
    i32.const -1097468391
    i32.le_u
-   if
+   if (result f32)
     i32.const 0
-    local.set $4
+    local.set $3
     local.get $0
-    local.set $1
+   else
+    f32.const 0
    end
+   local.set $1
   else
-   local.get $3
+   local.get $2
    i32.const 2139095040
    i32.ge_u
    if
@@ -1341,7 +1347,7 @@
     return
    end
   end
-  local.get $4
+  local.get $3
   if
    f32.const 1
    local.get $0
@@ -1350,15 +1356,15 @@
    i32.reinterpret_f32
    i32.const 4913933
    i32.add
-   local.tee $3
+   local.tee $2
    i32.const 23
    i32.shr_u
    i32.const 127
    i32.sub
-   local.tee $4
+   local.tee $3
    i32.const 25
    i32.lt_s
-   if
+   if (result f32)
     f32.const 1
     local.get $1
     local.get $0
@@ -1369,15 +1375,17 @@
     f32.const 1
     f32.sub
     f32.sub
-    local.get $4
+    local.get $3
     i32.const 2
     i32.ge_s
     select
     local.get $1
     f32.div
-    local.set $2
+   else
+    f32.const 0
    end
-   local.get $3
+   local.set $5
+   local.get $2
    i32.const 8388607
    i32.and
    i32.const 1060439283
@@ -1392,20 +1400,20 @@
   local.get $1
   f32.add
   f32.div
-  local.tee $5
-  local.get $5
+  local.tee $4
+  local.get $4
   f32.mul
   local.tee $6
   local.get $6
   f32.mul
   local.set $0
-  local.get $5
+  local.get $4
   f32.const 0.5
   local.get $1
   f32.mul
   local.get $1
   f32.mul
-  local.tee $5
+  local.tee $4
   local.get $6
   f32.const 0.6666666269302368
   local.get $0
@@ -1423,15 +1431,15 @@
   f32.add
   f32.add
   f32.mul
-  local.get $4
+  local.get $3
   f32.convert_i32_s
   local.tee $0
   f32.const 9.05800061445916e-06
   f32.mul
-  local.get $2
-  f32.add
-  f32.add
   local.get $5
+  f32.add
+  f32.add
+  local.get $4
   f32.sub
   local.get $1
   f32.add
@@ -2582,13 +2590,12 @@
   call $std/math/check<f32>
  )
  (func $~lib/math/NativeMath.atan2 (param $0 f64) (param $1 f64) (result f64)
-  (local $2 f64)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i64)
   (local $7 i32)
-  (local $8 i32)
   i32.const 1
   local.get $0
   local.get $0
@@ -2609,7 +2616,7 @@
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $7
+  local.set $5
   local.get $6
   i32.wrap_i64
   local.get $1
@@ -2618,11 +2625,11 @@
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $8
+  local.set $4
   local.get $6
   i32.wrap_i64
-  local.tee $5
-  local.get $8
+  local.tee $7
+  local.get $4
   i32.const 1072693248
   i32.sub
   i32.or
@@ -2632,24 +2639,24 @@
    call $~lib/math/NativeMath.atan
    return
   end
-  local.get $8
+  local.get $4
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
-  local.get $7
+  local.get $5
   i32.const 31
   i32.shr_u
   i32.or
+  local.set $2
+  local.get $4
+  i32.const 2147483647
+  i32.and
   local.set $4
-  local.get $8
+  local.get $5
   i32.const 2147483647
   i32.and
-  local.set $8
-  local.get $7
-  i32.const 2147483647
-  i32.and
-  local.tee $7
+  local.tee $5
   i32.or
   i32.eqz
   if
@@ -2657,11 +2664,11 @@
     block $case3|0
      block $case2|0
       block $case1|0
-       local.get $4
+       local.get $2
        i32.eqz
        br_if $case1|0
        block $tablify|0
-        local.get $4
+        local.get $2
         i32.const 1
         i32.sub
         br_table $case1|0 $case2|0 $case3|0 $tablify|0
@@ -2679,75 +2686,76 @@
    end
   end
   block $folding-inner0
-   local.get $5
-   local.get $8
+   local.get $4
+   local.get $7
    i32.or
    i32.eqz
    br_if $folding-inner0
-   local.get $8
+   local.get $4
    i32.const 2146435072
    i32.eq
    if
     f64.const 2.356194490192345
     f64.const 0.7853981633974483
-    local.get $4
+    local.get $2
     i32.const 2
     i32.and
     select
     f64.const 3.141592653589793
     f64.const 0
-    local.get $4
+    local.get $2
     i32.const 2
     i32.and
     select
-    local.get $7
+    local.get $5
     i32.const 2146435072
     i32.eq
     select
     local.tee $0
     f64.neg
     local.get $0
-    local.get $4
+    local.get $2
     i32.const 1
     i32.and
     select
     return
    end
    i32.const 1
-   local.get $7
+   local.get $5
    i32.const 2146435072
    i32.eq
-   local.get $8
+   local.get $4
    i32.const 67108864
    i32.add
-   local.get $7
+   local.get $5
    i32.lt_u
    select
    br_if $folding-inner0
-   local.get $7
+   local.get $5
    i32.const 67108864
    i32.add
-   local.get $8
+   local.get $4
    i32.lt_u
    i32.const 0
-   local.get $4
+   local.get $2
    i32.const 2
    i32.and
    select
-   i32.eqz
-   if
+   if (result f64)
+    f64.const 0
+   else
     local.get $0
     local.get $1
     f64.div
     f64.abs
     call $~lib/math/NativeMath.atan
-    local.set $2
    end
+   local.set $0
    block $break|1
     block $case3|1
      block $case2|1
       block $case1|1
-       local.get $4
+       local.get $2
        local.tee $3
        if
         local.get $3
@@ -2755,21 +2763,21 @@
         i32.sub
         br_table $case1|1 $case2|1 $case3|1 $break|1
        end
-       local.get $2
+       local.get $0
        return
       end
-      local.get $2
+      local.get $0
       f64.neg
       return
      end
      f64.const 3.141592653589793
-     local.get $2
+     local.get $0
      f64.const 1.2246467991473532e-16
      f64.sub
      f64.sub
      return
     end
-    local.get $2
+    local.get $0
     f64.const 1.2246467991473532e-16
     f64.sub
     f64.const 3.141592653589793
@@ -2780,7 +2788,7 @@
   end
   f64.const -1.5707963267948966
   f64.const 1.5707963267948966
-  local.get $4
+  local.get $2
   i32.const 1
   i32.and
   select
@@ -2804,10 +2812,9 @@
   end
  )
  (func $~lib/math/NativeMathf.atan2 (param $0 f32) (param $1 f32) (result f32)
-  (local $2 f32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
   i32.const 1
   local.get $0
   local.get $0
@@ -2827,7 +2834,7 @@
   local.set $3
   local.get $1
   i32.reinterpret_f32
-  local.tee $5
+  local.tee $4
   i32.const 1065353216
   i32.eq
   if
@@ -2835,7 +2842,7 @@
    call $~lib/math/NativeMathf.atan
    return
   end
-  local.get $5
+  local.get $4
   i32.const 30
   i32.shr_u
   i32.const 2
@@ -2844,11 +2851,11 @@
   i32.const 31
   i32.shr_u
   i32.or
-  local.set $4
-  local.get $5
+  local.set $2
+  local.get $4
   i32.const 2147483647
   i32.and
-  local.set $5
+  local.set $4
   local.get $3
   i32.const 2147483647
   i32.and
@@ -2858,19 +2865,19 @@
    block $break|0
     block $case3|0
      block $case2|0
-      local.get $4
+      local.get $2
       i32.eqz
-      local.get $4
+      local.get $2
       i32.const 1
       i32.eq
       i32.or
       i32.eqz
       if
-       local.get $4
+       local.get $2
        i32.const 2
        i32.eq
        br_if $case2|0
-       local.get $4
+       local.get $2
        i32.const 3
        i32.eq
        br_if $case3|0
@@ -2887,22 +2894,22 @@
    end
   end
   block $folding-inner0
-   local.get $5
+   local.get $4
    i32.eqz
    br_if $folding-inner0
-   local.get $5
+   local.get $4
    i32.const 2139095040
    i32.eq
    if
     f32.const 2.356194496154785
     f32.const 0.7853981852531433
-    local.get $4
+    local.get $2
     i32.const 2
     i32.and
     select
     f32.const 3.1415927410125732
     f32.const 0
-    local.get $4
+    local.get $2
     i32.const 2
     i32.and
     select
@@ -2914,7 +2921,7 @@
     local.get $0
     f32.neg
     local.get $0
-    local.get $4
+    local.get $2
     i32.const 1
     i32.and
     select
@@ -2924,7 +2931,7 @@
    local.get $3
    i32.const 2139095040
    i32.eq
-   local.get $5
+   local.get $4
    i32.const 218103808
    i32.add
    local.get $3
@@ -2934,27 +2941,28 @@
    local.get $3
    i32.const 218103808
    i32.add
-   local.get $5
+   local.get $4
    i32.lt_u
    i32.const 0
-   local.get $4
+   local.get $2
    i32.const 2
    i32.and
    select
-   i32.eqz
-   if
+   if (result f32)
+    f32.const 0
+   else
     local.get $0
     local.get $1
     f32.div
     f32.abs
     call $~lib/math/NativeMathf.atan
-    local.set $2
    end
+   local.set $0
    block $break|1
     block $case3|1
      block $case2|1
       block $case1|1
-       local.get $4
+       local.get $2
        local.tee $3
        if
         local.get $3
@@ -2962,21 +2970,21 @@
         i32.sub
         br_table $case1|1 $case2|1 $case3|1 $break|1
        end
-       local.get $2
+       local.get $0
        return
       end
-      local.get $2
+      local.get $0
       f32.neg
       return
      end
      f32.const 3.1415927410125732
-     local.get $2
+     local.get $0
      f32.const -8.742277657347586e-08
      f32.sub
      f32.sub
      return
     end
-    local.get $2
+    local.get $0
     f32.const -8.742277657347586e-08
     f32.sub
     f32.const 3.1415927410125732
@@ -2987,7 +2995,7 @@
   end
   f32.const -1.5707963705062866
   f32.const 1.5707963705062866
-  local.get $4
+  local.get $2
   i32.const 1
   i32.and
   select
@@ -7080,14 +7088,14 @@
  )
  (func $~lib/math/NativeMath.pow (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
-  (local $3 i32)
-  (local $4 f64)
-  (local $5 f64)
-  (local $6 i32)
-  (local $7 f64)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 f64)
+  (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
+  (local $10 f64)
   (local $11 i32)
   (local $12 f64)
   (local $13 i64)
@@ -7162,17 +7170,17 @@
   local.tee $15
   i32.const 2147483647
   i32.and
-  local.set $6
+  local.set $4
   local.get $1
   i64.reinterpret_f64
   local.tee $13
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $8
+  local.tee $7
   i32.const 2147483647
   i32.and
-  local.tee $9
+  local.tee $8
   local.get $13
   i32.wrap_i64
   local.tee $19
@@ -7185,22 +7193,22 @@
   i32.const 1
   local.get $19
   i32.const 0
-  local.get $9
+  local.get $8
   i32.const 2146435072
   i32.eq
   select
   i32.const 1
-  local.get $9
+  local.get $8
   i32.const 2146435072
   i32.gt_s
   i32.const 1
   local.get $18
   i32.const 0
-  local.get $6
+  local.get $4
   i32.const 2146435072
   i32.eq
   select
-  local.get $6
+  local.get $4
   i32.const 2146435072
   i32.gt_s
   select
@@ -7215,47 +7223,47 @@
   local.get $15
   i32.const 0
   i32.lt_s
-  if
-   local.get $9
+  if (result i32)
+   local.get $8
    i32.const 1128267776
    i32.ge_s
    if (result i32)
     i32.const 2
    else
-    local.get $9
+    local.get $8
     i32.const 1072693248
     i32.ge_s
     if (result i32)
      i32.const 52
      i32.const 20
-     local.get $9
+     local.get $8
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $10
+     local.tee $9
      i32.const 20
      i32.gt_s
-     local.tee $3
+     local.tee $5
      select
-     local.get $10
+     local.get $9
      i32.sub
      local.set $11
      i32.const 2
      local.get $19
-     local.get $9
-     local.get $3
+     local.get $8
+     local.get $5
      select
-     local.tee $3
+     local.tee $5
      local.get $11
      i32.shr_u
-     local.tee $10
+     local.tee $9
      i32.const 1
      i32.and
      i32.sub
      i32.const 0
-     local.get $3
-     local.get $10
+     local.get $5
+     local.get $9
      local.get $11
      i32.shl
      i32.eq
@@ -7264,28 +7272,30 @@
      i32.const 0
     end
    end
-   local.set $3
+  else
+   i32.const 0
   end
+  local.set $5
   local.get $19
   i32.eqz
   if
-   local.get $9
+   local.get $8
    i32.const 2146435072
    i32.eq
    if
     local.get $18
-    local.get $6
+    local.get $4
     i32.const 1072693248
     i32.sub
     i32.or
     if
-     local.get $6
+     local.get $4
      i32.const 1072693248
      i32.ge_s
      if
       local.get $1
       f64.const 0
-      local.get $8
+      local.get $7
       i32.const 0
       i32.ge_s
       select
@@ -7294,7 +7304,7 @@
       local.get $1
       f64.neg
       f64.const 0
-      local.get $8
+      local.get $7
       i32.const 0
       i32.lt_s
       select
@@ -7307,11 +7317,11 @@
     end
     unreachable
    end
-   local.get $9
+   local.get $8
    i32.const 1072693248
    i32.eq
    if
-    local.get $8
+    local.get $7
     i32.const 0
     i32.ge_s
     if
@@ -7323,7 +7333,7 @@
     f64.div
     return
    end
-   local.get $8
+   local.get $7
    i32.const 1073741824
    i32.eq
    if
@@ -7332,7 +7342,7 @@
     f64.mul
     return
    end
-   local.get $8
+   local.get $7
    i32.const 1071644672
    i32.eq
    if
@@ -7348,69 +7358,67 @@
   end
   local.get $0
   f64.abs
-  local.set $5
+  local.set $3
   local.get $18
   i32.eqz
   if
    i32.const 1
-   local.get $6
+   local.get $4
    i32.const 1072693248
    i32.eq
-   local.get $6
+   local.get $4
    i32.const 2146435072
    i32.eq
    i32.const 1
-   local.get $6
+   local.get $4
    select
    select
    if
     f64.const 1
-    local.get $5
+    local.get $3
     f64.div
-    local.get $5
-    local.get $8
+    local.get $3
+    local.get $7
     i32.const 0
     i32.lt_s
     select
-    local.set $5
+    local.set $3
     local.get $15
     i32.const 0
     i32.lt_s
     if (result f64)
-     local.get $3
-     local.get $6
+     local.get $5
+     local.get $4
      i32.const 1072693248
      i32.sub
      i32.or
      if (result f64)
-      local.get $5
-      f64.neg
-      local.get $5
       local.get $3
+      f64.neg
+      local.get $3
+      local.get $5
       i32.const 1
       i32.eq
       select
      else
-      local.get $5
-      local.get $5
+      local.get $3
+      local.get $3
       f64.sub
       local.tee $0
       local.get $0
       f64.div
      end
     else
-     local.get $5
+     local.get $3
     end
     return
    end
   end
-  f64.const 1
-  local.set $4
   local.get $15
   i32.const 0
   i32.lt_s
-  if
-   local.get $3
+  if (result f64)
+   local.get $5
    i32.eqz
    if
     local.get $0
@@ -7423,92 +7431,94 @@
    end
    f64.const -1
    f64.const 1
-   local.get $3
+   local.get $5
    i32.const 1
    i32.eq
    select
-   local.set $4
+  else
+   f64.const 1
   end
-  local.get $9
+  local.set $10
+  local.get $8
   i32.const 1105199104
   i32.gt_s
   if (result f64)
-   local.get $9
+   local.get $8
    i32.const 1139802112
    i32.gt_s
    if
-    local.get $6
+    local.get $4
     i32.const 1072693247
     i32.le_s
     if
      f64.const inf
      f64.const 0
-     local.get $8
+     local.get $7
      i32.const 0
      i32.lt_s
      select
      return
     end
-    local.get $6
+    local.get $4
     i32.const 1072693248
     i32.ge_s
     if
      f64.const inf
      f64.const 0
-     local.get $8
+     local.get $7
      i32.const 0
      i32.gt_s
      select
      return
     end
    end
-   local.get $6
+   local.get $4
    i32.const 1072693247
    i32.lt_s
    if
-    local.get $4
+    local.get $10
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
-    local.get $4
+    local.get $10
     f64.const 1e-300
     f64.mul
     f64.const 1e-300
     f64.mul
-    local.get $8
+    local.get $7
     i32.const 0
     i32.lt_s
     select
     return
    end
-   local.get $6
+   local.get $4
    i32.const 1072693248
    i32.gt_s
    if
-    local.get $4
+    local.get $10
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
-    local.get $4
+    local.get $10
     f64.const 1e-300
     f64.mul
     f64.const 1e-300
     f64.mul
-    local.get $8
+    local.get $7
     i32.const 0
     i32.gt_s
     select
     return
    end
    f64.const 1.4426950216293335
-   local.get $5
+   local.get $3
    f64.const 1
    f64.sub
    local.tee $0
    f64.mul
-   local.tee $5
+   local.tee $3
    local.get $0
    f64.const 1.9259629911266175e-08
    f64.mul
@@ -7534,86 +7544,86 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $7
+   local.set $6
    local.get $0
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $3
    f64.sub
    f64.sub
   else
-   local.get $6
+   local.get $4
    i32.const 1048576
    i32.lt_s
    if (result i32)
-    local.get $5
+    local.get $3
     f64.const 9007199254740992
     f64.mul
-    local.tee $5
+    local.tee $3
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.set $6
+    local.set $4
     i32.const -53
    else
     i32.const 0
    end
-   local.get $6
+   local.get $4
    i32.const 20
    i32.shr_s
    i32.const 1023
    i32.sub
    i32.add
-   local.set $8
-   local.get $6
+   local.set $7
+   local.get $4
    i32.const 1048575
    i32.and
-   local.tee $3
+   local.tee $5
    i32.const 1072693248
    i32.or
-   local.set $6
-   local.get $3
+   local.set $4
+   local.get $5
    i32.const 235662
    i32.gt_s
    if
-    local.get $3
+    local.get $5
     i32.const 767610
     i32.lt_s
     if
      i32.const 1
      local.set $16
     else
-     local.get $8
+     local.get $7
      i32.const 1
      i32.add
-     local.set $8
-     local.get $6
+     local.set $7
+     local.get $4
      i32.const -1048576
      i32.add
-     local.set $6
+     local.set $4
     end
    end
    f64.const 0.9617967009544373
-   local.get $5
+   local.get $3
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
-   local.get $6
+   local.get $4
    i64.extend_i32_s
    i64.const 32
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.tee $7
+   local.tee $6
    f64.const 1.5
    f64.const 1
    local.get $16
    select
    local.tee $2
    f64.sub
-   local.tee $5
+   local.tee $3
    f64.const 1
-   local.get $7
+   local.get $6
    local.get $2
    f64.add
    f64.div
@@ -7660,9 +7670,9 @@
    f64.add
    f64.mul
    local.get $0
-   local.get $5
+   local.get $3
    local.get $14
-   local.get $6
+   local.get $4
    i32.const 1
    i32.shr_s
    i32.const 536870912
@@ -7681,7 +7691,7 @@
    f64.mul
    f64.sub
    local.get $14
-   local.get $7
+   local.get $6
    local.get $0
    local.get $2
    f64.sub
@@ -7701,14 +7711,14 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.tee $7
+   local.tee $6
    f64.mul
-   local.tee $5
+   local.tee $3
    local.get $2
-   local.get $7
+   local.get $6
    f64.mul
    local.get $0
-   local.get $7
+   local.get $6
    f64.const 3
    f64.sub
    local.get $20
@@ -7731,7 +7741,7 @@
    f64.mul
    local.get $0
    local.get $2
-   local.get $5
+   local.get $3
    f64.sub
    f64.sub
    f64.const 0.9617966939259756
@@ -7748,9 +7758,9 @@
    f64.const 0
    local.get $16
    select
-   local.tee $5
+   local.tee $3
    f64.add
-   local.get $8
+   local.get $7
    f64.convert_i32_s
    local.tee $0
    f64.add
@@ -7758,18 +7768,18 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $7
+   local.set $6
    local.get $2
-   local.get $7
+   local.get $6
    local.get $0
    f64.sub
-   local.get $5
+   local.get $3
    f64.sub
    local.get $20
    f64.sub
    f64.sub
   end
-  local.set $5
+  local.set $3
   local.get $1
   local.get $1
   i64.reinterpret_f64
@@ -7778,15 +7788,15 @@
   f64.reinterpret_i64
   local.tee $0
   f64.sub
-  local.get $7
+  local.get $6
   f64.mul
   local.get $1
-  local.get $5
+  local.get $3
   f64.mul
   f64.add
   local.tee $1
   local.get $0
-  local.get $7
+  local.get $6
   f64.mul
   local.tee $2
   f64.add
@@ -7794,7 +7804,7 @@
   i64.reinterpret_f64
   local.tee $13
   i32.wrap_i64
-  local.set $3
+  local.set $5
   block $folding-inner1
    block $folding-inner0
     local.get $13
@@ -7805,7 +7815,7 @@
     i32.const 1083179008
     i32.ge_s
     if
-     local.get $3
+     local.get $5
      local.get $11
      i32.const 1083179008
      i32.sub
@@ -7826,7 +7836,7 @@
      i32.const 1083231232
      i32.ge_s
      i32.const 0
-     local.get $3
+     local.get $5
      local.get $11
      i32.const -1064252416
      i32.sub
@@ -7843,39 +7853,39 @@
     local.get $11
     i32.const 2147483647
     i32.and
-    local.tee $10
+    local.tee $9
     i32.const 20
     i32.shr_s
     i32.const 1023
     i32.sub
-    local.set $3
+    local.set $5
     i32.const 0
-    local.set $8
+    local.set $7
     local.get $1
-    local.get $10
+    local.get $9
     i32.const 1071644672
     i32.gt_s
     if
      i32.const 1048575
      local.get $11
      i32.const 1048576
-     local.get $3
+     local.get $5
      i32.const 1
      i32.add
      i32.shr_s
      i32.add
-     local.tee $10
+     local.tee $9
      i32.const 2147483647
      i32.and
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $3
+     local.tee $5
      i32.shr_s
      i32.const -1
      i32.xor
-     local.get $10
+     local.get $9
      i32.and
      i64.extend_i32_s
      i64.const 32
@@ -7883,23 +7893,23 @@
      f64.reinterpret_i64
      local.set $0
      i32.const 0
-     local.get $10
+     local.get $9
      i32.const 1048575
      i32.and
      i32.const 1048576
      i32.or
      i32.const 20
-     local.get $3
+     local.get $5
      i32.sub
      i32.shr_s
-     local.tee $8
+     local.tee $7
      i32.sub
-     local.get $8
+     local.get $7
      local.get $11
      i32.const 0
      i32.lt_s
      select
-     local.set $8
+     local.set $7
      local.get $2
      local.get $0
      f64.sub
@@ -7914,7 +7924,7 @@
     local.tee $0
     f64.const 0.6931471824645996
     f64.mul
-    local.tee $5
+    local.tee $3
     local.get $1
     local.get $0
     local.get $2
@@ -7932,7 +7942,7 @@
     local.get $2
     f64.mul
     local.set $0
-    local.get $4
+    local.get $10
     f64.const 1
     local.get $2
     local.get $2
@@ -7964,7 +7974,7 @@
     f64.div
     local.get $1
     local.get $2
-    local.get $5
+    local.get $3
     f64.sub
     f64.sub
     local.tee $0
@@ -7981,25 +7991,25 @@
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.get $8
+    local.get $7
     i32.const 20
     i32.shl
     i32.add
-    local.tee $3
+    local.tee $5
     i32.const 20
     i32.shr_s
     i32.const 0
     i32.le_s
     if (result f64)
      local.get $0
-     local.get $8
+     local.get $7
      call $~lib/math/NativeMath.scalbn
     else
      local.get $0
      i64.reinterpret_f64
      i64.const 4294967295
      i64.and
-     local.get $3
+     local.get $5
      i64.extend_i32_s
      i64.const 32
      i64.shl
@@ -8009,14 +8019,14 @@
     f64.mul
     return
    end
-   local.get $4
+   local.get $10
    f64.const 1.e+300
    f64.mul
    f64.const 1.e+300
    f64.mul
    return
   end
-  local.get $4
+  local.get $10
   f64.const 1e-300
   f64.mul
   f64.const 1e-300

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -842,31 +842,31 @@
  )
  (func $~lib/math/NativeMath.log1p (param $0 f64) (result f64)
   (local $1 f64)
-  (local $2 i32)
+  (local $2 f64)
   (local $3 i32)
-  (local $4 f64)
-  (local $5 i64)
-  (local $6 f64)
+  (local $4 i32)
+  (local $5 f64)
+  (local $6 i64)
   (local $7 f64)
   i32.const 1
-  local.set $3
+  local.set $4
   local.get $0
   i64.reinterpret_f64
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $2
+  local.tee $3
   i32.const 1071284858
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $2
+   local.get $3
    i32.const 31
    i32.shr_u
   end
   if
-   local.get $2
+   local.get $3
    i32.const -1074790400
    i32.ge_u
    if
@@ -886,7 +886,7 @@
     f64.div
     return
    end
-   local.get $2
+   local.get $3
    i32.const 1
    i32.shl
    i32.const 2034237440
@@ -895,17 +895,19 @@
     local.get $0
     return
    end
-   local.get $2
+   local.get $3
    i32.const -1076707644
    i32.le_u
-   if
+   if (result f64)
     i32.const 0
-    local.set $3
+    local.set $4
     local.get $0
-    local.set $1
+   else
+    f64.const 0
    end
+   local.set $1
   else
-   local.get $2
+   local.get $3
    i32.const 2146435072
    i32.ge_u
    if
@@ -913,29 +915,29 @@
     return
    end
   end
-  local.get $3
+  local.get $4
   if
    f64.const 1
    local.get $0
    f64.add
    i64.reinterpret_f64
-   local.tee $5
+   local.tee $6
    i64.const 32
    i64.shr_u
    i32.wrap_i64
    i32.const 614242
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 20
    i32.shr_u
    i32.const 1023
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 54
    i32.lt_s
-   if
+   if (result f64)
     f64.const 1
-    local.get $5
+    local.get $6
     f64.reinterpret_i64
     local.tee $1
     local.get $0
@@ -946,18 +948,20 @@
     f64.const 1
     f64.sub
     f64.sub
-    local.get $3
+    local.get $4
     i32.const 2
     i32.ge_s
     select
     local.get $1
     f64.div
-    local.set $6
+   else
+    f64.const 0
    end
-   local.get $5
+   local.set $2
+   local.get $6
    i64.const 4294967295
    i64.and
-   local.get $2
+   local.get $3
    i32.const 1048575
    i32.and
    i32.const 1072079006
@@ -976,20 +980,20 @@
   local.get $1
   f64.add
   f64.div
-  local.tee $4
-  local.get $4
+  local.tee $5
+  local.get $5
   f64.mul
   local.tee $7
   local.get $7
   f64.mul
   local.set $0
-  local.get $4
+  local.get $5
   f64.const 0.5
   local.get $1
   f64.mul
   local.get $1
   f64.mul
-  local.tee $4
+  local.tee $5
   local.get $7
   f64.const 0.6666666666666735
   local.get $0
@@ -1019,15 +1023,15 @@
   f64.add
   f64.add
   f64.mul
-  local.get $3
+  local.get $4
   f64.convert_i32_s
   local.tee $0
   f64.const 1.9082149292705877e-10
   f64.mul
-  local.get $6
+  local.get $2
   f64.add
   f64.add
-  local.get $4
+  local.get $5
   f64.sub
   local.get $1
   f64.add
@@ -1274,27 +1278,27 @@
  )
  (func $~lib/math/NativeMathf.log1p (param $0 f32) (result f32)
   (local $1 f32)
-  (local $2 i32)
+  (local $2 f32)
   (local $3 i32)
-  (local $4 f32)
+  (local $4 i32)
   (local $5 f32)
   (local $6 f32)
   i32.const 1
-  local.set $3
+  local.set $4
   local.get $0
   i32.reinterpret_f32
-  local.tee $2
+  local.tee $3
   i32.const 1054086096
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $2
+   local.get $3
    i32.const 31
    i32.shr_u
   end
   if
-   local.get $2
+   local.get $3
    i32.const -1082130432
    i32.ge_u
    if
@@ -1314,7 +1318,7 @@
     f32.div
     return
    end
-   local.get $2
+   local.get $3
    i32.const 1
    i32.shl
    i32.const 1728053248
@@ -1323,17 +1327,19 @@
     local.get $0
     return
    end
-   local.get $2
+   local.get $3
    i32.const -1097468391
    i32.le_u
-   if
+   if (result f32)
     i32.const 0
-    local.set $3
+    local.set $4
     local.get $0
-    local.set $1
+   else
+    f32.const 0
    end
+   local.set $1
   else
-   local.get $2
+   local.get $3
    i32.const 2139095040
    i32.ge_u
    if
@@ -1341,7 +1347,7 @@
     return
    end
   end
-  local.get $3
+  local.get $4
   if
    f32.const 1
    local.get $0
@@ -1350,15 +1356,15 @@
    i32.reinterpret_f32
    i32.const 4913933
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 23
    i32.shr_u
    i32.const 127
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 25
    i32.lt_s
-   if
+   if (result f32)
     f32.const 1
     local.get $1
     local.get $0
@@ -1369,15 +1375,17 @@
     f32.const 1
     f32.sub
     f32.sub
-    local.get $3
+    local.get $4
     i32.const 2
     i32.ge_s
     select
     local.get $1
     f32.div
-    local.set $5
+   else
+    f32.const 0
    end
-   local.get $2
+   local.set $2
+   local.get $3
    i32.const 8388607
    i32.and
    i32.const 1060439283
@@ -1392,20 +1400,20 @@
   local.get $1
   f32.add
   f32.div
-  local.tee $4
-  local.get $4
+  local.tee $5
+  local.get $5
   f32.mul
   local.tee $6
   local.get $6
   f32.mul
   local.set $0
-  local.get $4
+  local.get $5
   f32.const 0.5
   local.get $1
   f32.mul
   local.get $1
   f32.mul
-  local.tee $4
+  local.tee $5
   local.get $6
   f32.const 0.6666666269302368
   local.get $0
@@ -1423,15 +1431,15 @@
   f32.add
   f32.add
   f32.mul
-  local.get $3
+  local.get $4
   f32.convert_i32_s
   local.tee $0
   f32.const 9.05800061445916e-06
   f32.mul
+  local.get $2
+  f32.add
+  f32.add
   local.get $5
-  f32.add
-  f32.add
-  local.get $4
   f32.sub
   local.get $1
   f32.add
@@ -1889,17 +1897,16 @@
   local.tee $4
   i64.const 1049
   i64.ge_u
-  if
+  if (result f64)
    local.get $0
    call $~lib/math/NativeMath.log
    f64.const 0.6931471805599453
    f64.add
-   local.set $0
   else
    local.get $4
    i64.const 1024
    i64.ge_u
-   if
+   if (result f64)
     f64.const 2
     local.get $0
     f64.mul
@@ -1915,12 +1922,11 @@
     f64.div
     f64.add
     call $~lib/math/NativeMath.log
-    local.set $0
    else
     local.get $4
     i64.const 997
     i64.ge_u
-    if
+    if (result f64)
      local.get $0
      local.get $0
      local.get $0
@@ -1935,11 +1941,11 @@
      f64.div
      f64.add
      call $~lib/math/NativeMath.log1p
-     local.set $0
+    else
+     local.get $0
     end
    end
   end
-  local.get $0
   local.get $3
   f64.copysign
   local.get $1
@@ -1969,17 +1975,16 @@
   local.get $4
   i32.const 1166016512
   i32.ge_u
-  if
+  if (result f32)
    local.get $0
    call $~lib/math/NativeMathf.log
    f32.const 0.6931471824645996
    f32.add
-   local.set $0
   else
    local.get $4
    i32.const 1073741824
    i32.ge_u
-   if
+   if (result f32)
     f32.const 2
     local.get $0
     f32.mul
@@ -1995,12 +2000,11 @@
     f32.div
     f32.add
     call $~lib/math/NativeMathf.log
-    local.set $0
    else
     local.get $4
     i32.const 964689920
     i32.ge_u
-    if
+    if (result f32)
      local.get $0
      local.get $0
      local.get $0
@@ -2015,11 +2019,11 @@
      f32.div
      f32.add
      call $~lib/math/NativeMathf.log1p
-     local.set $0
+    else
+     local.get $0
     end
    end
   end
-  local.get $0
   local.get $3
   f32.copysign
   local.get $1
@@ -2483,11 +2487,11 @@
   local.tee $4
   i64.const 1022
   i64.lt_u
-  if
+  if (result f64)
    local.get $4
    i64.const 991
    i64.ge_u
-   if
+   if (result f64)
     f64.const 0.5
     f64.const 2
     local.get $0
@@ -2503,7 +2507,8 @@
     f64.add
     call $~lib/math/NativeMath.log1p
     f64.mul
-    local.set $0
+   else
+    local.get $0
    end
   else
    f64.const 0.5
@@ -2516,9 +2521,7 @@
    f64.mul
    call $~lib/math/NativeMath.log1p
    f64.mul
-   local.set $0
   end
-  local.get $0
   local.get $3
   f64.copysign
   local.get $1
@@ -2546,11 +2549,11 @@
   local.tee $4
   i32.const 1056964608
   i32.lt_u
-  if
+  if (result f32)
    local.get $4
    i32.const 796917760
    i32.ge_u
-   if
+   if (result f32)
     f32.const 0.5
     f32.const 2
     local.get $0
@@ -2565,7 +2568,8 @@
     f32.mul
     call $~lib/math/NativeMathf.log1p
     f32.mul
-    local.set $0
+   else
+    local.get $0
    end
   else
    f32.const 0.5
@@ -2578,9 +2582,7 @@
    f32.mul
    call $~lib/math/NativeMathf.log1p
    f32.mul
-   local.set $0
   end
-  local.get $0
   local.get $3
   f32.copysign
   local.get $1
@@ -2590,10 +2592,10 @@
  (func $~lib/math/NativeMath.atan2 (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i64)
-  (local $6 f64)
-  (local $7 i32)
+  (local $4 f64)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i64)
   (local $8 i32)
   i32.const 1
   local.get $0
@@ -2611,24 +2613,24 @@
   end
   local.get $0
   i64.reinterpret_f64
-  local.tee $5
+  local.tee $7
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $7
-  local.get $5
+  local.set $6
+  local.get $7
   i32.wrap_i64
   local.get $1
   i64.reinterpret_f64
-  local.tee $5
+  local.tee $7
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $8
-  local.get $5
+  local.set $5
+  local.get $7
   i32.wrap_i64
-  local.tee $4
-  local.get $8
+  local.tee $8
+  local.get $5
   i32.const 1072693248
   i32.sub
   i32.or
@@ -2638,24 +2640,24 @@
    call $~lib/math/NativeMath.atan
    return
   end
-  local.get $8
+  local.get $5
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
-  local.get $7
+  local.get $6
   i32.const 31
   i32.shr_u
   i32.or
-  local.set $3
-  local.get $8
+  local.set $2
+  local.get $5
   i32.const 2147483647
   i32.and
-  local.set $8
-  local.get $7
+  local.set $5
+  local.get $6
   i32.const 2147483647
   i32.and
-  local.tee $7
+  local.tee $6
   i32.or
   i32.eqz
   if
@@ -2663,11 +2665,11 @@
     block $case3|0
      block $case2|0
       block $case1|0
-       local.get $3
+       local.get $2
        i32.eqz
        br_if $case1|0
        block $tablify|0
-        local.get $3
+        local.get $2
         i32.const 1
         i32.sub
         br_table $case1|0 $case2|0 $case3|0 $tablify|0
@@ -2685,101 +2687,98 @@
    end
   end
   block $folding-inner0
-   local.get $4
+   local.get $5
    local.get $8
    i32.or
    i32.eqz
    br_if $folding-inner0
-   local.get $8
+   local.get $5
    i32.const 2146435072
    i32.eq
    if
-    local.get $7
+    f64.const 2.356194490192345
+    f64.const 0.7853981633974483
+    local.get $2
+    i32.const 2
+    i32.and
+    select
+    f64.const 3.141592653589793
+    f64.const 0
+    local.get $2
+    i32.const 2
+    i32.and
+    select
+    local.get $6
     i32.const 2146435072
     i32.eq
-    if
-     f64.const 2.356194490192345
-     f64.const 0.7853981633974483
-     local.get $3
-     i32.const 2
-     i32.and
-     select
-     local.set $0
-    else
-     f64.const 3.141592653589793
-     f64.const 0
-     local.get $3
-     i32.const 2
-     i32.and
-     select
-     local.set $0
-    end
-    local.get $0
+    select
+    local.tee $0
     f64.neg
     local.get $0
-    local.get $3
+    local.get $2
     i32.const 1
     i32.and
     select
     return
    end
    i32.const 1
-   local.get $7
+   local.get $6
    i32.const 2146435072
    i32.eq
-   local.get $8
+   local.get $5
    i32.const 67108864
    i32.add
-   local.get $7
+   local.get $6
    i32.lt_u
    select
    br_if $folding-inner0
-   local.get $7
+   local.get $6
    i32.const 67108864
    i32.add
-   local.get $8
+   local.get $5
    i32.lt_u
    i32.const 0
-   local.get $3
+   local.get $2
    i32.const 2
    i32.and
    select
-   i32.eqz
-   if
+   if (result f64)
+    f64.const 0
+   else
     local.get $0
     local.get $1
     f64.div
     f64.abs
     call $~lib/math/NativeMath.atan
-    local.set $6
    end
+   local.set $4
    block $break|1
     block $case3|1
      block $case2|1
       block $case1|1
-       local.get $3
-       local.tee $2
+       local.get $2
+       local.tee $3
        if
-        local.get $2
+        local.get $3
         i32.const 1
         i32.sub
         br_table $case1|1 $case2|1 $case3|1 $break|1
        end
-       local.get $6
+       local.get $4
        return
       end
-      local.get $6
+      local.get $4
       f64.neg
       return
      end
      f64.const 3.141592653589793
-     local.get $6
+     local.get $4
      f64.const 1.2246467991473532e-16
      f64.sub
      f64.sub
      return
     end
-    local.get $6
+    local.get $4
     f64.const 1.2246467991473532e-16
     f64.sub
     f64.const 3.141592653589793
@@ -2790,7 +2789,7 @@
   end
   f64.const -1.5707963267948966
   f64.const 1.5707963267948966
-  local.get $3
+  local.get $2
   i32.const 1
   i32.and
   select
@@ -2834,7 +2833,7 @@
   end
   local.get $0
   i32.reinterpret_f32
-  local.set $2
+  local.set $3
   local.get $1
   i32.reinterpret_f32
   local.tee $5
@@ -2850,37 +2849,37 @@
   i32.shr_u
   i32.const 2
   i32.and
-  local.get $2
+  local.get $3
   i32.const 31
   i32.shr_u
   i32.or
-  local.set $3
+  local.set $2
   local.get $5
   i32.const 2147483647
   i32.and
   local.set $5
-  local.get $2
+  local.get $3
   i32.const 2147483647
   i32.and
-  local.tee $2
+  local.tee $3
   i32.eqz
   if
    block $break|0
     block $case3|0
      block $case2|0
-      local.get $3
+      local.get $2
       i32.eqz
-      local.get $3
+      local.get $2
       i32.const 1
       i32.eq
       i32.or
       i32.eqz
       if
-       local.get $3
+       local.get $2
        i32.const 2
        i32.eq
        br_if $case2|0
-       local.get $3
+       local.get $2
        i32.const 3
        i32.eq
        br_if $case3|0
@@ -2904,75 +2903,71 @@
    i32.const 2139095040
    i32.eq
    if
+    f32.const 2.356194496154785
+    f32.const 0.7853981852531433
     local.get $2
+    i32.const 2
+    i32.and
+    select
+    f32.const 3.1415927410125732
+    f32.const 0
+    local.get $2
+    i32.const 2
+    i32.and
+    select
+    local.get $3
     i32.const 2139095040
     i32.eq
-    if
-     f32.const 2.356194496154785
-     f32.const 0.7853981852531433
-     local.get $3
-     i32.const 2
-     i32.and
-     select
-     local.set $0
-    else
-     f32.const 3.1415927410125732
-     f32.const 0
-     local.get $3
-     i32.const 2
-     i32.and
-     select
-     local.set $0
-    end
-    local.get $3
+    select
+    local.set $0
+    local.get $0
+    f32.neg
+    local.get $0
+    local.get $2
     i32.const 1
     i32.and
-    if
-     local.get $0
-     f32.neg
-     local.set $0
-    end
-    local.get $0
+    select
     return
    end
    i32.const 1
-   local.get $2
+   local.get $3
    i32.const 2139095040
    i32.eq
    local.get $5
    i32.const 218103808
    i32.add
-   local.get $2
+   local.get $3
    i32.lt_u
    select
    br_if $folding-inner0
-   local.get $2
+   local.get $3
    i32.const 218103808
    i32.add
    local.get $5
    i32.lt_u
    i32.const 0
-   local.get $3
+   local.get $2
    i32.const 2
    i32.and
    select
-   i32.eqz
-   if
+   if (result f32)
+    f32.const 0
+   else
     local.get $0
     local.get $1
     f32.div
     f32.abs
     call $~lib/math/NativeMathf.atan
-    local.set $4
    end
+   local.set $4
    block $break|1
     block $case3|1
      block $case2|1
       block $case1|1
-       local.get $3
-       local.tee $2
+       local.get $2
+       local.tee $3
        if
-        local.get $2
+        local.get $3
         i32.const 1
         i32.sub
         br_table $case1|1 $case2|1 $case3|1 $break|1
@@ -3002,7 +2997,7 @@
   end
   f32.const -1.5707963705062866
   f32.const 1.5707963705062866
-  local.get $3
+  local.get $2
   i32.const 1
   i32.and
   select
@@ -3301,7 +3296,7 @@
   i64.shr_s
   i64.const 1045
   i64.sub
-  local.tee $1
+  local.tee $2
   i64.const 6
   i64.shr_s
   i32.wrap_i64
@@ -3314,166 +3309,166 @@
   local.set $6
   local.get $7
   i64.load offset=8
-  local.set $3
+  local.set $4
   local.get $7
   i64.load offset=16
-  local.set $4
-  local.get $1
+  local.set $1
+  local.get $2
   i64.const 63
   i64.and
-  local.tee $1
+  local.tee $2
   i64.const 0
   i64.ne
   if
    local.get $6
-   local.get $1
+   local.get $2
    i64.shl
-   local.get $3
+   local.get $4
    i64.const 64
-   local.get $1
+   local.get $2
    i64.sub
-   local.tee $2
+   local.tee $3
    i64.shr_u
    i64.or
    local.set $6
+   local.get $4
+   local.get $2
+   i64.shl
+   local.get $1
    local.get $3
-   local.get $1
-   i64.shl
-   local.get $4
-   local.get $2
-   i64.shr_u
-   i64.or
-   local.set $3
-   local.get $4
-   local.get $1
-   i64.shl
-   local.get $7
-   i64.load offset=24
-   local.get $2
    i64.shr_u
    i64.or
    local.set $4
+   local.get $1
+   local.get $2
+   i64.shl
+   local.get $7
+   i64.load offset=24
+   local.get $3
+   i64.shr_u
+   i64.or
+   local.set $1
   end
   local.get $0
   i64.const 4503599627370495
   i64.and
   i64.const 4503599627370496
   i64.or
-  local.tee $1
+  local.tee $2
   i64.const 4294967295
   i64.and
-  local.tee $2
-  local.get $3
+  local.tee $3
+  local.get $4
   i64.const 32
   i64.shr_u
   local.tee $8
   i64.mul
-  local.get $3
+  local.get $4
   i64.const 4294967295
   i64.and
   local.tee $5
-  local.get $2
+  local.get $3
   i64.mul
   local.tee $9
   i64.const 32
   i64.shr_u
   i64.add
-  local.set $3
+  local.set $4
   local.get $5
-  local.get $1
+  local.get $2
   i64.const 32
   i64.shr_u
   local.tee $5
   i64.mul
-  local.get $3
+  local.get $4
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $2
+  local.set $3
   local.get $5
   local.get $8
   i64.mul
-  local.get $3
+  local.get $4
   i64.const 32
   i64.shr_u
   i64.add
-  local.get $2
+  local.get $3
   i64.const 32
   i64.shr_u
   i64.add
   global.set $~lib/math/res128_hi
   global.get $~lib/math/res128_hi
-  local.get $1
+  local.get $2
   local.get $6
   i64.mul
   i64.add
-  local.get $4
+  local.get $1
   i64.const 32
   i64.shr_u
-  local.get $1
+  local.get $2
   i64.const 32
   i64.shr_s
   i64.mul
-  local.tee $3
+  local.tee $4
   local.get $9
   i64.const 4294967295
   i64.and
-  local.get $2
+  local.get $3
   i64.const 32
   i64.shl
   i64.add
   i64.add
-  local.tee $1
-  local.get $3
+  local.tee $2
+  local.get $4
   i64.lt_u
   i64.extend_i32_u
   i64.add
   local.tee $8
   i64.const 2
   i64.shl
-  local.get $1
+  local.get $2
   i64.const 62
   i64.shr_u
   i64.or
   local.tee $6
   i64.const 63
   i64.shr_s
-  local.tee $4
+  local.tee $1
   i64.const 1
   i64.shr_s
   local.get $6
   i64.xor
-  local.tee $2
+  local.tee $3
   i64.clz
-  local.set $3
-  local.get $2
+  local.set $4
   local.get $3
-  i64.shl
   local.get $4
+  i64.shl
   local.get $1
+  local.get $2
   i64.const 2
   i64.shl
   i64.xor
   local.tee $5
   i64.const 64
-  local.get $3
+  local.get $4
   i64.sub
   i64.shr_u
   i64.or
-  local.tee $1
+  local.tee $2
   i64.const 4294967295
   i64.and
-  local.set $2
-  local.get $1
+  local.set $3
+  local.get $2
   i64.const 32
   i64.shr_u
   local.tee $9
   i64.const 560513588
   i64.mul
-  local.get $2
+  local.get $3
   i64.const 3373259426
   i64.mul
-  local.get $2
+  local.get $3
   i64.const 560513588
   i64.mul
   local.tee $10
@@ -3484,7 +3479,7 @@
   i64.const 4294967295
   i64.and
   i64.add
-  local.set $2
+  local.set $3
   local.get $9
   i64.const 3373259426
   i64.mul
@@ -3492,7 +3487,7 @@
   i64.const 32
   i64.shr_u
   i64.add
-  local.get $2
+  local.get $3
   i64.const 32
   i64.shr_u
   i64.add
@@ -3500,24 +3495,24 @@
   local.get $10
   i64.const 4294967295
   i64.and
-  local.get $2
+  local.get $3
   i64.const 32
   i64.shl
   i64.add
-  local.tee $2
+  local.tee $3
   f64.const 3.753184150245214e-04
-  local.get $1
+  local.get $2
   f64.convert_i64_u
   f64.mul
   f64.const 3.834951969714103e-04
   local.get $5
-  local.get $3
+  local.get $4
   i64.shl
   f64.convert_i64_u
   f64.mul
   f64.add
   i64.trunc_f64_u
-  local.tee $1
+  local.tee $2
   i64.lt_u
   i64.extend_i32_u
   global.get $~lib/math/res128_hi
@@ -3528,11 +3523,11 @@
   f64.convert_i64_u
   global.set $~lib/math/rempio2_y0
   f64.const 5.421010862427522e-20
-  local.get $1
+  local.get $2
   local.get $5
   i64.const 53
   i64.shl
-  local.get $2
+  local.get $3
   i64.const 11
   i64.shr_u
   i64.or
@@ -3542,7 +3537,7 @@
   global.set $~lib/math/rempio2_y1
   global.get $~lib/math/rempio2_y0
   i64.const 4372995238176751616
-  local.get $3
+  local.get $4
   i64.const 52
   i64.shl
   i64.sub
@@ -3563,7 +3558,7 @@
   local.get $8
   i64.const 62
   i64.shr_s
-  local.get $4
+  local.get $1
   i64.sub
   i32.wrap_i64
  )
@@ -3736,7 +3731,7 @@
      i32.sub
      i32.const 49
      i32.gt_u
-     if
+     if (result f64)
       local.get $3
       f64.const 8.4784276603689e-32
       f64.mul
@@ -3756,8 +3751,10 @@
       local.get $0
       local.get $4
       f64.sub
-      local.set $1
+     else
+      local.get $1
      end
+     local.set $1
     end
     local.get $1
     global.set $~lib/math/rempio2_y0
@@ -3887,17 +3884,15 @@
    f64.add
   end
   local.set $0
+  local.get $0
+  f64.neg
+  local.get $0
   local.get $6
   i32.const 1
   i32.add
   i32.const 2
   i32.and
-  if
-   local.get $0
-   f64.neg
-   local.set $0
-  end
-  local.get $0
+  select
  )
  (func $std/math/test_cos (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
@@ -4172,17 +4167,15 @@
    f32.demote_f64
   end
   local.set $0
+  local.get $0
+  f32.neg
+  local.get $0
   local.get $1
   i32.const 1
   i32.add
   i32.const 2
   i32.and
-  if
-   local.get $0
-   f32.neg
-   local.set $0
-  end
-  local.get $0
+  select
  )
  (func $std/math/test_cosf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
@@ -4604,13 +4597,13 @@
   f64.add
   local.set $0
   local.get $4
-  if
+  if (result f64)
    local.get $0
    local.get $4
    call $~lib/math/NativeMath.scalbn
-   local.set $0
+  else
+   local.get $0
   end
-  local.get $0
  )
  (func $std/math/test_cosh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 f64)
@@ -5063,13 +5056,13 @@
   f32.add
   local.set $0
   local.get $3
-  if
+  if (result f32)
    local.get $0
    local.get $3
    call $~lib/math/NativeMathf.scalbn
-   local.set $0
+  else
+   local.get $0
   end
-  local.get $0
  )
  (func $std/math/test_coshf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   (local $3 i32)
@@ -5181,9 +5174,9 @@
   call $std/math/check<f32>
  )
  (func $~lib/math/NativeMath.exp2 (param $0 f64) (result f64)
-  (local $1 f64)
-  (local $2 i64)
-  (local $3 i32)
+  (local $1 i32)
+  (local $2 f64)
+  (local $3 i64)
   (local $4 f64)
   (local $5 i64)
   (local $6 i32)
@@ -5191,75 +5184,75 @@
   block $~lib/util/math/exp2_lut|inlined.0
    local.get $0
    i64.reinterpret_f64
-   local.tee $2
+   local.tee $3
    i64.const 52
    i64.shr_u
    i64.const 2047
    i64.and
    i32.wrap_i64
-   local.tee $3
+   local.tee $1
    i32.const 969
    i32.sub
    i32.const 63
    i32.ge_u
    if
-    local.get $3
+    local.get $1
     i32.const 969
     i32.sub
     i32.const -2147483648
     i32.ge_u
     if
      f64.const 1
-     local.set $1
+     local.set $2
      br $~lib/util/math/exp2_lut|inlined.0
     end
-    local.get $3
+    local.get $1
     i32.const 1033
     i32.ge_u
     if
-     local.get $2
+     local.get $3
      i64.const -4503599627370496
      i64.eq
      br_if $~lib/util/math/exp2_lut|inlined.0
-     local.get $3
+     local.get $1
      i32.const 2047
      i32.ge_u
      if
       f64.const 1
       local.get $0
       f64.add
-      local.set $1
+      local.set $2
       br $~lib/util/math/exp2_lut|inlined.0
      end
-     local.get $2
+     local.get $3
      i64.const 63
      i64.shr_u
      i64.eqz
      if
       f64.const inf
-      local.set $1
+      local.set $2
       br $~lib/util/math/exp2_lut|inlined.0
      else
-      local.get $2
+      local.get $3
       i64.const -4570929321408987136
       i64.ge_u
       br_if $~lib/util/math/exp2_lut|inlined.0
      end
     end
     i32.const 0
+    local.get $1
     local.get $3
-    local.get $2
     i64.const 1
     i64.shl
     i64.const -9143996093422370816
     i64.gt_u
     select
-    local.set $3
+    local.set $1
    end
    local.get $0
    f64.const 52776558133248
    f64.add
-   local.tee $1
+   local.tee $2
    i64.reinterpret_f64
    local.tee $5
    i64.const 127
@@ -5277,16 +5270,16 @@
    i64.const 45
    i64.shl
    i64.add
-   local.set $2
+   local.set $3
    local.get $0
-   local.get $1
+   local.get $2
    f64.const 52776558133248
    f64.sub
    f64.sub
    local.tee $0
    local.get $0
    f64.mul
-   local.set $1
+   local.set $2
    local.get $6
    i64.load
    f64.reinterpret_i64
@@ -5294,7 +5287,7 @@
    f64.const 0.6931471805599453
    f64.mul
    f64.add
-   local.get $1
+   local.get $2
    f64.const 0.24022650695909065
    local.get $0
    f64.const 0.0555041086686087
@@ -5302,8 +5295,8 @@
    f64.add
    f64.mul
    f64.add
-   local.get $1
-   local.get $1
+   local.get $2
+   local.get $2
    f64.mul
    f64.const 0.009618131975721055
    local.get $0
@@ -5313,7 +5306,7 @@
    f64.mul
    f64.add
    local.set $0
-   local.get $3
+   local.get $1
    i32.eqz
    if
     block $~lib/util/math/specialcase2|inlined.0 (result f64)
@@ -5323,19 +5316,19 @@
      i64.eqz
      if
       f64.const 2
-      local.get $2
+      local.get $3
       i64.const 4503599627370496
       i64.sub
       f64.reinterpret_i64
-      local.tee $1
+      local.tee $2
       local.get $0
       f64.mul
-      local.get $1
+      local.get $2
       f64.add
       f64.mul
       br $~lib/util/math/specialcase2|inlined.0
      end
-     local.get $2
+     local.get $3
      i64.const 4602678819172646912
      i64.add
      f64.reinterpret_i64
@@ -5344,21 +5337,21 @@
      f64.mul
      local.get $4
      f64.add
-     local.tee $1
+     local.tee $2
      f64.const 1
      f64.lt
      if (result f64)
       f64.const 1
-      local.get $1
+      local.get $2
       f64.add
       local.tee $7
       f64.const 1
       local.get $7
       f64.sub
-      local.get $1
+      local.get $2
       f64.add
       local.get $4
-      local.get $1
+      local.get $2
       f64.sub
       local.get $4
       local.get $0
@@ -5369,24 +5362,24 @@
       f64.const 1
       f64.sub
      else
-      local.get $1
+      local.get $2
      end
      f64.const 2.2250738585072014e-308
      f64.mul
     end
-    local.set $1
+    local.set $2
     br $~lib/util/math/exp2_lut|inlined.0
    end
-   local.get $2
+   local.get $3
    f64.reinterpret_i64
-   local.tee $1
+   local.tee $2
    local.get $0
    f64.mul
-   local.get $1
+   local.get $2
    f64.add
-   local.set $1
+   local.set $2
   end
-  local.get $1
+  local.get $2
  )
  (func $std/math/test_exp2 (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
@@ -5551,22 +5544,22 @@
   i64.reinterpret_f64
   i64.const 9223372036854775807
   i64.and
-  local.tee $4
+  local.tee $2
   i64.lt_u
   if
    local.get $3
-   local.get $4
+   local.get $2
    local.set $3
-   local.set $4
+   local.set $2
   end
-  local.get $4
+  local.get $2
   f64.reinterpret_i64
   local.set $1
-  local.get $4
+  local.get $2
   i64.const 52
   i64.shr_u
   i32.wrap_i64
-  local.tee $6
+  local.tee $10
   i32.const 2047
   i32.eq
   if
@@ -5577,13 +5570,13 @@
   f64.reinterpret_i64
   local.set $0
   i32.const 1
-  local.get $4
+  local.get $2
   i64.eqz
   local.get $3
   i64.const 52
   i64.shr_u
   i32.wrap_i64
-  local.tee $10
+  local.tee $6
   i32.const 2047
   i32.eq
   select
@@ -5591,8 +5584,8 @@
    local.get $0
    return
   end
-  local.get $10
   local.get $6
+  local.get $10
   i32.sub
   i32.const 64
   i32.gt_s
@@ -5603,13 +5596,13 @@
    return
   end
   f64.const 1
-  local.set $9
-  local.get $10
+  local.set $7
+  local.get $6
   i32.const 1533
   i32.gt_s
   if (result f64)
    f64.const 5260135901548373507240989e186
-   local.set $9
+   local.set $7
    local.get $1
    f64.const 1.90109156629516e-211
    f64.mul
@@ -5618,12 +5611,12 @@
    f64.const 1.90109156629516e-211
    f64.mul
   else
-   local.get $6
+   local.get $10
    i32.const 573
    i32.lt_s
    if (result f64)
     f64.const 1.90109156629516e-211
-    local.set $9
+    local.set $7
     local.get $1
     f64.const 5260135901548373507240989e186
     f64.mul
@@ -5641,26 +5634,26 @@
   local.get $1
   f64.const 134217729
   f64.mul
-  local.tee $11
+  local.tee $5
   f64.sub
-  local.get $11
+  local.get $5
   f64.add
   local.tee $8
   f64.sub
-  local.set $5
+  local.set $11
   local.get $0
   local.get $0
   local.get $0
   f64.const 134217729
   f64.mul
-  local.tee $11
+  local.tee $5
   f64.sub
-  local.get $11
+  local.get $5
   f64.add
-  local.tee $7
+  local.tee $9
   f64.sub
-  local.set $11
-  local.get $9
+  local.set $5
+  local.get $7
   local.get $8
   local.get $8
   f64.mul
@@ -5672,13 +5665,13 @@
   f64.const 2
   local.get $8
   f64.mul
-  local.get $5
+  local.get $11
   f64.add
-  local.get $5
+  local.get $11
   f64.mul
   f64.add
-  local.get $7
-  local.get $7
+  local.get $9
+  local.get $9
   f64.mul
   local.get $0
   local.get $0
@@ -5686,11 +5679,11 @@
   local.tee $0
   f64.sub
   f64.const 2
-  local.get $7
+  local.get $9
   f64.mul
-  local.get $11
+  local.get $5
   f64.add
-  local.get $11
+  local.get $5
   f64.mul
   f64.add
   f64.add
@@ -5723,21 +5716,21 @@
   i32.reinterpret_f32
   i32.const 2147483647
   i32.and
-  local.tee $4
+  local.tee $2
   i32.lt_u
   if
    local.get $3
-   local.get $4
+   local.get $2
    local.set $3
-   local.set $4
+   local.set $2
   end
   local.get $3
   f32.reinterpret_i32
   local.set $0
-  local.get $4
+  local.get $2
   f32.reinterpret_i32
   local.set $1
-  local.get $4
+  local.get $2
   i32.const 2139095040
   i32.eq
   if
@@ -5746,12 +5739,12 @@
   end
   i32.const 1
   local.get $3
-  local.get $4
+  local.get $2
   i32.sub
   i32.const 209715200
   i32.ge_u
   i32.const 1
-  local.get $4
+  local.get $2
   i32.eqz
   local.get $3
   i32.const 2139095040
@@ -5780,7 +5773,7 @@
    f32.const 8.077935669463161e-28
    f32.mul
   else
-   local.get $4
+   local.get $2
    i32.const 562036736
    i32.lt_u
    if (result f32)
@@ -7099,12 +7092,12 @@
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 f64)
-  (local $7 i32)
+  (local $5 f64)
+  (local $6 i32)
+  (local $7 f64)
   (local $8 i32)
   (local $9 i32)
-  (local $10 f64)
+  (local $10 i32)
   (local $11 i32)
   (local $12 f64)
   (local $13 i64)
@@ -7179,17 +7172,17 @@
   local.tee $15
   i32.const 2147483647
   i32.and
-  local.set $4
+  local.set $6
   local.get $1
   i64.reinterpret_f64
   local.tee $13
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $7
+  local.tee $8
   i32.const 2147483647
   i32.and
-  local.tee $8
+  local.tee $9
   local.get $13
   i32.wrap_i64
   local.tee $19
@@ -7202,22 +7195,22 @@
   i32.const 1
   local.get $19
   i32.const 0
-  local.get $8
+  local.get $9
   i32.const 2146435072
   i32.eq
   select
   i32.const 1
-  local.get $8
+  local.get $9
   i32.const 2146435072
   i32.gt_s
   i32.const 1
   local.get $18
   i32.const 0
-  local.get $4
+  local.get $6
   i32.const 2146435072
   i32.eq
   select
-  local.get $4
+  local.get $6
   i32.const 2146435072
   i32.gt_s
   select
@@ -7232,47 +7225,47 @@
   local.get $15
   i32.const 0
   i32.lt_s
-  if
-   local.get $8
+  if (result i32)
+   local.get $9
    i32.const 1128267776
    i32.ge_s
    if (result i32)
     i32.const 2
    else
-    local.get $8
+    local.get $9
     i32.const 1072693248
     i32.ge_s
     if (result i32)
      i32.const 52
      i32.const 20
-     local.get $8
+     local.get $9
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $9
+     local.tee $10
      i32.const 20
      i32.gt_s
-     local.tee $5
+     local.tee $4
      select
-     local.get $9
+     local.get $10
      i32.sub
      local.set $11
      i32.const 2
      local.get $19
-     local.get $8
-     local.get $5
+     local.get $9
+     local.get $4
      select
-     local.tee $5
+     local.tee $4
      local.get $11
      i32.shr_u
-     local.tee $9
+     local.tee $10
      i32.const 1
      i32.and
      i32.sub
      i32.const 0
-     local.get $5
-     local.get $9
+     local.get $4
+     local.get $10
      local.get $11
      i32.shl
      i32.eq
@@ -7281,28 +7274,30 @@
      i32.const 0
     end
    end
-   local.set $5
+  else
+   i32.const 0
   end
+  local.set $4
   local.get $19
   i32.eqz
   if
-   local.get $8
+   local.get $9
    i32.const 2146435072
    i32.eq
    if
     local.get $18
-    local.get $4
+    local.get $6
     i32.const 1072693248
     i32.sub
     i32.or
     if
-     local.get $4
+     local.get $6
      i32.const 1072693248
      i32.ge_s
      if
       local.get $1
       f64.const 0
-      local.get $7
+      local.get $8
       i32.const 0
       i32.ge_s
       select
@@ -7311,7 +7306,7 @@
       local.get $1
       f64.neg
       f64.const 0
-      local.get $7
+      local.get $8
       i32.const 0
       i32.lt_s
       select
@@ -7324,11 +7319,11 @@
     end
     unreachable
    end
-   local.get $8
+   local.get $9
    i32.const 1072693248
    i32.eq
    if
-    local.get $7
+    local.get $8
     i32.const 0
     i32.ge_s
     if
@@ -7340,7 +7335,7 @@
     f64.div
     return
    end
-   local.get $7
+   local.get $8
    i32.const 1073741824
    i32.eq
    if
@@ -7349,7 +7344,7 @@
     f64.mul
     return
    end
-   local.get $7
+   local.get $8
    i32.const 1071644672
    i32.eq
    if
@@ -7365,69 +7360,69 @@
   end
   local.get $0
   f64.abs
-  local.set $2
+  local.set $5
   local.get $18
   i32.eqz
   if
    i32.const 1
-   local.get $4
+   local.get $6
    i32.const 1072693248
    i32.eq
-   local.get $4
+   local.get $6
    i32.const 2146435072
    i32.eq
    i32.const 1
-   local.get $4
+   local.get $6
    select
    select
    if
     f64.const 1
-    local.get $2
+    local.get $5
     f64.div
-    local.get $2
-    local.get $7
+    local.get $5
+    local.get $8
     i32.const 0
     i32.lt_s
     select
-    local.set $2
+    local.set $5
     local.get $15
     i32.const 0
     i32.lt_s
     if (result f64)
-     local.get $5
      local.get $4
+     local.get $6
      i32.const 1072693248
      i32.sub
      i32.or
      if (result f64)
-      local.get $2
-      f64.neg
-      local.get $2
       local.get $5
+      f64.neg
+      local.get $5
+      local.get $4
       i32.const 1
       i32.eq
       select
      else
-      local.get $2
-      local.get $2
+      local.get $5
+      local.get $5
       f64.sub
       local.tee $0
       local.get $0
       f64.div
      end
     else
-     local.get $2
+     local.get $5
     end
     return
    end
   end
   f64.const 1
-  local.set $10
+  local.set $3
   local.get $15
   i32.const 0
   i32.lt_s
-  if
-   local.get $5
+  if (result f64)
+   local.get $4
    i32.eqz
    if
     local.get $0
@@ -7440,92 +7435,94 @@
    end
    f64.const -1
    f64.const 1
-   local.get $5
+   local.get $4
    i32.const 1
    i32.eq
    select
-   local.set $10
+  else
+   f64.const 1
   end
-  local.get $8
+  local.set $3
+  local.get $9
   i32.const 1105199104
   i32.gt_s
   if (result f64)
-   local.get $8
+   local.get $9
    i32.const 1139802112
    i32.gt_s
    if
-    local.get $4
+    local.get $6
     i32.const 1072693247
     i32.le_s
     if
      f64.const inf
      f64.const 0
-     local.get $7
+     local.get $8
      i32.const 0
      i32.lt_s
      select
      return
     end
-    local.get $4
+    local.get $6
     i32.const 1072693248
     i32.ge_s
     if
      f64.const inf
      f64.const 0
-     local.get $7
+     local.get $8
      i32.const 0
      i32.gt_s
      select
      return
     end
    end
-   local.get $4
+   local.get $6
    i32.const 1072693247
    i32.lt_s
    if
-    local.get $10
+    local.get $3
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
-    local.get $10
+    local.get $3
     f64.const 1e-300
     f64.mul
     f64.const 1e-300
     f64.mul
-    local.get $7
+    local.get $8
     i32.const 0
     i32.lt_s
     select
     return
    end
-   local.get $4
+   local.get $6
    i32.const 1072693248
    i32.gt_s
    if
-    local.get $10
+    local.get $3
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
-    local.get $10
+    local.get $3
     f64.const 1e-300
     f64.mul
     f64.const 1e-300
     f64.mul
-    local.get $7
+    local.get $8
     i32.const 0
     i32.gt_s
     select
     return
    end
    f64.const 1.4426950216293335
-   local.get $2
+   local.get $5
    f64.const 1
    f64.sub
    local.tee $0
    f64.mul
-   local.tee $2
+   local.tee $5
    local.get $0
    f64.const 1.9259629911266175e-08
    f64.mul
@@ -7551,87 +7548,87 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $6
+   local.set $7
    local.get $0
-   local.get $6
-   local.get $2
+   local.get $7
+   local.get $5
    f64.sub
    f64.sub
   else
-   local.get $4
+   local.get $6
    i32.const 1048576
    i32.lt_s
    if (result i32)
-    local.get $2
+    local.get $5
     f64.const 9007199254740992
     f64.mul
-    local.tee $2
+    local.tee $5
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.set $4
+    local.set $6
     i32.const -53
    else
     i32.const 0
    end
-   local.get $4
+   local.get $6
    i32.const 20
    i32.shr_s
    i32.const 1023
    i32.sub
    i32.add
-   local.set $7
-   local.get $4
+   local.set $8
+   local.get $6
    i32.const 1048575
    i32.and
-   local.tee $5
+   local.tee $4
    i32.const 1072693248
    i32.or
-   local.set $4
-   local.get $5
+   local.set $6
+   local.get $4
    i32.const 235662
    i32.gt_s
    if
-    local.get $5
+    local.get $4
     i32.const 767610
     i32.lt_s
     if
      i32.const 1
      local.set $16
     else
-     local.get $7
+     local.get $8
      i32.const 1
      i32.add
-     local.set $7
-     local.get $4
+     local.set $8
+     local.get $6
      i32.const -1048576
      i32.add
-     local.set $4
+     local.set $6
     end
    end
    f64.const 0.9617967009544373
-   local.get $2
+   local.get $5
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
-   local.get $4
+   local.get $6
    i64.extend_i32_s
    i64.const 32
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.tee $6
+   local.tee $7
    f64.const 1.5
    f64.const 1
    local.get $16
    select
-   local.tee $3
-   f64.sub
    local.tee $2
+   f64.sub
+   local.tee $5
    f64.const 1
-   local.get $6
-   local.get $3
+   local.get $7
+   local.get $2
    f64.add
    f64.div
    local.tee $0
@@ -7677,9 +7674,9 @@
    f64.add
    f64.mul
    local.get $0
-   local.get $2
+   local.get $5
    local.get $14
-   local.get $4
+   local.get $6
    i32.const 1
    i32.shr_s
    i32.const 536870912
@@ -7698,15 +7695,15 @@
    f64.mul
    f64.sub
    local.get $14
-   local.get $6
+   local.get $7
    local.get $0
-   local.get $3
+   local.get $2
    f64.sub
    f64.sub
    f64.mul
    f64.sub
    f64.mul
-   local.tee $3
+   local.tee $2
    local.get $14
    local.get $17
    f64.add
@@ -7718,14 +7715,14 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.tee $6
+   local.tee $7
    f64.mul
-   local.tee $2
-   local.get $3
-   local.get $6
+   local.tee $5
+   local.get $2
+   local.get $7
    f64.mul
    local.get $0
-   local.get $6
+   local.get $7
    f64.const 3
    f64.sub
    local.get $20
@@ -7740,15 +7737,15 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.tee $3
+   local.tee $2
    f64.mul
    local.tee $20
    f64.const -7.028461650952758e-09
-   local.get $3
+   local.get $2
    f64.mul
    local.get $0
-   local.get $3
    local.get $2
+   local.get $5
    f64.sub
    f64.sub
    f64.const 0.9617966939259756
@@ -7759,15 +7756,15 @@
    local.get $16
    select
    f64.add
-   local.tee $3
+   local.tee $2
    f64.add
    f64.const 0.5849624872207642
    f64.const 0
    local.get $16
    select
-   local.tee $2
+   local.tee $5
    f64.add
-   local.get $7
+   local.get $8
    f64.convert_i32_s
    local.tee $0
    f64.add
@@ -7775,18 +7772,18 @@
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $6
-   local.get $3
-   local.get $6
+   local.set $7
+   local.get $2
+   local.get $7
    local.get $0
    f64.sub
-   local.get $2
+   local.get $5
    f64.sub
    local.get $20
    f64.sub
    f64.sub
   end
-  local.set $2
+  local.set $5
   local.get $1
   local.get $1
   i64.reinterpret_f64
@@ -7795,23 +7792,23 @@
   f64.reinterpret_i64
   local.tee $0
   f64.sub
-  local.get $6
+  local.get $7
   f64.mul
   local.get $1
-  local.get $2
+  local.get $5
   f64.mul
   f64.add
   local.tee $1
   local.get $0
-  local.get $6
+  local.get $7
   f64.mul
-  local.tee $3
+  local.tee $2
   f64.add
   local.tee $0
   i64.reinterpret_f64
   local.tee $13
   i32.wrap_i64
-  local.set $5
+  local.set $4
   block $folding-inner1
    block $folding-inner0
     local.get $13
@@ -7822,7 +7819,7 @@
     i32.const 1083179008
     i32.ge_s
     if
-     local.get $5
+     local.get $4
      local.get $11
      i32.const 1083179008
      i32.sub
@@ -7831,7 +7828,7 @@
      f64.const 8.008566259537294e-17
      f64.add
      local.get $0
-     local.get $3
+     local.get $2
      f64.sub
      f64.gt
      i32.or
@@ -7843,14 +7840,14 @@
      i32.const 1083231232
      i32.ge_s
      i32.const 0
-     local.get $5
+     local.get $4
      local.get $11
      i32.const -1064252416
      i32.sub
      i32.or
      local.get $1
      local.get $0
-     local.get $3
+     local.get $2
      f64.sub
      f64.le
      i32.or
@@ -7860,38 +7857,39 @@
     local.get $11
     i32.const 2147483647
     i32.and
-    local.tee $9
+    local.tee $10
     i32.const 20
     i32.shr_s
     i32.const 1023
     i32.sub
-    local.set $5
+    local.set $4
     i32.const 0
-    local.set $7
-    local.get $9
+    local.set $8
+    local.get $1
+    local.get $10
     i32.const 1071644672
     i32.gt_s
     if
      i32.const 1048575
      local.get $11
      i32.const 1048576
-     local.get $5
+     local.get $4
      i32.const 1
      i32.add
      i32.shr_s
      i32.add
-     local.tee $9
+     local.tee $10
      i32.const 2147483647
      i32.and
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $5
+     local.tee $4
      i32.shr_s
      i32.const -1
      i32.xor
-     local.get $9
+     local.get $10
      i32.and
      i64.extend_i32_s
      i64.const 32
@@ -7899,30 +7897,29 @@
      f64.reinterpret_i64
      local.set $0
      i32.const 0
-     local.get $9
+     local.get $10
      i32.const 1048575
      i32.and
      i32.const 1048576
      i32.or
      i32.const 20
-     local.get $5
+     local.get $4
      i32.sub
      i32.shr_s
-     local.tee $7
+     local.tee $8
      i32.sub
-     local.get $7
+     local.get $8
      local.get $11
      i32.const 0
      i32.lt_s
      select
-     local.set $7
-     local.get $3
+     local.set $8
+     local.get $2
      local.get $0
      f64.sub
-     local.set $3
+     local.set $2
     end
-    local.get $1
-    local.get $3
+    local.get $2
     f64.add
     i64.reinterpret_f64
     i64.const -4294967296
@@ -7931,10 +7928,10 @@
     local.tee $0
     f64.const 0.6931471824645996
     f64.mul
-    local.tee $2
+    local.tee $5
     local.get $1
     local.get $0
-    local.get $3
+    local.get $2
     f64.sub
     f64.sub
     f64.const 0.6931471805599453
@@ -7945,14 +7942,14 @@
     f64.add
     local.tee $1
     f64.add
-    local.tee $3
-    local.get $3
+    local.tee $2
+    local.get $2
     f64.mul
     local.set $0
-    local.get $10
+    local.get $3
     f64.const 1
-    local.get $3
-    local.get $3
+    local.get $2
+    local.get $2
     local.get $0
     f64.const 0.16666666666666602
     local.get $0
@@ -7980,17 +7977,17 @@
     f64.sub
     f64.div
     local.get $1
-    local.get $3
     local.get $2
+    local.get $5
     f64.sub
     f64.sub
     local.tee $0
-    local.get $3
+    local.get $2
     local.get $0
     f64.mul
     f64.add
     f64.sub
-    local.get $3
+    local.get $2
     f64.sub
     f64.sub
     local.tee $0
@@ -7998,25 +7995,25 @@
     i64.const 32
     i64.shr_u
     i32.wrap_i64
-    local.get $7
+    local.get $8
     i32.const 20
     i32.shl
     i32.add
-    local.tee $5
+    local.tee $4
     i32.const 20
     i32.shr_s
     i32.const 0
     i32.le_s
     if (result f64)
      local.get $0
-     local.get $7
+     local.get $8
      call $~lib/math/NativeMath.scalbn
     else
      local.get $0
      i64.reinterpret_f64
      i64.const 4294967295
      i64.and
-     local.get $5
+     local.get $4
      i64.extend_i32_s
      i64.const 32
      i64.shl
@@ -8026,14 +8023,14 @@
     f64.mul
     return
    end
-   local.get $10
+   local.get $3
    f64.const 1.e+300
    f64.mul
    f64.const 1.e+300
    f64.mul
    return
   end
-  local.get $10
+  local.get $3
   f64.const 1e-300
   f64.mul
   f64.const 1e-300
@@ -8562,6 +8559,7 @@
   i64.const 63
   i64.shr_u
   i32.wrap_i64
+  local.set $8
   local.get $3
   i64.eqz
   if (result i64)
@@ -8746,12 +8744,11 @@
   select
   select
   local.set $0
-  if
-   local.get $0
-   f64.neg
-   local.set $0
-  end
   local.get $0
+  f64.neg
+  local.get $0
+  local.get $8
+  select
  )
  (func $std/math/test_rem (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
@@ -8765,38 +8762,38 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 f32)
+  (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
+  (local $8 f32)
   (local $9 i32)
   local.get $0
   i32.reinterpret_f32
-  local.tee $3
+  local.tee $2
   i32.const 23
   i32.shr_u
   i32.const 255
   i32.and
-  local.set $9
+  local.set $4
   local.get $1
   i32.reinterpret_f32
-  local.tee $6
+  local.tee $7
   i32.const 23
   i32.shr_u
   i32.const 255
   i32.and
-  local.set $8
-  local.get $3
-  local.set $2
+  local.set $5
+  local.get $2
+  local.set $3
   i32.const 1
   local.get $1
   local.get $1
   f32.ne
-  local.get $9
+  local.get $4
   i32.const 255
   i32.eq
   i32.const 1
-  local.get $6
+  local.get $7
   i32.const 1
   i32.shl
   select
@@ -8810,7 +8807,7 @@
    f32.div
    return
   end
-  local.get $2
+  local.get $3
   i32.const 1
   i32.shl
   i32.eqz
@@ -8818,58 +8815,59 @@
    local.get $0
    return
   end
-  local.get $2
+  local.get $3
   i32.const 31
   i32.shr_u
-  local.get $9
+  local.set $9
+  local.get $4
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 8388607
    i32.and
    i32.const 8388608
    i32.or
   else
-   local.get $2
+   local.get $3
    i32.const 1
-   local.get $9
-   local.get $2
+   local.get $4
+   local.get $3
    i32.const 9
    i32.shl
    i32.clz
    i32.sub
-   local.tee $9
-   i32.sub
-   i32.shl
-  end
-  local.set $3
-  local.get $8
-  if (result i32)
-   local.get $6
-   i32.const 8388607
-   i32.and
-   i32.const 8388608
-   i32.or
-  else
-   local.get $6
-   i32.const 1
-   local.get $8
-   local.get $6
-   i32.const 9
-   i32.shl
-   i32.clz
-   i32.sub
-   local.tee $8
+   local.tee $4
    i32.sub
    i32.shl
   end
   local.set $2
+  local.get $5
+  if (result i32)
+   local.get $7
+   i32.const 8388607
+   i32.and
+   i32.const 8388608
+   i32.or
+  else
+   local.get $7
+   i32.const 1
+   local.get $5
+   local.get $7
+   i32.const 9
+   i32.shl
+   i32.clz
+   i32.sub
+   local.tee $5
+   i32.sub
+   i32.shl
+  end
+  local.set $3
   block $do-break|0
-   local.get $9
-   local.get $8
+   local.get $4
+   local.get $5
    i32.lt_s
    if
-    local.get $8
-    local.get $9
+    local.get $5
+    local.get $4
     i32.const 1
     i32.add
     i32.eq
@@ -8878,84 +8876,83 @@
     return
    end
    loop $while-continue|1
-    local.get $9
-    local.get $8
+    local.get $4
+    local.get $5
     i32.gt_s
     if
-     local.get $3
      local.get $2
+     local.get $3
      i32.ge_u
      if (result i32)
-      local.get $7
+      local.get $6
       i32.const 1
       i32.add
-      local.set $7
-      local.get $3
+      local.set $6
       local.get $2
+      local.get $3
       i32.sub
      else
-      local.get $3
+      local.get $2
      end
      i32.const 1
      i32.shl
-     local.set $3
-     local.get $7
+     local.set $2
+     local.get $6
      i32.const 1
      i32.shl
-     local.set $7
-     local.get $9
+     local.set $6
+     local.get $4
      i32.const 1
      i32.sub
-     local.set $9
+     local.set $4
      br $while-continue|1
     end
    end
-   local.get $3
    local.get $2
+   local.get $3
    i32.ge_u
    if
-    local.get $7
+    local.get $6
     i32.const 1
     i32.add
-    local.set $7
-    local.get $3
+    local.set $6
     local.get $2
-    i32.sub
-    local.set $3
-   end
-   local.get $3
-   i32.eqz
-   if
-    i32.const -30
-    local.set $9
-   else
-    local.get $9
     local.get $3
+    i32.sub
+    local.set $2
+   end
+   local.get $2
+   if
+    local.get $4
+    local.get $2
     i32.const 8
     i32.shl
     i32.clz
-    local.tee $2
+    local.tee $3
     i32.sub
-    local.set $9
-    local.get $3
+    local.set $4
     local.get $2
+    local.get $3
     i32.shl
-    local.set $3
+    local.set $2
+   else
+    i32.const -30
+    local.set $4
    end
   end
-  local.get $3
+  local.get $2
   i32.const 8388608
   i32.sub
-  local.get $9
+  local.get $4
   i32.const 23
   i32.shl
   i32.or
-  local.get $3
+  local.get $2
   i32.const 1
-  local.get $9
+  local.get $4
   i32.sub
   i32.shr_u
-  local.get $9
+  local.get $4
   i32.const 0
   i32.gt_s
   select
@@ -8963,7 +8960,7 @@
   local.tee $0
   local.get $0
   f32.add
-  local.set $5
+  local.set $8
   local.get $0
   local.get $1
   f32.abs
@@ -8972,37 +8969,36 @@
   local.get $0
   i32.const 1
   i32.const 1
-  local.get $7
+  local.get $6
   i32.const 1
   i32.and
   i32.const 0
-  local.get $5
+  local.get $8
   local.get $1
   f32.eq
   select
-  local.get $5
+  local.get $8
   local.get $1
   f32.gt
   select
   i32.const 0
-  local.get $8
-  local.get $9
+  local.get $5
+  local.get $4
   i32.const 1
   i32.add
   i32.eq
   select
-  local.get $8
-  local.get $9
+  local.get $4
+  local.get $5
   i32.eq
   select
   select
   local.set $0
-  if
-   local.get $0
-   f32.neg
-   local.set $0
-  end
   local.get $0
+  f32.neg
+  local.get $0
+  local.get $9
+  select
  )
  (func $std/math/test_remf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
@@ -9164,7 +9160,7 @@
      i32.sub
      i32.const 49
      i32.gt_u
-     if
+     if (result f64)
       local.get $3
       f64.const 8.4784276603689e-32
       f64.mul
@@ -9184,8 +9180,10 @@
       local.get $0
       local.get $4
       f64.sub
-      local.set $1
+     else
+      local.get $1
      end
+     local.set $1
     end
     local.get $1
     global.set $~lib/math/rempio2_y0
@@ -9315,15 +9313,13 @@
    f64.sub
   end
   local.set $0
+  local.get $0
+  f64.neg
+  local.get $0
   local.get $6
   i32.const 2
   i32.and
-  if
-   local.get $0
-   f64.neg
-   local.set $0
-  end
-  local.get $0
+  select
  )
  (func $std/math/test_sin (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
@@ -9601,15 +9597,13 @@
    f32.demote_f64
   end
   local.set $0
+  local.get $0
+  f32.neg
+  local.get $0
   local.get $1
   i32.const 2
   i32.and
-  if
-   local.get $0
-   f32.neg
-   local.set $0
-  end
-  local.get $0
+  select
  )
  (func $std/math/test_sinf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
@@ -10113,7 +10107,7 @@
      i32.sub
      i32.const 49
      i32.gt_u
-     if
+     if (result f64)
       local.get $5
       f64.const 8.4784276603689e-32
       f64.mul
@@ -10133,8 +10127,10 @@
       local.get $0
       local.get $3
       f64.sub
-      local.set $1
+     else
+      local.get $1
      end
+     local.set $1
     end
     local.get $1
     global.set $~lib/math/rempio2_y0
@@ -10186,9 +10182,9 @@
   end
  )
  (func $~lib/math/NativeMathf.tan (param $0 f32) (result f32)
-  (local $1 i32)
+  (local $1 f64)
   (local $2 i32)
-  (local $3 f64)
+  (local $3 i32)
   (local $4 f64)
   (local $5 f64)
   (local $6 i64)
@@ -10200,18 +10196,18 @@
   (local $12 i64)
   local.get $0
   i32.reinterpret_f32
-  local.tee $1
+  local.tee $2
   i32.const 31
   i32.shr_u
   local.set $11
-  local.get $1
+  local.get $2
   i32.const 2147483647
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 1061752794
   i32.le_u
   if
-   local.get $2
+   local.get $3
    i32.const 964689920
    i32.lt_u
    if
@@ -10226,9 +10222,9 @@
    local.tee $4
    local.get $5
    f64.mul
-   local.set $3
+   local.set $1
    local.get $5
-   local.get $3
+   local.get $1
    f64.const 0.3333313950307914
    local.get $4
    f64.const 0.13339200271297674
@@ -10236,18 +10232,18 @@
    f64.add
    f64.mul
    f64.add
-   local.get $3
+   local.get $1
    local.get $4
    local.get $4
    f64.mul
-   local.tee $3
+   local.tee $1
    f64.mul
    f64.const 0.05338123784456704
    local.get $4
    f64.const 0.024528318116654728
    f64.mul
    f64.add
-   local.get $3
+   local.get $1
    f64.const 0.002974357433599673
    local.get $4
    f64.const 0.009465647849436732
@@ -10260,7 +10256,7 @@
    f32.demote_f64
    return
   end
-  local.get $2
+  local.get $3
   i32.const 2139095040
   i32.ge_u
   if
@@ -10270,7 +10266,7 @@
    return
   end
   block $~lib/math/rempio2f|inlined.2 (result i32)
-   local.get $2
+   local.get $3
    i32.const 1305022427
    i32.lt_u
    if
@@ -10281,25 +10277,25 @@
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.tee $3
+    local.tee $1
     f64.const 1.5707963109016418
     f64.mul
     f64.sub
-    local.get $3
+    local.get $1
     f64.const 1.5893254773528196e-08
     f64.mul
     f64.sub
     global.set $~lib/math/rempio2f_y
-    local.get $3
+    local.get $1
     i32.trunc_f64_s
     br $~lib/math/rempio2f|inlined.2
    end
-   local.get $2
+   local.get $3
    i32.const 23
    i32.shr_s
    i32.const 152
    i32.sub
-   local.tee $1
+   local.tee $2
    i32.const 6
    i32.shr_s
    i32.const 3
@@ -10312,7 +10308,7 @@
    local.get $10
    i64.load offset=8
    local.set $8
-   local.get $1
+   local.get $2
    i32.const 63
    i32.and
    i64.extend_i32_s
@@ -10344,7 +10340,7 @@
    local.get $0
    f64.promote_f32
    f64.copysign
-   local.get $2
+   local.get $3
    i32.const 8388607
    i32.and
    i32.const 8388608
@@ -10383,12 +10379,13 @@
    i64.shr_u
    i64.add
    i32.wrap_i64
-   local.tee $1
+   local.tee $2
    i32.sub
-   local.get $1
+   local.get $2
    local.get $11
    select
   end
+  local.set $2
   global.get $~lib/math/rempio2f_y
   local.tee $5
   local.get $5
@@ -10396,9 +10393,9 @@
   local.tee $4
   local.get $5
   f64.mul
-  local.set $3
+  local.set $1
   local.get $5
-  local.get $3
+  local.get $1
   f64.const 0.3333313950307914
   local.get $4
   f64.const 0.13339200271297674
@@ -10406,18 +10403,18 @@
   f64.add
   f64.mul
   f64.add
-  local.get $3
+  local.get $1
   local.get $4
   local.get $4
   f64.mul
-  local.tee $3
+  local.tee $1
   f64.mul
   f64.const 0.05338123784456704
   local.get $4
   f64.const 0.024528318116654728
   f64.mul
   f64.add
-  local.get $3
+  local.get $1
   f64.const 0.002974357433599673
   local.get $4
   f64.const 0.009465647849436732
@@ -10427,16 +10424,15 @@
   f64.add
   f64.mul
   f64.add
-  local.set $3
+  local.set $1
+  f64.const -1
+  local.get $1
+  f64.div
+  local.get $1
+  local.get $2
   i32.const 1
   i32.and
-  if
-   f64.const -1
-   local.get $3
-   f64.div
-   local.set $3
-  end
-  local.get $3
+  select
   f32.demote_f64
  )
  (func $std/math/test_tanf (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
@@ -10446,39 +10442,40 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (param $0 f64) (result f64)
-  (local $1 f64)
-  (local $2 i32)
-  (local $3 i64)
+ (func $std/math/test_tanh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+  (local $3 i32)
+  (local $4 f64)
+  (local $5 i64)
   local.get $0
+  local.tee $4
   i64.reinterpret_f64
   i64.const 9223372036854775807
   i64.and
-  local.tee $3
+  local.tee $5
   f64.reinterpret_i64
-  local.set $1
-  local.get $3
+  local.set $0
+  local.get $5
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.tee $2
+  local.tee $3
   i32.const 1071748074
   i32.gt_u
   if
-   local.get $2
+   local.get $3
    i32.const 1077149696
    i32.gt_u
    if (result f64)
     f64.const 1
     f64.const 0
-    local.get $1
+    local.get $0
     f64.div
     f64.sub
    else
     f64.const 1
     f64.const 2
     f64.const 2
-    local.get $1
+    local.get $0
     f64.mul
     call $~lib/math/NativeMath.expm1
     f64.const 2
@@ -10486,53 +10483,49 @@
     f64.div
     f64.sub
    end
-   local.set $1
+   local.set $0
   else
-   local.get $2
+   local.get $3
    i32.const 1070618798
    i32.gt_u
    if
     f64.const 2
-    local.get $1
+    local.get $0
     f64.mul
     call $~lib/math/NativeMath.expm1
-    local.tee $1
-    local.get $1
+    local.tee $0
+    local.get $0
     f64.const 2
     f64.add
     f64.div
-    local.set $1
+    local.set $0
    else
-    local.get $2
+    local.get $3
     i32.const 1048576
     i32.ge_u
     if
      f64.const -2
-     local.get $1
+     local.get $0
      f64.mul
      call $~lib/math/NativeMath.expm1
-     local.tee $1
+     local.tee $0
      f64.neg
-     local.get $1
+     local.get $0
      f64.const 2
      f64.add
      f64.div
-     local.set $1
+     local.set $0
     end
    end
   end
-  local.get $1
   local.get $0
+  local.get $4
   f64.copysign
- )
- (func $std/math/test_tanh (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
-  local.get $0
-  call $~lib/math/NativeMath.tanh
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
+   local.get $4
    call $~lib/bindings/Math/tanh
    local.get $1
    local.get $2
@@ -10641,8 +10634,8 @@
  )
  (func $~lib/math/NativeMath.sincos (param $0 f64)
   (local $1 f64)
-  (local $2 f64)
-  (local $3 i64)
+  (local $2 i64)
+  (local $3 f64)
   (local $4 f64)
   (local $5 i32)
   (local $6 i32)
@@ -10651,7 +10644,7 @@
   (local $9 f64)
   local.get $0
   i64.reinterpret_f64
-  local.tee $3
+  local.tee $2
   i64.const 32
   i64.shr_u
   i32.wrap_i64
@@ -10680,27 +10673,27 @@
    local.get $0
    local.get $0
    f64.mul
-   local.tee $2
+   local.tee $3
    local.get $0
    f64.mul
    f64.const -0.16666666666666632
-   local.get $2
+   local.get $3
    f64.const 0.00833333333332249
-   local.get $2
+   local.get $3
    f64.const -1.984126982985795e-04
-   local.get $2
+   local.get $3
    f64.const 2.7557313707070068e-06
    f64.mul
    f64.add
    f64.mul
    f64.add
-   local.get $2
-   local.get $2
-   local.get $2
+   local.get $3
+   local.get $3
+   local.get $3
    f64.mul
    f64.mul
    f64.const -2.5050760253406863e-08
-   local.get $2
+   local.get $3
    f64.const 1.58969099521155e-10
    f64.mul
    f64.add
@@ -10716,7 +10709,7 @@
    local.get $0
    local.get $0
    f64.mul
-   local.tee $2
+   local.tee $3
    f64.mul
    local.tee $4
    f64.sub
@@ -10726,28 +10719,28 @@
    f64.sub
    local.get $4
    f64.sub
-   local.get $2
-   local.get $2
+   local.get $3
+   local.get $3
    f64.const 0.0416666666666666
-   local.get $2
+   local.get $3
    f64.const -0.001388888888887411
-   local.get $2
+   local.get $3
    f64.const 2.480158728947673e-05
    f64.mul
    f64.add
    f64.mul
    f64.add
    f64.mul
-   local.get $2
-   local.get $2
+   local.get $3
+   local.get $3
    f64.mul
    local.tee $4
    local.get $4
    f64.mul
    f64.const -2.7557314351390663e-07
-   local.get $2
+   local.get $3
    f64.const 2.087572321298175e-09
-   local.get $2
+   local.get $3
    f64.const -1.1359647557788195e-11
    f64.mul
    f64.add
@@ -10779,7 +10772,7 @@
    return
   end
   block $~lib/math/rempio2|inlined.3 (result i32)
-   local.get $3
+   local.get $2
    i64.const 32
    i64.shr_u
    i32.wrap_i64
@@ -10798,12 +10791,12 @@
     f64.const 0.6366197723675814
     f64.mul
     f64.nearest
-    local.tee $2
+    local.tee $3
     f64.const 1.5707963267341256
     f64.mul
     f64.sub
     local.tee $0
-    local.get $2
+    local.get $3
     f64.const 6.077100506506192e-11
     f64.mul
     local.tee $4
@@ -10821,12 +10814,12 @@
     i32.const 16
     i32.gt_u
     if
-     local.get $2
+     local.get $3
      f64.const 2.0222662487959506e-21
      f64.mul
      local.get $0
      local.get $0
-     local.get $2
+     local.get $3
      f64.const 6.077100506303966e-11
      f64.mul
      local.tee $4
@@ -10853,13 +10846,13 @@
      i32.sub
      i32.const 49
      i32.gt_u
-     if
-      local.get $2
+     if (result f64)
+      local.get $3
       f64.const 8.4784276603689e-32
       f64.mul
       local.get $0
       local.get $0
-      local.get $2
+      local.get $3
       f64.const 2.0222662487111665e-21
       f64.mul
       local.tee $4
@@ -10873,8 +10866,10 @@
       local.get $0
       local.get $4
       f64.sub
-      local.set $1
+     else
+      local.get $1
      end
+     local.set $1
     end
     local.get $1
     global.set $~lib/math/rempio2_y0
@@ -10884,12 +10879,12 @@
     local.get $4
     f64.sub
     global.set $~lib/math/rempio2_y1
-    local.get $2
+    local.get $3
     i32.trunc_f64_s
     br $~lib/math/rempio2|inlined.3
    end
    i32.const 0
-   local.get $3
+   local.get $2
    call $~lib/math/pio2_large_quot
    local.tee $5
    i32.sub
@@ -10905,14 +10900,14 @@
   local.tee $0
   local.get $4
   f64.mul
-  local.set $2
+  local.set $3
   local.get $4
   local.get $0
   f64.const 0.5
   global.get $~lib/math/rempio2_y1
   local.tee $1
   f64.mul
-  local.get $2
+  local.get $3
   f64.const 0.00833333333332249
   local.get $0
   f64.const -1.984126982985795e-04
@@ -10939,7 +10934,7 @@
   f64.mul
   local.get $1
   f64.sub
-  local.get $2
+  local.get $3
   f64.const -0.16666666666666632
   f64.mul
   f64.sub
@@ -10951,7 +10946,7 @@
   local.get $4
   local.get $4
   f64.mul
-  local.tee $2
+  local.tee $3
   f64.mul
   local.tee $7
   f64.sub
@@ -10961,28 +10956,28 @@
   f64.sub
   local.get $7
   f64.sub
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   f64.const 0.0416666666666666
-  local.get $2
+  local.get $3
   f64.const -0.001388888888887411
-  local.get $2
+  local.get $3
   f64.const 2.480158728947673e-05
   f64.mul
   f64.add
   f64.mul
   f64.add
   f64.mul
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   f64.mul
   local.tee $7
   local.get $7
   f64.mul
   f64.const -2.7557314351390663e-07
-  local.get $2
+  local.get $3
   f64.const 2.087572321298175e-09
-  local.get $2
+  local.get $3
   f64.const -1.1359647557788195e-11
   f64.mul
   f64.add
@@ -10997,7 +10992,7 @@
   f64.sub
   f64.add
   f64.add
-  local.tee $2
+  local.tee $3
   local.set $4
   local.get $6
   i32.const 1
@@ -11006,7 +11001,7 @@
    local.get $8
    f64.neg
    local.set $4
-   local.get $2
+   local.get $3
    local.set $0
   end
   local.get $6
@@ -11168,9 +11163,7 @@
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
-  (local $6 f64)
-  (local $7 f32)
-  (local $8 f32)
+  (local $6 f32)
   f64.const 2.718281828459045
   global.get $~lib/bindings/Math/E
   f64.const 0
@@ -38388,11 +38381,11 @@
     f32.reinterpret_i32
     f32.const 1
     f32.sub
-    local.tee $7
+    local.tee $6
     f32.const 1
     f32.lt
     i32.const 0
-    local.get $7
+    local.get $6
     f32.const 0
     f32.ge
     select

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -223,7 +223,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -243,35 +243,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -281,12 +281,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -294,7 +294,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -313,42 +313,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -363,12 +365,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -378,38 +380,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -427,7 +429,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -436,21 +438,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -477,7 +479,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -719,22 +721,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz
@@ -1300,7 +1301,6 @@
   call $~lib/memory/memory.fill
   local.get $1
   call $~lib/rt/pure/__retain
-  local.tee $0
  )
  (func $~lib/set/Set<i8>#constructor (result i32)
   (local $0 i32)
@@ -1404,51 +1404,51 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $3
+  local.set $6
+  local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
+  local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $3
-  local.set $4
+  local.set $8
+  local.get $4
+  local.set $2
   loop $while-continue|0
-   local.get $6
-   local.get $7
+   local.get $5
+   local.get $8
    i32.ne
    if
-    local.get $6
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $4
      local.get $2
+     local.get $3
      i32.load8_s
      i32.store8
-     local.get $4
-     local.get $5
      local.get $2
+     local.get $6
+     local.get $3
      i32.load8_s
      call $~lib/util/hash/hash8
      local.get $1
@@ -1456,72 +1456,72 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $4
      i32.store
-     local.get $4
+     local.get $2
      i32.const 8
      i32.add
-     local.set $4
+     local.set $2
     end
-    local.get $6
+    local.get $5
     i32.const 8
     i32.add
-    local.set $6
+    local.set $5
     br $while-continue|0
    end
   end
-  local.get $5
-  local.tee $4
+  local.get $6
+  local.tee $2
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
-  local.tee $6
-  i32.ne
-  if
-   local.get $4
-   call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $6
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $4
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $3
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $4
+  local.tee $5
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $5
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $2
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $2
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $2
+  local.get $3
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~lib/set/Set<i8>#add (param $0 i32) (param $1 i32) (result i32)
@@ -2061,8 +2061,8 @@
   local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $3
+  local.tee $5
+  local.set $8
   i32.const 16
   i32.const 4
   call $~lib/rt/tlsf/__alloc
@@ -2079,7 +2079,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $3
+  local.get $8
   i32.const 1073741808
   i32.gt_u
   if
@@ -2090,73 +2090,73 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $3
+  local.tee $3
+  local.get $8
   call $~lib/memory/memory.fill
-  local.get $1
+  local.get $3
   local.set $2
-  local.get $1
+  local.get $3
   local.get $0
   i32.load
-  local.tee $8
+  local.tee $4
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $8
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
   local.get $2
   i32.store
   local.get $0
-  local.get $1
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $3
+  local.get $8
   i32.store offset=8
   local.get $0
-  local.get $3
+  local.get $8
   i32.store offset=12
   loop $for-loop|0
-   local.get $5
    local.get $7
+   local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $5
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
-    local.tee $1
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $4
      local.get $1
+     local.get $3
      i32.load8_s
      call $~lib/array/Array<i8>#__set
-     local.get $4
+     local.get $1
      i32.const 1
      i32.add
-     local.set $4
+     local.set $1
     end
-    local.get $5
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $4
+  local.get $1
   call $~lib/array/Array<i8>#set:length
   local.get $0
  )
@@ -2642,51 +2642,51 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $3
+  local.set $6
+  local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
+  local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $3
-  local.set $4
+  local.set $8
+  local.get $4
+  local.set $2
   loop $while-continue|0
-   local.get $6
-   local.get $7
+   local.get $5
+   local.get $8
    i32.ne
    if
-    local.get $6
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $4
      local.get $2
+     local.get $3
      i32.load8_u
      i32.store8
-     local.get $4
-     local.get $5
      local.get $2
+     local.get $6
+     local.get $3
      i32.load8_u
      call $~lib/util/hash/hash8
      local.get $1
@@ -2694,72 +2694,72 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $4
      i32.store
-     local.get $4
+     local.get $2
      i32.const 8
      i32.add
-     local.set $4
+     local.set $2
     end
-    local.get $6
+    local.get $5
     i32.const 8
     i32.add
-    local.set $6
+    local.set $5
     br $while-continue|0
    end
   end
-  local.get $5
-  local.tee $4
+  local.get $6
+  local.tee $2
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
-  local.tee $6
-  i32.ne
-  if
-   local.get $4
-   call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $6
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $4
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $3
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $4
+  local.tee $5
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $5
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $2
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $2
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $2
+  local.get $3
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~lib/set/Set<u8>#add (param $0 i32) (param $1 i32) (result i32)
@@ -2861,8 +2861,8 @@
   local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $3
+  local.tee $5
+  local.set $8
   i32.const 16
   i32.const 6
   call $~lib/rt/tlsf/__alloc
@@ -2879,7 +2879,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $3
+  local.get $8
   i32.const 1073741808
   i32.gt_u
   if
@@ -2890,73 +2890,73 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
+  local.get $8
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $3
+  local.tee $3
+  local.get $8
   call $~lib/memory/memory.fill
-  local.get $1
+  local.get $3
   local.set $2
-  local.get $1
+  local.get $3
   local.get $0
   i32.load
-  local.tee $8
+  local.tee $4
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $8
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
   local.get $2
   i32.store
   local.get $0
-  local.get $1
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $3
+  local.get $8
   i32.store offset=8
   local.get $0
-  local.get $3
+  local.get $8
   i32.store offset=12
   loop $for-loop|0
-   local.get $5
    local.get $7
+   local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $5
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
-    local.tee $1
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $4
      local.get $1
+     local.get $3
      i32.load8_u
      call $~lib/array/Array<i8>#__set
-     local.get $4
+     local.get $1
      i32.const 1
      i32.add
-     local.set $4
+     local.set $1
     end
-    local.get $5
+    local.get $7
     i32.const 1
     i32.add
-    local.set $5
+    local.set $7
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $4
+  local.get $1
   call $~lib/array/Array<i8>#set:length
   local.get $0
  )
@@ -3459,51 +3459,51 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $3
+  local.set $6
+  local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
+  local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $3
-  local.set $4
+  local.set $8
+  local.get $4
+  local.set $2
   loop $while-continue|0
-   local.get $6
-   local.get $7
+   local.get $5
+   local.get $8
    i32.ne
    if
-    local.get $6
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $4
      local.get $2
+     local.get $3
      i32.load16_s
      i32.store16
-     local.get $4
-     local.get $5
      local.get $2
+     local.get $6
+     local.get $3
      i32.load16_s
      call $~lib/util/hash/hash16
      local.get $1
@@ -3511,72 +3511,72 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $4
      i32.store
-     local.get $4
+     local.get $2
      i32.const 8
      i32.add
-     local.set $4
+     local.set $2
     end
-    local.get $6
+    local.get $5
     i32.const 8
     i32.add
-    local.set $6
+    local.set $5
     br $while-continue|0
    end
   end
-  local.get $5
-  local.tee $4
+  local.get $6
+  local.tee $2
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
-  local.tee $6
-  i32.ne
-  if
-   local.get $4
-   call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $6
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $4
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $3
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $4
+  local.tee $5
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $5
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $2
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $2
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $2
+  local.get $3
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~lib/set/Set<i16>#add (param $0 i32) (param $1 i32) (result i32)
@@ -3728,11 +3728,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 8
   call $~lib/rt/tlsf/__alloc
@@ -3749,7 +3749,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 536870904
   i32.gt_u
   if
@@ -3760,76 +3760,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 1
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i32.load16_s
      call $~lib/array/Array<i16>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i16>#set:length
   local.get $0
  )
@@ -4284,51 +4284,51 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $3
+  local.set $6
+  local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
+  local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $3
-  local.set $4
+  local.set $8
+  local.get $4
+  local.set $2
   loop $while-continue|0
-   local.get $6
-   local.get $7
+   local.get $5
+   local.get $8
    i32.ne
    if
-    local.get $6
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $4
      local.get $2
+     local.get $3
      i32.load16_u
      i32.store16
-     local.get $4
-     local.get $5
      local.get $2
+     local.get $6
+     local.get $3
      i32.load16_u
      call $~lib/util/hash/hash16
      local.get $1
@@ -4336,72 +4336,72 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $4
      i32.store
-     local.get $4
+     local.get $2
      i32.const 8
      i32.add
-     local.set $4
+     local.set $2
     end
-    local.get $6
+    local.get $5
     i32.const 8
     i32.add
-    local.set $6
+    local.set $5
     br $while-continue|0
    end
   end
-  local.get $5
-  local.tee $4
+  local.get $6
+  local.tee $2
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
-  local.tee $6
-  i32.ne
-  if
-   local.get $4
-   call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $6
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $4
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $3
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $4
+  local.tee $5
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $5
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $2
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $2
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $2
+  local.get $3
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~lib/set/Set<u16>#add (param $0 i32) (param $1 i32) (result i32)
@@ -4501,11 +4501,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 10
   call $~lib/rt/tlsf/__alloc
@@ -4522,7 +4522,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 536870904
   i32.gt_u
   if
@@ -4533,76 +4533,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 1
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i32.load16_u
      call $~lib/array/Array<i16>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i16>#set:length
   local.get $0
  )
@@ -5117,51 +5117,51 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $3
+  local.set $6
+  local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
+  local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $3
-  local.set $4
+  local.set $8
+  local.get $4
+  local.set $2
   loop $while-continue|0
-   local.get $6
-   local.get $7
+   local.get $5
+   local.get $8
    i32.ne
    if
-    local.get $6
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $4
      local.get $2
+     local.get $3
      i32.load
      i32.store
-     local.get $4
-     local.get $5
      local.get $2
+     local.get $6
+     local.get $3
      i32.load
      call $~lib/util/hash/hash32
      local.get $1
@@ -5169,72 +5169,72 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $4
      i32.store
-     local.get $4
+     local.get $2
      i32.const 8
      i32.add
-     local.set $4
+     local.set $2
     end
-    local.get $6
+    local.get $5
     i32.const 8
     i32.add
-    local.set $6
+    local.set $5
     br $while-continue|0
    end
   end
-  local.get $5
-  local.tee $4
+  local.get $6
+  local.tee $2
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
-  local.tee $6
-  i32.ne
-  if
-   local.get $4
-   call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $6
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $4
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $3
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $4
+  local.tee $5
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $5
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $2
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $2
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $2
+  local.get $3
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~lib/set/Set<i32>#add (param $0 i32) (param $1 i32) (result i32)
@@ -5382,11 +5382,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 12
   call $~lib/rt/tlsf/__alloc
@@ -5403,7 +5403,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 268435452
   i32.gt_u
   if
@@ -5414,76 +5414,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 2
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i32.load
      call $~lib/array/Array<i32>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
@@ -5908,11 +5908,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 14
   call $~lib/rt/tlsf/__alloc
@@ -5929,7 +5929,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 268435452
   i32.gt_u
   if
@@ -5940,76 +5940,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 2
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i32.load
      call $~lib/array/Array<i32>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
@@ -6469,51 +6469,51 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $3
+  local.set $6
+  local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 4
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
+  local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 4
   i32.shl
   i32.add
-  local.set $7
-  local.get $3
-  local.set $4
+  local.set $8
+  local.get $4
+  local.set $2
   loop $while-continue|0
-   local.get $6
-   local.get $7
+   local.get $5
+   local.get $8
    i32.ne
    if
-    local.get $6
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $4
      local.get $2
+     local.get $3
      i64.load
      i64.store
-     local.get $4
-     local.get $5
      local.get $2
+     local.get $6
+     local.get $3
      i64.load
      call $~lib/util/hash/hash64
      local.get $1
@@ -6521,72 +6521,72 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=8
+     local.get $3
      local.get $2
-     local.get $4
      i32.store
-     local.get $4
+     local.get $2
      i32.const 16
      i32.add
-     local.set $4
+     local.set $2
     end
-    local.get $6
+    local.get $5
     i32.const 16
     i32.add
-    local.set $6
+    local.set $5
     br $while-continue|0
    end
   end
-  local.get $5
-  local.tee $4
+  local.get $6
+  local.tee $2
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
-  local.tee $6
-  i32.ne
-  if
-   local.get $4
-   call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $6
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $4
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $3
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $4
+  local.tee $5
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $5
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $2
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $2
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $2
+  local.get $3
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~lib/set/Set<i64>#add (param $0 i32) (param $1 i64) (result i32)
@@ -6734,11 +6734,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 16
   call $~lib/rt/tlsf/__alloc
@@ -6755,7 +6755,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 134217726
   i32.gt_u
   if
@@ -6766,76 +6766,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 3
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 4
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i64.load
      call $~lib/array/Array<i64>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )
@@ -7295,11 +7295,11 @@
   (local $9 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   local.get $0
   i32.load offset=16
-  local.tee $7
-  local.set $6
+  local.tee $8
+  local.set $7
   i32.const 16
   i32.const 18
   call $~lib/rt/tlsf/__alloc
@@ -7316,7 +7316,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $8
   i32.const 134217726
   i32.gt_u
   if
@@ -7327,76 +7327,76 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.const 3
   i32.shl
-  local.tee $5
+  local.tee $6
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $5
+  local.tee $3
+  local.get $6
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $4
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $3
+   local.set $2
+   local.get $4
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $5
+  local.get $6
   i32.store offset=8
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=12
   loop $for-loop|0
+   local.get $9
    local.get $8
-   local.get $7
    i32.lt_s
    if
-    local.get $4
-    local.get $8
+    local.get $5
+    local.get $9
     i32.const 4
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
      local.get $0
-     local.get $9
-     local.get $2
+     local.get $1
+     local.get $3
      i64.load
      call $~lib/array/Array<i64>#__set
-     local.get $9
+     local.get $1
      i32.const 1
      i32.add
-     local.set $9
+     local.set $1
     end
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $9
+  local.get $1
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )
@@ -7792,51 +7792,51 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $3
+  local.set $6
+  local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
+  local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $7
-  local.get $3
-  local.set $4
+  local.set $8
+  local.get $4
+  local.set $2
   loop $while-continue|0
-   local.get $6
-   local.get $7
+   local.get $5
+   local.get $8
    i32.ne
    if
-    local.get $6
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $4
      local.get $2
+     local.get $3
      f32.load
      f32.store
-     local.get $4
-     local.get $5
      local.get $2
+     local.get $6
+     local.get $3
      f32.load
      i32.reinterpret_f32
      call $~lib/util/hash/hash32
@@ -7845,72 +7845,72 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=4
+     local.get $3
      local.get $2
-     local.get $4
      i32.store
-     local.get $4
+     local.get $2
      i32.const 8
      i32.add
-     local.set $4
+     local.set $2
     end
-    local.get $6
+    local.get $5
     i32.const 8
     i32.add
-    local.set $6
+    local.set $5
     br $while-continue|0
    end
   end
-  local.get $5
-  local.tee $4
+  local.get $6
+  local.tee $2
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
-  local.tee $6
-  i32.ne
-  if
-   local.get $4
-   call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $6
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $4
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $3
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $4
+  local.tee $5
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $5
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $2
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $2
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $2
+  local.get $3
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~lib/set/Set<f32>#add (param $0 i32) (param $1 f32) (result i32)
@@ -8000,8 +8000,8 @@
  (func $~lib/set/Set<f32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 f32)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 f32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -8010,11 +8010,11 @@
   (local $10 i32)
   local.get $0
   i32.load offset=8
-  local.set $5
+  local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $8
-  local.set $7
+  local.tee $9
+  local.set $8
   i32.const 16
   i32.const 20
   call $~lib/rt/tlsf/__alloc
@@ -8031,7 +8031,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $8
+  local.get $9
   i32.const 268435452
   i32.gt_u
   if
@@ -8042,66 +8042,66 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $8
   i32.const 2
   i32.shl
-  local.tee $6
+  local.tee $7
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $6
+  local.tee $3
+  local.get $7
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $5
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
+   local.set $2
+   local.get $5
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=8
   local.get $0
-  local.get $7
+  local.get $8
   i32.store offset=12
   loop $for-loop|0
+   local.get $10
    local.get $9
-   local.get $8
    i32.lt_s
    if
-    local.get $5
-    local.get $9
+    local.get $6
+    local.get $10
     i32.const 3
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=4
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
+     local.get $3
      f32.load
-     local.set $3
-     local.get $10
+     local.set $4
+     local.get $1
      local.get $0
      i32.load offset=12
      i32.ge_u
      if
-      local.get $10
+      local.get $1
       i32.const 0
       i32.lt_s
       if
@@ -8113,38 +8113,38 @@
        unreachable
       end
       local.get $0
-      local.get $10
+      local.get $1
       i32.const 1
       i32.add
-      local.tee $2
+      local.tee $3
       i32.const 2
       call $~lib/array/ensureSize
       local.get $0
-      local.get $2
+      local.get $3
       i32.store offset=12
      end
      local.get $0
      i32.load offset=4
-     local.get $10
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
-     local.get $3
+     local.get $4
      f32.store
-     local.get $10
+     local.get $1
      i32.const 1
      i32.add
-     local.set $10
+     local.set $1
     end
-    local.get $9
+    local.get $10
     i32.const 1
     i32.add
-    local.set $9
+    local.set $10
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $10
+  local.get $1
   call $~lib/array/Array<i32>#set:length
   local.get $0
  )
@@ -8622,51 +8622,51 @@
   local.get $1
   i32.const 1
   i32.add
-  local.tee $3
+  local.tee $4
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $3
+  local.set $6
+  local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $8
+  local.tee $7
   i32.const 4
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
+  local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $0
   i32.load offset=16
   i32.const 4
   i32.shl
   i32.add
-  local.set $7
-  local.get $3
-  local.set $4
+  local.set $8
+  local.get $4
+  local.set $2
   loop $while-continue|0
-   local.get $6
-   local.get $7
+   local.get $5
+   local.get $8
    i32.ne
    if
-    local.get $6
-    local.tee $2
+    local.get $5
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $4
      local.get $2
+     local.get $3
      f64.load
      f64.store
-     local.get $4
-     local.get $5
      local.get $2
+     local.get $6
+     local.get $3
      f64.load
      i64.reinterpret_f64
      call $~lib/util/hash/hash64
@@ -8675,72 +8675,72 @@
      i32.const 2
      i32.shl
      i32.add
-     local.tee $2
+     local.tee $3
      i32.load
      i32.store offset=8
+     local.get $3
      local.get $2
-     local.get $4
      i32.store
-     local.get $4
+     local.get $2
      i32.const 16
      i32.add
-     local.set $4
+     local.set $2
     end
-    local.get $6
+    local.get $5
     i32.const 16
     i32.add
-    local.set $6
+    local.set $5
     br $while-continue|0
    end
   end
-  local.get $5
-  local.tee $4
+  local.get $6
+  local.tee $2
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.load
-  local.tee $6
-  i32.ne
-  if
-   local.get $4
-   call $~lib/rt/pure/__retain
-   local.set $4
-   local.get $6
-   call $~lib/rt/pure/__release
-  end
-  local.get $2
-  local.get $4
-  i32.store
-  local.get $2
-  local.get $1
-  i32.store offset=4
-  local.get $2
-  local.set $1
-  local.get $3
-  local.tee $2
-  local.get $1
-  i32.load offset=8
-  local.tee $4
+  local.tee $5
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $4
+   local.get $5
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $2
+  i32.store
+  local.get $3
+  local.get $1
+  i32.store offset=4
+  local.get $3
+  local.set $1
+  local.get $4
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $2
    call $~lib/rt/pure/__release
   end
   local.get $1
-  local.get $2
+  local.get $3
   i32.store offset=8
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $4
   call $~lib/rt/pure/__release
  )
  (func $~lib/set/Set<f64>#add (param $0 i32) (param $1 f64) (result i32)
@@ -8830,8 +8830,8 @@
  (func $~lib/set/Set<f64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 f64)
-  (local $4 i32)
+  (local $3 i32)
+  (local $4 f64)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -8840,11 +8840,11 @@
   (local $10 i32)
   local.get $0
   i32.load offset=8
-  local.set $5
+  local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $8
-  local.set $7
+  local.tee $9
+  local.set $8
   i32.const 16
   i32.const 22
   call $~lib/rt/tlsf/__alloc
@@ -8861,7 +8861,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $8
+  local.get $9
   i32.const 134217726
   i32.gt_u
   if
@@ -8872,66 +8872,66 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $7
+  local.get $8
   i32.const 3
   i32.shl
-  local.tee $6
+  local.tee $7
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $2
-  local.get $6
+  local.tee $3
+  local.get $7
   call $~lib/memory/memory.fill
-  local.get $2
-  local.set $1
-  local.get $2
+  local.get $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $5
   i32.ne
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $4
+   local.set $2
+   local.get $5
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $1
+  local.get $2
   i32.store
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=8
   local.get $0
-  local.get $7
+  local.get $8
   i32.store offset=12
   loop $for-loop|0
+   local.get $10
    local.get $9
-   local.get $8
    i32.lt_s
    if
-    local.get $5
-    local.get $9
+    local.get $6
+    local.get $10
     i32.const 4
     i32.shl
     i32.add
-    local.tee $2
+    local.tee $3
     i32.load offset=8
     i32.const 1
     i32.and
     i32.eqz
     if
-     local.get $2
+     local.get $3
      f64.load
-     local.set $3
-     local.get $10
+     local.set $4
+     local.get $1
      local.get $0
      i32.load offset=12
      i32.ge_u
      if
-      local.get $10
+      local.get $1
       i32.const 0
       i32.lt_s
       if
@@ -8943,38 +8943,38 @@
        unreachable
       end
       local.get $0
-      local.get $10
+      local.get $1
       i32.const 1
       i32.add
-      local.tee $2
+      local.tee $3
       i32.const 3
       call $~lib/array/ensureSize
       local.get $0
-      local.get $2
+      local.get $3
       i32.store offset=12
      end
      local.get $0
      i32.load offset=4
-     local.get $10
+     local.get $1
      i32.const 3
      i32.shl
      i32.add
-     local.get $3
+     local.get $4
      f64.store
-     local.get $10
+     local.get $1
      i32.const 1
      i32.add
-     local.set $10
+     local.set $1
     end
-    local.get $9
+    local.get $10
     i32.const 1
     i32.add
-    local.set $9
+    local.set $10
     br $for-loop|0
    end
   end
   local.get $0
-  local.get $10
+  local.get $1
   call $~lib/array/Array<i64>#set:length
   local.get $0
  )

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1408,34 +1408,34 @@
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $6
+  local.set $5
   local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
   local.set $2
   loop $while-continue|0
-   local.get $5
-   local.get $8
+   local.get $6
+   local.get $7
    i32.ne
    if
-    local.get $5
+    local.get $6
     local.tee $3
     i32.load offset=4
     i32.const 1
@@ -1447,7 +1447,7 @@
      i32.load8_s
      i32.store8
      local.get $2
-     local.get $6
+     local.get $5
      local.get $3
      i32.load8_s
      call $~lib/util/hash/hash8
@@ -1467,25 +1467,25 @@
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 8
     i32.add
-    local.set $5
+    local.set $6
     br $while-continue|0
    end
   end
-  local.get $6
+  local.get $5
   local.tee $2
   local.get $0
   local.tee $3
   i32.load
-  local.tee $5
+  local.tee $6
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $5
+   local.get $6
    call $~lib/rt/pure/__release
   end
   local.get $3
@@ -1513,13 +1513,13 @@
   local.get $3
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
@@ -2061,8 +2061,8 @@
   local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $5
-  local.set $8
+  local.tee $7
+  local.set $4
   i32.const 16
   i32.const 4
   call $~lib/rt/tlsf/__alloc
@@ -2079,7 +2079,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $8
+  local.get $4
   i32.const 1073741808
   i32.gt_u
   if
@@ -2090,49 +2090,49 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $3
-  local.get $8
+  local.tee $2
+  local.get $4
   call $~lib/memory/memory.fill
-  local.get $3
-  local.set $2
-  local.get $3
+  local.get $2
+  local.set $3
+  local.get $2
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $8
   i32.ne
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $4
+   local.set $3
+   local.get $8
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $2
+  local.get $3
   i32.store
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=4
   local.get $0
-  local.get $8
+  local.get $4
   i32.store offset=8
   local.get $0
-  local.get $8
+  local.get $4
   i32.store offset=12
   loop $for-loop|0
-   local.get $7
    local.get $5
+   local.get $7
    i32.lt_s
    if
     local.get $6
-    local.get $7
+    local.get $5
     i32.const 3
     i32.shl
     i32.add
-    local.tee $3
+    local.tee $2
     i32.load offset=4
     i32.const 1
     i32.and
@@ -2140,7 +2140,7 @@
     if
      local.get $0
      local.get $1
-     local.get $3
+     local.get $2
      i32.load8_s
      call $~lib/array/Array<i8>#__set
      local.get $1
@@ -2148,10 +2148,10 @@
      i32.add
      local.set $1
     end
-    local.get $7
+    local.get $5
     i32.const 1
     i32.add
-    local.set $7
+    local.set $5
     br $for-loop|0
    end
   end
@@ -2646,34 +2646,34 @@
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $6
+  local.set $5
   local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
   local.set $2
   loop $while-continue|0
-   local.get $5
-   local.get $8
+   local.get $6
+   local.get $7
    i32.ne
    if
-    local.get $5
+    local.get $6
     local.tee $3
     i32.load offset=4
     i32.const 1
@@ -2685,7 +2685,7 @@
      i32.load8_u
      i32.store8
      local.get $2
-     local.get $6
+     local.get $5
      local.get $3
      i32.load8_u
      call $~lib/util/hash/hash8
@@ -2705,25 +2705,25 @@
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 8
     i32.add
-    local.set $5
+    local.set $6
     br $while-continue|0
    end
   end
-  local.get $6
+  local.get $5
   local.tee $2
   local.get $0
   local.tee $3
   i32.load
-  local.tee $5
+  local.tee $6
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $5
+   local.get $6
    call $~lib/rt/pure/__release
   end
   local.get $3
@@ -2751,13 +2751,13 @@
   local.get $3
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
@@ -2861,8 +2861,8 @@
   local.set $6
   local.get $0
   i32.load offset=16
-  local.tee $5
-  local.set $8
+  local.tee $7
+  local.set $4
   i32.const 16
   i32.const 6
   call $~lib/rt/tlsf/__alloc
@@ -2879,7 +2879,7 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $8
+  local.get $4
   i32.const 1073741808
   i32.gt_u
   if
@@ -2890,49 +2890,49 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
+  local.get $4
   i32.const 0
   call $~lib/rt/tlsf/__alloc
-  local.tee $3
-  local.get $8
+  local.tee $2
+  local.get $4
   call $~lib/memory/memory.fill
-  local.get $3
-  local.set $2
-  local.get $3
+  local.get $2
+  local.set $3
+  local.get $2
   local.get $0
   i32.load
-  local.tee $4
+  local.tee $8
   i32.ne
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $4
+   local.set $3
+   local.get $8
    call $~lib/rt/pure/__release
   end
   local.get $0
-  local.get $2
+  local.get $3
   i32.store
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=4
   local.get $0
-  local.get $8
+  local.get $4
   i32.store offset=8
   local.get $0
-  local.get $8
+  local.get $4
   i32.store offset=12
   loop $for-loop|0
-   local.get $7
    local.get $5
+   local.get $7
    i32.lt_s
    if
     local.get $6
-    local.get $7
+    local.get $5
     i32.const 3
     i32.shl
     i32.add
-    local.tee $3
+    local.tee $2
     i32.load offset=4
     i32.const 1
     i32.and
@@ -2940,7 +2940,7 @@
     if
      local.get $0
      local.get $1
-     local.get $3
+     local.get $2
      i32.load8_u
      call $~lib/array/Array<i8>#__set
      local.get $1
@@ -2948,10 +2948,10 @@
      i32.add
      local.set $1
     end
-    local.get $7
+    local.get $5
     i32.const 1
     i32.add
-    local.set $7
+    local.set $5
     br $for-loop|0
    end
   end
@@ -3463,34 +3463,34 @@
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $6
+  local.set $5
   local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
   local.set $2
   loop $while-continue|0
-   local.get $5
-   local.get $8
+   local.get $6
+   local.get $7
    i32.ne
    if
-    local.get $5
+    local.get $6
     local.tee $3
     i32.load offset=4
     i32.const 1
@@ -3502,7 +3502,7 @@
      i32.load16_s
      i32.store16
      local.get $2
-     local.get $6
+     local.get $5
      local.get $3
      i32.load16_s
      call $~lib/util/hash/hash16
@@ -3522,25 +3522,25 @@
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 8
     i32.add
-    local.set $5
+    local.set $6
     br $while-continue|0
    end
   end
-  local.get $6
+  local.get $5
   local.tee $2
   local.get $0
   local.tee $3
   i32.load
-  local.tee $5
+  local.tee $6
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $5
+   local.get $6
    call $~lib/rt/pure/__release
   end
   local.get $3
@@ -3568,13 +3568,13 @@
   local.get $3
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
@@ -4288,34 +4288,34 @@
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $6
+  local.set $5
   local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
   local.set $2
   loop $while-continue|0
-   local.get $5
-   local.get $8
+   local.get $6
+   local.get $7
    i32.ne
    if
-    local.get $5
+    local.get $6
     local.tee $3
     i32.load offset=4
     i32.const 1
@@ -4327,7 +4327,7 @@
      i32.load16_u
      i32.store16
      local.get $2
-     local.get $6
+     local.get $5
      local.get $3
      i32.load16_u
      call $~lib/util/hash/hash16
@@ -4347,25 +4347,25 @@
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 8
     i32.add
-    local.set $5
+    local.set $6
     br $while-continue|0
    end
   end
-  local.get $6
+  local.get $5
   local.tee $2
   local.get $0
   local.tee $3
   i32.load
-  local.tee $5
+  local.tee $6
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $5
+   local.get $6
    call $~lib/rt/pure/__release
   end
   local.get $3
@@ -4393,13 +4393,13 @@
   local.get $3
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
@@ -5121,34 +5121,34 @@
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $6
+  local.set $5
   local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
   local.set $2
   loop $while-continue|0
-   local.get $5
-   local.get $8
+   local.get $6
+   local.get $7
    i32.ne
    if
-    local.get $5
+    local.get $6
     local.tee $3
     i32.load offset=4
     i32.const 1
@@ -5160,7 +5160,7 @@
      i32.load
      i32.store
      local.get $2
-     local.get $6
+     local.get $5
      local.get $3
      i32.load
      call $~lib/util/hash/hash32
@@ -5180,25 +5180,25 @@
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 8
     i32.add
-    local.set $5
+    local.set $6
     br $while-continue|0
    end
   end
-  local.get $6
+  local.get $5
   local.tee $2
   local.get $0
   local.tee $3
   i32.load
-  local.tee $5
+  local.tee $6
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $5
+   local.get $6
    call $~lib/rt/pure/__release
   end
   local.get $3
@@ -5226,13 +5226,13 @@
   local.get $3
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
@@ -6473,34 +6473,34 @@
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $6
+  local.set $5
   local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 4
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $0
   i32.load offset=16
   i32.const 4
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
   local.set $2
   loop $while-continue|0
-   local.get $5
-   local.get $8
+   local.get $6
+   local.get $7
    i32.ne
    if
-    local.get $5
+    local.get $6
     local.tee $3
     i32.load offset=8
     i32.const 1
@@ -6512,7 +6512,7 @@
      i64.load
      i64.store
      local.get $2
-     local.get $6
+     local.get $5
      local.get $3
      i64.load
      call $~lib/util/hash/hash64
@@ -6532,25 +6532,25 @@
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 16
     i32.add
-    local.set $5
+    local.set $6
     br $while-continue|0
    end
   end
-  local.get $6
+  local.get $5
   local.tee $2
   local.get $0
   local.tee $3
   i32.load
-  local.tee $5
+  local.tee $6
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $5
+   local.get $6
    call $~lib/rt/pure/__release
   end
   local.get $3
@@ -6578,13 +6578,13 @@
   local.get $3
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
@@ -7796,34 +7796,34 @@
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $6
+  local.set $5
   local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 3
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $0
   i32.load offset=16
   i32.const 3
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
   local.set $2
   loop $while-continue|0
-   local.get $5
-   local.get $8
+   local.get $6
+   local.get $7
    i32.ne
    if
-    local.get $5
+    local.get $6
     local.tee $3
     i32.load offset=4
     i32.const 1
@@ -7835,7 +7835,7 @@
      f32.load
      f32.store
      local.get $2
-     local.get $6
+     local.get $5
      local.get $3
      f32.load
      i32.reinterpret_f32
@@ -7856,25 +7856,25 @@
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 8
     i32.add
-    local.set $5
+    local.set $6
     br $while-continue|0
    end
   end
-  local.get $6
+  local.get $5
   local.tee $2
   local.get $0
   local.tee $3
   i32.load
-  local.tee $5
+  local.tee $6
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $5
+   local.get $6
    call $~lib/rt/pure/__release
   end
   local.get $3
@@ -7902,13 +7902,13 @@
   local.get $3
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
@@ -8626,34 +8626,34 @@
   i32.const 2
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $6
+  local.set $5
   local.get $4
   i32.const 3
   i32.shl
   i32.const 3
   i32.div_s
-  local.tee $7
+  local.tee $8
   i32.const 4
   i32.shl
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $0
   i32.load offset=16
   i32.const 4
   i32.shl
   i32.add
-  local.set $8
+  local.set $7
   local.get $4
   local.set $2
   loop $while-continue|0
-   local.get $5
-   local.get $8
+   local.get $6
+   local.get $7
    i32.ne
    if
-    local.get $5
+    local.get $6
     local.tee $3
     i32.load offset=8
     i32.const 1
@@ -8665,7 +8665,7 @@
      f64.load
      f64.store
      local.get $2
-     local.get $6
+     local.get $5
      local.get $3
      f64.load
      i64.reinterpret_f64
@@ -8686,25 +8686,25 @@
      i32.add
      local.set $2
     end
-    local.get $5
+    local.get $6
     i32.const 16
     i32.add
-    local.set $5
+    local.set $6
     br $while-continue|0
    end
   end
-  local.get $6
+  local.get $5
   local.tee $2
   local.get $0
   local.tee $3
   i32.load
-  local.tee $5
+  local.tee $6
   i32.ne
   if
    local.get $2
    call $~lib/rt/pure/__retain
    local.set $2
-   local.get $5
+   local.get $6
    call $~lib/rt/pure/__release
   end
   local.get $3
@@ -8732,13 +8732,13 @@
   local.get $3
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $8
   i32.store offset=12
   local.get $1
   local.get $1
   i32.load offset=20
   i32.store offset=16
-  local.get $6
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -1569,10 +1569,10 @@
   (local $4 i32)
   local.get $0
   i32.load offset=4
-  local.tee $4
+  local.tee $3
   i32.const 268435455
   i32.and
-  local.set $2
+  local.set $1
   local.get $0
   call $~lib/rt/rtrace/ondecrement
   local.get $0
@@ -1587,7 +1587,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $1
   i32.const 1
   i32.eq
   if
@@ -1598,45 +1598,45 @@
        local.get $0
        i32.const 16
        i32.add
-       local.tee $1
+       local.tee $2
        i32.const 8
        i32.sub
        i32.load
        br_table $__inlined_func$~lib/rt/__visit_members $__inlined_func$~lib/rt/__visit_members $switch$1$case$4 $__inlined_func$~lib/rt/__visit_members $__inlined_func$~lib/rt/__visit_members $switch$1$case$7 $switch$1$default
       end
-      local.get $1
+      local.get $2
       i32.load
-      local.tee $2
+      local.tee $1
       if
-       local.get $2
+       local.get $1
        call $~lib/rt/pure/__visit
       end
       br $__inlined_func$~lib/rt/__visit_members
      end
-     local.get $1
-     local.tee $2
      local.get $2
+     local.tee $1
+     local.get $1
      i32.const 16
      i32.sub
      i32.load offset=12
      i32.add
-     local.set $1
+     local.set $2
      loop $while-continue|0
-      local.get $2
       local.get $1
+      local.get $2
       i32.lt_u
       if
-       local.get $2
+       local.get $1
        i32.load
-       local.tee $3
+       local.tee $4
        if
-        local.get $3
+        local.get $4
         call $~lib/rt/pure/__visit
        end
-       local.get $2
+       local.get $1
        i32.const 4
        i32.add
-       local.set $2
+       local.set $1
        br $while-continue|0
       end
      end
@@ -1644,7 +1644,7 @@
     end
     unreachable
    end
-   local.get $4
+   local.get $3
    i32.const -2147483648
    i32.and
    if
@@ -1667,7 +1667,7 @@
    local.get $0
    call $~lib/rt/rtrace/onfree
   else
-   local.get $2
+   local.get $1
    i32.const 0
    i32.le_u
    if
@@ -1679,10 +1679,10 @@
     unreachable
    end
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 1
    i32.sub
-   local.get $4
+   local.get $3
    i32.const -268435456
    i32.and
    i32.or

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -257,7 +257,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -277,35 +277,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -315,12 +315,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -328,7 +328,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -347,42 +347,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -397,12 +399,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -412,38 +414,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -461,7 +463,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -470,21 +472,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -511,7 +513,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -729,22 +731,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -549,7 +549,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -569,35 +569,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -607,12 +607,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -620,7 +620,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -639,42 +639,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -689,12 +691,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -704,38 +706,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -753,7 +755,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -762,21 +764,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -803,7 +805,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -1045,22 +1047,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz
@@ -1886,26 +1887,26 @@
   (local $10 i32)
   local.get $0
   call $~lib/string/String#get:length
-  local.tee $6
+  local.tee $8
   i32.eqz
   if
    local.get $0
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $6
+  local.get $8
   i32.const 3
   i32.mul
   i32.const 1
   i32.shl
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $6
   i32.const 1216
   call $~lib/string/String#get:length
   local.set $3
   loop $for-loop|0
    local.get $7
-   local.get $6
+   local.get $8
    i32.lt_u
    if
     local.get $7
@@ -1920,7 +1921,7 @@
     if
      block $for-continue|0
       local.get $7
-      local.get $6
+      local.get $8
       i32.const 1
       i32.sub
       i32.lt_u
@@ -1938,7 +1939,7 @@
        local.get $0
        i32.add
        i32.load16_u offset=2
-       local.tee $9
+       local.tee $5
        i32.const 56319
        i32.sub
        i32.const 1025
@@ -1948,7 +1949,7 @@
         i32.const 1
         i32.add
         local.set $7
-        local.get $9
+        local.get $5
         i32.const 1023
         i32.and
         local.get $2
@@ -1964,21 +1965,21 @@
         i32.const 131072
         i32.ge_u
         if
-         local.get $10
+         local.get $4
          i32.const 1
          i32.shl
-         local.get $8
+         local.get $6
          i32.add
-         local.get $9
+         local.get $5
          i32.const 16
          i32.shl
          local.get $1
          i32.or
          i32.store
-         local.get $10
+         local.get $4
          i32.const 1
          i32.add
-         local.set $10
+         local.set $4
          br $for-continue|0
         end
        end
@@ -1989,10 +1990,10 @@
       i32.const 25
       i32.le_u
       if
-       local.get $10
+       local.get $4
        i32.const 1
        i32.shl
-       local.get $8
+       local.get $6
        i32.add
        local.get $2
        i32.const 26
@@ -2006,25 +2007,25 @@
        i32.sub
        i32.const 64056
        i32.le_u
-       if
+       if (result i32)
         block $~lib/util/casemap/bsearch|inlined.0 (result i32)
          local.get $3
          local.set $1
          i32.const 0
-         local.set $5
+         local.set $9
          loop $while-continue|1
-          local.get $5
+          local.get $9
           local.get $1
           i32.le_s
           if
            local.get $1
-           local.get $5
+           local.get $9
            i32.add
            i32.const 3
            i32.shr_u
            i32.const 2
            i32.shl
-           local.tee $9
+           local.tee $5
            i32.const 1
            i32.shl
            i32.const 1216
@@ -2032,24 +2033,24 @@
            i32.load16_u
            local.get $2
            i32.sub
-           local.tee $4
+           local.tee $10
            if
-            local.get $4
+            local.get $10
             i32.const 31
             i32.shr_u
             if
-             local.get $9
+             local.get $5
              i32.const 4
              i32.add
-             local.set $5
+             local.set $9
             else
-             local.get $9
+             local.get $5
              i32.const 4
              i32.sub
              local.set $1
             end
            else
-            local.get $9
+            local.get $5
             br $~lib/util/casemap/bsearch|inlined.0
            end
            br $while-continue|1
@@ -2057,9 +2058,10 @@
          end
          i32.const -1
         end
-        local.set $1
+       else
+        i32.const -1
        end
-       local.get $1
+       local.tee $1
        i32.const -1
        i32.xor
        if
@@ -2071,16 +2073,16 @@
         local.tee $1
         i32.load16_u offset=6
         local.set $2
-        local.get $10
+        local.get $4
         i32.const 1
         i32.shl
-        local.get $8
+        local.get $6
         i32.add
-        local.tee $9
+        local.tee $5
         local.get $1
         i32.load offset=2
         i32.store
-        local.get $9
+        local.get $5
         local.get $2
         i32.store16 offset=4
         local.get $2
@@ -2088,9 +2090,9 @@
         i32.ne
         i32.const 1
         i32.add
-        local.get $10
+        local.get $4
         i32.add
-        local.set $10
+        local.set $4
        else
         local.get $2
         i32.const 1
@@ -2101,18 +2103,18 @@
         i32.const 65536
         i32.lt_s
         if
-         local.get $10
+         local.get $4
          i32.const 1
          i32.shl
-         local.get $8
+         local.get $6
          i32.add
          local.get $2
          i32.store16
         else
-         local.get $10
+         local.get $4
          i32.const 1
          i32.shl
-         local.get $8
+         local.get $6
          i32.add
          local.get $2
          i32.const 65536
@@ -2131,19 +2133,19 @@
          i32.shl
          i32.or
          i32.store
-         local.get $10
+         local.get $4
          i32.const 1
          i32.add
-         local.set $10
+         local.set $4
         end
        end
       end
      end
     else
-     local.get $10
+     local.get $4
      i32.const 1
      i32.shl
-     local.get $8
+     local.get $6
      i32.add
      local.get $2
      i32.const 97
@@ -2164,15 +2166,15 @@
     i32.const 1
     i32.add
     local.set $7
-    local.get $10
+    local.get $4
     i32.const 1
     i32.add
-    local.set $10
+    local.set $4
     br $for-loop|0
    end
   end
-  local.get $8
-  local.get $10
+  local.get $6
+  local.get $4
   i32.const 1
   i32.shl
   call $~lib/rt/tlsf/__realloc
@@ -2365,28 +2367,27 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (local $11 i32)
   local.get $0
   call $~lib/string/String#get:length
-  local.tee $7
+  local.tee $9
   i32.eqz
   if
    local.get $0
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $7
+  local.get $9
   i32.const 2
   i32.shl
   call $~lib/rt/tlsf/__alloc
-  local.set $10
+  local.set $8
   loop $for-loop|0
-   local.get $5
-   local.get $7
+   local.get $6
+   local.get $9
    i32.lt_u
    if
     local.get $0
-    local.get $5
+    local.get $6
     i32.const 1
     i32.shl
     i32.add
@@ -2396,8 +2397,8 @@
     i32.shr_u
     if
      block $for-continue|0
-      local.get $5
-      local.get $7
+      local.get $6
+      local.get $9
       i32.const 1
       i32.sub
       i32.lt_u
@@ -2410,7 +2411,7 @@
       select
       if
        local.get $0
-       local.get $5
+       local.get $6
        i32.const 1
        i32.shl
        i32.add
@@ -2421,10 +2422,10 @@
        i32.const 1025
        i32.lt_u
        if
-        local.get $5
+        local.get $6
         i32.const 1
         i32.add
-        local.set $5
+        local.set $6
         local.get $4
         i32.const 1023
         i32.and
@@ -2441,8 +2442,8 @@
         i32.const 131072
         i32.ge_u
         if
-         local.get $10
-         local.get $11
+         local.get $8
+         local.get $7
          i32.const 1
          i32.shl
          i32.add
@@ -2452,10 +2453,10 @@
          i32.shl
          i32.or
          i32.store
-         local.get $11
+         local.get $7
          i32.const 1
          i32.add
-         local.set $11
+         local.set $7
          br $for-continue|0
         end
        end
@@ -2464,39 +2465,38 @@
       i32.const 304
       i32.eq
       if
-       local.get $10
-       local.get $11
+       local.get $8
+       local.get $7
        i32.const 1
        i32.shl
        i32.add
        i32.const 50790505
        i32.store
-       local.get $11
+       local.get $7
        i32.const 1
        i32.add
-       local.set $11
+       local.set $7
       else
        local.get $2
        i32.const 931
        i32.eq
        if
-        local.get $10
-        local.get $11
+        local.get $8
+        local.get $7
         i32.const 1
         i32.shl
         i32.add
-        local.get $7
+        local.get $9
         i32.const 1
         i32.gt_u
         if (result i32)
          block $~lib/util/string/isFinalSigma|inlined.0 (result i32)
           local.get $0
           local.set $4
-          local.get $5
           i32.const 0
-          local.set $9
+          local.set $3
           i32.const 0
-          local.get $5
+          local.get $6
           local.tee $2
           i32.const 30
           i32.sub
@@ -2505,10 +2505,10 @@
           local.get $1
           i32.gt_s
           select
-          local.set $8
+          local.set $10
           loop $while-continue|1
            local.get $2
-           local.get $8
+           local.get $10
            i32.gt_s
            if
             block $~lib/util/string/codePointBefore|inlined.0 (result i32)
@@ -2528,7 +2528,7 @@
              i32.shl
              i32.add
              i32.load16_u
-             local.tee $3
+             local.tee $5
              i32.const 64512
              i32.and
              i32.const 56320
@@ -2554,7 +2554,7 @@
               i32.const 55296
               i32.eq
               if
-               local.get $3
+               local.get $5
                i32.const 1023
                i32.and
                local.get $1
@@ -2569,8 +2569,8 @@
               end
              end
              i32.const 65533
-             local.get $3
-             local.get $3
+             local.get $5
+             local.get $5
              i32.const 63488
              i32.and
              i32.const 55296
@@ -2578,13 +2578,13 @@
              select
             end
             local.tee $1
-            local.set $3
+            local.set $5
             local.get $1
             i32.const 918000
             i32.lt_u
             if (result i32)
              i32.const 6658
-             local.get $3
+             local.get $5
              call $~lib/util/string/stagedBinaryLookup
             else
              i32.const 0
@@ -2606,7 +2606,7 @@
              br_if $~lib/util/string/isFinalSigma|inlined.0
              drop
              i32.const 1
-             local.set $9
+             local.set $3
             end
             local.get $2
             local.get $1
@@ -2620,25 +2620,26 @@
            end
           end
           i32.const 0
-          local.get $9
+          local.get $3
           i32.eqz
           br_if $~lib/util/string/isFinalSigma|inlined.0
           drop
+          local.get $6
           i32.const 1
           i32.add
           local.tee $2
           i32.const 30
           i32.add
           local.tee $1
-          local.get $7
+          local.get $9
           local.get $1
-          local.get $7
+          local.get $9
           i32.lt_s
           select
-          local.set $6
+          local.set $3
           loop $while-continue|2
            local.get $2
-           local.get $6
+           local.get $3
            i32.lt_s
            if
             local.get $4
@@ -2652,7 +2653,7 @@
             i32.and
             i32.const 55296
             i32.eq
-            local.get $7
+            local.get $9
             local.get $2
             i32.const 1
             i32.add
@@ -2665,7 +2666,7 @@
              i32.shl
              i32.add
              i32.load16_u offset=2
-             local.tee $3
+             local.tee $5
              i32.const 64512
              i32.and
              i32.const 56320
@@ -2674,7 +2675,7 @@
               local.get $1
               i32.const 10
               i32.shl
-              local.get $3
+              local.get $5
               i32.add
               i32.const -56613888
               i32.add
@@ -2682,19 +2683,20 @@
              end
             end
             local.get $1
-            local.tee $3
+            local.set $5
+            local.get $1
             i32.const 918000
             i32.lt_u
             if (result i32)
              i32.const 6658
-             local.get $3
+             local.get $5
              call $~lib/util/string/stagedBinaryLookup
             else
              i32.const 0
             end
             i32.eqz
             if
-             local.get $3
+             local.get $1
              local.tee $2
              i32.const 127370
              i32.lt_u
@@ -2709,7 +2711,7 @@
              br $~lib/util/string/isFinalSigma|inlined.0
             end
             local.get $2
-            local.get $3
+            local.get $1
             i32.const 65536
             i32.ge_u
             i32.const 1
@@ -2737,8 +2739,8 @@
         i32.const 25
         i32.le_u
         if
-         local.get $10
-         local.get $11
+         local.get $8
+         local.get $7
          i32.const 1
          i32.shl
          i32.add
@@ -2756,16 +2758,16 @@
          i32.const 65536
          i32.lt_s
          if
-          local.get $10
-          local.get $11
+          local.get $8
+          local.get $7
           i32.const 1
           i32.shl
           i32.add
           local.get $2
           i32.store16
          else
-          local.get $10
-          local.get $11
+          local.get $8
+          local.get $7
           i32.const 1
           i32.shl
           i32.add
@@ -2786,18 +2788,18 @@
           i32.shl
           i32.or
           i32.store
-          local.get $11
+          local.get $7
           i32.const 1
           i32.add
-          local.set $11
+          local.set $7
          end
         end
        end
       end
      end
     else
-     local.get $10
-     local.get $11
+     local.get $8
+     local.get $7
      i32.const 1
      i32.shl
      i32.add
@@ -2814,19 +2816,19 @@
      i32.or
      i32.store16
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
-    local.get $11
+    local.set $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $11
+    local.set $7
     br $for-loop|0
    end
   end
-  local.get $10
-  local.get $11
+  local.get $8
+  local.get $7
   i32.const 1
   i32.shl
   call $~lib/rt/tlsf/__realloc
@@ -3187,8 +3189,8 @@
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
-  (local $3 i32)
-  (local $4 i64)
+  (local $3 i64)
+  (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i64)
@@ -4428,11 +4430,11 @@
    unreachable
   end
   loop $for-loop|0
-   local.get $3
+   local.get $4
    i32.const 1114111
    i32.le_s
    if
-    local.get $3
+    local.get $4
     call $~lib/string/String.fromCodePoint
     local.tee $12
     call $~lib/string/String#toLowerCase
@@ -4444,7 +4446,7 @@
     i32.const 0
     call $~lib/string/String#codePointAt
     i64.extend_i32_s
-    local.set $4
+    local.set $3
     local.get $5
     i32.const 1
     call $~lib/string/String#codePointAt
@@ -4453,12 +4455,12 @@
     i64.const 0
     i64.ge_u
     if
-     local.get $4
+     local.get $3
      local.get $0
      i64.const 16
      i64.shl
      i64.add
-     local.set $4
+     local.set $3
     end
     local.get $5
     i32.const 2
@@ -4468,12 +4470,12 @@
     i64.const 0
     i64.ge_u
     if
-     local.get $4
+     local.get $3
      local.get $0
      i64.const 32
      i64.shl
      i64.add
-     local.set $4
+     local.set $3
     end
     local.get $6
     i32.const 0
@@ -4510,12 +4512,12 @@
      i64.add
      local.set $0
     end
-    local.get $3
+    local.get $4
     i32.const 0
     call $std/string-casemapping/toLowerCaseFromIndex
     i64.extend_i32_s
     local.set $1
-    local.get $3
+    local.get $4
     i32.const 1
     call $std/string-casemapping/toLowerCaseFromIndex
     i64.extend_i32_s
@@ -4530,7 +4532,7 @@
      i64.add
      local.set $1
     end
-    local.get $3
+    local.get $4
     i32.const 2
     call $std/string-casemapping/toLowerCaseFromIndex
     i64.extend_i32_s
@@ -4545,12 +4547,12 @@
      i64.add
      local.set $1
     end
-    local.get $3
+    local.get $4
     i32.const 0
     call $std/string-casemapping/toUpperCaseFromIndex
     i64.extend_i32_s
     local.set $2
-    local.get $3
+    local.get $4
     i32.const 1
     call $std/string-casemapping/toUpperCaseFromIndex
     i64.extend_i32_s
@@ -4565,7 +4567,7 @@
      i64.add
      local.set $2
     end
-    local.get $3
+    local.get $4
     i32.const 2
     call $std/string-casemapping/toUpperCaseFromIndex
     i64.extend_i32_s
@@ -4581,12 +4583,12 @@
      local.set $2
     end
     local.get $1
-    local.get $4
+    local.get $3
     i64.ne
     if
      i32.const 18160
      i32.const 1
-     local.get $3
+     local.get $4
      f64.convert_i32_s
      f64.const 0
      f64.const 0
@@ -4594,7 +4596,7 @@
      f64.const 0
      call $~lib/builtins/trace
      i32.const 18240
-     local.get $4
+     local.get $3
      call $~lib/util/number/utoa64
      local.tee $8
      call $~lib/string/String.__concat
@@ -4634,7 +4636,7 @@
     if
      i32.const 18720
      i32.const 1
-     local.get $3
+     local.get $4
      f64.convert_i32_s
      f64.const 0
      f64.const 0
@@ -4682,10 +4684,10 @@
     call $~lib/rt/pure/__release
     local.get $6
     call $~lib/rt/pure/__release
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
-    local.set $3
+    local.set $4
     br $for-loop|0
    end
   end

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -2000,8 +2000,6 @@
        i32.sub
        i32.store16
       else
-       i32.const -1
-       local.set $1
        local.get $2
        i32.const 223
        i32.sub

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -2000,14 +2000,12 @@
        i32.sub
        i32.store16
       else
-       i32.const -1
-       local.set $1
        local.get $2
        i32.const 223
        i32.sub
        i32.const 64056
        i32.le_u
-       if
+       if (result i32)
         block $~lib/util/casemap/bsearch|inlined.0 (result i32)
          local.get $3
          local.set $1
@@ -2058,9 +2056,10 @@
          end
          i32.const -1
         end
-        local.set $1
+       else
+        i32.const -1
        end
-       local.get $1
+       local.tee $1
        i32.const -1
        i32.xor
        if

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -1887,26 +1887,26 @@
   (local $10 i32)
   local.get $0
   call $~lib/string/String#get:length
-  local.tee $8
+  local.tee $6
   i32.eqz
   if
    local.get $0
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $8
+  local.get $6
   i32.const 3
   i32.mul
   i32.const 1
   i32.shl
   call $~lib/rt/tlsf/__alloc
-  local.set $6
+  local.set $8
   i32.const 1216
   call $~lib/string/String#get:length
   local.set $3
   loop $for-loop|0
    local.get $7
-   local.get $8
+   local.get $6
    i32.lt_u
    if
     local.get $7
@@ -1921,7 +1921,7 @@
     if
      block $for-continue|0
       local.get $7
-      local.get $8
+      local.get $6
       i32.const 1
       i32.sub
       i32.lt_u
@@ -1939,7 +1939,7 @@
        local.get $0
        i32.add
        i32.load16_u offset=2
-       local.tee $5
+       local.tee $9
        i32.const 56319
        i32.sub
        i32.const 1025
@@ -1949,7 +1949,7 @@
         i32.const 1
         i32.add
         local.set $7
-        local.get $5
+        local.get $9
         i32.const 1023
         i32.and
         local.get $2
@@ -1965,21 +1965,21 @@
         i32.const 131072
         i32.ge_u
         if
-         local.get $4
+         local.get $10
          i32.const 1
          i32.shl
-         local.get $6
+         local.get $8
          i32.add
-         local.get $5
+         local.get $9
          i32.const 16
          i32.shl
          local.get $1
          i32.or
          i32.store
-         local.get $4
+         local.get $10
          i32.const 1
          i32.add
-         local.set $4
+         local.set $10
          br $for-continue|0
         end
        end
@@ -1990,40 +1990,42 @@
       i32.const 25
       i32.le_u
       if
-       local.get $4
+       local.get $10
        i32.const 1
        i32.shl
-       local.get $6
+       local.get $8
        i32.add
        local.get $2
        i32.const 26
        i32.sub
        i32.store16
       else
+       i32.const -1
+       local.set $1
        local.get $2
        i32.const 223
        i32.sub
        i32.const 64056
        i32.le_u
-       if (result i32)
+       if
         block $~lib/util/casemap/bsearch|inlined.0 (result i32)
          local.get $3
          local.set $1
          i32.const 0
-         local.set $9
+         local.set $5
          loop $while-continue|1
-          local.get $9
+          local.get $5
           local.get $1
           i32.le_s
           if
            local.get $1
-           local.get $9
+           local.get $5
            i32.add
            i32.const 3
            i32.shr_u
            i32.const 2
            i32.shl
-           local.tee $5
+           local.tee $9
            i32.const 1
            i32.shl
            i32.const 1216
@@ -2031,24 +2033,24 @@
            i32.load16_u
            local.get $2
            i32.sub
-           local.tee $10
+           local.tee $4
            if
-            local.get $10
+            local.get $4
             i32.const 31
             i32.shr_u
             if
-             local.get $5
+             local.get $9
              i32.const 4
              i32.add
-             local.set $9
+             local.set $5
             else
-             local.get $5
+             local.get $9
              i32.const 4
              i32.sub
              local.set $1
             end
            else
-            local.get $5
+            local.get $9
             br $~lib/util/casemap/bsearch|inlined.0
            end
            br $while-continue|1
@@ -2056,10 +2058,9 @@
          end
          i32.const -1
         end
-       else
-        i32.const -1
+        local.set $1
        end
-       local.tee $1
+       local.get $1
        i32.const -1
        i32.xor
        if
@@ -2071,16 +2072,16 @@
         local.tee $1
         i32.load16_u offset=6
         local.set $2
-        local.get $4
+        local.get $10
         i32.const 1
         i32.shl
-        local.get $6
+        local.get $8
         i32.add
-        local.tee $5
+        local.tee $9
         local.get $1
         i32.load offset=2
         i32.store
-        local.get $5
+        local.get $9
         local.get $2
         i32.store16 offset=4
         local.get $2
@@ -2088,9 +2089,9 @@
         i32.ne
         i32.const 1
         i32.add
-        local.get $4
+        local.get $10
         i32.add
-        local.set $4
+        local.set $10
        else
         local.get $2
         i32.const 1
@@ -2101,18 +2102,18 @@
         i32.const 65536
         i32.lt_s
         if
-         local.get $4
+         local.get $10
          i32.const 1
          i32.shl
-         local.get $6
+         local.get $8
          i32.add
          local.get $2
          i32.store16
         else
-         local.get $4
+         local.get $10
          i32.const 1
          i32.shl
-         local.get $6
+         local.get $8
          i32.add
          local.get $2
          i32.const 65536
@@ -2131,19 +2132,19 @@
          i32.shl
          i32.or
          i32.store
-         local.get $4
+         local.get $10
          i32.const 1
          i32.add
-         local.set $4
+         local.set $10
         end
        end
       end
      end
     else
-     local.get $4
+     local.get $10
      i32.const 1
      i32.shl
-     local.get $6
+     local.get $8
      i32.add
      local.get $2
      i32.const 97
@@ -2164,15 +2165,15 @@
     i32.const 1
     i32.add
     local.set $7
-    local.get $4
+    local.get $10
     i32.const 1
     i32.add
-    local.set $4
+    local.set $10
     br $for-loop|0
    end
   end
-  local.get $6
-  local.get $4
+  local.get $8
+  local.get $10
   i32.const 1
   i32.shl
   call $~lib/rt/tlsf/__realloc
@@ -2365,43 +2366,44 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   local.get $0
   call $~lib/string/String#get:length
-  local.tee $9
+  local.tee $11
   i32.eqz
   if
    local.get $0
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $9
+  local.get $11
   i32.const 2
   i32.shl
   call $~lib/rt/tlsf/__alloc
-  local.set $8
+  local.set $9
   loop $for-loop|0
-   local.get $6
-   local.get $9
+   local.get $4
+   local.get $11
    i32.lt_u
    if
     local.get $0
-    local.get $6
+    local.get $4
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u
-    local.tee $2
+    local.tee $1
     i32.const 7
     i32.shr_u
     if
      block $for-continue|0
-      local.get $6
-      local.get $9
+      local.get $4
+      local.get $11
       i32.const 1
       i32.sub
       i32.lt_u
       i32.const 0
-      local.get $2
+      local.get $1
       i32.const 55295
       i32.sub
       i32.const 1025
@@ -2409,26 +2411,26 @@
       select
       if
        local.get $0
-       local.get $6
+       local.get $4
        i32.const 1
        i32.shl
        i32.add
        i32.load16_u offset=2
-       local.tee $4
+       local.tee $6
        i32.const 56319
        i32.sub
        i32.const 1025
        i32.lt_u
        if
-        local.get $6
+        local.get $4
         i32.const 1
         i32.add
-        local.set $6
-        local.get $4
+        local.set $4
+        local.get $6
         i32.const 1023
         i32.and
-        local.get $2
-        local.tee $1
+        local.get $1
+        local.tee $2
         i32.const 1023
         i32.and
         i32.const 10
@@ -2436,126 +2438,127 @@
         i32.or
         i32.const 65536
         i32.add
-        local.tee $2
+        local.tee $1
         i32.const 131072
         i32.ge_u
         if
+         local.get $9
          local.get $8
-         local.get $7
          i32.const 1
          i32.shl
          i32.add
-         local.get $1
-         local.get $4
+         local.get $2
+         local.get $6
          i32.const 16
          i32.shl
          i32.or
          i32.store
-         local.get $7
+         local.get $8
          i32.const 1
          i32.add
-         local.set $7
+         local.set $8
          br $for-continue|0
         end
        end
       end
-      local.get $2
+      local.get $1
       i32.const 304
       i32.eq
       if
+       local.get $9
        local.get $8
-       local.get $7
        i32.const 1
        i32.shl
        i32.add
        i32.const 50790505
        i32.store
-       local.get $7
+       local.get $8
        i32.const 1
        i32.add
-       local.set $7
+       local.set $8
       else
-       local.get $2
+       local.get $1
        i32.const 931
        i32.eq
        if
+        local.get $9
         local.get $8
-        local.get $7
         i32.const 1
         i32.shl
         i32.add
-        local.get $9
+        local.get $11
         i32.const 1
         i32.gt_u
         if (result i32)
          block $~lib/util/string/isFinalSigma|inlined.0 (result i32)
           local.get $0
-          local.set $4
+          local.set $6
+          local.get $4
           i32.const 0
           local.set $3
           i32.const 0
-          local.get $6
-          local.tee $2
+          local.get $4
+          local.tee $1
           i32.const 30
           i32.sub
-          local.tee $1
+          local.tee $2
           i32.const 0
-          local.get $1
+          local.get $2
           i32.gt_s
           select
           local.set $10
           loop $while-continue|1
-           local.get $2
+           local.get $1
            local.get $10
            i32.gt_s
            if
             block $~lib/util/string/codePointBefore|inlined.0 (result i32)
-             local.get $2
-             local.set $1
+             local.get $1
+             local.set $2
              i32.const -1
-             local.get $2
+             local.get $1
              i32.const 0
              i32.le_s
              br_if $~lib/util/string/codePointBefore|inlined.0
              drop
-             local.get $4
-             local.get $1
+             local.get $6
+             local.get $2
              i32.const 1
              i32.sub
              i32.const 1
              i32.shl
              i32.add
              i32.load16_u
-             local.tee $5
+             local.tee $7
              i32.const 64512
              i32.and
              i32.const 56320
              i32.eq
-             local.get $1
+             local.get $2
              i32.const 2
              i32.sub
              i32.const 0
              i32.ge_s
              i32.and
              if
-              local.get $4
-              local.get $1
+              local.get $6
+              local.get $2
               i32.const 2
               i32.sub
               i32.const 1
               i32.shl
               i32.add
               i32.load16_u
-              local.tee $1
+              local.tee $2
               i32.const 64512
               i32.and
               i32.const 55296
               i32.eq
               if
-               local.get $5
+               local.get $7
                i32.const 1023
                i32.and
-               local.get $1
+               local.get $2
                i32.const 1023
                i32.and
                i32.const 10
@@ -2567,22 +2570,22 @@
               end
              end
              i32.const 65533
-             local.get $5
-             local.get $5
+             local.get $7
+             local.get $7
              i32.const 63488
              i32.and
              i32.const 55296
              i32.eq
              select
             end
-            local.tee $1
-            local.set $5
-            local.get $1
+            local.tee $2
+            local.set $7
+            local.get $2
             i32.const 918000
             i32.lt_u
             if (result i32)
              i32.const 6658
-             local.get $5
+             local.get $7
              call $~lib/util/string/stagedBinaryLookup
             else
              i32.const 0
@@ -2590,112 +2593,7 @@
             i32.eqz
             if
              i32.const 0
-             local.get $1
-             i32.const 127370
-             i32.lt_u
-             if (result i32)
-              i32.const 9666
-              local.get $1
-              call $~lib/util/string/stagedBinaryLookup
-             else
-              i32.const 0
-             end
-             i32.eqz
-             br_if $~lib/util/string/isFinalSigma|inlined.0
-             drop
-             i32.const 1
-             local.set $3
-            end
-            local.get $2
-            local.get $1
-            i32.const 65536
-            i32.ge_s
-            i32.const 1
-            i32.add
-            i32.sub
-            local.set $2
-            br $while-continue|1
-           end
-          end
-          i32.const 0
-          local.get $3
-          i32.eqz
-          br_if $~lib/util/string/isFinalSigma|inlined.0
-          drop
-          local.get $6
-          i32.const 1
-          i32.add
-          local.tee $2
-          i32.const 30
-          i32.add
-          local.tee $1
-          local.get $9
-          local.get $1
-          local.get $9
-          i32.lt_s
-          select
-          local.set $3
-          loop $while-continue|2
-           local.get $2
-           local.get $3
-           i32.lt_s
-           if
-            local.get $4
-            local.get $2
-            i32.const 1
-            i32.shl
-            i32.add
-            i32.load16_u
-            local.tee $1
-            i32.const 64512
-            i32.and
-            i32.const 55296
-            i32.eq
-            local.get $9
-            local.get $2
-            i32.const 1
-            i32.add
-            i32.ne
-            i32.and
-            if
-             local.get $4
              local.get $2
-             i32.const 1
-             i32.shl
-             i32.add
-             i32.load16_u offset=2
-             local.tee $5
-             i32.const 64512
-             i32.and
-             i32.const 56320
-             i32.eq
-             if
-              local.get $1
-              i32.const 10
-              i32.shl
-              local.get $5
-              i32.add
-              i32.const -56613888
-              i32.add
-              local.set $1
-             end
-            end
-            local.get $1
-            local.set $5
-            local.get $1
-            i32.const 918000
-            i32.lt_u
-            if (result i32)
-             i32.const 6658
-             local.get $5
-             call $~lib/util/string/stagedBinaryLookup
-            else
-             i32.const 0
-            end
-            i32.eqz
-            if
-             local.get $1
-             local.tee $2
              i32.const 127370
              i32.lt_u
              if (result i32)
@@ -2706,16 +2604,121 @@
               i32.const 0
              end
              i32.eqz
+             br_if $~lib/util/string/isFinalSigma|inlined.0
+             drop
+             i32.const 1
+             local.set $3
+            end
+            local.get $1
+            local.get $2
+            i32.const 65536
+            i32.ge_s
+            i32.const 1
+            i32.add
+            i32.sub
+            local.set $1
+            br $while-continue|1
+           end
+          end
+          i32.const 0
+          local.get $3
+          i32.eqz
+          br_if $~lib/util/string/isFinalSigma|inlined.0
+          drop
+          i32.const 1
+          i32.add
+          local.tee $1
+          i32.const 30
+          i32.add
+          local.tee $2
+          local.get $11
+          local.get $2
+          local.get $11
+          i32.lt_s
+          select
+          local.set $5
+          loop $while-continue|2
+           local.get $1
+           local.get $5
+           i32.lt_s
+           if
+            local.get $6
+            local.get $1
+            i32.const 1
+            i32.shl
+            i32.add
+            i32.load16_u
+            local.tee $2
+            i32.const 64512
+            i32.and
+            i32.const 55296
+            i32.eq
+            local.get $11
+            local.get $1
+            i32.const 1
+            i32.add
+            i32.ne
+            i32.and
+            if (result i32)
+             local.get $6
+             local.get $1
+             i32.const 1
+             i32.shl
+             i32.add
+             i32.load16_u offset=2
+             local.tee $7
+             i32.const 64512
+             i32.and
+             i32.const 56320
+             i32.eq
+             if (result i32)
+              local.get $2
+              i32.const 10
+              i32.shl
+              local.get $7
+              i32.add
+              i32.const -56613888
+              i32.add
+             else
+              local.get $2
+             end
+            else
+             local.get $2
+            end
+            local.tee $7
+            i32.const 918000
+            i32.lt_u
+            if (result i32)
+             i32.const 6658
+             local.get $7
+             call $~lib/util/string/stagedBinaryLookup
+            else
+             i32.const 0
+            end
+            i32.eqz
+            if
+             local.get $7
+             local.tee $1
+             i32.const 127370
+             i32.lt_u
+             if (result i32)
+              i32.const 9666
+              local.get $1
+              call $~lib/util/string/stagedBinaryLookup
+             else
+              i32.const 0
+             end
+             i32.eqz
              br $~lib/util/string/isFinalSigma|inlined.0
             end
-            local.get $2
             local.get $1
+            local.get $7
             i32.const 65536
             i32.ge_u
             i32.const 1
             i32.add
             i32.add
-            local.set $2
+            local.set $1
             br $while-continue|2
            end
           end
@@ -2731,53 +2734,53 @@
         end
         i32.store16
        else
-        local.get $2
+        local.get $1
         i32.const 9398
         i32.sub
         i32.const 25
         i32.le_u
         if
+         local.get $9
          local.get $8
-         local.get $7
          i32.const 1
          i32.shl
          i32.add
-         local.get $2
+         local.get $1
          i32.const 26
          i32.add
          i32.store16
         else
-         local.get $2
+         local.get $1
          i32.const 0
          call $~lib/util/casemap/casemap
          i32.const 2097151
          i32.and
-         local.tee $2
+         local.tee $1
          i32.const 65536
          i32.lt_s
          if
+          local.get $9
           local.get $8
-          local.get $7
           i32.const 1
           i32.shl
           i32.add
-          local.get $2
+          local.get $1
           i32.store16
          else
+          local.get $9
           local.get $8
-          local.get $7
           i32.const 1
           i32.shl
           i32.add
-          local.get $2
+          local.get $1
           i32.const 65536
           i32.sub
-          local.tee $2
+          local.tee $1
           i32.const 10
           i32.shr_u
           i32.const 55296
           i32.or
-          local.get $2
+          local.get $1
           i32.const 1023
           i32.and
           i32.const 56320
@@ -2786,23 +2789,23 @@
           i32.shl
           i32.or
           i32.store
-          local.get $7
+          local.get $8
           i32.const 1
           i32.add
-          local.set $7
+          local.set $8
          end
         end
        end
       end
      end
     else
+     local.get $9
      local.get $8
-     local.get $7
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
-     local.get $2
+     local.get $1
+     local.get $1
      i32.const 65
      i32.sub
      i32.const 26
@@ -2814,19 +2817,19 @@
      i32.or
      i32.store16
     end
-    local.get $6
+    local.get $4
     i32.const 1
     i32.add
-    local.set $6
-    local.get $7
+    local.set $4
+    local.get $8
     i32.const 1
     i32.add
-    local.set $7
+    local.set $8
     br $for-loop|0
    end
   end
+  local.get $9
   local.get $8
-  local.get $7
   i32.const 1
   i32.shl
   call $~lib/rt/tlsf/__realloc

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -290,7 +290,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -310,35 +310,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -348,12 +348,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -361,7 +361,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -380,42 +380,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -430,12 +432,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -445,38 +447,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -494,7 +496,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -503,21 +505,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -544,7 +546,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -786,22 +788,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -1672,15 +1672,15 @@
   (local $7 i32)
   i32.const 1040
   call $~lib/string/String.UTF16.encode
-  local.set $0
+  local.set $1
   i32.const 1040
   call $~lib/string/String.UTF16.byteLength
-  local.set $7
-  local.get $0
-  local.tee $1
+  local.set $2
+  local.get $1
+  local.tee $0
   i32.const 0
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $6
+  local.tee $3
   i32.const 1296
   call $~lib/string/String.__eq
   i32.eqz
@@ -1692,10 +1692,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.get $7
+  local.get $0
+  local.get $2
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $5
+  local.tee $4
   i32.const 1040
   call $~lib/string/String.__eq
   i32.eqz
@@ -1707,10 +1707,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 4
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $4
+  local.tee $5
   i32.const 1312
   call $~lib/string/String.__eq
   i32.eqz
@@ -1722,12 +1722,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 4
   i32.add
   i32.const 2
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $3
+  local.tee $6
   i32.const 1344
   call $~lib/string/String.__eq
   i32.eqz
@@ -1739,12 +1739,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 4
   i32.add
   i32.const 4
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $2
+  local.tee $7
   i32.const 1376
   call $~lib/string/String.__eq
   i32.eqz
@@ -1756,12 +1756,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 8
   i32.add
   i32.const 4
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $7
+  local.tee $2
   i32.const 1408
   call $~lib/string/String.__eq
   i32.eqz
@@ -1773,12 +1773,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 12
   i32.add
   i32.const 0
   call $~lib/string/String.UTF16.decodeUnsafe
-  local.tee $1
+  local.tee $0
   i32.const 1296
   call $~lib/string/String.__eq
   i32.eqz
@@ -1790,21 +1790,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $5
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $5
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $~lib/string/String.UTF8.byteLength (param $0 i32) (param $1 i32) (result i32)
@@ -2888,17 +2888,17 @@
   i32.const 1040
   i32.const 1
   call $~lib/string/String.UTF8.encode
-  local.set $0
+  local.set $1
   i32.const 1040
   i32.const 0
   call $~lib/string/String.UTF8.byteLength
-  local.set $9
-  local.get $0
-  local.tee $1
+  local.set $2
+  local.get $1
+  local.tee $0
   i32.const 0
   i32.const 0
   call $~lib/string/String.UTF8.decodeUnsafe
-  local.tee $8
+  local.tee $3
   i32.const 1296
   call $~lib/string/String.__eq
   i32.eqz
@@ -2910,11 +2910,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.get $9
+  local.get $0
+  local.get $2
   i32.const 0
   call $~lib/string/String.UTF8.decodeUnsafe
-  local.tee $7
+  local.tee $4
   i32.const 1040
   call $~lib/string/String.__eq
   i32.eqz
@@ -2926,11 +2926,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 4
   i32.const 0
   call $~lib/string/String.UTF8.decodeUnsafe
-  local.tee $6
+  local.tee $5
   i32.const 1312
   call $~lib/string/String.__eq
   i32.eqz
@@ -2942,13 +2942,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 4
   i32.add
   i32.const 2
   i32.const 0
   call $~lib/string/String.UTF8.decodeUnsafe
-  local.tee $5
+  local.tee $6
   i32.const 1376
   call $~lib/string/String.__eq
   i32.eqz
@@ -2960,13 +2960,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 6
   i32.add
   i32.const 4
   i32.const 0
   call $~lib/string/String.UTF8.decodeUnsafe
-  local.tee $4
+  local.tee $7
   i32.const 1408
   call $~lib/string/String.__eq
   i32.eqz
@@ -2978,13 +2978,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.add
   i32.const 0
   i32.const 0
   call $~lib/string/String.UTF8.decodeUnsafe
-  local.tee $3
+  local.tee $8
   i32.const 1296
   call $~lib/string/String.__eq
   i32.eqz
@@ -2996,13 +2996,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 4
   i32.add
   i32.const 100
   i32.const 1
   call $~lib/string/String.UTF8.decodeUnsafe
-  local.tee $2
+  local.tee $9
   i32.const 1552
   call $~lib/string/String.__eq
   i32.eqz
@@ -3014,13 +3014,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 6
   i32.add
   i32.const 100
   i32.const 1
   call $~lib/string/String.UTF8.decodeUnsafe
-  local.tee $9
+  local.tee $2
   i32.const 1408
   call $~lib/string/String.__eq
   i32.eqz
@@ -3032,13 +3032,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 10
   i32.add
   i32.const 100
   i32.const 1
   call $~lib/string/String.UTF8.decodeUnsafe
-  local.tee $1
+  local.tee $0
   i32.const 1296
   call $~lib/string/String.__eq
   i32.eqz
@@ -3050,25 +3050,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $5
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $5
   call $~lib/rt/pure/__release
-  local.get $2
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $2
   call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/string-encoding/testLarge (param $0 i32)

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -3394,36 +3394,36 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i64)
+  (local $6 i64)
+  (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
+  (local $9 f64)
   (local $10 i64)
-  (local $11 i64)
-  (local $12 f64)
+  (local $11 f64)
+  (local $12 i64)
   (local $13 i64)
-  (local $14 f64)
+  (local $14 i32)
   (local $15 i32)
-  (local $16 i32)
-  (local $17 i64)
+  (local $16 i64)
+  (local $17 i32)
   block $folding-inner0
    local.get $0
    call $~lib/rt/pure/__retain
-   local.tee $5
+   local.tee $3
    call $~lib/string/String#get:length
-   local.tee $6
+   local.tee $17
    i32.eqz
    br_if $folding-inner0
-   local.get $5
+   local.get $3
    local.tee $0
    i32.load16_u
-   local.set $8
+   local.set $15
    f64.const 1
-   local.set $14
+   local.set $9
    loop $while-continue|0
-    local.get $6
+    local.get $17
     if (result i32)
-     local.get $8
+     local.get $15
      call $~lib/util/string/isSpace
     else
      i32.const 0
@@ -3434,43 +3434,43 @@
      i32.add
      local.tee $0
      i32.load16_u
-     local.set $8
-     local.get $6
+     local.set $15
+     local.get $17
      i32.const 1
      i32.sub
-     local.set $6
+     local.set $17
      br $while-continue|0
     end
    end
-   local.get $6
+   local.get $17
    i32.eqz
    br_if $folding-inner0
-   local.get $8
+   local.get $15
    i32.const 45
    i32.eq
    if (result i32)
-    local.get $6
+    local.get $17
     i32.const 1
     i32.sub
-    local.tee $6
+    local.tee $17
     i32.eqz
     br_if $folding-inner0
     f64.const -1
-    local.set $14
+    local.set $9
     local.get $0
     i32.const 2
     i32.add
     local.tee $0
     i32.load16_u
    else
-    local.get $8
+    local.get $15
     i32.const 43
     i32.eq
     if (result i32)
-     local.get $6
+     local.get $17
      i32.const 1
      i32.sub
-     local.tee $6
+     local.tee $17
      i32.eqz
      br_if $folding-inner0
      local.get $0
@@ -3479,14 +3479,14 @@
      local.tee $0
      i32.load16_u
     else
-     local.get $8
+     local.get $15
     end
    end
-   local.tee $8
+   local.tee $15
    i32.const 73
    i32.eq
    i32.const 0
-   local.get $6
+   local.get $17
    i32.const 8
    i32.ge_s
    select
@@ -3504,22 +3504,22 @@
      i32.const 0
     end
     if
-     local.get $5
+     local.get $3
      call $~lib/rt/pure/__release
      f64.const inf
-     local.get $14
+     local.get $9
      f64.copysign
      return
     end
     br $folding-inner0
    end
-   local.get $8
+   local.get $15
    i32.const 48
    i32.sub
    i32.const 10
    i32.ge_u
    i32.const 0
-   local.get $8
+   local.get $15
    i32.const 46
    i32.ne
    select
@@ -3527,7 +3527,7 @@
    local.get $0
    local.set $4
    loop $while-continue|1
-    local.get $8
+    local.get $15
     i32.const 48
     i32.eq
     if
@@ -3536,24 +3536,24 @@
      i32.add
      local.tee $0
      i32.load16_u
-     local.set $8
-     local.get $6
+     local.set $15
+     local.get $17
      i32.const 1
      i32.sub
-     local.set $6
+     local.set $17
      br $while-continue|1
     end
    end
-   local.get $6
+   local.get $17
    i32.const 0
    i32.le_s
    if
-    local.get $5
+    local.get $3
     call $~lib/rt/pure/__release
     f64.const 0
     return
    end
-   local.get $8
+   local.get $15
    i32.const 46
    i32.eq
    if
@@ -3566,10 +3566,10 @@
     i32.const 2
     i32.add
     local.set $0
-    local.get $6
+    local.get $17
     i32.const 1
     i32.sub
-    local.tee $6
+    local.tee $17
     if (result i32)
      i32.const 0
     else
@@ -3577,22 +3577,22 @@
     end
     br_if $folding-inner0
     i32.const 1
-    local.set $15
+    local.set $8
     loop $for-loop|2
      local.get $0
      i32.load16_u
-     local.tee $8
+     local.tee $15
      i32.const 48
      i32.eq
      if
-      local.get $6
+      local.get $17
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $2
+      local.set $17
+      local.get $1
       i32.const 1
       i32.sub
-      local.set $2
+      local.set $1
       local.get $0
       i32.const 2
       i32.add
@@ -3600,16 +3600,16 @@
       br $for-loop|2
      end
     end
-    local.get $6
+    local.get $17
     i32.const 0
     i32.le_s
     if
-     local.get $5
+     local.get $3
      call $~lib/rt/pure/__release
      f64.const 0
      return
     end
-    local.get $8
+    local.get $15
     i32.const 48
     i32.sub
     i32.const 10
@@ -3617,65 +3617,65 @@
     i32.const 0
     i32.const 0
     local.get $4
-    local.get $2
+    local.get $1
     select
     select
     br_if $folding-inner0
    end
-   local.get $8
+   local.get $15
    i32.const 48
    i32.sub
-   local.set $9
+   local.set $14
    loop $for-loop|3
     i32.const 1
-    local.get $15
+    local.get $8
     i32.eqz
     i32.const 0
-    local.get $8
+    local.get $15
     i32.const 46
     i32.eq
     select
-    local.get $9
+    local.get $14
     i32.const 10
     i32.lt_u
     select
     if
      block $for-break3
-      local.get $9
+      local.get $14
       i32.const 10
       i32.lt_u
       if
-       local.get $9
+       local.get $14
        i64.extend_i32_u
-       local.get $7
+       local.get $16
        i64.const 10
        i64.mul
        i64.add
-       local.get $7
-       local.get $9
+       local.get $16
+       local.get $14
        i32.eqz
        i32.eqz
        i64.extend_i32_u
        i64.or
-       local.get $1
+       local.get $2
        i32.const 19
        i32.lt_s
        select
-       local.set $7
-       local.get $1
+       local.set $16
+       local.get $2
        i32.const 1
        i32.add
-       local.set $1
-      else
-       local.get $1
        local.set $2
+      else
+       local.get $2
+       local.set $1
        i32.const 1
-       local.set $15
+       local.set $8
       end
-      local.get $6
+      local.get $17
       i32.const 1
       i32.sub
-      local.tee $6
+      local.tee $17
       i32.eqz
       br_if $for-break3
       local.get $0
@@ -3683,74 +3683,74 @@
       i32.add
       local.tee $0
       i32.load16_u
-      local.tee $8
+      local.tee $15
       i32.const 48
       i32.sub
-      local.set $9
+      local.set $14
       br $for-loop|3
      end
     end
    end
-   local.get $2
    local.get $1
-   local.get $15
+   local.get $2
+   local.get $8
    select
    i32.const 19
-   local.get $1
+   local.get $2
    i32.const 19
-   local.get $1
+   local.get $2
    i32.lt_s
    select
    i32.sub
    local.set $4
    i32.const 1
-   local.set $1
+   local.set $2
    block $~lib/util/string/parseExp|inlined.0
     local.get $0
-    local.tee $2
+    local.tee $1
     i32.load16_u
     i32.const 32
     i32.or
     i32.const 101
     i32.ne
     br_if $~lib/util/string/parseExp|inlined.0
-    local.get $2
+    local.get $1
     i32.const 2
     i32.add
-    local.tee $9
+    local.tee $14
     i32.load16_u
     local.tee $0
     i32.const 45
     i32.eq
     if (result i32)
-     local.get $6
+     local.get $17
      i32.const 1
      i32.sub
-     local.tee $6
+     local.tee $17
      i32.eqz
      br_if $~lib/util/string/parseExp|inlined.0
      i32.const -1
-     local.set $1
-     local.get $9
+     local.set $2
+     local.get $14
      i32.const 2
      i32.add
-     local.tee $9
+     local.tee $14
      i32.load16_u
     else
      local.get $0
      i32.const 43
      i32.eq
      if (result i32)
-      local.get $6
+      local.get $17
       i32.const 1
       i32.sub
-      local.tee $6
+      local.tee $17
       i32.eqz
       br_if $~lib/util/string/parseExp|inlined.0
-      local.get $9
+      local.get $14
       i32.const 2
       i32.add
-      local.tee $9
+      local.tee $14
       i32.load16_u
      else
       local.get $0
@@ -3762,16 +3762,16 @@
      i32.const 48
      i32.eq
      if
-      local.get $6
+      local.get $17
       i32.const 1
       i32.sub
-      local.tee $6
+      local.tee $17
       i32.eqz
       br_if $~lib/util/string/parseExp|inlined.0
-      local.get $9
+      local.get $14
       i32.const 2
       i32.add
-      local.tee $9
+      local.tee $14
       i32.load16_u
       local.set $0
       br $while-continue|4
@@ -3786,33 +3786,33 @@
      i32.const 10
      i32.lt_u
      i32.const 0
-     local.get $6
+     local.get $17
      select
      if
-      local.get $3
+      local.get $5
       i32.const 3200
       i32.ge_s
       if
-       local.get $1
+       local.get $2
        i32.const 3200
        i32.mul
-       local.set $16
+       local.set $7
        br $~lib/util/string/parseExp|inlined.0
       end
       local.get $0
-      local.get $3
+      local.get $5
       i32.const 10
       i32.mul
       i32.add
-      local.set $3
-      local.get $6
+      local.set $5
+      local.get $17
       i32.const 1
       i32.sub
-      local.set $6
-      local.get $9
+      local.set $17
+      local.get $14
       i32.const 2
       i32.add
-      local.tee $9
+      local.tee $14
       i32.load16_u
       i32.const 48
       i32.sub
@@ -3820,20 +3820,20 @@
       br $for-loop|5
      end
     end
-    local.get $1
-    local.get $3
+    local.get $2
+    local.get $5
     i32.mul
-    local.set $16
+    local.set $7
    end
    block $~lib/util/string/scientific|inlined.0
     i32.const 1
     local.get $4
-    local.get $16
+    local.get $7
     i32.add
     local.tee $0
     i32.const -342
     i32.lt_s
-    local.get $7
+    local.get $16
     i64.eqz
     select
     br_if $~lib/util/string/scientific|inlined.0
@@ -3842,12 +3842,12 @@
     i32.gt_s
     if
      f64.const inf
-     local.set $12
+     local.set $11
      br $~lib/util/string/scientific|inlined.0
     end
-    local.get $7
+    local.get $16
     f64.convert_i64_u
-    local.set $12
+    local.set $11
     local.get $0
     i32.eqz
     br_if $~lib/util/string/scientific|inlined.0
@@ -3860,7 +3860,7 @@
     i32.gt_s
     select
     if
-     local.get $12
+     local.get $11
      local.get $0
      i32.const 3
      i32.shl
@@ -3868,20 +3868,20 @@
      i32.add
      f64.load
      f64.mul
-     local.set $12
+     local.set $11
      i32.const 22
      local.set $0
     end
-    local.get $7
+    local.get $16
     i64.const 9007199254740991
     i64.le_u
     if (result i32)
      local.get $0
      i32.const 31
      i32.shr_s
-     local.tee $1
+     local.tee $2
      local.get $0
-     local.get $1
+     local.get $2
      i32.add
      i32.xor
      i32.const 22
@@ -3894,7 +3894,7 @@
      i32.const 0
      i32.gt_s
      if
-      local.get $12
+      local.get $11
       local.get $0
       i32.const 3
       i32.shl
@@ -3902,10 +3902,10 @@
       i32.add
       f64.load
       f64.mul
-      local.set $12
+      local.set $11
       br $~lib/util/string/scientific|inlined.0
      end
-     local.get $12
+     local.get $11
      i32.const 0
      local.get $0
      i32.sub
@@ -3920,33 +3920,33 @@
      i32.const 0
      i32.lt_s
      if (result f64)
-      local.get $7
-      local.get $7
+      local.get $16
+      local.get $16
       i64.clz
-      local.tee $10
+      local.tee $13
       i64.shl
-      local.set $7
+      local.set $16
       local.get $0
-      local.tee $1
+      local.tee $2
       i64.extend_i32_s
-      local.get $10
+      local.get $13
       i64.sub
-      local.set $10
+      local.set $13
       loop $for-loop|6
-       local.get $1
+       local.get $2
        i32.const -14
        i32.le_s
        if
         f64.const 0.00004294967296
-        local.get $7
+        local.get $16
         i64.const 6103515625
         i64.rem_u
-        local.get $7
+        local.get $16
         i64.const 6103515625
         i64.div_u
-        local.tee $13
+        local.tee $10
         i64.clz
-        local.tee $11
+        local.tee $12
         i64.const 18
         i64.sub
         i64.shl
@@ -3954,91 +3954,91 @@
         f64.mul
         f64.nearest
         i64.trunc_f64_u
-        local.get $13
-        local.get $11
+        local.get $10
+        local.get $12
         i64.shl
         i64.add
-        local.set $7
-        local.get $10
-        local.get $11
+        local.set $16
+        local.get $13
+        local.get $12
         i64.sub
-        local.set $10
-        local.get $1
+        local.set $13
+        local.get $2
         i32.const 14
         i32.add
-        local.set $1
+        local.set $2
         br $for-loop|6
        end
       end
-      local.get $7
+      local.get $16
       i32.const 0
-      local.get $1
+      local.get $2
       i32.sub
       call $~lib/math/ipow32
       i64.extend_i32_s
-      local.tee $13
+      local.tee $10
       i64.div_u
-      local.tee $17
+      local.tee $6
       i64.clz
-      local.set $11
-      local.get $7
-      local.get $13
+      local.set $12
+      local.get $16
+      local.get $10
       i64.rem_u
       f64.convert_i64_u
       i64.reinterpret_f64
-      local.get $11
+      local.get $12
       i64.const 52
       i64.shl
       i64.add
       f64.reinterpret_i64
-      local.get $13
+      local.get $10
       f64.convert_i64_u
       f64.div
       i64.trunc_f64_u
-      local.get $17
-      local.get $11
+      local.get $6
+      local.get $12
       i64.shl
       i64.add
       f64.convert_i64_u
-      local.get $10
-      local.get $11
+      local.get $13
+      local.get $12
       i64.sub
       i32.wrap_i64
       call $~lib/math/NativeMath.scalbn
      else
-      local.get $7
-      local.get $7
+      local.get $16
+      local.get $16
       i64.ctz
-      local.tee $10
+      local.tee $13
       i64.shr_u
-      local.set $7
-      local.get $10
+      local.set $16
+      local.get $13
       local.get $0
-      local.tee $3
+      local.tee $5
       i64.extend_i32_s
       i64.add
       global.set $~lib/util/string/__fixmulShift
       loop $for-loop|7
-       local.get $3
+       local.get $5
        i32.const 13
        i32.ge_s
        if
         i64.const 32
-        local.get $7
+        local.get $16
         i64.const 32
         i64.shr_u
         i64.const 1220703125
         i64.mul
-        local.get $7
+        local.get $16
         i64.const 4294967295
         i64.and
         i64.const 1220703125
         i64.mul
-        local.tee $7
+        local.tee $16
         i64.const 32
         i64.shr_u
         i64.add
-        local.tee $10
+        local.tee $13
         i64.const 32
         i64.shr_u
         i32.wrap_i64
@@ -4046,11 +4046,11 @@
         local.tee $0
         i64.extend_i32_u
         i64.sub
-        local.tee $11
+        local.tee $12
         global.get $~lib/util/string/__fixmulShift
         i64.add
         global.set $~lib/util/string/__fixmulShift
-        local.get $7
+        local.get $16
         local.get $0
         i64.extend_i32_u
         i64.shl
@@ -4058,46 +4058,46 @@
         i64.shr_u
         i64.const 1
         i64.and
-        local.get $10
+        local.get $13
         local.get $0
         i64.extend_i32_u
         i64.shl
-        local.get $7
+        local.get $16
         i64.const 4294967295
         i64.and
-        local.get $11
+        local.get $12
         i64.shr_u
         i64.or
         i64.add
-        local.set $7
-        local.get $3
+        local.set $16
+        local.get $5
         i32.const 13
         i32.sub
-        local.set $3
+        local.set $5
         br $for-loop|7
        end
       end
-      local.get $3
+      local.get $5
       call $~lib/math/ipow32
       local.tee $0
       i64.extend_i32_u
-      local.get $7
+      local.get $16
       i64.const 4294967295
       i64.and
       i64.mul
-      local.set $10
+      local.set $13
       i64.const 32
       local.get $0
       i64.extend_i32_u
-      local.get $7
+      local.get $16
       i64.const 32
       i64.shr_u
       i64.mul
-      local.get $10
+      local.get $13
       i64.const 32
       i64.shr_u
       i64.add
-      local.tee $7
+      local.tee $16
       i64.const 32
       i64.shr_u
       i32.wrap_i64
@@ -4105,11 +4105,11 @@
       local.tee $0
       i64.extend_i32_u
       i64.sub
-      local.tee $11
+      local.tee $12
       global.get $~lib/util/string/__fixmulShift
       i64.add
       global.set $~lib/util/string/__fixmulShift
-      local.get $10
+      local.get $13
       local.get $0
       i64.extend_i32_u
       i64.shl
@@ -4117,14 +4117,14 @@
       i64.shr_u
       i64.const 1
       i64.and
-      local.get $7
+      local.get $16
       local.get $0
       i64.extend_i32_u
       i64.shl
-      local.get $10
+      local.get $13
       i64.const 4294967295
       i64.and
-      local.get $11
+      local.get $12
       i64.shr_u
       i64.or
       i64.add
@@ -4134,16 +4134,16 @@
       call $~lib/math/NativeMath.scalbn
      end
     end
-    local.set $12
+    local.set $11
    end
-   local.get $5
+   local.get $3
    call $~lib/rt/pure/__release
-   local.get $12
-   local.get $14
+   local.get $11
+   local.get $9
    f64.copysign
    return
   end
-  local.get $5
+  local.get $3
   call $~lib/rt/pure/__release
   f64.const nan:0x8000000000000
  )
@@ -7916,12 +7916,12 @@
    i32.const -1
    i32.const 0
    global.get $std/string/str
-   local.tee $0
+   local.tee $1
    call $~lib/string/String#get:length
    i32.ge_u
    br_if $__inlined_func$~lib/string/String#charCodeAt
    drop
-   local.get $0
+   local.get $1
    i32.load16_u
   end
   i32.const 104
@@ -8078,6 +8078,15 @@
   end
   global.get $std/string/str
   local.set $12
+  i32.const 1616
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 1616
+   call $~lib/rt/pure/__release
+   i32.const 1648
+   local.set $0
+  end
   block $__inlined_func$~lib/string/String#startsWith
    i32.const 0
    local.get $12
@@ -8088,30 +8097,30 @@
    i32.lt_s
    select
    local.tee $9
-   i32.const 1616
+   local.get $0
    call $~lib/string/String#get:length
-   local.tee $0
+   local.tee $1
    i32.add
    local.get $3
    i32.gt_s
    if
-    i32.const 1616
+    local.get $0
     call $~lib/rt/pure/__release
     i32.const 0
-    local.set $0
+    local.set $1
     br $__inlined_func$~lib/string/String#startsWith
    end
    local.get $12
    local.get $9
-   i32.const 1616
    local.get $0
+   local.get $1
    call $~lib/util/string/compareImpl
    i32.eqz
-   local.set $0
-   i32.const 1616
+   local.set $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
-  local.get $0
+  local.get $1
   i32.eqz
   if
    i32.const 0
@@ -8121,42 +8130,41 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/string/str
-  local.set $9
   block $__inlined_func$~lib/string/String#endsWith
    i32.const 536870904
-   local.get $9
+   global.get $std/string/str
+   local.tee $9
    call $~lib/string/String#get:length
-   local.tee $0
+   local.tee $1
    i32.const 536870904
-   local.get $0
+   local.get $1
    i32.lt_s
    select
    i32.const 1680
    call $~lib/string/String#get:length
-   local.tee $1
-   i32.sub
    local.tee $0
+   i32.sub
+   local.tee $1
    i32.const 0
    i32.lt_s
    if
     i32.const 1680
     call $~lib/rt/pure/__release
     i32.const 0
-    local.set $0
+    local.set $1
     br $__inlined_func$~lib/string/String#endsWith
    end
    local.get $9
-   local.get $0
-   i32.const 1680
    local.get $1
+   i32.const 1680
+   local.get $0
    call $~lib/util/string/compareImpl
    i32.eqz
-   local.set $0
+   local.set $1
    i32.const 1680
    call $~lib/rt/pure/__release
   end
-  local.get $0
+  local.get $1
   i32.eqz
   if
    i32.const 0
@@ -10982,9 +10990,9 @@
   i32.const 1328
   i32.const 11392
   call $~lib/string/String.__concat
-  local.tee $0
-  call $~lib/rt/pure/__retain
   local.tee $1
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 11424
   call $~lib/string/String.__eq
   i32.eqz
@@ -10996,7 +11004,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1328
   call $~lib/string/String.__ne
   i32.eqz
@@ -11008,9 +11016,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   call $~lib/rt/pure/__release
   i32.const 1280
   i32.const 1280
@@ -11361,9 +11369,9 @@
   call $~lib/string/String.fromCodePoint
   local.tee $9
   call $~lib/string/String.__concat
-  local.tee $1
-  call $~lib/rt/pure/__retain
   local.tee $0
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -11380,9 +11388,9 @@
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 1872
   call $~lib/string/String#get:length
@@ -12515,19 +12523,19 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/string/String#split
-  local.tee $1
+  local.tee $0
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $10
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $10
@@ -12544,10 +12552,10 @@
   i32.const 1280
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.load offset=12
   if
    i32.const 0
@@ -12562,7 +12570,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $10
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $10
   i32.load offset=12
@@ -12572,11 +12580,11 @@
    local.get $10
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $13
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $13
@@ -12593,22 +12601,22 @@
   i32.const 5744
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 13360
    call $~lib/string/String.__eq
    local.set $6
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $6
@@ -12626,7 +12634,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $6
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $6
   i32.load offset=12
@@ -12636,11 +12644,11 @@
    local.get $6
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $14
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $14
@@ -12648,11 +12656,11 @@
    local.get $6
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $15
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $15
@@ -12660,11 +12668,11 @@
    local.get $6
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $16
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $16
@@ -12681,46 +12689,46 @@
   i32.const 13424
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $17
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $17
   if
-   local.get $1
+   local.get $0
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $18
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $18
   if
-   local.get $1
+   local.get $0
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $4
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $4
@@ -12738,7 +12746,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $4
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   i32.load offset=12
@@ -12748,11 +12756,11 @@
    local.get $4
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $19
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $19
@@ -12760,11 +12768,11 @@
    local.get $4
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $20
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $20
@@ -12772,11 +12780,11 @@
    local.get $4
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $21
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $21
@@ -12784,11 +12792,11 @@
    local.get $4
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $22
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $22
@@ -12805,58 +12813,58 @@
   i32.const 2064
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 4
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $23
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $23
   if
-   local.get $1
+   local.get $0
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $24
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $24
   if
-   local.get $1
+   local.get $0
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $25
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $25
   if
-   local.get $1
+   local.get $0
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $5
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $5
@@ -12874,7 +12882,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $5
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $5
   i32.load offset=12
@@ -12884,11 +12892,11 @@
    local.get $5
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $26
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $26
@@ -12896,11 +12904,11 @@
    local.get $5
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $27
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $27
@@ -12908,11 +12916,11 @@
    local.get $5
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $28
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $28
@@ -12920,11 +12928,11 @@
    local.get $5
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $29
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $29
@@ -12941,46 +12949,46 @@
   i32.const 1280
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $30
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $30
   if
-   local.get $1
+   local.get $0
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $31
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $31
   if
-   local.get $1
+   local.get $0
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $11
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $11
@@ -12997,10 +13005,10 @@
   i32.const 1280
   i32.const 0
   call $~lib/string/String#split
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.load offset=12
   if
    i32.const 0
@@ -13015,7 +13023,7 @@
   i32.const 1
   call $~lib/string/String#split
   local.set $11
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $11
   i32.load offset=12
@@ -13025,11 +13033,11 @@
    local.get $11
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $32
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $32
@@ -13046,22 +13054,22 @@
   i32.const 2064
   i32.const 1
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $11
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $7
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $7
@@ -13079,7 +13087,7 @@
   i32.const 4
   call $~lib/string/String#split
   local.set $7
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $7
   i32.load offset=12
@@ -13089,11 +13097,11 @@
    local.get $7
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $33
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $33
@@ -13101,11 +13109,11 @@
    local.get $7
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $34
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $34
@@ -13113,11 +13121,11 @@
    local.get $7
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $8
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $8
@@ -13145,11 +13153,11 @@
    local.get $8
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $35
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $35
@@ -13157,11 +13165,11 @@
    local.get $8
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $36
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $36
@@ -13169,11 +13177,11 @@
    local.get $8
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $37
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $37
@@ -13190,46 +13198,46 @@
   i32.const 2064
   i32.const -1
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $38
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $38
   if
-   local.get $1
+   local.get $0
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $39
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $39
   if
-   local.get $1
+   local.get $0
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $40
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $40
@@ -13242,7 +13250,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 10
@@ -16033,7 +16041,7 @@
   end
   f64.const 1.1e-64
   call $~lib/util/number/dtoa
-  local.tee $1
+  local.tee $0
   i32.const 21408
   call $~lib/string/String.__eq
   i32.eqz
@@ -16047,7 +16055,7 @@
   end
   f64.const 0.000035689
   call $~lib/util/number/dtoa
-  local.tee $0
+  local.tee $1
   i32.const 21440
   call $~lib/string/String.__eq
   i32.eqz
@@ -16651,9 +16659,9 @@
   call $~lib/rt/pure/__release
   local.get $40
   call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/string/getString (result i32)

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -7916,12 +7916,12 @@
    i32.const -1
    i32.const 0
    global.get $std/string/str
-   local.tee $1
+   local.tee $0
    call $~lib/string/String#get:length
    i32.ge_u
    br_if $__inlined_func$~lib/string/String#charCodeAt
    drop
-   local.get $1
+   local.get $0
    i32.load16_u
   end
   i32.const 104
@@ -8079,14 +8079,14 @@
   global.get $std/string/str
   local.set $12
   i32.const 1616
-  local.tee $0
-  i32.eqz
-  if
+  if (result i32)
+   i32.const 1616
+  else
    i32.const 1616
    call $~lib/rt/pure/__release
-   i32.const 1648
-   local.set $0
+   i32.const 0
   end
+  drop
   block $__inlined_func$~lib/string/String#startsWith
    i32.const 0
    local.get $12
@@ -8097,30 +8097,30 @@
    i32.lt_s
    select
    local.tee $9
-   local.get $0
+   i32.const 1616
    call $~lib/string/String#get:length
-   local.tee $1
+   local.tee $0
    i32.add
    local.get $3
    i32.gt_s
    if
-    local.get $0
+    i32.const 1616
     call $~lib/rt/pure/__release
     i32.const 0
-    local.set $1
+    local.set $0
     br $__inlined_func$~lib/string/String#startsWith
    end
    local.get $12
    local.get $9
+   i32.const 1616
    local.get $0
-   local.get $1
    call $~lib/util/string/compareImpl
    i32.eqz
-   local.set $1
-   local.get $0
+   local.set $0
+   i32.const 1616
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $0
   i32.eqz
   if
    i32.const 0
@@ -8130,41 +8130,42 @@
    call $~lib/builtins/abort
    unreachable
   end
+  global.get $std/string/str
+  local.set $9
   block $__inlined_func$~lib/string/String#endsWith
    i32.const 536870904
-   global.get $std/string/str
-   local.tee $9
+   local.get $9
    call $~lib/string/String#get:length
-   local.tee $1
+   local.tee $0
    i32.const 536870904
-   local.get $1
+   local.get $0
    i32.lt_s
    select
    i32.const 1680
    call $~lib/string/String#get:length
-   local.tee $0
-   i32.sub
    local.tee $1
+   i32.sub
+   local.tee $0
    i32.const 0
    i32.lt_s
    if
     i32.const 1680
     call $~lib/rt/pure/__release
     i32.const 0
-    local.set $1
+    local.set $0
     br $__inlined_func$~lib/string/String#endsWith
    end
    local.get $9
-   local.get $1
-   i32.const 1680
    local.get $0
+   i32.const 1680
+   local.get $1
    call $~lib/util/string/compareImpl
    i32.eqz
-   local.set $1
+   local.set $0
    i32.const 1680
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $0
   i32.eqz
   if
    i32.const 0
@@ -10990,9 +10991,9 @@
   i32.const 1328
   i32.const 11392
   call $~lib/string/String.__concat
-  local.tee $1
-  call $~lib/rt/pure/__retain
   local.tee $0
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 11424
   call $~lib/string/String.__eq
   i32.eqz
@@ -11004,7 +11005,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1328
   call $~lib/string/String.__ne
   i32.eqz
@@ -11016,9 +11017,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 1280
   i32.const 1280
@@ -11369,9 +11370,9 @@
   call $~lib/string/String.fromCodePoint
   local.tee $9
   call $~lib/string/String.__concat
-  local.tee $0
-  call $~lib/rt/pure/__retain
   local.tee $1
+  call $~lib/rt/pure/__retain
+  local.tee $0
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -11388,9 +11389,9 @@
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   call $~lib/rt/pure/__release
   i32.const 1872
   call $~lib/string/String#get:length
@@ -12523,19 +12524,19 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/string/String#split
-  local.tee $0
+  local.tee $1
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $10
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $10
@@ -12552,10 +12553,10 @@
   i32.const 1280
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.load offset=12
   if
    i32.const 0
@@ -12570,7 +12571,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $10
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $10
   i32.load offset=12
@@ -12580,11 +12581,11 @@
    local.get $10
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $13
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $13
@@ -12601,22 +12602,22 @@
   i32.const 5744
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 13360
    call $~lib/string/String.__eq
    local.set $6
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $6
@@ -12634,7 +12635,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $6
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $6
   i32.load offset=12
@@ -12644,11 +12645,11 @@
    local.get $6
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $14
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $14
@@ -12656,11 +12657,11 @@
    local.get $6
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $15
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $15
@@ -12668,11 +12669,11 @@
    local.get $6
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $16
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $16
@@ -12689,46 +12690,46 @@
   i32.const 13424
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $17
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $17
   if
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $18
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $18
   if
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $4
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $4
@@ -12746,7 +12747,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $4
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $4
   i32.load offset=12
@@ -12756,11 +12757,11 @@
    local.get $4
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $19
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $19
@@ -12768,11 +12769,11 @@
    local.get $4
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $20
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $20
@@ -12780,11 +12781,11 @@
    local.get $4
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $21
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $21
@@ -12792,11 +12793,11 @@
    local.get $4
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $22
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $22
@@ -12813,58 +12814,58 @@
   i32.const 2064
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 4
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $23
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $23
   if
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $24
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $24
   if
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $25
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $25
   if
-   local.get $0
+   local.get $1
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $5
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $5
@@ -12882,7 +12883,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $5
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $5
   i32.load offset=12
@@ -12892,11 +12893,11 @@
    local.get $5
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $26
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $26
@@ -12904,11 +12905,11 @@
    local.get $5
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $27
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $27
@@ -12916,11 +12917,11 @@
    local.get $5
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $28
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $28
@@ -12928,11 +12929,11 @@
    local.get $5
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $29
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $29
@@ -12949,46 +12950,46 @@
   i32.const 1280
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $30
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $30
   if
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $31
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $31
   if
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $11
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $11
@@ -13005,10 +13006,10 @@
   i32.const 1280
   i32.const 0
   call $~lib/string/String#split
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.load offset=12
   if
    i32.const 0
@@ -13023,7 +13024,7 @@
   i32.const 1
   call $~lib/string/String#split
   local.set $11
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $11
   i32.load offset=12
@@ -13033,11 +13034,11 @@
    local.get $11
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $32
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $32
@@ -13054,22 +13055,22 @@
   i32.const 2064
   i32.const 1
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $11
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $7
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $7
@@ -13087,7 +13088,7 @@
   i32.const 4
   call $~lib/string/String#split
   local.set $7
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $7
   i32.load offset=12
@@ -13097,11 +13098,11 @@
    local.get $7
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $33
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $33
@@ -13109,11 +13110,11 @@
    local.get $7
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $34
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $34
@@ -13121,11 +13122,11 @@
    local.get $7
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $8
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $8
@@ -13153,11 +13154,11 @@
    local.get $8
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $35
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $35
@@ -13165,11 +13166,11 @@
    local.get $8
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $36
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $36
@@ -13177,11 +13178,11 @@
    local.get $8
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $37
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $37
@@ -13198,46 +13199,46 @@
   i32.const 2064
   i32.const -1
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $38
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $38
   if
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $39
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $39
   if
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $40
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $40
@@ -13250,7 +13251,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 10
@@ -16041,7 +16042,7 @@
   end
   f64.const 1.1e-64
   call $~lib/util/number/dtoa
-  local.tee $0
+  local.tee $1
   i32.const 21408
   call $~lib/string/String.__eq
   i32.eqz
@@ -16055,7 +16056,7 @@
   end
   f64.const 0.000035689
   call $~lib/util/number/dtoa
-  local.tee $1
+  local.tee $0
   i32.const 21440
   call $~lib/string/String.__eq
   i32.eqz
@@ -16659,9 +16660,9 @@
   call $~lib/rt/pure/__release
   local.get $40
   call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   call $~lib/rt/pure/__release
  )
  (func $std/string/getString (result i32)

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -7916,12 +7916,12 @@
    i32.const -1
    i32.const 0
    global.get $std/string/str
-   local.tee $1
+   local.tee $0
    call $~lib/string/String#get:length
    i32.ge_u
    br_if $__inlined_func$~lib/string/String#charCodeAt
    drop
-   local.get $1
+   local.get $0
    i32.load16_u
   end
   i32.const 104
@@ -8078,16 +8078,6 @@
   end
   global.get $std/string/str
   local.set $12
-  i32.const 1616
-  local.tee $0
-  if (result i32)
-   i32.const 1616
-  else
-   i32.const 1616
-   call $~lib/rt/pure/__release
-   i32.const 1648
-  end
-  local.set $0
   block $__inlined_func$~lib/string/String#startsWith
    i32.const 0
    local.get $12
@@ -8100,7 +8090,7 @@
    local.tee $9
    i32.const 1616
    call $~lib/string/String#get:length
-   local.tee $1
+   local.tee $0
    i32.add
    local.get $3
    i32.gt_s
@@ -8108,20 +8098,20 @@
     i32.const 1616
     call $~lib/rt/pure/__release
     i32.const 0
-    local.set $1
+    local.set $0
     br $__inlined_func$~lib/string/String#startsWith
    end
    local.get $12
    local.get $9
    i32.const 1616
-   local.get $1
+   local.get $0
    call $~lib/util/string/compareImpl
    i32.eqz
-   local.set $1
+   local.set $0
    i32.const 1616
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $0
   i32.eqz
   if
    i32.const 0
@@ -8137,36 +8127,36 @@
    i32.const 536870904
    local.get $9
    call $~lib/string/String#get:length
-   local.tee $1
+   local.tee $0
    i32.const 536870904
-   local.get $1
+   local.get $0
    i32.lt_s
    select
    i32.const 1680
    call $~lib/string/String#get:length
-   local.tee $0
-   i32.sub
    local.tee $1
+   i32.sub
+   local.tee $0
    i32.const 0
    i32.lt_s
    if
     i32.const 1680
     call $~lib/rt/pure/__release
     i32.const 0
-    local.set $1
+    local.set $0
     br $__inlined_func$~lib/string/String#endsWith
    end
    local.get $9
-   local.get $1
-   i32.const 1680
    local.get $0
+   i32.const 1680
+   local.get $1
    call $~lib/util/string/compareImpl
    i32.eqz
-   local.set $1
+   local.set $0
    i32.const 1680
    call $~lib/rt/pure/__release
   end
-  local.get $1
+  local.get $0
   i32.eqz
   if
    i32.const 0
@@ -10992,9 +10982,9 @@
   i32.const 1328
   i32.const 11392
   call $~lib/string/String.__concat
-  local.tee $1
-  call $~lib/rt/pure/__retain
   local.tee $0
+  call $~lib/rt/pure/__retain
+  local.tee $1
   i32.const 11424
   call $~lib/string/String.__eq
   i32.eqz
@@ -11006,7 +10996,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1328
   call $~lib/string/String.__ne
   i32.eqz
@@ -11018,9 +11008,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 1280
   i32.const 1280
@@ -11371,9 +11361,9 @@
   call $~lib/string/String.fromCodePoint
   local.tee $9
   call $~lib/string/String.__concat
-  local.tee $0
-  call $~lib/rt/pure/__retain
   local.tee $1
+  call $~lib/rt/pure/__retain
+  local.tee $0
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -11390,9 +11380,9 @@
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   call $~lib/rt/pure/__release
   i32.const 1872
   call $~lib/string/String#get:length
@@ -12525,19 +12515,19 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/string/String#split
-  local.tee $0
+  local.tee $1
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $10
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $10
@@ -12554,10 +12544,10 @@
   i32.const 1280
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.load offset=12
   if
    i32.const 0
@@ -12572,7 +12562,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $10
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $10
   i32.load offset=12
@@ -12582,11 +12572,11 @@
    local.get $10
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $13
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $13
@@ -12603,22 +12593,22 @@
   i32.const 5744
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 13360
    call $~lib/string/String.__eq
    local.set $6
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $6
@@ -12636,7 +12626,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $6
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $6
   i32.load offset=12
@@ -12646,11 +12636,11 @@
    local.get $6
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $14
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $14
@@ -12658,11 +12648,11 @@
    local.get $6
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $15
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $15
@@ -12670,11 +12660,11 @@
    local.get $6
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $16
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $16
@@ -12691,46 +12681,46 @@
   i32.const 13424
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $17
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $17
   if
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $18
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $18
   if
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $4
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $4
@@ -12748,7 +12738,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $4
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $4
   i32.load offset=12
@@ -12758,11 +12748,11 @@
    local.get $4
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $19
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $19
@@ -12770,11 +12760,11 @@
    local.get $4
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $20
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $20
@@ -12782,11 +12772,11 @@
    local.get $4
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $21
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $21
@@ -12794,11 +12784,11 @@
    local.get $4
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $22
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $22
@@ -12815,58 +12805,58 @@
   i32.const 2064
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 4
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $23
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $23
   if
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $24
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $24
   if
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $25
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $25
   if
-   local.get $0
+   local.get $1
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $5
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $5
@@ -12884,7 +12874,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $5
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $5
   i32.load offset=12
@@ -12894,11 +12884,11 @@
    local.get $5
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $26
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $26
@@ -12906,11 +12896,11 @@
    local.get $5
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $27
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $27
@@ -12918,11 +12908,11 @@
    local.get $5
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $28
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $28
@@ -12930,11 +12920,11 @@
    local.get $5
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $29
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $29
@@ -12951,46 +12941,46 @@
   i32.const 1280
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $30
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $30
   if
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $31
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $31
   if
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $11
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $11
@@ -13007,10 +12997,10 @@
   i32.const 1280
   i32.const 0
   call $~lib/string/String#split
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.load offset=12
   if
    i32.const 0
@@ -13025,7 +13015,7 @@
   i32.const 1
   call $~lib/string/String#split
   local.set $11
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $11
   i32.load offset=12
@@ -13035,11 +13025,11 @@
    local.get $11
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $32
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $32
@@ -13056,22 +13046,22 @@
   i32.const 2064
   i32.const 1
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $11
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $7
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $7
@@ -13089,7 +13079,7 @@
   i32.const 4
   call $~lib/string/String#split
   local.set $7
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $7
   i32.load offset=12
@@ -13099,11 +13089,11 @@
    local.get $7
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $33
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $33
@@ -13111,11 +13101,11 @@
    local.get $7
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $34
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $34
@@ -13123,11 +13113,11 @@
    local.get $7
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $8
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $8
@@ -13155,11 +13145,11 @@
    local.get $8
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $35
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $35
@@ -13167,11 +13157,11 @@
    local.get $8
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $36
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $36
@@ -13179,11 +13169,11 @@
    local.get $8
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $37
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $37
@@ -13200,46 +13190,46 @@
   i32.const 2064
   i32.const -1
   call $~lib/string/String#split
-  local.set $0
+  local.set $1
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $38
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $38
   if
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $39
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $39
   if
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $1
+   local.tee $0
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $40
-   local.get $1
+   local.get $0
    call $~lib/rt/pure/__release
   end
   local.get $40
@@ -13252,7 +13242,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 10
@@ -16043,7 +16033,7 @@
   end
   f64.const 1.1e-64
   call $~lib/util/number/dtoa
-  local.tee $0
+  local.tee $1
   i32.const 21408
   call $~lib/string/String.__eq
   i32.eqz
@@ -16057,7 +16047,7 @@
   end
   f64.const 0.000035689
   call $~lib/util/number/dtoa
-  local.tee $1
+  local.tee $0
   i32.const 21440
   call $~lib/string/String.__eq
   i32.eqz
@@ -16661,9 +16651,9 @@
   call $~lib/rt/pure/__release
   local.get $40
   call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   call $~lib/rt/pure/__release
  )
  (func $std/string/getString (result i32)

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -863,7 +863,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -883,35 +883,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -921,12 +921,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -934,7 +934,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -953,42 +953,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -1003,12 +1005,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -1018,38 +1020,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -1067,7 +1069,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -1076,21 +1078,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -1117,7 +1119,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -1359,22 +1361,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz
@@ -2655,7 +2656,7 @@
    local.get $1
    i32.const 45
    i32.eq
-   if
+   if (result i32)
     local.get $0
     i32.const 1
     i32.sub
@@ -2669,12 +2670,11 @@
     i32.add
     local.tee $2
     i32.load16_u
-    local.set $1
    else
     local.get $1
     i32.const 43
     i32.eq
-    if
+    if (result i32)
      local.get $0
      i32.const 1
      i32.sub
@@ -2686,9 +2686,11 @@
      i32.add
      local.tee $2
      i32.load16_u
-     local.set $1
+    else
+     local.get $1
     end
    end
+   local.set $1
    local.get $0
    i32.const 2
    i32.gt_s
@@ -2882,7 +2884,7 @@
    local.get $1
    i32.const 45
    i32.eq
-   if
+   if (result i32)
     local.get $0
     i32.const 1
     i32.sub
@@ -2896,12 +2898,11 @@
     i32.add
     local.tee $2
     i32.load16_u
-    local.set $1
    else
     local.get $1
     i32.const 43
     i32.eq
-    if
+    if (result i32)
      local.get $0
      i32.const 1
      i32.sub
@@ -2913,9 +2914,11 @@
      i32.add
      local.tee $2
      i32.load16_u
-     local.set $1
+    else
+     local.get $1
     end
    end
+   local.set $1
    local.get $0
    i32.const 2
    i32.gt_s
@@ -3098,7 +3101,7 @@
    local.get $1
    i32.const 45
    i32.eq
-   if
+   if (result i32)
     local.get $0
     i32.const 1
     i32.sub
@@ -3112,12 +3115,11 @@
     i32.add
     local.tee $2
     i32.load16_u
-    local.set $1
    else
     local.get $1
     i32.const 43
     i32.eq
-    if
+    if (result i32)
      local.get $0
      i32.const 1
      i32.sub
@@ -3129,9 +3131,11 @@
      i32.add
      local.tee $2
      i32.load16_u
-     local.set $1
+    else
+     local.get $1
     end
    end
+   local.set $1
    local.get $0
    i32.const 2
    i32.gt_s
@@ -4760,13 +4764,13 @@
   block $folding-inner0
    local.get $0
    call $~lib/string/String#get:length
-   local.tee $3
+   local.tee $4
    local.get $7
    call $~lib/string/String#get:length
    local.tee $10
    i32.le_u
    if
-    local.get $3
+    local.get $4
     local.get $10
     i32.lt_u
     if (result i32)
@@ -4798,9 +4802,9 @@
      local.set $0
      br $folding-inner0
     end
-    local.get $3
+    local.get $4
     local.get $2
-    local.get $3
+    local.get $4
     i32.const 1
     i32.add
     i32.mul
@@ -4809,7 +4813,7 @@
     i32.shl
     i32.const 1
     call $~lib/rt/tlsf/__alloc
-    local.tee $4
+    local.tee $3
     local.get $5
     local.get $2
     i32.const 1
@@ -4819,10 +4823,10 @@
     local.set $1
     loop $for-loop|0
      local.get $9
-     local.get $3
+     local.get $4
      i32.lt_u
      if
-      local.get $4
+      local.get $3
       local.get $1
       i32.const 1
       i32.shl
@@ -4834,7 +4838,7 @@
       i32.add
       i32.load16_u
       i32.store16
-      local.get $4
+      local.get $3
       local.get $1
       i32.const 1
       i32.add
@@ -4858,7 +4862,7 @@
       br $for-loop|0
      end
     end
-    local.get $4
+    local.get $3
     call $~lib/rt/pure/__retain
     local.set $0
     br $folding-inner0
@@ -4867,27 +4871,27 @@
    local.get $10
    i32.eq
    if
-    local.get $3
+    local.get $4
     i32.const 1
     i32.shl
-    local.tee $3
+    local.tee $4
     i32.const 1
     call $~lib/rt/tlsf/__alloc
     local.tee $1
     local.get $0
-    local.get $3
+    local.get $4
     call $~lib/memory/memory.copy
     loop $while-continue|1
      local.get $0
      local.get $7
      local.get $6
      call $~lib/string/String#indexOf
-     local.tee $3
+     local.tee $4
      i32.const -1
      i32.xor
      if
       local.get $1
-      local.get $3
+      local.get $4
       i32.const 1
       i32.shl
       i32.add
@@ -4896,7 +4900,7 @@
       i32.const 1
       i32.shl
       call $~lib/memory/memory.copy
-      local.get $3
+      local.get $4
       local.get $10
       i32.add
       local.set $6
@@ -4908,7 +4912,7 @@
     local.set $0
     br $folding-inner0
    end
-   local.get $3
+   local.get $4
    local.set $1
    loop $while-continue|2
     local.get $0
@@ -4919,21 +4923,21 @@
     i32.const -1
     i32.xor
     if
-     local.get $4
+     local.get $3
      i32.eqz
      if
-      local.get $3
+      local.get $4
       i32.const 1
       i32.shl
       i32.const 1
       call $~lib/rt/tlsf/__alloc
-      local.set $4
+      local.set $3
      end
      local.get $8
      local.get $1
      i32.gt_u
      if
-      local.get $4
+      local.get $3
       local.get $1
       i32.const 1
       i32.shl
@@ -4941,9 +4945,9 @@
       i32.const 1
       i32.shl
       call $~lib/rt/tlsf/__realloc
-      local.set $4
+      local.set $3
      end
-     local.get $4
+     local.get $3
      local.get $8
      i32.const 1
      i32.shl
@@ -4960,7 +4964,7 @@
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $4
+     local.get $3
      local.get $6
      local.get $8
      i32.add
@@ -4990,7 +4994,7 @@
     local.get $1
     i32.gt_u
     if
-     local.get $4
+     local.get $3
      local.get $1
      i32.const 1
      i32.shl
@@ -4998,14 +5002,14 @@
      i32.const 1
      i32.shl
      call $~lib/rt/tlsf/__realloc
-     local.set $4
+     local.set $3
     end
-    local.get $3
+    local.get $4
     local.get $6
     i32.sub
     local.tee $2
     if
-     local.get $4
+     local.get $3
      local.get $8
      i32.const 1
      i32.shl
@@ -5027,13 +5031,13 @@
     local.tee $0
     i32.gt_u
     if (result i32)
-     local.get $4
+     local.get $3
      local.get $0
      i32.const 1
      i32.shl
      call $~lib/rt/tlsf/__realloc
     else
-     local.get $4
+     local.get $3
     end
     call $~lib/rt/pure/__retain
     local.set $0
@@ -7912,12 +7916,12 @@
    i32.const -1
    i32.const 0
    global.get $std/string/str
-   local.tee $0
+   local.tee $1
    call $~lib/string/String#get:length
    i32.ge_u
    br_if $__inlined_func$~lib/string/String#charCodeAt
    drop
-   local.get $0
+   local.get $1
    i32.load16_u
   end
   i32.const 104
@@ -8075,14 +8079,15 @@
   global.get $std/string/str
   local.set $12
   i32.const 1616
-  local.tee $1
-  i32.eqz
-  if
+  local.tee $0
+  if (result i32)
+   i32.const 1616
+  else
    i32.const 1616
    call $~lib/rt/pure/__release
    i32.const 1648
-   local.set $1
   end
+  local.set $0
   block $__inlined_func$~lib/string/String#startsWith
    i32.const 0
    local.get $12
@@ -8093,30 +8098,30 @@
    i32.lt_s
    select
    local.tee $9
-   local.get $1
+   i32.const 1616
    call $~lib/string/String#get:length
-   local.tee $0
+   local.tee $1
    i32.add
    local.get $3
    i32.gt_s
    if
-    local.get $1
+    i32.const 1616
     call $~lib/rt/pure/__release
     i32.const 0
-    local.set $0
+    local.set $1
     br $__inlined_func$~lib/string/String#startsWith
    end
    local.get $12
    local.get $9
+   i32.const 1616
    local.get $1
-   local.get $0
    call $~lib/util/string/compareImpl
    i32.eqz
-   local.set $0
-   local.get $1
+   local.set $1
+   i32.const 1616
    call $~lib/rt/pure/__release
   end
-  local.get $0
+  local.get $1
   i32.eqz
   if
    i32.const 0
@@ -8132,36 +8137,36 @@
    i32.const 536870904
    local.get $9
    call $~lib/string/String#get:length
-   local.tee $0
+   local.tee $1
    i32.const 536870904
-   local.get $0
+   local.get $1
    i32.lt_s
    select
    i32.const 1680
    call $~lib/string/String#get:length
-   local.tee $1
-   i32.sub
    local.tee $0
+   i32.sub
+   local.tee $1
    i32.const 0
    i32.lt_s
    if
     i32.const 1680
     call $~lib/rt/pure/__release
     i32.const 0
-    local.set $0
+    local.set $1
     br $__inlined_func$~lib/string/String#endsWith
    end
    local.get $9
-   local.get $0
-   i32.const 1680
    local.get $1
+   i32.const 1680
+   local.get $0
    call $~lib/util/string/compareImpl
    i32.eqz
-   local.set $0
+   local.set $1
    i32.const 1680
    call $~lib/rt/pure/__release
   end
-  local.get $0
+  local.get $1
   i32.eqz
   if
    i32.const 0
@@ -10987,9 +10992,9 @@
   i32.const 1328
   i32.const 11392
   call $~lib/string/String.__concat
-  local.tee $0
-  call $~lib/rt/pure/__retain
   local.tee $1
+  call $~lib/rt/pure/__retain
+  local.tee $0
   i32.const 11424
   call $~lib/string/String.__eq
   i32.eqz
@@ -11001,7 +11006,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1328
   call $~lib/string/String.__ne
   i32.eqz
@@ -11013,9 +11018,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/rt/pure/__release
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   call $~lib/rt/pure/__release
   i32.const 1280
   i32.const 1280
@@ -11366,9 +11371,9 @@
   call $~lib/string/String.fromCodePoint
   local.tee $9
   call $~lib/string/String.__concat
-  local.tee $1
-  call $~lib/rt/pure/__retain
   local.tee $0
+  call $~lib/rt/pure/__retain
+  local.tee $1
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -11385,9 +11390,9 @@
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 1872
   call $~lib/string/String#get:length
@@ -12520,19 +12525,19 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/string/String#split
-  local.tee $1
+  local.tee $0
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $10
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $10
@@ -12549,10 +12554,10 @@
   i32.const 1280
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.load offset=12
   if
    i32.const 0
@@ -12567,7 +12572,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $10
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $10
   i32.load offset=12
@@ -12577,11 +12582,11 @@
    local.get $10
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $13
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $13
@@ -12598,22 +12603,22 @@
   i32.const 5744
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 13360
    call $~lib/string/String.__eq
    local.set $6
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $6
@@ -12631,7 +12636,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $6
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $6
   i32.load offset=12
@@ -12641,11 +12646,11 @@
    local.get $6
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $14
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $14
@@ -12653,11 +12658,11 @@
    local.get $6
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $15
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $15
@@ -12665,11 +12670,11 @@
    local.get $6
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $16
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $16
@@ -12686,46 +12691,46 @@
   i32.const 13424
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $17
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $17
   if
-   local.get $1
+   local.get $0
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $18
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $18
   if
-   local.get $1
+   local.get $0
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $4
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $4
@@ -12743,7 +12748,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $4
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $4
   i32.load offset=12
@@ -12753,11 +12758,11 @@
    local.get $4
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $19
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $19
@@ -12765,11 +12770,11 @@
    local.get $4
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $20
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $20
@@ -12777,11 +12782,11 @@
    local.get $4
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $21
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $21
@@ -12789,11 +12794,11 @@
    local.get $4
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $22
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $22
@@ -12810,58 +12815,58 @@
   i32.const 2064
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 4
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $23
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $23
   if
-   local.get $1
+   local.get $0
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $24
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $24
   if
-   local.get $1
+   local.get $0
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $25
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $25
   if
-   local.get $1
+   local.get $0
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $5
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $5
@@ -12879,7 +12884,7 @@
   i32.const 2147483647
   call $~lib/string/String#split
   local.set $5
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $5
   i32.load offset=12
@@ -12889,11 +12894,11 @@
    local.get $5
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $26
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $26
@@ -12901,11 +12906,11 @@
    local.get $5
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $27
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $27
@@ -12913,11 +12918,11 @@
    local.get $5
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $28
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $28
@@ -12925,11 +12930,11 @@
    local.get $5
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1280
    call $~lib/string/String.__eq
    local.set $29
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $29
@@ -12946,46 +12951,46 @@
   i32.const 1280
   i32.const 2147483647
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $30
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $30
   if
-   local.get $1
+   local.get $0
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $31
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $31
   if
-   local.get $1
+   local.get $0
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $11
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $11
@@ -13002,10 +13007,10 @@
   i32.const 1280
   i32.const 0
   call $~lib/string/String#split
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.load offset=12
   if
    i32.const 0
@@ -13020,7 +13025,7 @@
   i32.const 1
   call $~lib/string/String#split
   local.set $11
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   local.get $11
   i32.load offset=12
@@ -13030,11 +13035,11 @@
    local.get $11
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $32
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $32
@@ -13051,22 +13056,22 @@
   i32.const 2064
   i32.const 1
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $11
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 1
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $7
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $7
@@ -13084,7 +13089,7 @@
   i32.const 4
   call $~lib/string/String#split
   local.set $7
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $7
   i32.load offset=12
@@ -13094,11 +13099,11 @@
    local.get $7
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $33
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $33
@@ -13106,11 +13111,11 @@
    local.get $7
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $34
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $34
@@ -13118,11 +13123,11 @@
    local.get $7
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $8
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $8
@@ -13150,11 +13155,11 @@
    local.get $8
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $35
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $35
@@ -13162,11 +13167,11 @@
    local.get $8
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $36
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $36
@@ -13174,11 +13179,11 @@
    local.get $8
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $37
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $37
@@ -13195,46 +13200,46 @@
   i32.const 2064
   i32.const -1
   call $~lib/string/String#split
-  local.set $1
+  local.set $0
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.load offset=12
   i32.const 3
   i32.eq
   if
-   local.get $1
+   local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 1328
    call $~lib/string/String.__eq
    local.set $38
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $38
   if
-   local.get $1
+   local.get $0
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 11392
    call $~lib/string/String.__eq
    local.set $39
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $39
   if
-   local.get $1
+   local.get $0
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $0
+   local.tee $1
    i32.const 12240
    call $~lib/string/String.__eq
    local.set $40
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $40
@@ -13247,7 +13252,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 10
@@ -16038,7 +16043,7 @@
   end
   f64.const 1.1e-64
   call $~lib/util/number/dtoa
-  local.tee $1
+  local.tee $0
   i32.const 21408
   call $~lib/string/String.__eq
   i32.eqz
@@ -16052,7 +16057,7 @@
   end
   f64.const 0.000035689
   call $~lib/util/number/dtoa
-  local.tee $0
+  local.tee $1
   i32.const 21440
   call $~lib/string/String.__eq
   i32.eqz
@@ -16656,9 +16661,9 @@
   call $~lib/rt/pure/__release
   local.get $40
   call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   call $~lib/rt/pure/__release
  )
  (func $std/string/getString (result i32)

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -28213,6 +28213,77 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  i32.const 4656
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.load offset=12
+  i32.const 3
+  i32.add
+  local.get $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.gt_s
+  if
+   i32.const 1376
+   i32.const 1440
+   i32.const 1775
+   i32.const 47
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 24
+  i32.add
+  local.set $3
+  local.get $2
+  i32.load offset=4
+  local.set $4
+  local.get $2
+  i32.load offset=12
+  local.set $5
+  loop $for-loop|0
+   local.get $1
+   local.get $5
+   i32.lt_s
+   if
+    local.get $3
+    local.get $1
+    i32.const 3
+    i32.shl
+    i32.add
+    local.get $4
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    f64.promote_f32
+    f64.store
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  i32.const 4656
+  call $~lib/rt/pure/__release
+ )
  (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -28387,15 +28458,15 @@
   (local $14 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $7
+  local.tee $6
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $7
+  local.get $6
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $7
+  local.get $6
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -28419,51 +28490,51 @@
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $8
+  local.tee $7
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $8
+  local.get $7
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $8
+  local.get $7
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $13
+  local.tee $14
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $1
   call $~lib/rt/pure/__retain
-  local.set $1
-  block $folding-inner1
+  local.set $2
+  block $folding-inner0
    i32.const 4592
    call $~lib/rt/pure/__retain
-   local.tee $2
+   local.tee $3
    i32.load offset=12
-   local.get $1
+   local.get $2
    i32.load offset=8
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner1
-   local.get $1
-   i32.load offset=4
-   local.set $4
+   br_if $folding-inner0
    local.get $2
+   i32.load offset=4
+   local.set $8
+   local.get $3
    i32.load offset=4
    local.set $9
-   local.get $2
+   local.get $3
    i32.load offset=12
-   local.set $6
+   local.set $10
    loop $for-loop|0
     local.get $0
-    local.get $6
+    local.get $10
     i32.lt_s
     if
-     local.get $4
+     local.get $8
      local.get $0
      i32.const 3
      i32.shl
@@ -28483,93 +28554,36 @@
      br $for-loop|0
     end
    end
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__release
    i32.const 4592
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $1
    i32.const 10
    i32.const 3
    i32.const 17
    i32.const 8144
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $9
+   local.tee $8
    call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
-   i32.const 0
-   local.set $0
-   local.get $3
-   call $~lib/rt/pure/__retain
-   local.set $1
-   i32.const 4656
-   call $~lib/rt/pure/__retain
-   local.tee $2
-   i32.load offset=12
-   i32.const 3
-   i32.add
    local.get $1
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner1
+   call $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>>
    local.get $1
-   i32.load offset=4
-   i32.const 24
-   i32.add
-   local.set $4
-   local.get $2
-   i32.load offset=4
-   local.set $6
-   local.get $2
-   i32.load offset=12
-   local.set $10
-   loop $for-loop|00
-    local.get $0
-    local.get $10
-    i32.lt_s
-    if
-     local.get $4
-     local.get $0
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $6
-     local.get $0
-     i32.const 2
-     i32.shl
-     i32.add
-     f32.load
-     f64.promote_f32
-     f64.store
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $for-loop|00
-    end
-   end
-   local.get $2
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
-   i32.const 4656
-   call $~lib/rt/pure/__release
-   local.get $3
    i32.const 10
    i32.const 3
    i32.const 17
    i32.const 8288
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $6
+   local.tee $9
    call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
-   local.get $3
-   local.get $7
+   local.get $1
+   local.get $6
    call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array>
-   local.get $3
+   local.get $1
    i32.const 10
    i32.const 3
    i32.const 17
@@ -28583,31 +28597,31 @@
    local.get $5
    call $~lib/rt/pure/__retain
    local.set $4
-   local.get $3
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $2
    local.get $4
    call $~lib/rt/pure/__retain
-   local.tee $2
+   local.tee $3
    i32.load offset=8
-   local.get $1
+   local.get $2
    i32.load offset=8
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner1
-   local.get $1
+   br_if $folding-inner0
+   local.get $2
    i32.load offset=4
    local.set $11
-   local.get $2
+   local.get $3
    i32.load offset=4
    local.set $12
-   local.get $2
+   local.get $3
    i32.load offset=8
-   local.set $14
-   loop $for-loop|001
+   local.set $13
+   loop $for-loop|00
     local.get $0
-    local.get $14
+    local.get $13
     i32.lt_s
     if
      local.get $11
@@ -28625,58 +28639,58 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|001
+     br $for-loop|00
     end
    end
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__release
    local.get $4
    call $~lib/rt/pure/__release
-   local.get $3
-   local.get $8
+   local.get $1
+   local.get $7
    call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array>
    i32.const 0
    local.set $0
-   local.get $3
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.set $1
+   local.set $2
    i32.const 4800
    call $~lib/rt/pure/__retain
-   local.tee $2
+   local.tee $3
    i32.load offset=12
    i32.const 7
    i32.add
-   local.get $1
+   local.get $2
    i32.load offset=8
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner1
-   local.get $1
+   br_if $folding-inner0
+   local.get $2
    i32.load offset=4
    i32.const 56
    i32.add
-   local.set $4
-   local.get $2
-   i32.load offset=4
    local.set $11
-   local.get $2
-   i32.load offset=12
+   local.get $3
+   i32.load offset=4
    local.set $12
+   local.get $3
+   i32.load offset=12
+   local.set $13
    loop $for-loop|01
     local.get $0
-    local.get $12
+    local.get $13
     i32.lt_s
     if
-     local.get $4
+     local.get $11
      local.get $0
      i32.const 3
      i32.shl
      i32.add
      local.get $0
-     local.get $11
+     local.get $12
      i32.add
      i32.load8_s
      f64.convert_i32_s
@@ -28688,13 +28702,13 @@
      br $for-loop|01
     end
    end
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__release
    i32.const 4800
    call $~lib/rt/pure/__release
-   local.get $3
+   local.get $1
    i32.const 10
    i32.const 3
    i32.const 17
@@ -28705,19 +28719,19 @@
    call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $7
+   local.get $6
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
+   local.get $7
+   call $~lib/rt/pure/__release
+   local.get $14
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
    local.get $8
    call $~lib/rt/pure/__release
-   local.get $13
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
    local.get $9
-   call $~lib/rt/pure/__release
-   local.get $6
    call $~lib/rt/pure/__release
    local.get $10
    call $~lib/rt/pure/__release

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -5976,12 +5976,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $2
+   local.get $1
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $2
+    local.get $1
     i32.const 2
     i32.shl
     i32.add
@@ -5994,27 +5994,27 @@
     i32.gt_s
     if
      local.get $5
-     local.get $1
+     local.get $2
      i32.const 2
      i32.shl
      i32.add
      local.get $6
      i32.store
-     local.get $1
+     local.get $2
      i32.const 1
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $2
+    local.get $1
     i32.const 1
     i32.add
-    local.set $2
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $1
+  local.get $2
   i32.const 2
   i32.shl
   local.tee $2
@@ -6167,12 +6167,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $2
+   local.get $1
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $2
+    local.get $1
     i32.const 2
     i32.shl
     i32.add
@@ -6185,27 +6185,27 @@
     i32.gt_u
     if
      local.get $5
-     local.get $1
+     local.get $2
      i32.const 2
      i32.shl
      i32.add
      local.get $6
      i32.store
-     local.get $1
+     local.get $2
      i32.const 1
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $2
+    local.get $1
     i32.const 1
     i32.add
-    local.set $2
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $1
+  local.get $2
   i32.const 2
   i32.shl
   local.tee $2
@@ -6358,12 +6358,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $2
+   local.get $1
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $2
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -6376,27 +6376,27 @@
     i64.gt_s
     if
      local.get $5
-     local.get $1
+     local.get $2
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      i64.store
-     local.get $1
+     local.get $2
      i32.const 1
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $2
+    local.get $1
     i32.const 1
     i32.add
-    local.set $2
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $1
+  local.get $2
   i32.const 3
   i32.shl
   local.tee $2
@@ -6549,12 +6549,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $2
+   local.get $1
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $2
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -6567,27 +6567,27 @@
     i64.gt_u
     if
      local.get $5
-     local.get $1
+     local.get $2
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      i64.store
-     local.get $1
+     local.get $2
      i32.const 1
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $2
+    local.get $1
     i32.const 1
     i32.add
-    local.set $2
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $1
+  local.get $2
   i32.const 3
   i32.shl
   local.tee $2
@@ -6740,12 +6740,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $2
+   local.get $1
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $2
+    local.get $1
     i32.const 2
     i32.shl
     i32.add
@@ -6758,27 +6758,27 @@
     f32.gt
     if
      local.get $5
-     local.get $1
+     local.get $2
      i32.const 2
      i32.shl
      i32.add
      local.get $6
      f32.store
-     local.get $1
+     local.get $2
      i32.const 1
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $2
+    local.get $1
     i32.const 1
     i32.add
-    local.set $2
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $1
+  local.get $2
   i32.const 2
   i32.shl
   local.tee $2
@@ -6931,12 +6931,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $2
+   local.get $1
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $2
+    local.get $1
     i32.const 3
     i32.shl
     i32.add
@@ -6949,27 +6949,27 @@
     f64.gt
     if
      local.get $5
-     local.get $1
+     local.get $2
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      f64.store
-     local.get $1
+     local.get $2
      i32.const 1
      i32.add
-     local.set $1
+     local.set $2
     end
-    local.get $2
+    local.get $1
     i32.const 1
     i32.add
-    local.set $2
+    local.set $1
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $1
+  local.get $2
   i32.const 3
   i32.shl
   local.tee $2

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -2347,66 +2347,66 @@
  (func $~lib/util/sort/insertionSort<f64> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f64)
+  (local $4 i32)
   (local $5 f64)
-  (local $6 i32)
+  (local $6 f64)
   loop $for-loop|0
-   local.get $6
+   local.get $4
    local.get $1
    i32.lt_s
    if
     local.get $0
-    local.get $6
+    local.get $4
     i32.const 3
     i32.shl
     i32.add
     f64.load
     local.set $5
-    local.get $6
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $2
     loop $while-continue|1
-     local.get $3
+     local.get $2
      i32.const 0
      i32.ge_s
      if
       block $while-break|1
        local.get $0
-       local.get $3
+       local.get $2
        i32.const 3
        i32.shl
        i32.add
        f64.load
-       local.set $4
+       local.set $6
        i32.const 2
        global.set $~argumentsLength
        local.get $5
-       local.get $4
+       local.get $6
        call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
        i32.const 0
        i32.ge_s
        br_if $while-break|1
-       local.get $3
-       local.tee $2
+       local.get $2
+       local.tee $3
        i32.const 1
        i32.sub
-       local.set $3
+       local.set $2
        local.get $0
-       local.get $2
+       local.get $3
        i32.const 1
        i32.add
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $6
        f64.store
        br $while-continue|1
       end
      end
     end
     local.get $0
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
     i32.const 3
@@ -2414,10 +2414,10 @@
     i32.add
     local.get $5
     f64.store
-    local.get $6
+    local.get $4
     i32.const 1
     i32.add
-    local.set $6
+    local.set $4
     br $for-loop|0
    end
   end
@@ -5976,12 +5976,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -5994,27 +5994,27 @@
     i32.gt_s
     if
      local.get $5
-     local.get $2
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
      local.get $6
      i32.store
-     local.get $2
+     local.get $1
      i32.const 1
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $2
+  local.get $1
   i32.const 2
   i32.shl
   local.tee $2
@@ -6167,12 +6167,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -6185,27 +6185,27 @@
     i32.gt_u
     if
      local.get $5
-     local.get $2
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
      local.get $6
      i32.store
-     local.get $2
+     local.get $1
      i32.const 1
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $2
+  local.get $1
   i32.const 2
   i32.shl
   local.tee $2
@@ -6358,12 +6358,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 3
     i32.shl
     i32.add
@@ -6376,27 +6376,27 @@
     i64.gt_s
     if
      local.get $5
-     local.get $2
+     local.get $1
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      i64.store
-     local.get $2
+     local.get $1
      i32.const 1
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $2
+  local.get $1
   i32.const 3
   i32.shl
   local.tee $2
@@ -6549,12 +6549,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 3
     i32.shl
     i32.add
@@ -6567,27 +6567,27 @@
     i64.gt_u
     if
      local.get $5
-     local.get $2
+     local.get $1
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      i64.store
-     local.get $2
+     local.get $1
      i32.const 1
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $2
+  local.get $1
   i32.const 3
   i32.shl
   local.tee $2
@@ -6740,12 +6740,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -6758,27 +6758,27 @@
     f32.gt
     if
      local.get $5
-     local.get $2
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
      local.get $6
      f32.store
-     local.get $2
+     local.get $1
      i32.const 1
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $2
+  local.get $1
   i32.const 2
   i32.shl
   local.tee $2
@@ -6931,12 +6931,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $4
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 3
     i32.shl
     i32.add
@@ -6949,27 +6949,27 @@
     f64.gt
     if
      local.get $5
-     local.get $2
+     local.get $1
      i32.const 3
      i32.shl
      i32.add
      local.get $6
      f64.store
-     local.get $2
+     local.get $1
      i32.const 1
      i32.add
-     local.set $2
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
   local.get $0
   local.get $5
-  local.get $2
+  local.get $1
   i32.const 3
   i32.shl
   local.tee $2
@@ -28991,22 +28991,22 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
+  (local $8 f64)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
+  (local $10 f32)
+  (local $11 f64)
+  (local $12 f32)
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
   (local $16 i32)
   (local $17 i32)
   (local $18 i32)
-  (local $19 f32)
-  (local $20 f64)
-  (local $21 f32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
   (local $22 i32)
-  (local $23 f64)
+  (local $23 i32)
   (local $24 i32)
   (local $25 i32)
   (local $26 i32)
@@ -29019,19 +29019,19 @@
   call $std/typedarray/testInstantiate
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -29045,7 +29045,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   if
    i32.const 0
@@ -29055,7 +29055,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.load offset=8
   i32.const 12
   i32.ne
@@ -29067,7 +29067,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 1
@@ -29080,7 +29080,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 2
@@ -29093,7 +29093,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 2
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -29106,14 +29106,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#subarray
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -29127,7 +29127,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 4
   i32.ne
@@ -29139,7 +29139,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -29151,7 +29151,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 2
@@ -29164,50 +29164,50 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 8
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $1
+  local.tee $0
   i32.const 0
   f64.const 1
   call $~lib/typedarray/Float64Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   f64.const 2
   call $~lib/typedarray/Float64Array#__set
-  local.get $1
+  local.get $0
   i32.const 2
   f64.const 7
   call $~lib/typedarray/Float64Array#__set
-  local.get $1
+  local.get $0
   i32.const 3
   f64.const 6
   call $~lib/typedarray/Float64Array#__set
-  local.get $1
+  local.get $0
   i32.const 4
   f64.const 5
   call $~lib/typedarray/Float64Array#__set
-  local.get $1
+  local.get $0
   i32.const 5
   f64.const 4
   call $~lib/typedarray/Float64Array#__set
-  local.get $1
+  local.get $0
   i32.const 6
   f64.const 3
   call $~lib/typedarray/Float64Array#__set
-  local.get $1
+  local.get $0
   i32.const 7
   f64.const 8
   call $~lib/typedarray/Float64Array#__set
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const 6
   call $~lib/typedarray/Float64Array#subarray
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.load offset=8
   i32.const 3
   i32.shr_u
@@ -29221,7 +29221,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 16
   i32.ne
@@ -29233,7 +29233,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 32
   i32.ne
@@ -29248,68 +29248,68 @@
   i32.const 0
   global.set $~argumentsLength
   block $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
-   local.get $0
+   local.get $1
    call $~lib/rt/pure/__retain
-   local.tee $28
+   local.tee $3
    i32.load offset=8
    i32.const 3
    i32.shr_u
-   local.tee $29
+   local.tee $2
    i32.const 1
    i32.le_s
    br_if $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
-   local.get $28
+   local.get $3
    i32.load offset=4
-   local.set $1
-   local.get $29
+   local.set $0
+   local.get $2
    i32.const 2
    i32.eq
    if
-    local.get $1
+    local.get $0
     f64.load offset=8
-    local.set $23
-    local.get $1
+    local.set $8
+    local.get $0
     f64.load
-    local.set $20
+    local.set $11
     i32.const 2
     global.set $~argumentsLength
-    local.get $23
-    local.get $20
+    local.get $8
+    local.get $11
     call $~lib/util/sort/COMPARATOR<f64>~anonymous|0
     i32.const 0
     i32.lt_s
     if
-     local.get $1
-     local.get $20
+     local.get $0
+     local.get $11
      f64.store offset=8
-     local.get $1
-     local.get $23
+     local.get $0
+     local.get $8
      f64.store
     end
     br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
-   local.get $29
+   local.get $2
    i32.const 256
    i32.lt_s
    if
-    local.get $1
-    local.get $29
+    local.get $0
+    local.get $2
     call $~lib/util/sort/insertionSort<f64>
    else
-    local.get $1
-    local.get $29
+    local.get $0
+    local.get $2
     call $~lib/util/sort/weakHeapSort<f64>
    end
   end
-  local.get $28
+  local.get $3
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/typedarray/Float64Array#__get
   f64.const 4
   f64.eq
   if (result i32)
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/typedarray/Float64Array#__get
    f64.const 5
@@ -29318,7 +29318,7 @@
    i32.const 0
   end
   if (result i32)
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/typedarray/Float64Array#__get
    f64.const 6
@@ -29327,7 +29327,7 @@
    i32.const 0
   end
   if (result i32)
-   local.get $0
+   local.get $1
    i32.const 3
    call $~lib/typedarray/Float64Array#__get
    f64.const 7
@@ -29344,23 +29344,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.const -32
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const 256
   call $~lib/typedarray/Uint8ClampedArray#__set
-  local.get $1
+  local.get $0
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#__get
   if
@@ -29371,7 +29371,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 2
@@ -29384,7 +29384,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 2
   call $~lib/typedarray/Uint8ClampedArray#__get
   i32.const 255
@@ -29397,44 +29397,44 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   i32.const 5
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 1504
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $2
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -29445,20 +29445,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 0
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 1584
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $28
+  local.tee $3
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -29469,20 +29469,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 1616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $4
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -29493,20 +29493,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const -2
   i32.const 2147483647
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 1648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $5
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -29517,20 +29517,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 1680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $6
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -29541,17 +29541,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int8Array#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -29563,7 +29563,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 1
   i32.ne
@@ -29575,7 +29575,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -29587,14 +29587,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 0
   i32.const 14
   i32.const 1712
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $7
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -29605,14 +29605,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 0
   i32.const 14
   i32.const 1744
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $9
   call $std/typedarray/isInt8ArrayEqual
   i32.eqz
   if
@@ -29623,60 +29623,60 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $29
-  call $~lib/rt/pure/__release
-  local.get $28
-  call $~lib/rt/pure/__release
-  local.get $27
-  call $~lib/rt/pure/__release
-  local.get $26
-  call $~lib/rt/pure/__release
-  local.get $25
-  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $2
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
   call $~lib/rt/pure/__release
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 1
   i32.const 3
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $2
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -29687,20 +29687,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 0
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1824
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $28
+  local.tee $3
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -29711,20 +29711,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 0
   i32.const -3
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $4
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -29735,20 +29735,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const -2
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1920
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $5
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -29759,20 +29759,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 0
   i32.const 1
   i32.const 0
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 1968
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $6
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -29783,17 +29783,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#subarray
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#fill
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -29807,7 +29807,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 4
   i32.ne
@@ -29819,7 +29819,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 12
   i32.ne
@@ -29831,14 +29831,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 3
   i32.const 2
   i32.const 15
   i32.const 2016
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $7
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -29849,14 +29849,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2048
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $9
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -29867,55 +29867,55 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $29
-  call $~lib/rt/pure/__release
-  local.get $28
-  call $~lib/rt/pure/__release
-  local.get $27
-  call $~lib/rt/pure/__release
-  local.get $26
-  call $~lib/rt/pure/__release
-  local.get $25
-  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $2
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
   call $~lib/rt/pure/__release
   i32.const 6
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 5
   i32.const 6
   call $~lib/typedarray/Int8Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 6
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $0
+  local.tee $1
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 2
@@ -29928,7 +29928,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 5
   i32.ne
@@ -29940,7 +29940,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 1
   i32.ne
@@ -29952,7 +29952,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 5
   i32.ne
@@ -29964,11 +29964,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   i32.const 5
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $29
+  local.tee $2
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 3
@@ -29981,7 +29981,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -29993,7 +29993,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 2
   i32.ne
@@ -30005,7 +30005,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -30017,11 +30017,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int8Array#subarray
-  local.tee $28
+  local.tee $3
   i32.const 0
   call $~lib/typedarray/Int8Array#__get
   i32.const 4
@@ -30034,7 +30034,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $3
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -30046,7 +30046,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $3
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 3
   i32.ne
@@ -30058,7 +30058,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $3
   i32.load offset=8
   i32.const 3
   i32.ne
@@ -30070,54 +30070,54 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $29
+  local.get $1
   call $~lib/rt/pure/__release
-  local.get $28
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
   call $~lib/rt/pure/__release
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.set $29
-  local.get $1
+  local.set $2
+  local.get $0
   i32.const 0
   i32.const 3
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $28
+  local.tee $3
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2096
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $4
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30128,26 +30128,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.const 1
   i32.const 3
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $26
+  local.tee $5
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2144
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $6
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30158,25 +30158,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 1
   i32.const 2
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $24
+  local.tee $7
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2192
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $9
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30187,25 +30187,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 2
   i32.const 2
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $18
+  local.tee $13
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2240
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $14
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30216,25 +30216,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $16
+  local.tee $15
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2288
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $16
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30245,25 +30245,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 1
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $14
+  local.tee $17
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2336
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $18
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30274,25 +30274,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 1
   i32.const 2
   i32.const 4
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $12
+  local.tee $19
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2384
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $20
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30303,25 +30303,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.const -2
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $10
+  local.tee $21
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2432
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $22
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30332,25 +30332,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.const -2
   i32.const -1
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $8
+  local.tee $23
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2480
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $7
+  local.tee $24
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30361,25 +30361,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.get $0
+  local.get $1
   call $~lib/rt/pure/__release
-  local.tee $0
+  local.tee $1
   i32.const -4
   i32.const -3
   i32.const -2
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $6
+  local.tee $25
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2528
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $5
+  local.tee $26
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30390,26 +30390,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.set $1
-  local.get $0
-  call $~lib/rt/pure/__release
+  local.set $0
   local.get $1
+  call $~lib/rt/pure/__release
+  local.get $0
   i32.const -4
   i32.const -3
   i32.const -1
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $4
+  local.tee $27
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2576
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $3
+  local.tee $28
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30420,26 +30420,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.set $0
-  local.get $1
-  call $~lib/rt/pure/__release
+  local.set $1
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
   i32.const -4
   i32.const -3
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#copyWithin
-  local.tee $1
+  local.tee $0
   i32.const 5
   i32.const 2
   i32.const 15
   i32.const 2624
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $29
   call $std/typedarray/isInt32ArrayEqual
   i32.eqz
   if
@@ -30450,85 +30450,85 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $29
-  call $~lib/rt/pure/__release
-  local.get $28
-  call $~lib/rt/pure/__release
-  local.get $27
-  call $~lib/rt/pure/__release
-  local.get $26
-  call $~lib/rt/pure/__release
-  local.get $25
-  call $~lib/rt/pure/__release
-  local.get $24
-  call $~lib/rt/pure/__release
-  local.get $22
-  call $~lib/rt/pure/__release
-  local.get $18
-  call $~lib/rt/pure/__release
-  local.get $17
-  call $~lib/rt/pure/__release
-  local.get $16
-  call $~lib/rt/pure/__release
-  local.get $15
-  call $~lib/rt/pure/__release
-  local.get $14
-  call $~lib/rt/pure/__release
-  local.get $13
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $11
-  call $~lib/rt/pure/__release
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $5
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $9
+  call $~lib/rt/pure/__release
+  local.get $13
+  call $~lib/rt/pure/__release
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $17
+  call $~lib/rt/pure/__release
+  local.get $18
+  call $~lib/rt/pure/__release
+  local.get $19
+  call $~lib/rt/pure/__release
+  local.get $20
+  call $~lib/rt/pure/__release
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $22
+  call $~lib/rt/pure/__release
+  local.get $23
+  call $~lib/rt/pure/__release
+  local.get $24
+  call $~lib/rt/pure/__release
+  local.get $25
+  call $~lib/rt/pure/__release
+  local.get $26
+  call $~lib/rt/pure/__release
+  local.get $27
+  call $~lib/rt/pure/__release
+  local.get $28
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $29
+  call $~lib/rt/pure/__release
   i32.const 5
   call $~lib/typedarray/Int32Array#constructor
-  local.tee $1
+  local.tee $0
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 3
   i32.const 4
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 4
   i32.const 5
   call $~lib/typedarray/Int32Array#__set
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 4
   call $~lib/typedarray/Int32Array#subarray
-  local.tee $29
+  local.tee $2
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -30542,7 +30542,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.const 4
   i32.ne
@@ -30554,7 +30554,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.load offset=8
   i32.const 12
   i32.ne
@@ -30566,11 +30566,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   i32.const 1
   i32.const 3
   call $~lib/typedarray/Int32Array#slice
-  local.tee $0
+  local.tee $1
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 2
@@ -30583,7 +30583,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -30596,7 +30596,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -30610,7 +30610,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   if
    i32.const 0
@@ -30620,7 +30620,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.load offset=8
   i32.const 8
   i32.ne
@@ -30632,11 +30632,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $29
+  local.get $2
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int32Array#slice
-  local.tee $28
+  local.tee $3
   i32.const 0
   call $~lib/typedarray/Int32Array#__get
   i32.const 3
@@ -30649,7 +30649,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $3
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -30663,7 +30663,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $3
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   if
    i32.const 0
@@ -30673,7 +30673,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $3
   i32.load offset=8
   i32.const 4
   i32.ne
@@ -30685,12 +30685,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  local.get $1
+  local.get $0
+  local.get $0
   i32.const 0
   i32.const 2147483647
   call $~lib/typedarray/Int32Array#slice
-  local.tee $27
+  local.tee $4
   i32.eq
   if
    i32.const 0
@@ -30700,11 +30700,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $27
+  local.get $4
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.get $1
+  local.get $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
@@ -30717,9 +30717,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $27
+  local.get $4
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
-  local.get $1
+  local.get $0
   call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
   i32.ne
   if
@@ -30730,9 +30730,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $27
+  local.get $4
   i32.load offset=8
-  local.get $1
+  local.get $0
   i32.load offset=8
   i32.ne
   if
@@ -30743,68 +30743,68 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $29
-  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $28
+  local.get $2
   call $~lib/rt/pure/__release
-  local.get $27
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
   call $~lib/rt/pure/__release
   i32.const 3
   call $~lib/typedarray/Int8Array#constructor
-  local.tee $27
+  local.tee $4
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $2
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int8Array#__set
-  local.get $29
+  local.get $2
   i32.const 1
   i32.const 2
   call $~lib/typedarray/Int8Array#__set
-  local.get $29
+  local.get $2
   i32.const 2
   i32.const 3
   call $~lib/typedarray/Int8Array#__set
   i32.const 0
-  local.set $1
-  i32.const 0
   local.set $0
-  local.get $29
+  i32.const 0
+  local.set $1
+  local.get $2
   call $~lib/rt/pure/__retain
-  local.tee $28
+  local.tee $3
   i32.load offset=4
-  local.set $26
-  local.get $28
+  local.set $5
+  local.get $3
   i32.load offset=8
-  local.set $25
+  local.set $6
   loop $for-loop|0
-   local.get $1
-   local.get $25
+   local.get $0
+   local.get $6
    i32.lt_s
    if
-    local.get $1
-    local.get $26
+    local.get $0
+    local.get $5
     i32.add
     i32.load8_s
-    local.set $24
+    local.set $7
     i32.const 4
     global.set $~argumentsLength
-    local.get $0
-    local.get $24
-    i32.add
-    local.set $0
     local.get $1
-    i32.const 1
+    local.get $7
     i32.add
     local.set $1
+    local.get $0
+    i32.const 1
+    i32.add
+    local.set $0
     br $for-loop|0
    end
   end
-  local.get $28
+  local.get $3
   call $~lib/rt/pure/__release
   block $folding-inner18
    block $folding-inner0
@@ -30822,33 +30822,33 @@
                block $folding-inner4
                 block $folding-inner3
                  block $folding-inner2
-                  local.get $0
+                  local.get $1
                   i32.const 255
                   i32.and
                   i32.const 6
                   i32.ne
                   br_if $folding-inner2
-                  local.get $27
+                  local.get $4
                   call $~lib/rt/pure/__release
-                  local.get $29
+                  local.get $2
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Uint8Array#constructor
-                  local.tee $0
-                  call $~lib/rt/pure/__retain
                   local.tee $1
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Uint8Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Uint8Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Uint8Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 3
                   call $~lib/typedarray/Uint8Array#reduce<u8>
                   i32.const 255
@@ -30856,27 +30856,27 @@
                   i32.const 6
                   i32.ne
                   br_if $folding-inner2
-                  local.get $0
-                  call $~lib/rt/pure/__release
                   local.get $1
+                  call $~lib/rt/pure/__release
+                  local.get $0
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Uint8ClampedArray#constructor
-                  local.tee $0
-                  call $~lib/rt/pure/__retain
                   local.tee $1
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Uint8ClampedArray#__set
-                  local.get $1
+                  local.get $0
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Uint8ClampedArray#__set
-                  local.get $1
+                  local.get $0
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Uint8ClampedArray#__set
-                  local.get $1
+                  local.get $0
                   i32.const 4
                   call $~lib/typedarray/Uint8Array#reduce<u8>
                   i32.const 255
@@ -30884,456 +30884,456 @@
                   i32.const 6
                   i32.ne
                   br_if $folding-inner2
-                  local.get $0
-                  call $~lib/rt/pure/__release
                   local.get $1
+                  call $~lib/rt/pure/__release
+                  local.get $0
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Int16Array#constructor
-                  local.tee $27
+                  local.tee $4
                   call $~lib/rt/pure/__retain
-                  local.tee $29
+                  local.tee $2
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Int16Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Int16Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Int16Array#__set
                   i32.const 0
-                  local.set $1
-                  i32.const 0
                   local.set $0
-                  local.get $29
+                  i32.const 0
+                  local.set $1
+                  local.get $2
                   call $~lib/rt/pure/__retain
-                  local.tee $28
+                  local.tee $3
                   i32.load offset=4
-                  local.set $26
-                  local.get $28
+                  local.set $5
+                  local.get $3
                   i32.load offset=8
                   i32.const 1
                   i32.shr_u
-                  local.set $25
+                  local.set $6
                   loop $for-loop|00
-                   local.get $1
-                   local.get $25
+                   local.get $0
+                   local.get $6
                    i32.lt_s
                    if
-                    local.get $26
-                    local.get $1
+                    local.get $5
+                    local.get $0
                     i32.const 1
                     i32.shl
                     i32.add
                     i32.load16_s
-                    local.set $24
+                    local.set $7
                     i32.const 4
                     global.set $~argumentsLength
-                    local.get $0
-                    local.get $24
-                    i32.add
-                    local.set $0
                     local.get $1
-                    i32.const 1
+                    local.get $7
                     i32.add
                     local.set $1
+                    local.get $0
+                    i32.const 1
+                    i32.add
+                    local.set $0
                     br $for-loop|00
                    end
                   end
-                  local.get $28
+                  local.get $3
                   call $~lib/rt/pure/__release
-                  local.get $0
+                  local.get $1
                   i32.const 65535
                   i32.and
                   i32.const 6
                   i32.ne
                   br_if $folding-inner2
-                  local.get $27
+                  local.get $4
                   call $~lib/rt/pure/__release
-                  local.get $29
+                  local.get $2
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Uint16Array#constructor
-                  local.tee $27
+                  local.tee $4
                   call $~lib/rt/pure/__retain
-                  local.tee $29
+                  local.tee $2
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Uint16Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Uint16Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Uint16Array#__set
                   i32.const 0
-                  local.set $1
-                  i32.const 0
                   local.set $0
-                  local.get $29
+                  i32.const 0
+                  local.set $1
+                  local.get $2
                   call $~lib/rt/pure/__retain
-                  local.tee $28
+                  local.tee $3
                   i32.load offset=4
-                  local.set $26
-                  local.get $28
+                  local.set $5
+                  local.get $3
                   i32.load offset=8
                   i32.const 1
                   i32.shr_u
-                  local.set $25
+                  local.set $6
                   loop $for-loop|01
-                   local.get $1
-                   local.get $25
+                   local.get $0
+                   local.get $6
                    i32.lt_s
                    if
-                    local.get $26
-                    local.get $1
+                    local.get $5
+                    local.get $0
                     i32.const 1
                     i32.shl
                     i32.add
                     i32.load16_u
-                    local.set $24
+                    local.set $7
                     i32.const 4
                     global.set $~argumentsLength
-                    local.get $0
-                    local.get $24
-                    i32.add
-                    local.set $0
                     local.get $1
-                    i32.const 1
+                    local.get $7
                     i32.add
                     local.set $1
+                    local.get $0
+                    i32.const 1
+                    i32.add
+                    local.set $0
                     br $for-loop|01
                    end
                   end
-                  local.get $28
+                  local.get $3
                   call $~lib/rt/pure/__release
-                  local.get $0
+                  local.get $1
                   i32.const 65535
                   i32.and
                   i32.const 6
                   i32.ne
                   br_if $folding-inner2
-                  local.get $27
+                  local.get $4
                   call $~lib/rt/pure/__release
-                  local.get $29
+                  local.get $2
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Int32Array#constructor
-                  local.tee $0
-                  call $~lib/rt/pure/__retain
                   local.tee $1
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Int32Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Int32Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Int32Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 7
                   call $~lib/typedarray/Int32Array#reduce<i32>
                   i32.const 6
                   i32.ne
                   br_if $folding-inner2
-                  local.get $0
-                  call $~lib/rt/pure/__release
                   local.get $1
+                  call $~lib/rt/pure/__release
+                  local.get $0
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Uint32Array#constructor
-                  local.tee $0
-                  call $~lib/rt/pure/__retain
                   local.tee $1
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Uint32Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Uint32Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Uint32Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 8
                   call $~lib/typedarray/Int32Array#reduce<i32>
                   i32.const 6
                   i32.ne
                   br_if $folding-inner2
-                  local.get $0
-                  call $~lib/rt/pure/__release
                   local.get $1
+                  call $~lib/rt/pure/__release
+                  local.get $0
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Int64Array#constructor
-                  local.tee $0
-                  call $~lib/rt/pure/__retain
                   local.tee $1
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
                   i32.const 0
                   i64.const 1
                   call $~lib/typedarray/Int64Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 1
                   i64.const 2
                   call $~lib/typedarray/Int64Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 2
                   i64.const 3
                   call $~lib/typedarray/Int64Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 9
                   call $~lib/typedarray/Int64Array#reduce<i64>
                   i64.const 6
                   i64.ne
                   br_if $folding-inner2
-                  local.get $0
-                  call $~lib/rt/pure/__release
                   local.get $1
+                  call $~lib/rt/pure/__release
+                  local.get $0
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Uint64Array#constructor
-                  local.tee $0
-                  call $~lib/rt/pure/__retain
                   local.tee $1
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
                   i32.const 0
                   i64.const 1
                   call $~lib/typedarray/Uint64Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 1
                   i64.const 2
                   call $~lib/typedarray/Uint64Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 2
                   i64.const 3
                   call $~lib/typedarray/Uint64Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 10
                   call $~lib/typedarray/Int64Array#reduce<i64>
                   i64.const 6
                   i64.ne
                   br_if $folding-inner2
-                  local.get $0
-                  call $~lib/rt/pure/__release
                   local.get $1
+                  call $~lib/rt/pure/__release
+                  local.get $0
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Float32Array#constructor
-                  local.tee $28
+                  local.tee $3
                   call $~lib/rt/pure/__retain
-                  local.tee $0
+                  local.tee $1
                   i32.const 0
                   f32.const 1
                   call $~lib/typedarray/Float32Array#__set
-                  local.get $0
+                  local.get $1
                   i32.const 1
                   f32.const 2
                   call $~lib/typedarray/Float32Array#__set
-                  local.get $0
+                  local.get $1
                   i32.const 2
                   f32.const 3
                   call $~lib/typedarray/Float32Array#__set
                   i32.const 0
-                  local.set $1
-                  local.get $0
+                  local.set $0
+                  local.get $1
                   call $~lib/rt/pure/__retain
-                  local.tee $29
+                  local.tee $2
                   i32.load offset=4
-                  local.set $27
-                  local.get $29
+                  local.set $4
+                  local.get $2
                   i32.load offset=8
                   i32.const 2
                   i32.shr_u
-                  local.set $26
+                  local.set $5
                   loop $for-loop|02
-                   local.get $1
-                   local.get $26
+                   local.get $0
+                   local.get $5
                    i32.lt_s
                    if
-                    local.get $27
-                    local.get $1
+                    local.get $4
+                    local.get $0
                     i32.const 2
                     i32.shl
                     i32.add
                     f32.load
-                    local.set $19
+                    local.set $12
                     i32.const 4
                     global.set $~argumentsLength
-                    local.get $21
-                    local.get $19
+                    local.get $10
+                    local.get $12
                     f32.add
-                    local.set $21
-                    local.get $1
+                    local.set $10
+                    local.get $0
                     i32.const 1
                     i32.add
-                    local.set $1
+                    local.set $0
                     br $for-loop|02
                    end
                   end
-                  local.get $29
+                  local.get $2
                   call $~lib/rt/pure/__release
-                  local.get $21
+                  local.get $10
                   f32.const 6
                   f32.ne
                   br_if $folding-inner2
-                  local.get $28
+                  local.get $3
                   call $~lib/rt/pure/__release
-                  local.get $0
+                  local.get $1
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Float64Array#constructor
-                  local.tee $28
+                  local.tee $3
                   call $~lib/rt/pure/__retain
-                  local.tee $0
+                  local.tee $1
                   i32.const 0
                   f64.const 1
                   call $~lib/typedarray/Float64Array#__set
-                  local.get $0
+                  local.get $1
                   i32.const 1
                   f64.const 2
                   call $~lib/typedarray/Float64Array#__set
-                  local.get $0
+                  local.get $1
                   i32.const 2
                   f64.const 3
                   call $~lib/typedarray/Float64Array#__set
                   i32.const 0
-                  local.set $1
+                  local.set $0
                   f64.const 0
-                  local.set $23
-                  local.get $0
+                  local.set $8
+                  local.get $1
                   call $~lib/rt/pure/__retain
-                  local.tee $29
+                  local.tee $2
                   i32.load offset=4
-                  local.set $27
-                  local.get $29
+                  local.set $4
+                  local.get $2
                   i32.load offset=8
                   i32.const 3
                   i32.shr_u
-                  local.set $26
+                  local.set $5
                   loop $for-loop|03
-                   local.get $1
-                   local.get $26
+                   local.get $0
+                   local.get $5
                    i32.lt_s
                    if
-                    local.get $27
-                    local.get $1
+                    local.get $4
+                    local.get $0
                     i32.const 3
                     i32.shl
                     i32.add
                     f64.load
-                    local.set $20
+                    local.set $11
                     i32.const 4
                     global.set $~argumentsLength
-                    local.get $23
-                    local.get $20
+                    local.get $8
+                    local.get $11
                     f64.add
-                    local.set $23
-                    local.get $1
+                    local.set $8
+                    local.get $0
                     i32.const 1
                     i32.add
-                    local.set $1
+                    local.set $0
                     br $for-loop|03
                    end
                   end
-                  local.get $29
+                  local.get $2
                   call $~lib/rt/pure/__release
-                  local.get $23
+                  local.get $8
                   f64.const 6
                   f64.ne
                   br_if $folding-inner2
-                  local.get $28
+                  local.get $3
                   call $~lib/rt/pure/__release
-                  local.get $0
+                  local.get $1
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Int8Array#constructor
-                  local.tee $27
+                  local.tee $4
                   call $~lib/rt/pure/__retain
-                  local.tee $29
+                  local.tee $2
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Int8Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Int8Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Int8Array#__set
                   i32.const 0
-                  local.set $0
-                  local.get $29
+                  local.set $1
+                  local.get $2
                   call $~lib/rt/pure/__retain
-                  local.tee $28
+                  local.tee $3
                   i32.load offset=4
-                  local.set $26
-                  local.get $28
+                  local.set $5
+                  local.get $3
                   i32.load offset=8
                   i32.const 1
                   i32.sub
-                  local.set $1
+                  local.set $0
                   loop $for-loop|04
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    i32.ge_s
                    if
-                    local.get $1
-                    local.get $26
+                    local.get $0
+                    local.get $5
                     i32.add
                     i32.load8_s
-                    local.set $25
+                    local.set $6
                     i32.const 4
                     global.set $~argumentsLength
-                    local.get $0
-                    local.get $25
-                    i32.add
-                    local.set $0
                     local.get $1
+                    local.get $6
+                    i32.add
+                    local.set $1
+                    local.get $0
                     i32.const 1
                     i32.sub
-                    local.set $1
+                    local.set $0
                     br $for-loop|04
                    end
                   end
-                  local.get $28
+                  local.get $3
                   call $~lib/rt/pure/__release
-                  local.get $0
+                  local.get $1
                   i32.const 255
                   i32.and
                   i32.const 6
                   i32.ne
                   br_if $folding-inner3
-                  local.get $27
+                  local.get $4
                   call $~lib/rt/pure/__release
-                  local.get $29
+                  local.get $2
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Uint8Array#constructor
-                  local.tee $0
-                  call $~lib/rt/pure/__retain
                   local.tee $1
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Uint8Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Uint8Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Uint8Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 14
                   call $~lib/typedarray/Uint8Array#reduceRight<u8>
                   i32.const 255
@@ -31341,27 +31341,27 @@
                   i32.const 6
                   i32.ne
                   br_if $folding-inner3
-                  local.get $0
-                  call $~lib/rt/pure/__release
                   local.get $1
+                  call $~lib/rt/pure/__release
+                  local.get $0
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Uint8ClampedArray#constructor
-                  local.tee $0
-                  call $~lib/rt/pure/__retain
                   local.tee $1
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Uint8ClampedArray#__set
-                  local.get $1
+                  local.get $0
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Uint8ClampedArray#__set
-                  local.get $1
+                  local.get $0
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Uint8ClampedArray#__set
-                  local.get $1
+                  local.get $0
                   i32.const 15
                   call $~lib/typedarray/Uint8Array#reduceRight<u8>
                   i32.const 255
@@ -31369,1011 +31369,1011 @@
                   i32.const 6
                   i32.ne
                   br_if $folding-inner3
-                  local.get $0
-                  call $~lib/rt/pure/__release
                   local.get $1
+                  call $~lib/rt/pure/__release
+                  local.get $0
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Int16Array#constructor
-                  local.tee $27
+                  local.tee $4
                   call $~lib/rt/pure/__retain
-                  local.tee $29
+                  local.tee $2
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Int16Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Int16Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Int16Array#__set
                   i32.const 0
-                  local.set $0
-                  local.get $29
+                  local.set $1
+                  local.get $2
                   call $~lib/rt/pure/__retain
-                  local.tee $28
+                  local.tee $3
                   i32.load offset=4
-                  local.set $26
-                  local.get $28
+                  local.set $5
+                  local.get $3
                   i32.load offset=8
                   i32.const 1
                   i32.shr_u
                   i32.const 1
                   i32.sub
-                  local.set $1
+                  local.set $0
                   loop $for-loop|05
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    i32.ge_s
                    if
-                    local.get $26
-                    local.get $1
+                    local.get $5
+                    local.get $0
                     i32.const 1
                     i32.shl
                     i32.add
                     i32.load16_s
-                    local.set $25
+                    local.set $6
                     i32.const 4
                     global.set $~argumentsLength
-                    local.get $0
-                    local.get $25
-                    i32.add
-                    local.set $0
                     local.get $1
+                    local.get $6
+                    i32.add
+                    local.set $1
+                    local.get $0
                     i32.const 1
                     i32.sub
-                    local.set $1
+                    local.set $0
                     br $for-loop|05
                    end
                   end
-                  local.get $28
+                  local.get $3
                   call $~lib/rt/pure/__release
-                  local.get $0
+                  local.get $1
                   i32.const 65535
                   i32.and
                   i32.const 6
                   i32.ne
                   br_if $folding-inner3
-                  local.get $27
+                  local.get $4
                   call $~lib/rt/pure/__release
-                  local.get $29
+                  local.get $2
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Uint16Array#constructor
-                  local.tee $27
+                  local.tee $4
                   call $~lib/rt/pure/__retain
-                  local.tee $29
+                  local.tee $2
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Uint16Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Uint16Array#__set
-                  local.get $29
+                  local.get $2
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Uint16Array#__set
                   i32.const 0
-                  local.set $0
-                  local.get $29
+                  local.set $1
+                  local.get $2
                   call $~lib/rt/pure/__retain
-                  local.tee $28
+                  local.tee $3
                   i32.load offset=4
-                  local.set $26
-                  local.get $28
+                  local.set $5
+                  local.get $3
                   i32.load offset=8
                   i32.const 1
                   i32.shr_u
                   i32.const 1
                   i32.sub
-                  local.set $1
+                  local.set $0
                   loop $for-loop|06
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    i32.ge_s
                    if
-                    local.get $26
-                    local.get $1
+                    local.get $5
+                    local.get $0
                     i32.const 1
                     i32.shl
                     i32.add
                     i32.load16_u
-                    local.set $25
+                    local.set $6
                     i32.const 4
                     global.set $~argumentsLength
-                    local.get $0
-                    local.get $25
-                    i32.add
-                    local.set $0
                     local.get $1
+                    local.get $6
+                    i32.add
+                    local.set $1
+                    local.get $0
                     i32.const 1
                     i32.sub
-                    local.set $1
+                    local.set $0
                     br $for-loop|06
                    end
                   end
-                  local.get $28
+                  local.get $3
                   call $~lib/rt/pure/__release
-                  local.get $0
+                  local.get $1
                   i32.const 65535
                   i32.and
                   i32.const 6
                   i32.ne
                   br_if $folding-inner3
-                  local.get $27
+                  local.get $4
                   call $~lib/rt/pure/__release
-                  local.get $29
+                  local.get $2
                   call $~lib/rt/pure/__release
                   i32.const 3
                   call $~lib/typedarray/Int32Array#constructor
-                  local.tee $0
-                  call $~lib/rt/pure/__retain
                   local.tee $1
+                  call $~lib/rt/pure/__retain
+                  local.tee $0
                   i32.const 0
                   i32.const 1
                   call $~lib/typedarray/Int32Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 1
                   i32.const 2
                   call $~lib/typedarray/Int32Array#__set
-                  local.get $1
+                  local.get $0
                   i32.const 2
                   i32.const 3
                   call $~lib/typedarray/Int32Array#__set
                   block $folding-inner1
-                   local.get $1
+                   local.get $0
                    i32.const 18
                    call $~lib/typedarray/Int32Array#reduceRight<i32>
                    i32.const 6
                    i32.ne
                    br_if $folding-inner1
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 19
                    call $~lib/typedarray/Int32Array#reduceRight<i32>
                    i32.const 6
                    i32.ne
                    br_if $folding-inner1
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 1
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 2
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 3
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 20
                    call $~lib/typedarray/Int64Array#reduceRight<i64>
                    i64.const 6
                    i64.ne
                    br_if $folding-inner1
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 1
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 2
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 3
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 21
                    call $~lib/typedarray/Int64Array#reduceRight<i64>
                    i64.const 6
                    i64.ne
                    br_if $folding-inner1
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float32Array#constructor
-                   local.tee $28
+                   local.tee $3
                    call $~lib/rt/pure/__retain
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    f32.const 1
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    f32.const 2
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    f32.const 3
                    call $~lib/typedarray/Float32Array#__set
                    f32.const 0
-                   local.set $21
-                   local.get $0
+                   local.set $10
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $29
+                   local.tee $2
                    i32.load offset=4
-                   local.set $27
-                   local.get $29
+                   local.set $4
+                   local.get $2
                    i32.load offset=8
                    i32.const 2
                    i32.shr_u
                    i32.const 1
                    i32.sub
-                   local.set $1
+                   local.set $0
                    loop $for-loop|07
-                    local.get $1
+                    local.get $0
                     i32.const 0
                     i32.ge_s
                     if
-                     local.get $27
-                     local.get $1
+                     local.get $4
+                     local.get $0
                      i32.const 2
                      i32.shl
                      i32.add
                      f32.load
-                     local.set $19
+                     local.set $12
                      i32.const 4
                      global.set $~argumentsLength
-                     local.get $21
-                     local.get $19
+                     local.get $10
+                     local.get $12
                      f32.add
-                     local.set $21
-                     local.get $1
+                     local.set $10
+                     local.get $0
                      i32.const 1
                      i32.sub
-                     local.set $1
+                     local.set $0
                      br $for-loop|07
                     end
                    end
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $21
+                   local.get $10
                    f32.const 6
                    f32.ne
                    br_if $folding-inner1
-                   local.get $28
+                   local.get $3
                    call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float64Array#constructor
-                   local.tee $28
+                   local.tee $3
                    call $~lib/rt/pure/__retain
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    f64.const 1
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    f64.const 2
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    f64.const 3
                    call $~lib/typedarray/Float64Array#__set
                    f64.const 0
-                   local.set $23
-                   local.get $0
+                   local.set $8
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $29
+                   local.tee $2
                    i32.load offset=4
-                   local.set $27
-                   local.get $29
+                   local.set $4
+                   local.get $2
                    i32.load offset=8
                    i32.const 3
                    i32.shr_u
                    i32.const 1
                    i32.sub
-                   local.set $1
+                   local.set $0
                    loop $for-loop|08
-                    local.get $1
+                    local.get $0
                     i32.const 0
                     i32.ge_s
                     if
-                     local.get $27
-                     local.get $1
+                     local.get $4
+                     local.get $0
                      i32.const 3
                      i32.shl
                      i32.add
                      f64.load
-                     local.set $20
+                     local.set $11
                      i32.const 4
                      global.set $~argumentsLength
-                     local.get $23
-                     local.get $20
+                     local.get $8
+                     local.get $11
                      f64.add
-                     local.set $23
-                     local.get $1
+                     local.set $8
+                     local.get $0
                      i32.const 1
                      i32.sub
-                     local.set $1
+                     local.set $0
                      br $for-loop|08
                     end
                    end
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $23
+                   local.get $8
                    f64.const 6
                    f64.ne
                    br_if $folding-inner1
-                   local.get $28
+                   local.get $3
                    call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int8Array#constructor
-                   local.tee $24
+                   local.tee $7
                    call $~lib/rt/pure/__retain
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int8Array#__set
                    i32.const 0
-                   local.set $1
-                   local.get $0
+                   local.set $0
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $26
+                   local.tee $5
                    i32.load offset=8
-                   local.set $28
-                   local.get $26
+                   local.set $3
+                   local.get $5
                    i32.load offset=4
-                   local.set $22
+                   local.set $9
                    i32.const 12
                    i32.const 3
                    call $~lib/rt/tlsf/__alloc
-                   local.set $29
-                   local.get $28
+                   local.set $2
+                   local.get $3
                    i32.const 0
                    call $~lib/rt/tlsf/__alloc
-                   local.set $27
+                   local.set $4
                    loop $for-loop|09
-                    local.get $1
-                    local.get $28
+                    local.get $0
+                    local.get $3
                     i32.lt_s
                     if
-                     local.get $1
-                     local.get $22
+                     local.get $0
+                     local.get $9
                      i32.add
                      i32.load8_s
-                     local.set $25
+                     local.set $6
                      i32.const 3
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $27
+                     local.get $0
+                     local.get $4
                      i32.add
-                     local.get $25
-                     local.get $25
+                     local.get $6
+                     local.get $6
                      i32.mul
                      i32.store8
-                     local.get $1
+                     local.get $0
                      i32.const 1
                      i32.add
-                     local.set $1
+                     local.set $0
                      br $for-loop|09
                     end
                    end
-                   local.get $29
-                   local.get $27
+                   local.get $2
+                   local.get $4
                    call $~lib/rt/pure/__retain
                    i32.store
-                   local.get $29
-                   local.get $27
+                   local.get $2
+                   local.get $4
                    i32.store offset=4
-                   local.get $29
-                   local.get $28
+                   local.get $2
+                   local.get $3
                    i32.store offset=8
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__retain
-                   local.set $1
-                   local.get $26
+                   local.set $0
+                   local.get $5
                    call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    call $~lib/typedarray/Int8Array#__get
                    i32.const 1
                    i32.ne
                    br_if $folding-inner4
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    call $~lib/typedarray/Int8Array#__get
                    i32.const 4
                    i32.ne
                    br_if $folding-inner5
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    call $~lib/typedarray/Int8Array#__get
                    i32.const 9
                    i32.ne
                    br_if $folding-inner6
-                   local.get $24
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $7
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#constructor
-                   local.tee $24
+                   local.tee $7
                    call $~lib/rt/pure/__retain
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#__set
                    i32.const 0
-                   local.set $1
-                   local.get $0
+                   local.set $0
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $26
+                   local.tee $5
                    i32.load offset=8
-                   local.set $28
-                   local.get $26
+                   local.set $3
+                   local.get $5
                    i32.load offset=4
-                   local.set $22
+                   local.set $9
                    i32.const 12
                    i32.const 4
                    call $~lib/rt/tlsf/__alloc
-                   local.set $29
-                   local.get $28
+                   local.set $2
+                   local.get $3
                    i32.const 0
                    call $~lib/rt/tlsf/__alloc
-                   local.set $27
+                   local.set $4
                    loop $for-loop|010
-                    local.get $1
-                    local.get $28
+                    local.get $0
+                    local.get $3
                     i32.lt_s
                     if
-                     local.get $1
-                     local.get $22
+                     local.get $0
+                     local.get $9
                      i32.add
                      i32.load8_u
-                     local.set $25
+                     local.set $6
                      i32.const 3
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $27
+                     local.get $0
+                     local.get $4
                      i32.add
-                     local.get $25
-                     local.get $25
+                     local.get $6
+                     local.get $6
                      i32.mul
                      i32.store8
-                     local.get $1
+                     local.get $0
                      i32.const 1
                      i32.add
-                     local.set $1
+                     local.set $0
                      br $for-loop|010
                     end
                    end
-                   local.get $29
-                   local.get $27
+                   local.get $2
+                   local.get $4
                    call $~lib/rt/pure/__retain
                    i32.store
-                   local.get $29
-                   local.get $27
+                   local.get $2
+                   local.get $4
                    i32.store offset=4
-                   local.get $29
-                   local.get $28
+                   local.get $2
+                   local.get $3
                    i32.store offset=8
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__retain
-                   local.set $1
-                   local.get $26
+                   local.set $0
+                   local.get $5
                    call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    call $~lib/typedarray/Uint8Array#__get
                    i32.const 1
                    i32.ne
                    br_if $folding-inner4
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    call $~lib/typedarray/Uint8Array#__get
                    i32.const 4
                    i32.ne
                    br_if $folding-inner5
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    call $~lib/typedarray/Uint8Array#__get
                    i32.const 9
                    i32.ne
                    br_if $folding-inner6
-                   local.get $24
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $7
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                   local.tee $24
+                   local.tee $7
                    call $~lib/rt/pure/__retain
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#__set
                    i32.const 0
-                   local.set $1
-                   local.get $0
+                   local.set $0
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $26
+                   local.tee $5
                    i32.load offset=8
-                   local.set $28
-                   local.get $26
+                   local.set $3
+                   local.get $5
                    i32.load offset=4
-                   local.set $22
+                   local.set $9
                    i32.const 12
                    i32.const 5
                    call $~lib/rt/tlsf/__alloc
-                   local.set $29
-                   local.get $28
+                   local.set $2
+                   local.get $3
                    i32.const 0
                    call $~lib/rt/tlsf/__alloc
-                   local.set $27
+                   local.set $4
                    loop $for-loop|011
-                    local.get $1
-                    local.get $28
+                    local.get $0
+                    local.get $3
                     i32.lt_s
                     if
-                     local.get $1
-                     local.get $22
+                     local.get $0
+                     local.get $9
                      i32.add
                      i32.load8_u
-                     local.set $25
+                     local.set $6
                      i32.const 3
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $27
+                     local.get $0
+                     local.get $4
                      i32.add
-                     local.get $25
-                     local.get $25
+                     local.get $6
+                     local.get $6
                      i32.mul
                      i32.store8
-                     local.get $1
+                     local.get $0
                      i32.const 1
                      i32.add
-                     local.set $1
+                     local.set $0
                      br $for-loop|011
                     end
                    end
-                   local.get $29
-                   local.get $27
+                   local.get $2
+                   local.get $4
                    call $~lib/rt/pure/__retain
                    i32.store
-                   local.get $29
-                   local.get $27
+                   local.get $2
+                   local.get $4
                    i32.store offset=4
-                   local.get $29
-                   local.get $28
+                   local.get $2
+                   local.get $3
                    i32.store offset=8
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__retain
-                   local.set $1
-                   local.get $26
+                   local.set $0
+                   local.get $5
                    call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    call $~lib/typedarray/Uint8ClampedArray#__get
                    i32.const 1
                    i32.ne
                    br_if $folding-inner4
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    call $~lib/typedarray/Uint8ClampedArray#__get
                    i32.const 4
                    i32.ne
                    br_if $folding-inner5
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    call $~lib/typedarray/Uint8ClampedArray#__get
                    i32.const 9
                    i32.ne
                    br_if $folding-inner6
-                   local.get $24
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $7
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $29
+                   local.tee $2
                    call $~lib/rt/pure/__retain
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int16Array#map
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    call $~lib/typedarray/Int16Array#__get
                    i32.const 1
                    i32.ne
                    br_if $folding-inner4
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    call $~lib/typedarray/Int16Array#__get
                    i32.const 4
                    i32.ne
                    br_if $folding-inner5
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    call $~lib/typedarray/Int16Array#__get
                    i32.const 9
                    i32.ne
                    br_if $folding-inner6
-                   local.get $29
-                   call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $2
                    call $~lib/rt/pure/__release
                    local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $29
+                   local.tee $2
                    call $~lib/rt/pure/__retain
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint16Array#map
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    call $~lib/typedarray/Uint16Array#__get
                    i32.const 1
                    i32.ne
                    br_if $folding-inner4
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    call $~lib/typedarray/Uint16Array#__get
                    i32.const 4
                    i32.ne
                    br_if $folding-inner5
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    call $~lib/typedarray/Uint16Array#__get
                    i32.const 9
                    i32.ne
                    br_if $folding-inner6
-                   local.get $29
-                   call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $2
                    call $~lib/rt/pure/__release
                    local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int32Array#constructor
-                   local.tee $29
+                   local.tee $2
                    call $~lib/rt/pure/__retain
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int32Array#map
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    call $~lib/typedarray/Int32Array#__get
                    i32.const 1
                    i32.ne
                    br_if $folding-inner4
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    call $~lib/typedarray/Int32Array#__get
                    i32.const 4
                    i32.ne
                    br_if $folding-inner5
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    call $~lib/typedarray/Int32Array#__get
                    i32.const 9
                    i32.ne
                    br_if $folding-inner6
-                   local.get $29
-                   call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $2
                    call $~lib/rt/pure/__release
                    local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#constructor
-                   local.tee $29
+                   local.tee $2
                    call $~lib/rt/pure/__retain
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint32Array#map
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    call $~lib/typedarray/Uint32Array#__get
                    i32.const 1
                    i32.ne
                    br_if $folding-inner4
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    call $~lib/typedarray/Uint32Array#__get
                    i32.const 4
                    i32.ne
                    br_if $folding-inner5
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    call $~lib/typedarray/Uint32Array#__get
                    i32.const 9
                    i32.ne
                    br_if $folding-inner6
-                   local.get $29
-                   call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $2
                    call $~lib/rt/pure/__release
                    local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int64Array#constructor
-                   local.tee $29
+                   local.tee $2
                    call $~lib/rt/pure/__retain
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    i64.const 1
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 2
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 3
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int64Array#map
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    call $~lib/typedarray/Int64Array#__get
                    i64.const 1
                    i64.ne
                    br_if $folding-inner4
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    call $~lib/typedarray/Int64Array#__get
                    i64.const 4
                    i64.ne
                    br_if $folding-inner5
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    call $~lib/typedarray/Int64Array#__get
                    i64.const 9
                    i64.ne
                    br_if $folding-inner6
-                   local.get $29
-                   call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $2
                    call $~lib/rt/pure/__release
                    local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint64Array#constructor
-                   local.tee $29
+                   local.tee $2
                    call $~lib/rt/pure/__retain
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    i64.const 1
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 2
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 3
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint64Array#map
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    call $~lib/typedarray/Uint64Array#__get
                    i64.const 1
                    i64.ne
                    br_if $folding-inner4
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    call $~lib/typedarray/Uint64Array#__get
                    i64.const 4
                    i64.ne
                    br_if $folding-inner5
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    call $~lib/typedarray/Uint64Array#__get
                    i64.const 9
                    i64.ne
                    br_if $folding-inner6
-                   local.get $29
-                   call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $2
                    call $~lib/rt/pure/__release
                    local.get $0
                    call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float32Array#constructor
-                   local.tee $29
+                   local.tee $2
                    call $~lib/rt/pure/__retain
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    f32.const 1
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f32.const 2
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f32.const 3
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Float32Array#map
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    call $~lib/typedarray/Float32Array#__get
                    f32.const 1
                    f32.ne
                    br_if $folding-inner4
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    call $~lib/typedarray/Float32Array#__get
                    f32.const 4
                    f32.ne
                    br_if $folding-inner5
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    call $~lib/typedarray/Float32Array#__get
                    f32.const 9
                    f32.ne
                    br_if $folding-inner6
-                   local.get $29
-                   call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $2
                    call $~lib/rt/pure/__release
                    local.get $0
                    call $~lib/rt/pure/__release
+                   local.get $1
+                   call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float64Array#constructor
-                   local.tee $29
+                   local.tee $2
                    call $~lib/rt/pure/__retain
-                   local.tee $1
+                   local.tee $0
                    i32.const 0
                    f64.const 1
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f64.const 2
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f64.const 3
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Float64Array#map
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    call $~lib/typedarray/Float64Array#__get
                    f64.const 1
                    f64.ne
                    br_if $folding-inner4
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    call $~lib/typedarray/Float64Array#__get
                    f64.const 4
                    f64.ne
                    br_if $folding-inner5
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    call $~lib/typedarray/Float64Array#__get
                    f64.const 9
                    f64.ne
                    br_if $folding-inner6
-                   local.get $29
-                   call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $2
                    call $~lib/rt/pure/__release
                    local.get $0
+                   call $~lib/rt/pure/__release
+                   local.get $1
                    call $~lib/rt/pure/__release
                    call $std/typedarray/testArrayFilter<~lib/typedarray/Int8Array,i8>
                    call $std/typedarray/testArrayFilter<~lib/typedarray/Uint8Array,u8>
@@ -32388,1003 +32388,1003 @@
                    call $std/typedarray/testArrayFilter<~lib/typedarray/Float64Array,f64>
                    i32.const 3
                    call $~lib/typedarray/Int8Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 46
                    call $~lib/typedarray/Int8Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 47
                    call $~lib/typedarray/Int8Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 48
                    call $~lib/typedarray/Uint8Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 49
                    call $~lib/typedarray/Uint8Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 50
                    call $~lib/typedarray/Uint8Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 51
                    call $~lib/typedarray/Uint8Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 52
                    call $~lib/typedarray/Int16Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 53
                    call $~lib/typedarray/Int16Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 54
                    call $~lib/typedarray/Uint16Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 55
                    call $~lib/typedarray/Uint16Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 56
                    call $~lib/typedarray/Int32Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 57
                    call $~lib/typedarray/Int32Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 58
                    call $~lib/typedarray/Int32Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 59
                    call $~lib/typedarray/Int32Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 2
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 4
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 6
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 60
                    call $~lib/typedarray/Int64Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 61
                    call $~lib/typedarray/Int64Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 2
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 4
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 6
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 62
                    call $~lib/typedarray/Int64Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 63
                    call $~lib/typedarray/Int64Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    f32.const 2
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f32.const 4
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f32.const 6
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 64
                    call $~lib/typedarray/Float32Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 65
                    call $~lib/typedarray/Float32Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    f64.const 2
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f64.const 4
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f64.const 6
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 66
                    call $~lib/typedarray/Float64Array#some
                    i32.eqz
                    br_if $folding-inner7
-                   local.get $1
+                   local.get $0
                    i32.const 67
                    call $~lib/typedarray/Float64Array#some
                    br_if $folding-inner8
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int8Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 68
                    call $~lib/typedarray/Int8Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 69
                    call $~lib/typedarray/Int8Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 70
                    call $~lib/typedarray/Uint8Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 71
                    call $~lib/typedarray/Uint8Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 72
                    call $~lib/typedarray/Uint8Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 73
                    call $~lib/typedarray/Uint8Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 74
                    call $~lib/typedarray/Int16Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 75
                    call $~lib/typedarray/Int16Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 76
                    call $~lib/typedarray/Uint16Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 77
                    call $~lib/typedarray/Uint16Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 78
                    call $~lib/typedarray/Int32Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 79
                    call $~lib/typedarray/Int32Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 80
                    call $~lib/typedarray/Int32Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 81
                    call $~lib/typedarray/Int32Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 1
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 2
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 3
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 82
                    call $~lib/typedarray/Int64Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 83
                    call $~lib/typedarray/Int64Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 1
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 2
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 3
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 84
                    call $~lib/typedarray/Int64Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 85
                    call $~lib/typedarray/Int64Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    f32.const 1
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f32.const 2
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f32.const 3
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 86
                    call $~lib/typedarray/Float32Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 87
                    call $~lib/typedarray/Float32Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    f64.const 1
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f64.const 2
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f64.const 3
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 88
                    call $~lib/typedarray/Float64Array#findIndex
                    i32.const 1
                    i32.ne
                    br_if $folding-inner9
-                   local.get $1
+                   local.get $0
                    i32.const 89
                    call $~lib/typedarray/Float64Array#findIndex
                    i32.const -1
                    i32.ne
                    br_if $folding-inner10
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int8Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 90
                    call $~lib/typedarray/Int8Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 91
                    call $~lib/typedarray/Int8Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 92
                    call $~lib/typedarray/Uint8Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 93
                    call $~lib/typedarray/Uint8Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 94
                    call $~lib/typedarray/Uint8Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 95
                    call $~lib/typedarray/Uint8Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 96
                    call $~lib/typedarray/Int16Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 97
                    call $~lib/typedarray/Int16Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 98
                    call $~lib/typedarray/Uint16Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 99
                    call $~lib/typedarray/Uint16Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 100
                    call $~lib/typedarray/Int32Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 101
                    call $~lib/typedarray/Int32Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 2
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 4
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 6
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 102
                    call $~lib/typedarray/Int32Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 103
                    call $~lib/typedarray/Int32Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Int64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 2
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 4
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 6
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 104
                    call $~lib/typedarray/Int64Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 105
                    call $~lib/typedarray/Int64Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Uint64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 2
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 4
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 6
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 106
                    call $~lib/typedarray/Int64Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 107
                    call $~lib/typedarray/Int64Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    f32.const 2
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f32.const 4
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f32.const 6
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 108
                    call $~lib/typedarray/Float32Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 109
                    call $~lib/typedarray/Float32Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 3
                    call $~lib/typedarray/Float64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    f64.const 2
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f64.const 4
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f64.const 6
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 110
                    call $~lib/typedarray/Float64Array#every
                    i32.eqz
                    br_if $folding-inner11
-                   local.get $1
+                   local.get $0
                    i32.const 111
                    call $~lib/typedarray/Float64Array#every
                    br_if $folding-inner12
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Int8Array#constructor
-                   local.tee $28
+                   local.tee $3
                    call $~lib/rt/pure/__retain
-                   local.tee $0
+                   local.tee $1
                    global.set $std/typedarray/forEachSelf
-                   local.get $0
+                   local.get $1
                    i32.const 0
                    i32.const 2704
                    i32.const 0
@@ -33394,7 +33394,7 @@
                    i32.const 24
                    i32.shr_s
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    i32.const 2704
                    i32.const 1
@@ -33404,7 +33404,7 @@
                    i32.const 24
                    i32.shr_s
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    i32.const 2704
                    i32.const 2
@@ -33415,55 +33415,55 @@
                    i32.shr_s
                    call $~lib/typedarray/Int8Array#__set
                    i32.const 0
-                   local.set $1
-                   local.get $0
+                   local.set $0
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $29
+                   local.tee $2
                    i32.load offset=4
-                   local.set $27
-                   local.get $29
+                   local.set $4
+                   local.get $2
                    i32.load offset=8
-                   local.set $26
+                   local.set $5
                    loop $for-loop|012
-                    local.get $1
-                    local.get $26
+                    local.get $0
+                    local.get $5
                     i32.lt_s
                     if
-                     local.get $1
-                     local.get $27
+                     local.get $0
+                     local.get $4
                      i32.add
                      i32.load8_s
                      i32.const 3
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $29
+                     local.get $0
+                     local.get $2
                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0
-                     local.get $1
+                     local.get $0
                      i32.const 1
                      i32.add
-                     local.set $1
+                     local.set $0
                      br $for-loop|012
                     end
                    end
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $28
+                   local.get $3
                    call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    global.set $std/typedarray/forEachSelf
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    i32.const 2704
                    i32.const 0
@@ -33471,7 +33471,7 @@
                    i32.const 255
                    i32.and
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2704
                    i32.const 1
@@ -33479,7 +33479,7 @@
                    i32.const 255
                    i32.and
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 2704
                    i32.const 2
@@ -33487,26 +33487,26 @@
                    i32.const 255
                    i32.and
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 113
                    call $~lib/typedarray/Uint8Array#forEach
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    global.set $std/typedarray/forEachSelf
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    i32.const 2704
                    i32.const 0
@@ -33514,7 +33514,7 @@
                    i32.const 255
                    i32.and
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2704
                    i32.const 1
@@ -33522,7 +33522,7 @@
                    i32.const 255
                    i32.and
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 2704
                    i32.const 2
@@ -33530,26 +33530,26 @@
                    i32.const 255
                    i32.and
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 114
                    call $~lib/typedarray/Uint8Array#forEach
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $28
+                   local.tee $3
                    call $~lib/rt/pure/__retain
-                   local.tee $0
+                   local.tee $1
                    global.set $std/typedarray/forEachSelf
-                   local.get $0
+                   local.get $1
                    i32.const 0
                    i32.const 2704
                    i32.const 0
@@ -33559,7 +33559,7 @@
                    i32.const 16
                    i32.shr_s
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    i32.const 2704
                    i32.const 1
@@ -33569,7 +33569,7 @@
                    i32.const 16
                    i32.shr_s
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    i32.const 2704
                    i32.const 2
@@ -33580,59 +33580,59 @@
                    i32.shr_s
                    call $~lib/typedarray/Int16Array#__set
                    i32.const 0
-                   local.set $1
-                   local.get $0
+                   local.set $0
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $29
+                   local.tee $2
                    i32.load offset=4
-                   local.set $27
-                   local.get $29
+                   local.set $4
+                   local.get $2
                    i32.load offset=8
                    i32.const 1
                    i32.shr_u
-                   local.set $26
+                   local.set $5
                    loop $for-loop|013
-                    local.get $1
-                    local.get $26
+                    local.get $0
+                    local.get $5
                     i32.lt_s
                     if
-                     local.get $27
-                     local.get $1
+                     local.get $4
+                     local.get $0
                      i32.const 1
                      i32.shl
                      i32.add
                      i32.load16_s
                      i32.const 3
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $29
+                     local.get $0
+                     local.get $2
                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0
-                     local.get $1
+                     local.get $0
                      i32.const 1
                      i32.add
-                     local.set $1
+                     local.set $0
                      br $for-loop|013
                     end
                    end
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $28
+                   local.get $3
                    call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $28
+                   local.tee $3
                    call $~lib/rt/pure/__retain
-                   local.tee $0
+                   local.tee $1
                    global.set $std/typedarray/forEachSelf
-                   local.get $0
+                   local.get $1
                    i32.const 0
                    i32.const 2704
                    i32.const 0
@@ -33640,7 +33640,7 @@
                    i32.const 65535
                    i32.and
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    i32.const 2704
                    i32.const 1
@@ -33648,7 +33648,7 @@
                    i32.const 65535
                    i32.and
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    i32.const 2704
                    i32.const 2
@@ -33657,169 +33657,209 @@
                    i32.and
                    call $~lib/typedarray/Uint16Array#__set
                    i32.const 0
-                   local.set $1
-                   local.get $0
+                   local.set $0
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $29
+                   local.tee $2
                    i32.load offset=4
-                   local.set $27
-                   local.get $29
+                   local.set $4
+                   local.get $2
                    i32.load offset=8
                    i32.const 1
                    i32.shr_u
-                   local.set $26
+                   local.set $5
                    loop $for-loop|014
-                    local.get $1
-                    local.get $26
+                    local.get $0
+                    local.get $5
                     i32.lt_s
                     if
-                     local.get $27
-                     local.get $1
+                     local.get $4
+                     local.get $0
                      i32.const 1
                      i32.shl
                      i32.add
                      i32.load16_u
                      i32.const 3
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $29
+                     local.get $0
+                     local.get $2
                      call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0
-                     local.get $1
+                     local.get $0
                      i32.const 1
                      i32.add
-                     local.set $1
+                     local.set $0
                      br $for-loop|014
                     end
                    end
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $28
+                   local.get $3
                    call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Int32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    global.set $std/typedarray/forEachSelf
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    i32.const 2704
                    i32.const 0
                    call $~lib/array/Array<i32>#__get
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2704
                    i32.const 1
                    call $~lib/array/Array<i32>#__get
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 2704
                    i32.const 2
                    call $~lib/array/Array<i32>#__get
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 117
                    call $~lib/typedarray/Int32Array#forEach
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    global.set $std/typedarray/forEachSelf
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    i32.const 2704
                    i32.const 0
                    call $~lib/array/Array<i32>#__get
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2704
                    i32.const 1
                    call $~lib/array/Array<i32>#__get
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 2704
                    i32.const 2
                    call $~lib/array/Array<i32>#__get
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 118
                    call $~lib/typedarray/Int32Array#forEach
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Int64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    global.set $std/typedarray/forEachSelf
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    i32.const 2704
                    i32.const 0
                    call $~lib/array/Array<i32>#__get
                    i64.extend_i32_s
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2704
                    i32.const 1
                    call $~lib/array/Array<i32>#__get
                    i64.extend_i32_s
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 2704
                    i32.const 2
                    call $~lib/array/Array<i32>#__get
                    i64.extend_i32_s
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 119
                    call $~lib/typedarray/Int64Array#forEach
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Uint64Array#constructor
+                   local.tee $1
+                   call $~lib/rt/pure/__retain
                    local.tee $0
+                   global.set $std/typedarray/forEachSelf
+                   local.get $0
+                   i32.const 0
+                   i32.const 2704
+                   i32.const 0
+                   call $~lib/array/Array<i32>#__get
+                   i64.extend_i32_s
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $0
+                   i32.const 1
+                   i32.const 2704
+                   i32.const 1
+                   call $~lib/array/Array<i32>#__get
+                   i64.extend_i32_s
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $0
+                   i32.const 2
+                   i32.const 2704
+                   i32.const 2
+                   call $~lib/array/Array<i32>#__get
+                   i64.extend_i32_s
+                   call $~lib/typedarray/Uint64Array#__set
+                   local.get $0
+                   i32.const 120
+                   call $~lib/typedarray/Int64Array#forEach
+                   global.get $std/typedarray/forEachCallCount
+                   i32.const 3
+                   i32.ne
+                   br_if $folding-inner13
+                   local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
+                   call $~lib/rt/pure/__release
+                   i32.const 0
+                   global.set $std/typedarray/forEachCallCount
+                   i32.const 3
+                   call $~lib/typedarray/Float32Array#constructor
+                   local.tee $3
                    call $~lib/rt/pure/__retain
                    local.tee $1
                    global.set $std/typedarray/forEachSelf
@@ -33828,130 +33868,90 @@
                    i32.const 2704
                    i32.const 0
                    call $~lib/array/Array<i32>#__get
-                   i64.extend_i32_s
-                   call $~lib/typedarray/Uint64Array#__set
+                   f32.convert_i32_s
+                   call $~lib/typedarray/Float32Array#__set
                    local.get $1
                    i32.const 1
                    i32.const 2704
                    i32.const 1
                    call $~lib/array/Array<i32>#__get
-                   i64.extend_i32_s
-                   call $~lib/typedarray/Uint64Array#__set
+                   f32.convert_i32_s
+                   call $~lib/typedarray/Float32Array#__set
                    local.get $1
                    i32.const 2
                    i32.const 2704
                    i32.const 2
                    call $~lib/array/Array<i32>#__get
-                   i64.extend_i32_s
-                   call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
-                   i32.const 120
-                   call $~lib/typedarray/Int64Array#forEach
-                   global.get $std/typedarray/forEachCallCount
-                   i32.const 3
-                   i32.ne
-                   br_if $folding-inner13
-                   local.get $0
-                   call $~lib/rt/pure/__release
-                   local.get $1
-                   call $~lib/rt/pure/__release
+                   f32.convert_i32_s
+                   call $~lib/typedarray/Float32Array#__set
                    i32.const 0
-                   global.set $std/typedarray/forEachCallCount
-                   i32.const 3
-                   call $~lib/typedarray/Float32Array#constructor
-                   local.tee $28
+                   local.set $0
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $0
-                   global.set $std/typedarray/forEachSelf
-                   local.get $0
-                   i32.const 0
-                   i32.const 2704
-                   i32.const 0
-                   call $~lib/array/Array<i32>#__get
-                   f32.convert_i32_s
-                   call $~lib/typedarray/Float32Array#__set
-                   local.get $0
-                   i32.const 1
-                   i32.const 2704
-                   i32.const 1
-                   call $~lib/array/Array<i32>#__get
-                   f32.convert_i32_s
-                   call $~lib/typedarray/Float32Array#__set
-                   local.get $0
-                   i32.const 2
-                   i32.const 2704
-                   i32.const 2
-                   call $~lib/array/Array<i32>#__get
-                   f32.convert_i32_s
-                   call $~lib/typedarray/Float32Array#__set
-                   i32.const 0
-                   local.set $1
-                   local.get $0
-                   call $~lib/rt/pure/__retain
-                   local.tee $29
+                   local.tee $2
                    i32.load offset=4
-                   local.set $27
-                   local.get $29
+                   local.set $4
+                   local.get $2
                    i32.load offset=8
                    i32.const 2
                    i32.shr_u
-                   local.set $26
+                   local.set $5
                    loop $for-loop|015
-                    local.get $1
-                    local.get $26
+                    local.get $0
+                    local.get $5
                     i32.lt_s
                     if
-                     local.get $27
-                     local.get $1
+                     local.get $4
+                     local.get $0
                      i32.const 2
                      i32.shl
                      i32.add
                      f32.load
                      i32.const 3
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $29
+                     local.get $0
+                     local.get $2
                      call $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0
-                     local.get $1
+                     local.get $0
                      i32.const 1
                      i32.add
-                     local.set $1
+                     local.set $0
                      br $for-loop|015
                     end
                    end
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $28
+                   local.get $3
                    call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $1
                    call $~lib/rt/pure/__release
                    i32.const 0
                    global.set $std/typedarray/forEachCallCount
                    i32.const 3
                    call $~lib/typedarray/Float64Array#constructor
-                   local.tee $28
+                   local.tee $3
                    call $~lib/rt/pure/__retain
-                   local.tee $0
+                   local.tee $1
                    global.set $std/typedarray/forEachSelf
-                   local.get $0
+                   local.get $1
                    i32.const 0
                    i32.const 2704
                    i32.const 0
                    call $~lib/array/Array<i32>#__get
                    f64.convert_i32_s
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    i32.const 2704
                    i32.const 1
                    call $~lib/array/Array<i32>#__get
                    f64.convert_i32_s
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    i32.const 2704
                    i32.const 2
@@ -33959,49 +33959,49 @@
                    f64.convert_i32_s
                    call $~lib/typedarray/Float64Array#__set
                    i32.const 0
-                   local.set $1
-                   local.get $0
+                   local.set $0
+                   local.get $1
                    call $~lib/rt/pure/__retain
-                   local.tee $29
+                   local.tee $2
                    i32.load offset=4
-                   local.set $27
-                   local.get $29
+                   local.set $4
+                   local.get $2
                    i32.load offset=8
                    i32.const 3
                    i32.shr_u
-                   local.set $26
+                   local.set $5
                    loop $for-loop|016
-                    local.get $1
-                    local.get $26
+                    local.get $0
+                    local.get $5
                     i32.lt_s
                     if
-                     local.get $27
-                     local.get $1
+                     local.get $4
+                     local.get $0
                      i32.const 3
                      i32.shl
                      i32.add
                      f64.load
                      i32.const 3
                      global.set $~argumentsLength
-                     local.get $1
-                     local.get $29
+                     local.get $0
+                     local.get $2
                      call $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0
-                     local.get $1
+                     local.get $0
                      i32.const 1
                      i32.add
-                     local.set $1
+                     local.set $0
                      br $for-loop|016
                     end
                    end
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
                    global.get $std/typedarray/forEachCallCount
                    i32.const 3
                    i32.ne
                    br_if $folding-inner13
-                   local.get $28
+                   local.get $3
                    call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $1
                    call $~lib/rt/pure/__release
                    call $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8>
                    call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
@@ -34027,11 +34027,11 @@
                    call $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64>
                    i32.const 1
                    call $~lib/typedarray/Float64Array#constructor
-                   local.tee $29
+                   local.tee $2
                    i32.const 0
                    f64.const nan:0x8000000000000
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $29
+                   local.get $2
                    f64.const nan:0x8000000000000
                    i32.const 0
                    call $~lib/typedarray/Float64Array#indexOf
@@ -34046,71 +34046,71 @@
                     unreachable
                    end
                    i32.const 0
-                   local.set $1
+                   local.set $0
                    i32.const 0
-                   local.set $28
+                   local.set $3
                    block $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
-                    local.get $29
+                    local.get $2
                     call $~lib/rt/pure/__retain
-                    local.tee $0
+                    local.tee $1
                     i32.load offset=8
                     i32.const 3
                     i32.shr_u
-                    local.tee $27
+                    local.tee $4
                     if (result i32)
                      i32.const 0
-                     local.get $27
+                     local.get $4
                      i32.ge_s
                     else
                      i32.const 1
                     end
                     if
-                     local.get $0
+                     local.get $1
                      call $~lib/rt/pure/__release
                      br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
                     end
-                    local.get $0
+                    local.get $1
                     i32.load offset=4
-                    local.set $25
+                    local.set $6
                     loop $while-continue|0
-                     local.get $1
-                     local.get $27
+                     local.get $0
+                     local.get $4
                      i32.lt_s
                      if
-                      local.get $25
-                      local.get $1
+                      local.get $6
+                      local.get $0
                       i32.const 3
                       i32.shl
                       i32.add
                       f64.load
-                      local.tee $23
+                      local.tee $8
                       f64.const nan:0x8000000000000
                       f64.eq
                       if (result i32)
                        i32.const 1
                       else
-                       local.get $23
-                       local.get $23
+                       local.get $8
+                       local.get $8
                        f64.ne
                       end
                       if
-                       local.get $0
+                       local.get $1
                        call $~lib/rt/pure/__release
                        i32.const 1
-                       local.set $28
+                       local.set $3
                        br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
                       end
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $while-continue|0
                      end
                     end
-                    local.get $0
+                    local.get $1
                     call $~lib/rt/pure/__release
                    end
-                   local.get $28
+                   local.get $3
                    i32.const 0
                    i32.ne
                    i32.const 1
@@ -34125,11 +34125,11 @@
                    end
                    i32.const 1
                    call $~lib/typedarray/Float32Array#constructor
-                   local.tee $28
+                   local.tee $3
                    i32.const 0
                    f32.const nan:0x400000
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $28
+                   local.get $3
                    f32.const nan:0x400000
                    i32.const 0
                    call $~lib/typedarray/Float32Array#indexOf
@@ -34144,71 +34144,71 @@
                     unreachable
                    end
                    i32.const 0
-                   local.set $1
+                   local.set $0
                    i32.const 0
-                   local.set $27
+                   local.set $4
                    block $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
-                    local.get $28
+                    local.get $3
                     call $~lib/rt/pure/__retain
-                    local.tee $0
+                    local.tee $1
                     i32.load offset=8
                     i32.const 2
                     i32.shr_u
-                    local.tee $26
+                    local.tee $5
                     if (result i32)
                      i32.const 0
-                     local.get $26
+                     local.get $5
                      i32.ge_s
                     else
                      i32.const 1
                     end
                     if
-                     local.get $0
+                     local.get $1
                      call $~lib/rt/pure/__release
                      br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
                     end
-                    local.get $0
+                    local.get $1
                     i32.load offset=4
-                    local.set $24
+                    local.set $7
                     loop $while-continue|017
-                     local.get $1
-                     local.get $26
+                     local.get $0
+                     local.get $5
                      i32.lt_s
                      if
-                      local.get $24
-                      local.get $1
+                      local.get $7
+                      local.get $0
                       i32.const 2
                       i32.shl
                       i32.add
                       f32.load
-                      local.tee $21
+                      local.tee $10
                       f32.const nan:0x400000
                       f32.eq
                       if (result i32)
                        i32.const 1
                       else
-                       local.get $21
-                       local.get $21
+                       local.get $10
+                       local.get $10
                        f32.ne
                       end
                       if
-                       local.get $0
+                       local.get $1
                        call $~lib/rt/pure/__release
                        i32.const 1
-                       local.set $27
+                       local.set $4
                        br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
                       end
-                      local.get $1
+                      local.get $0
                       i32.const 1
                       i32.add
-                      local.set $1
+                      local.set $0
                       br $while-continue|017
                      end
                     end
-                    local.get $0
+                    local.get $1
                     call $~lib/rt/pure/__release
                    end
-                   local.get $27
+                   local.get $4
                    i32.const 0
                    i32.ne
                    i32.const 1
@@ -34221,525 +34221,525 @@
                     call $~lib/builtins/abort
                     unreachable
                    end
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
+                   local.get $3
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Int8Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    i32.const 4
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    i32.const 5
                    call $~lib/typedarray/Int8Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int8Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner0
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int8Array#join
-                   local.tee $28
+                   local.tee $3
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner18
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $3
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Uint8Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    i32.const 4
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    i32.const 5
                    call $~lib/typedarray/Uint8Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint8Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner0
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint8Array#join
-                   local.tee $28
-                   local.get $28
+                   local.tee $3
+                   local.get $3
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner18
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   call $~lib/rt/pure/__release
-                   local.get $0
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    i32.const 4
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    i32.const 5
                    call $~lib/typedarray/Uint8ClampedArray#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint8Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner0
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint8Array#join
-                   local.tee $28
-                   local.get $28
+                   local.tee $3
+                   local.get $3
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner18
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   call $~lib/rt/pure/__release
-                   local.get $0
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    i32.const 4
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    i32.const 5
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int16Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner0
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int16Array#join
-                   local.tee $28
+                   local.tee $3
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner18
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $3
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Uint16Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    i32.const 4
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    i32.const 5
                    call $~lib/typedarray/Uint16Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint16Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner0
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint16Array#join
-                   local.tee $28
+                   local.tee $3
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner18
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $3
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Int32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    i32.const 4
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    i32.const 5
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int32Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner0
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int32Array#join
-                   local.tee $28
+                   local.tee $3
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner18
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $3
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Uint32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i32.const 2
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i32.const 3
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    i32.const 4
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    i32.const 5
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint32Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner0
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint32Array#join
-                   local.tee $28
+                   local.tee $3
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner18
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $3
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Int64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 1
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 2
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 3
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    i64.const 4
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    i64.const 5
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int64Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner0
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Int64Array#join
-                   local.tee $28
+                   local.tee $3
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner18
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $3
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Uint64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    i64.const 1
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    i64.const 2
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    i64.const 3
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    i64.const 4
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    i64.const 5
                    call $~lib/typedarray/Uint64Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint64Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner0
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Uint64Array#join
-                   local.tee $28
+                   local.tee $3
                    i32.const 3296
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner18
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $3
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Float32Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    f32.const 1
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f32.const 2
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f32.const 3
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    f32.const 4
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    f32.const 5
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Float32Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 4400
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner16
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Float32Array#join
-                   local.tee $28
+                   local.tee $3
                    i32.const 4400
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner17
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
-                   call $~lib/rt/pure/__release
-                   local.get $0
+                   local.get $3
                    call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 5
                    call $~lib/typedarray/Float64Array#constructor
-                   local.tee $0
-                   call $~lib/rt/pure/__retain
                    local.tee $1
+                   call $~lib/rt/pure/__retain
+                   local.tee $0
                    i32.const 0
                    f64.const 1
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 1
                    f64.const 2
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 2
                    f64.const 3
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 3
                    f64.const 4
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    i32.const 4
                    f64.const 5
                    call $~lib/typedarray/Float64Array#__set
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Float64Array#join
-                   local.tee $29
+                   local.tee $2
                    i32.const 4400
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner16
-                   local.get $1
+                   local.get $0
                    call $~lib/typedarray/Float64Array#join
-                   local.tee $28
+                   local.tee $3
                    i32.const 4400
                    call $~lib/string/String.__eq
                    i32.eqz
                    br_if $folding-inner17
-                   local.get $29
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $28
+                   local.get $3
+                   call $~lib/rt/pure/__release
+                   local.get $1
                    call $~lib/rt/pure/__release
                    local.get $0
                    call $~lib/rt/pure/__release
-                   local.get $1
-                   call $~lib/rt/pure/__release
                    i32.const 0
                    call $~lib/arraybuffer/ArrayBuffer#constructor
-                   local.set $1
+                   local.set $0
                    i32.const 2
                    global.set $~argumentsLength
-                   local.get $1
+                   local.get $0
                    i32.const 0
                    call $~lib/typedarray/Uint8Array.wrap@varargs
-                   local.tee $29
+                   local.tee $2
                    i32.load offset=8
                    if
                     i32.const 0
@@ -34751,18 +34751,18 @@
                    end
                    i32.const 2
                    call $~lib/arraybuffer/ArrayBuffer#constructor
-                   local.set $0
-                   local.get $1
+                   local.set $1
+                   local.get $0
                    call $~lib/rt/pure/__release
                    i32.const 2
                    global.set $~argumentsLength
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    call $~lib/typedarray/Uint8Array.wrap@varargs
-                   local.set $1
-                   local.get $29
+                   local.set $0
+                   local.get $2
                    call $~lib/rt/pure/__release
-                   local.get $1
+                   local.get $0
                    i32.load offset=8
                    if
                     i32.const 0
@@ -34772,9 +34772,9 @@
                     call $~lib/builtins/abort
                     unreachable
                    end
-                   local.get $0
-                   call $~lib/rt/pure/__release
                    local.get $1
+                   call $~lib/rt/pure/__release
+                   local.get $0
                    call $~lib/rt/pure/__release
                    call $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8>
                    call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
@@ -34800,135 +34800,135 @@
                    call $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array>
                    i32.const 10
                    call $~lib/typedarray/Uint8ClampedArray#constructor
-                   local.set $1
+                   local.set $0
                    i32.const 3
                    call $~lib/typedarray/Float32Array#constructor
-                   local.tee $27
+                   local.tee $4
                    i32.const 0
                    f32.const 400
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $27
+                   local.get $4
                    i32.const 1
                    f32.const nan:0x400000
                    call $~lib/typedarray/Float32Array#__set
-                   local.get $27
+                   local.get $4
                    i32.const 2
                    f32.const inf
                    call $~lib/typedarray/Float32Array#__set
                    i32.const 4
                    call $~lib/typedarray/Int64Array#constructor
-                   local.tee $0
+                   local.tee $1
                    i32.const 0
                    i64.const -10
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 1
                    i64.const 100
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 2
                    i64.const 10
                    call $~lib/typedarray/Int64Array#__set
-                   local.get $0
+                   local.get $1
                    i32.const 3
                    i64.const 300
                    call $~lib/typedarray/Int64Array#__set
                    i32.const 2
                    call $~lib/typedarray/Int32Array#constructor
-                   local.tee $26
+                   local.tee $5
                    i32.const 0
                    i32.const 300
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $26
+                   local.get $5
                    i32.const 1
                    i32.const -1
                    call $~lib/typedarray/Int32Array#__set
-                   local.get $1
-                   local.get $27
-                   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array>
-                   local.get $1
                    local.get $0
+                   local.get $4
+                   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array>
+                   local.get $0
+                   local.get $1
                    i32.const 4
                    call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
-                   local.get $1
-                   local.get $26
+                   local.get $0
+                   local.get $5
                    call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array>
-                   local.get $1
+                   local.get $0
                    i32.const 10
                    i32.const 0
                    i32.const 18
                    i32.const 8576
                    call $~lib/rt/__allocArray
                    call $~lib/rt/pure/__retain
-                   local.tee $25
+                   local.tee $6
                    call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
                    i32.const 4
                    call $~lib/typedarray/Uint32Array#constructor
-                   local.tee $29
+                   local.tee $2
                    i32.const 0
                    i32.const 1
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $29
+                   local.get $2
                    i32.const 1
                    i32.const 300
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $29
+                   local.get $2
                    i32.const 2
                    i32.const 100
                    call $~lib/typedarray/Uint32Array#__set
-                   local.get $29
+                   local.get $2
                    i32.const 3
                    i32.const -1
                    call $~lib/typedarray/Uint32Array#__set
                    i32.const 4
                    call $~lib/typedarray/Int16Array#constructor
-                   local.tee $28
+                   local.tee $3
                    i32.const 0
                    i32.const -10
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $28
+                   local.get $3
                    i32.const 1
                    i32.const 100
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $28
+                   local.get $3
                    i32.const 2
                    i32.const 10
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $28
+                   local.get $3
                    i32.const 3
                    i32.const 300
                    call $~lib/typedarray/Int16Array#__set
-                   local.get $1
-                   local.get $29
+                   local.get $0
+                   local.get $2
                    call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array>
-                   local.get $1
-                   local.get $28
+                   local.get $0
+                   local.get $3
                    i32.const 5
                    call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
-                   local.get $1
+                   local.get $0
                    i32.const 10
                    i32.const 0
                    i32.const 18
                    i32.const 8608
                    call $~lib/rt/__allocArray
                    call $~lib/rt/pure/__retain
-                   local.tee $24
+                   local.tee $7
                    call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-                   local.get $1
-                   call $~lib/rt/pure/__release
-                   local.get $27
-                   call $~lib/rt/pure/__release
                    local.get $0
                    call $~lib/rt/pure/__release
-                   local.get $26
+                   local.get $4
                    call $~lib/rt/pure/__release
-                   local.get $25
+                   local.get $1
                    call $~lib/rt/pure/__release
-                   local.get $29
+                   local.get $5
                    call $~lib/rt/pure/__release
-                   local.get $28
+                   local.get $6
                    call $~lib/rt/pure/__release
-                   local.get $24
+                   local.get $2
+                   call $~lib/rt/pure/__release
+                   local.get $3
+                   call $~lib/rt/pure/__release
+                   local.get $7
                    call $~lib/rt/pure/__release
                    return
                   end

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
@@ -17840,15 +17840,16 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
@@ -17856,7 +17857,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -17867,12 +17868,12 @@
    local.get $0
    i32.load8_s
    call $~lib/util/number/itoa32
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
   local.get $4
-  local.get $2
+  local.get $3
   call $~lib/string/String#get:length
   local.tee $5
   i32.const 11
@@ -17893,7 +17894,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -17902,25 +17903,25 @@
     i32.add
     i32.load8_s
     call $~lib/util/number/itoa_buffered<i8>
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $5
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $3
      local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $5
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $6
     i32.const 1
@@ -17931,7 +17932,7 @@
   end
   local.get $7
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -17940,7 +17941,7 @@
   i32.add
   i32.load8_s
   call $~lib/util/number/itoa_buffered<i8>
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -17948,13 +17949,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -17963,7 +17964,6 @@
   i32.load offset=4
   local.get $0
   i32.load offset=8
-  i32.const 3264
   call $~lib/util/string/joinIntegerArray<i8>
   i32.const 3264
   call $~lib/rt/pure/__release
@@ -18161,15 +18161,16 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
@@ -18177,7 +18178,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -18188,12 +18189,12 @@
    local.get $0
    i32.load8_u
    call $~lib/util/number/utoa32
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
   local.get $4
-  local.get $2
+  local.get $3
   call $~lib/string/String#get:length
   local.tee $5
   i32.const 10
@@ -18214,7 +18215,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -18223,25 +18224,25 @@
     i32.add
     i32.load8_u
     call $~lib/util/number/itoa_buffered<u8>
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $5
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $3
      local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $5
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $6
     i32.const 1
@@ -18252,7 +18253,7 @@
   end
   local.get $7
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -18261,7 +18262,7 @@
   i32.add
   i32.load8_u
   call $~lib/util/number/itoa_buffered<u8>
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -18269,13 +18270,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -18284,7 +18285,6 @@
   i32.load offset=4
   local.get $0
   i32.load offset=8
-  i32.const 3264
   call $~lib/util/string/joinIntegerArray<u8>
   i32.const 3264
   call $~lib/rt/pure/__release
@@ -18350,15 +18350,16 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<i16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
@@ -18366,7 +18367,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -18377,12 +18378,12 @@
    local.get $0
    i32.load16_s
    call $~lib/util/number/itoa32
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
   local.get $4
-  local.get $2
+  local.get $3
   call $~lib/string/String#get:length
   local.tee $5
   i32.const 11
@@ -18403,7 +18404,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -18414,25 +18415,25 @@
     i32.add
     i32.load16_s
     call $~lib/util/number/itoa_buffered<i16>
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $5
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $3
      local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $5
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $6
     i32.const 1
@@ -18443,7 +18444,7 @@
   end
   local.get $7
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -18454,7 +18455,7 @@
   i32.add
   i32.load16_s
   call $~lib/util/number/itoa_buffered<i16>
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -18462,13 +18463,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -18479,7 +18480,6 @@
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  i32.const 3264
   call $~lib/util/string/joinIntegerArray<i16>
   i32.const 3264
   call $~lib/rt/pure/__release
@@ -18514,15 +18514,16 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
@@ -18530,7 +18531,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -18541,12 +18542,12 @@
    local.get $0
    i32.load16_u
    call $~lib/util/number/utoa32
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
   local.get $4
-  local.get $2
+  local.get $3
   call $~lib/string/String#get:length
   local.tee $5
   i32.const 10
@@ -18567,7 +18568,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -18578,25 +18579,25 @@
     i32.add
     i32.load16_u
     call $~lib/util/number/itoa_buffered<u16>
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $5
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $3
      local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $5
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $6
     i32.const 1
@@ -18607,7 +18608,7 @@
   end
   local.get $7
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -18618,7 +18619,7 @@
   i32.add
   i32.load16_u
   call $~lib/util/number/itoa_buffered<u16>
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -18626,13 +18627,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -18643,7 +18644,6 @@
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  i32.const 3264
   call $~lib/util/string/joinIntegerArray<u16>
   i32.const 3264
   call $~lib/rt/pure/__release
@@ -18691,15 +18691,16 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
@@ -18707,7 +18708,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -18718,12 +18719,12 @@
    local.get $0
    i32.load
    call $~lib/util/number/itoa32
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
   local.get $4
-  local.get $2
+  local.get $3
   call $~lib/string/String#get:length
   local.tee $5
   i32.const 11
@@ -18744,7 +18745,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -18755,25 +18756,25 @@
     i32.add
     i32.load
     call $~lib/util/number/itoa_buffered<i32>
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $5
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $3
      local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $5
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $6
     i32.const 1
@@ -18784,7 +18785,7 @@
   end
   local.get $7
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -18795,7 +18796,7 @@
   i32.add
   i32.load
   call $~lib/util/number/itoa_buffered<i32>
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -18803,13 +18804,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -18820,7 +18821,6 @@
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  i32.const 3264
   call $~lib/util/string/joinIntegerArray<i32>
   i32.const 3264
   call $~lib/rt/pure/__release
@@ -18846,15 +18846,16 @@
   call $~lib/util/number/utoa_dec_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
@@ -18862,7 +18863,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -18873,12 +18874,12 @@
    local.get $0
    i32.load
    call $~lib/util/number/utoa32
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
   local.get $4
-  local.get $2
+  local.get $3
   call $~lib/string/String#get:length
   local.tee $5
   i32.const 10
@@ -18899,7 +18900,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -18910,25 +18911,25 @@
     i32.add
     i32.load
     call $~lib/util/number/itoa_buffered<u32>
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $5
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $3
      local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $5
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $6
     i32.const 1
@@ -18939,7 +18940,7 @@
   end
   local.get $7
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -18950,7 +18951,7 @@
   i32.add
   i32.load
   call $~lib/util/number/itoa_buffered<u32>
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -18958,13 +18959,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -18975,7 +18976,6 @@
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  i32.const 3264
   call $~lib/util/string/joinIntegerArray<u32>
   i32.const 3264
   call $~lib/rt/pure/__release
@@ -19117,16 +19117,17 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i64)
+ (func $~lib/util/string/joinIntegerArray<i64> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i64)
+  (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $4
   local.get $1
   i32.const 1
   i32.sub
@@ -19134,7 +19135,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $4
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -19148,28 +19149,28 @@
     i64.load
     i32.wrap_i64
     i64.extend_i32_s
-    local.tee $4
+    local.tee $3
     i64.eqz
     br_if $__inlined_func$~lib/util/number/itoa64
     drop
-    local.get $4
+    local.get $3
     i64.const 63
     i64.shr_u
     i32.wrap_i64
     local.tee $0
     if
      i64.const 0
-     local.get $4
+     local.get $3
      i64.sub
-     local.set $4
+     local.set $3
     end
-    local.get $4
+    local.get $3
     i64.const 4294967295
     i64.le_u
     if
-     local.get $4
+     local.get $3
      i32.wrap_i64
-     local.tee $3
+     local.tee $2
      call $~lib/util/number/decimalCount32
      local.get $0
      i32.add
@@ -19179,22 +19180,22 @@
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $1
-     local.get $3
+     local.get $2
      local.get $5
      call $~lib/util/number/utoa_dec_simple<u32>
     else
-     local.get $4
+     local.get $3
      call $~lib/util/number/decimalCount64High
      local.get $0
      i32.add
-     local.tee $3
+     local.tee $2
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $1
-     local.get $4
      local.get $3
+     local.get $2
      call $~lib/util/number/utoa_dec_simple<u64>
     end
     local.get $0
@@ -19206,12 +19207,12 @@
     local.get $1
     call $~lib/rt/pure/__retain
    end
-   local.get $2
+   local.get $4
    call $~lib/rt/pure/__release
    return
   end
   local.get $5
-  local.get $2
+  local.get $4
   call $~lib/string/String#get:length
   local.tee $6
   i32.const 21
@@ -19232,7 +19233,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -19243,25 +19244,25 @@
     i32.add
     i64.load
     call $~lib/util/number/itoa_buffered<i64>
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $6
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $4
      local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $6
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $7
     i32.const 1
@@ -19272,7 +19273,7 @@
   end
   local.get $8
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -19283,7 +19284,7 @@
   i32.add
   i64.load
   call $~lib/util/number/itoa_buffered<i64>
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -19291,13 +19292,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $4
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -19308,7 +19309,6 @@
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  i32.const 3264
   call $~lib/util/string/joinIntegerArray<i64>
   i32.const 3264
   call $~lib/rt/pure/__release
@@ -19351,16 +19351,17 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
@@ -19368,7 +19369,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -19392,14 +19393,14 @@
      i32.wrap_i64
      local.tee $1
      call $~lib/util/number/decimalCount32
-     local.tee $3
+     local.tee $2
      i32.const 1
      i32.shl
      i32.const 1
      call $~lib/rt/tlsf/__alloc
      local.tee $0
      local.get $1
-     local.get $3
+     local.get $2
      call $~lib/util/number/utoa_dec_simple<u32>
     else
      local.get $5
@@ -19417,12 +19418,12 @@
     local.get $0
     call $~lib/rt/pure/__retain
    end
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
   local.get $4
-  local.get $2
+  local.get $3
   call $~lib/string/String#get:length
   local.tee $6
   i32.const 20
@@ -19443,7 +19444,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -19454,25 +19455,25 @@
     i32.add
     i64.load
     call $~lib/util/number/itoa_buffered<u64>
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $6
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $3
      local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $6
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $7
     i32.const 1
@@ -19483,7 +19484,7 @@
   end
   local.get $8
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -19494,7 +19495,7 @@
   i32.add
   i64.load
   call $~lib/util/number/itoa_buffered<u64>
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -19502,13 +19503,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -19519,7 +19520,6 @@
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  i32.const 3264
   call $~lib/util/string/joinIntegerArray<u64>
   i32.const 3264
   call $~lib/rt/pure/__release
@@ -20575,15 +20575,16 @@
   local.get $1
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f32> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
@@ -20591,7 +20592,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -20603,12 +20604,12 @@
    f32.load
    f64.promote_f32
    call $~lib/util/number/dtoa
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
   local.get $4
-  local.get $2
+  local.get $3
   call $~lib/string/String#get:length
   local.tee $5
   i32.const 28
@@ -20629,7 +20630,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -20641,25 +20642,25 @@
     f32.load
     f64.promote_f32
     call $~lib/util/number/dtoa_buffered
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $5
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $3
      local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $5
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $6
     i32.const 1
@@ -20670,7 +20671,7 @@
   end
   local.get $7
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -20682,7 +20683,7 @@
   f32.load
   f64.promote_f32
   call $~lib/util/number/dtoa_buffered
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -20690,13 +20691,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -20707,20 +20708,20 @@
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  i32.const 3264
   call $~lib/util/string/joinFloatArray<f32>
   i32.const 3264
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  local.get $2
+  i32.const 3264
   call $~lib/rt/pure/__retain
-  local.set $2
+  local.set $3
   local.get $1
   i32.const 1
   i32.sub
@@ -20728,7 +20729,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 2928
    return
@@ -20739,12 +20740,12 @@
    local.get $0
    f64.load
    call $~lib/util/number/dtoa
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    return
   end
   local.get $4
-  local.get $2
+  local.get $3
   call $~lib/string/String#get:length
   local.tee $5
   i32.const 28
@@ -20765,7 +20766,7 @@
    i32.lt_s
    if
     local.get $1
-    local.get $3
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -20776,25 +20777,25 @@
     i32.add
     f64.load
     call $~lib/util/number/dtoa_buffered
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
+    local.set $2
     local.get $5
     if
      local.get $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $2
+     local.get $3
      local.get $5
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $2
      local.get $5
      i32.add
-     local.set $3
+     local.set $2
     end
     local.get $6
     i32.const 1
@@ -20805,7 +20806,7 @@
   end
   local.get $7
   local.get $1
-  local.get $3
+  local.get $2
   i32.const 1
   i32.shl
   i32.add
@@ -20816,7 +20817,7 @@
   i32.add
   f64.load
   call $~lib/util/number/dtoa_buffered
-  local.get $3
+  local.get $2
   i32.add
   local.tee $0
   i32.gt_s
@@ -20824,13 +20825,13 @@
    local.get $1
    local.get $0
    call $~lib/string/String#substring
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    local.get $1
    call $~lib/rt/pure/__release
    return
   end
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $1
  )
@@ -20841,7 +20842,6 @@
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  i32.const 3264
   call $~lib/util/string/joinFloatArray<f64>
   i32.const 3264
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -28213,77 +28213,6 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  i32.const 4656
-  call $~lib/rt/pure/__retain
-  local.tee $2
-  i32.load offset=12
-  i32.const 3
-  i32.add
-  local.get $0
-  i32.load offset=8
-  i32.const 3
-  i32.shr_u
-  i32.gt_s
-  if
-   i32.const 1376
-   i32.const 1440
-   i32.const 1775
-   i32.const 47
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.load offset=4
-  i32.const 24
-  i32.add
-  local.set $3
-  local.get $2
-  i32.load offset=4
-  local.set $4
-  local.get $2
-  i32.load offset=12
-  local.set $5
-  loop $for-loop|0
-   local.get $1
-   local.get $5
-   i32.lt_s
-   if
-    local.get $3
-    local.get $1
-    i32.const 3
-    i32.shl
-    i32.add
-    local.get $4
-    local.get $1
-    i32.const 2
-    i32.shl
-    i32.add
-    f32.load
-    f64.promote_f32
-    f64.store
-    local.get $1
-    i32.const 1
-    i32.add
-    local.set $1
-    br $for-loop|0
-   end
-  end
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
-  i32.const 4656
-  call $~lib/rt/pure/__release
- )
  (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -28458,15 +28387,15 @@
   (local $14 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $6
+  local.tee $7
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $6
+  local.get $7
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $6
+  local.get $7
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -28490,51 +28419,51 @@
   call $~lib/typedarray/Uint8Array#__set
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $7
+  local.tee $8
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $7
+  local.get $8
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $7
+  local.get $8
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   i32.const 10
   call $~lib/typedarray/Float64Array#constructor
-  local.tee $14
+  local.tee $13
   call $~lib/rt/pure/__retain
-  local.tee $1
+  local.tee $3
   call $~lib/rt/pure/__retain
-  local.set $2
-  block $folding-inner0
+  local.set $1
+  block $folding-inner1
    i32.const 4592
    call $~lib/rt/pure/__retain
-   local.tee $3
+   local.tee $2
    i32.load offset=12
-   local.get $2
+   local.get $1
    i32.load offset=8
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner0
+   br_if $folding-inner1
+   local.get $1
+   i32.load offset=4
+   local.set $4
    local.get $2
    i32.load offset=4
-   local.set $8
-   local.get $3
-   i32.load offset=4
    local.set $9
-   local.get $3
+   local.get $2
    i32.load offset=12
-   local.set $10
+   local.set $6
    loop $for-loop|0
     local.get $0
-    local.get $10
+    local.get $6
     i32.lt_s
     if
-     local.get $8
+     local.get $4
      local.get $0
      i32.const 3
      i32.shl
@@ -28554,36 +28483,93 @@
      br $for-loop|0
     end
    end
-   local.get $3
-   call $~lib/rt/pure/__release
    local.get $2
+   call $~lib/rt/pure/__release
+   local.get $1
    call $~lib/rt/pure/__release
    i32.const 4592
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $3
    i32.const 10
    i32.const 3
    i32.const 17
    i32.const 8144
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $8
+   local.tee $9
    call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
+   i32.const 0
+   local.set $0
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.set $1
+   i32.const 4656
+   call $~lib/rt/pure/__retain
+   local.tee $2
+   i32.load offset=12
+   i32.const 3
+   i32.add
    local.get $1
-   call $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>>
+   i32.load offset=8
+   i32.const 3
+   i32.shr_u
+   i32.gt_s
+   br_if $folding-inner1
    local.get $1
+   i32.load offset=4
+   i32.const 24
+   i32.add
+   local.set $4
+   local.get $2
+   i32.load offset=4
+   local.set $6
+   local.get $2
+   i32.load offset=12
+   local.set $10
+   loop $for-loop|00
+    local.get $0
+    local.get $10
+    i32.lt_s
+    if
+     local.get $4
+     local.get $0
+     i32.const 3
+     i32.shl
+     i32.add
+     local.get $6
+     local.get $0
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     f64.promote_f32
+     f64.store
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $for-loop|00
+    end
+   end
+   local.get $2
+   call $~lib/rt/pure/__release
+   local.get $1
+   call $~lib/rt/pure/__release
+   i32.const 4656
+   call $~lib/rt/pure/__release
+   local.get $3
    i32.const 10
    i32.const 3
    i32.const 17
    i32.const 8288
    call $~lib/rt/__allocArray
    call $~lib/rt/pure/__retain
-   local.tee $9
+   local.tee $6
    call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
-   local.get $1
-   local.get $6
+   local.get $3
+   local.get $7
    call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array>
-   local.get $1
+   local.get $3
    i32.const 10
    i32.const 3
    i32.const 17
@@ -28597,31 +28583,31 @@
    local.get $5
    call $~lib/rt/pure/__retain
    local.set $4
-   local.get $1
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $1
    local.get $4
    call $~lib/rt/pure/__retain
-   local.tee $3
+   local.tee $2
    i32.load offset=8
-   local.get $2
+   local.get $1
    i32.load offset=8
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner0
-   local.get $2
+   br_if $folding-inner1
+   local.get $1
    i32.load offset=4
    local.set $11
-   local.get $3
+   local.get $2
    i32.load offset=4
    local.set $12
-   local.get $3
+   local.get $2
    i32.load offset=8
-   local.set $13
-   loop $for-loop|00
+   local.set $14
+   loop $for-loop|001
     local.get $0
-    local.get $13
+    local.get $14
     i32.lt_s
     if
      local.get $11
@@ -28639,58 +28625,58 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|00
+     br $for-loop|001
     end
    end
-   local.get $3
-   call $~lib/rt/pure/__release
    local.get $2
+   call $~lib/rt/pure/__release
+   local.get $1
    call $~lib/rt/pure/__release
    local.get $4
    call $~lib/rt/pure/__release
-   local.get $1
-   local.get $7
+   local.get $3
+   local.get $8
    call $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array>
    i32.const 0
    local.set $0
-   local.get $1
+   local.get $3
    call $~lib/rt/pure/__retain
-   local.set $2
+   local.set $1
    i32.const 4800
    call $~lib/rt/pure/__retain
-   local.tee $3
+   local.tee $2
    i32.load offset=12
    i32.const 7
    i32.add
-   local.get $2
+   local.get $1
    i32.load offset=8
    i32.const 3
    i32.shr_u
    i32.gt_s
-   br_if $folding-inner0
-   local.get $2
+   br_if $folding-inner1
+   local.get $1
    i32.load offset=4
    i32.const 56
    i32.add
-   local.set $11
-   local.get $3
+   local.set $4
+   local.get $2
    i32.load offset=4
-   local.set $12
-   local.get $3
+   local.set $11
+   local.get $2
    i32.load offset=12
-   local.set $13
+   local.set $12
    loop $for-loop|01
     local.get $0
-    local.get $13
+    local.get $12
     i32.lt_s
     if
-     local.get $11
+     local.get $4
      local.get $0
      i32.const 3
      i32.shl
      i32.add
      local.get $0
-     local.get $12
+     local.get $11
      i32.add
      i32.load8_s
      f64.convert_i32_s
@@ -28702,13 +28688,13 @@
      br $for-loop|01
     end
    end
-   local.get $3
-   call $~lib/rt/pure/__release
    local.get $2
+   call $~lib/rt/pure/__release
+   local.get $1
    call $~lib/rt/pure/__release
    i32.const 4800
    call $~lib/rt/pure/__release
-   local.get $1
+   local.get $3
    i32.const 10
    i32.const 3
    i32.const 17
@@ -28719,19 +28705,19 @@
    call $std/typedarray/valuesEqual<~lib/typedarray/Float64Array>
    local.get $0
    call $~lib/rt/pure/__release
-   local.get $6
+   local.get $7
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $7
-   call $~lib/rt/pure/__release
-   local.get $14
-   call $~lib/rt/pure/__release
-   local.get $1
-   call $~lib/rt/pure/__release
    local.get $8
    call $~lib/rt/pure/__release
+   local.get $13
+   call $~lib/rt/pure/__release
+   local.get $3
+   call $~lib/rt/pure/__release
    local.get $9
+   call $~lib/rt/pure/__release
+   local.get $6
    call $~lib/rt/pure/__release
    local.get $10
    call $~lib/rt/pure/__release

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -400,7 +400,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -420,35 +420,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -458,12 +458,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -471,7 +471,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -490,42 +490,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -540,12 +542,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -555,38 +557,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -604,7 +606,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -613,21 +615,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -654,7 +656,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4
@@ -896,22 +898,21 @@
    local.set $1
   else
    local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
    i32.const 536870904
    i32.lt_u
-   if
-    local.get $1
-    i32.const 1
-    i32.const 27
-    local.get $1
-    i32.clz
-    i32.sub
-    i32.shl
-    i32.add
-    i32.const 1
-    i32.sub
-    local.set $1
-   end
-   local.get $1
+   select
+   local.tee $1
    i32.const 31
    local.get $1
    i32.clz
@@ -5578,7 +5579,7 @@
   i32.const 12
   i32.const 6
   call $~lib/rt/tlsf/__alloc
-  local.set $2
+  local.set $3
   local.get $0
   i32.const 1
   i32.shl
@@ -5589,12 +5590,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $0
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -5603,46 +5604,46 @@
     i32.const 3
     global.set $~argumentsLength
     local.get $6
-    local.get $1
+    local.get $2
     local.get $4
     call $std/typedarray/testArrayFilter<~lib/typedarray/Int16Array,i16>~anonymous|0
     if
      local.get $5
-     local.get $3
+     local.get $1
      i32.const 1
      i32.shl
      i32.add
      local.get $6
      i32.store16
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
-  local.get $5
   local.get $3
+  local.get $5
+  local.get $1
   i32.const 1
   i32.shl
   local.tee $0
   call $~lib/rt/tlsf/__realloc
-  local.tee $1
+  local.tee $2
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=8
+  local.get $3
   local.get $2
-  local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__retain
   local.get $4
   call $~lib/rt/pure/__release
@@ -5772,7 +5773,7 @@
   i32.const 12
   i32.const 7
   call $~lib/rt/tlsf/__alloc
-  local.set $2
+  local.set $3
   local.get $0
   i32.const 1
   i32.shl
@@ -5783,12 +5784,12 @@
   i32.load offset=4
   local.set $7
   loop $for-loop|0
-   local.get $1
+   local.get $2
    local.get $0
    i32.lt_s
    if
     local.get $7
-    local.get $1
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
@@ -5797,46 +5798,46 @@
     i32.const 3
     global.set $~argumentsLength
     local.get $6
-    local.get $1
+    local.get $2
     local.get $4
     call $std/typedarray/testArrayFilter<~lib/typedarray/Uint16Array,u16>~anonymous|0
     if
      local.get $5
-     local.get $3
+     local.get $1
      i32.const 1
      i32.shl
      i32.add
      local.get $6
      i32.store16
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
     end
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
-    local.set $1
+    local.set $2
     br $for-loop|0
    end
   end
-  local.get $2
-  local.get $5
   local.get $3
+  local.get $5
+  local.get $1
   i32.const 1
   i32.shl
   local.tee $0
   call $~lib/rt/tlsf/__realloc
-  local.tee $1
+  local.tee $2
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=8
+  local.get $3
   local.get $2
-  local.get $1
   i32.store offset=4
-  local.get $2
+  local.get $3
   call $~lib/rt/pure/__retain
   local.get $4
   call $~lib/rt/pure/__release
@@ -8469,7 +8470,7 @@
      local.get $1
      i32.const 8388608
      i32.ge_u
-     if
+     if (result i32)
       local.get $1
       i32.const 8388608
       i32.eq
@@ -8477,9 +8478,9 @@
       local.get $1
       i32.const 8388608
       i32.sub
-      local.set $1
+     else
+      local.get $1
      end
-     local.get $1
      i32.const 1
      i32.shl
      local.set $1
@@ -8684,7 +8685,7 @@
      local.get $1
      i64.const 4503599627370496
      i64.ge_u
-     if
+     if (result i64)
       local.get $1
       i64.const 4503599627370496
       i64.eq
@@ -8692,9 +8693,9 @@
       local.get $1
       i64.const 4503599627370496
       i64.sub
-      local.set $1
+     else
+      local.get $1
      end
-     local.get $1
      i64.const 1
      i64.shl
      local.set $1
@@ -20867,7 +20868,6 @@
   call $~lib/memory/memory.fill
   local.get $1
   call $~lib/rt/pure/__retain
-  local.tee $0
  )
  (func $~lib/typedarray/Uint8Array.wrap (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)

--- a/tests/compiler/ternary.optimized.wat
+++ b/tests/compiler/ternary.optimized.wat
@@ -1,4 +1,12 @@
 (module
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (memory $0 0)
  (export "memory" (memory $0))
+ (export "test" (func $ternary/test))
+ (func $ternary/test (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $1
+  local.get $2
+  local.get $0
+  select
+ )
 )

--- a/tests/compiler/ternary.ts
+++ b/tests/compiler/ternary.ts
@@ -7,3 +7,7 @@ var a: i32;
 a = 0 ? unreachable() : 1;
 a = 1 ? 1 : unreachable();
 a = (0 ? unreachable() : 1) ? 1 : unreachable();
+
+export function test(x: i32, y: i32, z: i32): i32 {
+  return x ? y : z;
+}

--- a/tests/compiler/ternary.untouched.wat
+++ b/tests/compiler/ternary.untouched.wat
@@ -1,9 +1,11 @@
 (module
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
  (global $ternary/a (mut i32) (i32.const 0))
  (export "memory" (memory $0))
+ (export "test" (func $ternary/test))
  (start $~start)
  (func $start:ternary
   i32.const 1
@@ -18,6 +20,14 @@
   global.set $ternary/a
   i32.const 1
   global.set $ternary/a
+ )
+ (func $ternary/test (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $1
+  else
+   local.get $2
+  end
  )
  (func $~start
   call $start:ternary

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -292,7 +292,7 @@
   end
   local.get $1
   i32.load
-  local.tee $3
+  local.tee $4
   i32.const 1
   i32.and
   i32.eqz
@@ -312,35 +312,35 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $4
-  i32.load
   local.tee $5
+  i32.load
+  local.tee $2
   i32.const 1
   i32.and
   if
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.const 16
    i32.add
-   local.get $5
+   local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
+   local.tee $3
    i32.const 1073741808
    i32.lt_u
    if
     local.get $0
-    local.get $4
+    local.get $5
     call $~lib/rt/tlsf/removeBlock
     local.get $1
-    local.get $2
     local.get $3
+    local.get $4
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
     local.get $1
     i32.const 16
@@ -350,12 +350,12 @@
     i32.const -4
     i32.and
     i32.add
-    local.tee $4
+    local.tee $5
     i32.load
-    local.set $5
+    local.set $2
    end
   end
-  local.get $3
+  local.get $4
   i32.const 2
   i32.and
   if
@@ -363,7 +363,7 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $2
+   local.tee $3
    i32.load
    local.tee $7
    i32.const 1
@@ -382,42 +382,44 @@
    i32.and
    i32.const 16
    i32.add
-   local.get $3
+   local.get $4
    i32.const -4
    i32.and
    i32.add
    local.tee $8
    i32.const 1073741808
    i32.lt_u
-   if
+   if (result i32)
     local.get $0
-    local.get $2
+    local.get $3
     call $~lib/rt/tlsf/removeBlock
-    local.get $2
+    local.get $3
     local.get $8
     local.get $7
     i32.const 3
     i32.and
     i32.or
-    local.tee $3
+    local.tee $4
     i32.store
-    local.get $2
-    local.set $1
+    local.get $3
+   else
+    local.get $1
    end
+   local.set $1
   end
-  local.get $4
   local.get $5
+  local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $3
+  local.get $4
   i32.const -4
   i32.and
-  local.tee $2
+  local.tee $3
   i32.const 16
   i32.ge_u
   if (result i32)
-   local.get $2
+   local.get $3
    i32.const 1073741808
    i32.lt_u
   else
@@ -432,12 +434,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   local.get $1
   i32.const 16
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.ne
   if
    i32.const 0
@@ -447,38 +449,38 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.const 4
   i32.sub
   local.get $1
   i32.store
-  local.get $2
+  local.get $3
   i32.const 256
   i32.lt_u
   if
-   local.get $2
+   local.get $3
    i32.const 4
    i32.shr_u
-   local.set $2
+   local.set $3
   else
-   local.get $2
+   local.get $3
    i32.const 31
-   local.get $2
+   local.get $3
    i32.clz
    i32.sub
-   local.tee $3
+   local.tee $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $4
    i32.const 7
    i32.sub
    local.set $6
   end
-  local.get $2
+  local.get $3
   i32.const 16
   i32.lt_u
   i32.const 0
@@ -496,7 +498,7 @@
    unreachable
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -505,21 +507,21 @@
   i32.shl
   i32.add
   i32.load offset=96
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.store offset=16
   local.get $1
-  local.get $3
+  local.get $4
   i32.store offset=20
-  local.get $3
+  local.get $4
   if
-   local.get $3
+   local.get $4
    local.get $1
    i32.store offset=16
   end
   local.get $0
-  local.get $2
+  local.get $3
   local.get $6
   i32.const 4
   i32.shl
@@ -546,7 +548,7 @@
   local.get $0
   i32.load offset=4
   i32.const 1
-  local.get $2
+  local.get $3
   i32.shl
   i32.or
   i32.store offset=4

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -1058,22 +1058,22 @@
   i32.const 0
   global.set $while/ran
   i32.const 10
-  local.set $1
+  local.set $0
   loop $while-continue|0
-   local.get $1
+   local.get $0
    if
-    local.get $1
-    i32.const 1
-    i32.sub
-    local.set $1
     local.get $0
     i32.const 1
-    i32.add
+    i32.sub
     local.set $0
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
     br $while-continue|0
    end
   end
-  local.get $1
+  local.get $0
   if
    i32.const 0
    i32.const 1040
@@ -1082,7 +1082,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   i32.const 10
   i32.ne
   if
@@ -1111,25 +1111,25 @@
   i32.const 0
   global.set $while/ran
   i32.const 1
-  local.set $1
+  local.set $0
   loop $while-continue|00
-   local.get $1
-   local.tee $0
+   local.get $0
+   local.tee $1
    i32.const 1
    i32.sub
-   local.set $1
-   local.get $0
+   local.set $0
+   local.get $1
    if (result i32)
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
-    local.tee $2
+    local.tee $3
    else
     i32.const 0
    end
    br_if $while-continue|00
   end
-  local.get $1
+  local.get $0
   i32.const -1
   i32.ne
   if
@@ -1140,7 +1140,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   i32.const 1
   i32.ne
   if
@@ -1156,15 +1156,15 @@
   i32.const 0
   global.set $while/ran
   loop $while-continue|01
-   local.get $3
+   local.get $2
    i32.const 1
    i32.add
-   local.tee $3
+   local.tee $2
    i32.const 10
    i32.ne
    br_if $while-continue|01
   end
-  local.get $3
+  local.get $2
   i32.const 10
   i32.ne
   if
@@ -1178,17 +1178,17 @@
   i32.const 1
   global.set $while/ran
   i32.const 0
-  local.set $3
+  local.set $2
   loop $while-continue|002
-   local.get $3
+   local.get $2
    i32.const 1
    i32.add
-   local.tee $3
+   local.tee $2
    i32.const 10
    i32.ne
    br_if $while-continue|002
   end
-  local.get $3
+  local.get $2
   i32.const 10
   i32.ne
   if
@@ -1214,18 +1214,18 @@
   i32.const 0
   global.set $while/ran
   i32.const 10
-  local.set $3
+  local.set $2
   loop $while-continue|04
-   local.get $3
+   local.get $2
    if
-    local.get $3
+    local.get $2
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $2
     br $while-continue|04
    end
   end
-  local.get $3
+  local.get $2
   if
    i32.const 0
    i32.const 1040
@@ -1239,30 +1239,30 @@
   i32.const 0
   global.set $while/ran
   i32.const 10
-  local.set $1
-  i32.const 10
   local.set $0
+  i32.const 10
+  local.set $1
   loop $while-continue|03
-   local.get $1
+   local.get $0
    if
     loop $while-continue|1
-     local.get $0
+     local.get $1
      if
-      local.get $0
+      local.get $1
       i32.const 1
       i32.sub
-      local.set $0
+      local.set $1
       br $while-continue|1
      end
     end
-    local.get $1
+    local.get $0
     i32.const 1
     i32.sub
-    local.set $1
+    local.set $0
     br $while-continue|03
    end
   end
-  local.get $1
+  local.get $0
   if
    i32.const 0
    i32.const 1040
@@ -1271,7 +1271,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
+  local.get $1
   if
    i32.const 0
    i32.const 1040
@@ -1285,38 +1285,38 @@
   i32.const 0
   global.set $while/ran
   i32.const 0
-  local.set $3
+  local.set $2
   call $while/Ref#constructor
-  local.set $1
+  local.set $0
   loop $while-continue|05
-   local.get $1
+   local.get $0
    if
-    local.get $3
+    local.get $2
     i32.const 1
     i32.add
-    local.tee $3
+    local.tee $2
     i32.const 10
     i32.eq
     if
      i32.const 0
-     local.set $0
-     local.get $1
+     local.set $1
+     local.get $0
      if
-      local.get $1
+      local.get $0
       call $~lib/rt/pure/__release
      end
     else
      call $while/Ref#constructor
-     local.set $0
-     local.get $1
+     local.set $1
+     local.get $0
      call $~lib/rt/pure/__release
     end
-    local.get $0
-    local.set $1
+    local.get $1
+    local.set $0
     br $while-continue|05
    end
   end
-  local.get $3
+  local.get $2
   i32.const 10
   i32.ne
   if
@@ -1327,7 +1327,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   if
    i32.const 0
    i32.const 1040
@@ -1338,7 +1338,7 @@
   end
   i32.const 1
   global.set $while/ran
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   global.get $while/ran
   i32.eqz
@@ -1353,37 +1353,37 @@
   i32.const 0
   global.set $while/ran
   i32.const 0
-  local.set $3
+  local.set $2
   call $while/Ref#constructor
-  local.set $1
+  local.set $0
   loop $while-continue|06
    block $while-break|0
     call $while/Ref#constructor
-    local.tee $2
+    local.tee $3
     call $~lib/rt/pure/__release
-    local.get $2
+    local.get $3
     if
-     local.get $3
+     local.get $2
      i32.const 1
      i32.add
-     local.tee $3
+     local.tee $2
      i32.const 10
      i32.eq
      if
-      local.get $1
+      local.get $0
       if
-       local.get $1
+       local.get $0
        call $~lib/rt/pure/__release
       end
       i32.const 0
-      local.set $1
+      local.set $0
       br $while-break|0
      end
      br $while-continue|06
     end
    end
   end
-  local.get $3
+  local.get $2
   i32.const 10
   i32.ne
   if
@@ -1394,7 +1394,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $0
   if
    i32.const 0
    i32.const 1040
@@ -1405,7 +1405,7 @@
   end
   i32.const 1
   global.set $while/ran
-  local.get $1
+  local.get $0
   call $~lib/rt/pure/__release
   global.get $while/ran
   i32.eqz
@@ -1420,12 +1420,12 @@
   i32.const 0
   global.set $while/ran
   i32.const 0
-  local.set $3
+  local.set $2
   loop $while-continue|067
-   local.get $3
+   local.get $2
    i32.const 1
    i32.add
-   local.tee $3
+   local.tee $2
    i32.const 1
    i32.lt_s
    br_if $while-continue|067
@@ -1435,12 +1435,12 @@
   i32.const 0
   global.set $while/ran
   i32.const 0
-  local.set $3
+  local.set $2
   loop $while-continue|08
-   local.get $3
+   local.get $2
    i32.const 1
    i32.add
-   local.tee $3
+   local.tee $2
    i32.const 1
    i32.lt_s
    br_if $while-continue|08


### PR DESCRIPTION
Found unoptimal CFG cases which happening only when pipeline uses flatten passes. Fixing via one extra simplify-local pass

Details: https://github.com/WebAssembly/binaryen/issues/2933

- [x] I've read the contributing guidelines