### PR TITLE
Handle strict field initialization in inlined ctors

### DIFF
--- a/tests/compiler/field-initialization-errors.json
+++ b/tests/compiler/field-initialization-errors.json
@@ -5,6 +5,7 @@
   "stderr": [
     "TS2564: Property 'field-initialization-errors/Ref.a' has no initializer",
     "TS2564: Property 'field-initialization-errors/Ref_Ctor.a' has no initializer",
+    "TS2564: Property 'field-initialization-errors/Ref_InlineCtor.a' has no initializer",
     "TS2564: Property 'field-initialization-errors/Ref_Ctor_Branch.a' has no initializer",
     "TS2565: Property 'field-initialization-errors/Ref_Ctor_Use_Init.a' is used before being assigned.",
     "TS2564: Property 'field-initialization-errors/Ref_Ctor_Call_Init.a' has no initializer",

--- a/tests/compiler/field-initialization-errors.ts
+++ b/tests/compiler/field-initialization-errors.ts
@@ -16,6 +16,16 @@ class Ref_Ctor {
   new Ref_Ctor();
 }
 
+// Uninitialized with inline ctor
+class Ref_InlineCtor {
+  a: ArrayBuffer; // TS2564
+  @inline constructor() {
+  }
+}
+{
+  new Ref_InlineCtor();
+}
+
 // Uninitialized in any branch
 class Ref_Ctor_Branch {
   a: ArrayBuffer; // TS2564

--- a/tests/compiler/field-initialization.optimized.wat
+++ b/tests/compiler/field-initialization.optimized.wat
@@ -817,6 +817,52 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 4
+  i32.const 23
+  call $~lib/rt/stub/__alloc
+  local.tee $0
+  i32.const 0
+  i32.const 0
+  call $~lib/rt/stub/__alloc
+  i32.store
+  local.get $0
+  i32.load
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 218
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 4
+  i32.const 24
+  call $~lib/rt/stub/__alloc
+  local.tee $0
+  i32.const 0
+  i32.store
+  i32.const 0
+  i32.const 0
+  call $~lib/rt/stub/__alloc
+  local.set $1
+  local.get $0
+  i32.load
+  drop
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  i32.load
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1040
+   i32.const 230
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
  )
  (func $~start
   call $start:field-initialization

--- a/tests/compiler/field-initialization.ts
+++ b/tests/compiler/field-initialization.ts
@@ -204,3 +204,28 @@ class Flow_Balanced {
   let o = new Flow_Balanced(true);
   assert(o.a != null);
 }
+
+// inlined ctors
+
+class Ref_Init_InlineCtor {
+  a: ArrayBuffer = new ArrayBuffer(0); // OK
+  @inline
+  constructor() {
+  }
+}
+{
+  let o = new Ref_Init_InlineCtor();
+  assert(o.a != null);
+}
+
+class Ref_InlineCtor_Init {
+  a: ArrayBuffer; // OK (in ctor)
+  @inline
+  constructor() {
+    this.a = new ArrayBuffer(0);
+  }
+}
+{
+  let o = new Ref_InlineCtor_Init();
+  assert(o.a != null);
+}

--- a/tests/compiler/field-initialization.untouched.wat
+++ b/tests/compiler/field-initialization.untouched.wat
@@ -1583,6 +1583,81 @@
   end
   local.get $4
   call $~lib/rt/stub/__release
+  i32.const 0
+  local.set $1
+  local.get $1
+  i32.eqz
+  if
+   i32.const 4
+   i32.const 23
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $1
+  end
+  local.get $1
+  i32.const 0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  i32.store
+  local.get $1
+  local.set $1
+  local.get $1
+  i32.load
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 218
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  call $~lib/rt/stub/__release
+  i32.const 0
+  local.set $0
+  local.get $0
+  i32.eqz
+  if
+   i32.const 4
+   i32.const 24
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  local.tee $2
+  i32.const 0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.load
+  call $~lib/rt/stub/__release
+  local.get $3
+  i32.store
+  local.get $0
+  local.set $0
+  local.get $0
+  i32.load
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 230
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/rt/stub/__release
  )
  (func $~start
   call $start:field-initialization


### PR DESCRIPTION
As [reported](https://github.com/AssemblyScript/assemblyscript/pull/1349#issuecomment-652237081) on the original PR, strict field initialization did not account for inlined constructors that must be checked per inlined flow.

- [x] I've read the contributing guidelines