### PR TITLE
Support lazy global and function exports

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -2239,7 +2239,7 @@ export class Program extends DiagnosticEmitter {
       validDecorators |= DecoratorFlags.EXTERNAL;
     } else {
       validDecorators |= DecoratorFlags.INLINE;
-      if (declaration.range.source.isLibrary) {
+      if (declaration.range.source.isLibrary || declaration.is(CommonFlags.EXPORT)) {
         validDecorators |= DecoratorFlags.LAZY;
       }
     }

--- a/tests/compiler/exports-lazy.json
+++ b/tests/compiler/exports-lazy.json
@@ -1,0 +1,5 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ]
+}

--- a/tests/compiler/exports-lazy.optimized.wat
+++ b/tests/compiler/exports-lazy.optimized.wat
@@ -1,0 +1,13 @@
+(module
+ (type $none_=>_none (func))
+ (memory $0 1)
+ (data (i32.const 1024) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\01\00\00\00\02\00\00\00\03")
+ (data (i32.const 1056) "\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00\10\04\00\00\10\04\00\00\0c\00\00\00\03")
+ (global $exports-lazy/lazyGlobalUsed i32 (i32.const 1072))
+ (export "memory" (memory $0))
+ (export "lazyGlobalUsed" (global $exports-lazy/lazyGlobalUsed))
+ (export "lazyFuncUsed" (func $~start))
+ (func $~start
+  nop
+ )
+)

--- a/tests/compiler/exports-lazy.ts
+++ b/tests/compiler/exports-lazy.ts
@@ -1,0 +1,9 @@
+@lazy export const lazyGlobalUnused: i32[] = [1,2,3];
+
+@lazy export const lazyGlobalUsed: i32[] = [1,2,3];
+lazyGlobalUsed;
+
+@lazy export function lazyFuncUnused(): void {}
+
+@lazy export function lazyFuncUsed(): void {}
+lazyFuncUsed();

--- a/tests/compiler/exports-lazy.untouched.wat
+++ b/tests/compiler/exports-lazy.untouched.wat
@@ -1,0 +1,25 @@
+(module
+ (type $none_=>_none (func))
+ (memory $0 1)
+ (data (i32.const 16) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00")
+ (data (i32.const 48) "\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00 \00\00\00 \00\00\00\0c\00\00\00\03\00\00\00")
+ (table $0 1 funcref)
+ (global $exports-lazy/lazyGlobalUsed i32 (i32.const 64))
+ (export "memory" (memory $0))
+ (export "lazyGlobalUsed" (global $exports-lazy/lazyGlobalUsed))
+ (export "lazyFuncUsed" (func $exports-lazy/lazyFuncUsed))
+ (start $~start)
+ (func $start:exports-lazy
+  (local $0 i32)
+  (local $1 i32)
+  global.get $exports-lazy/lazyGlobalUsed
+  drop
+  call $exports-lazy/lazyFuncUsed
+ )
+ (func $~start
+  call $start:exports-lazy
+ )
+ (func $exports-lazy/lazyFuncUsed
+  nop
+ )
+)


### PR DESCRIPTION
Fixes a code generation problem with globals that are both a module export and declared `@lazy`, as reported by @MaxGraey on Discord, by extending the concept a bit to explicitly support annotating global and function exports as lazy (only yielding a module export if referenced from other code, and otherwise omitting).

- [x] I've read the contributing guidelines