### PR TITLE
Emit text format before emitting JS

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -719,7 +719,11 @@ exports.main = function main(argv, options, callback) {
   // Prepare output
   if (!args.noEmit) {
     let hasStdout = false;
-    let hasOutput = false;
+    let hasOutput = args.textFile != null
+                 || args.binaryFile != null
+                 || args.jsFile != null
+                 || args.tsdFile != null
+                 || args.idlFile != null;
 
     if (args.outFile != null) {
       if (/\.was?t$/.test(args.outFile) && args.textFile == null) {
@@ -752,7 +756,6 @@ exports.main = function main(argv, options, callback) {
         writeStdout(wasm.output);
         hasStdout = true;
       }
-      hasOutput = true;
 
       // Post-process source map
       if (wasm.sourceMap != null) {
@@ -776,24 +779,22 @@ exports.main = function main(argv, options, callback) {
       }
     }
 
-    // Write JS
-    if (args.jsFile != null) {
-      let js;
-      if (args.jsFile.length) {
+    // Write text (also fallback)
+    if (args.textFile != null || !hasOutput) {
+      let wat;
+      if (args.textFile != null && args.textFile.length) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          js = module.toAsmjs();
+          wat = module.toText();
         });
-        writeFile(args.jsFile, js, baseDir);
+        writeFile(args.textFile, wat, baseDir);
       } else if (!hasStdout) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          js = module.toAsmjs();
+          wat = module.toText();
         });
-        writeStdout(js);
-        hasStdout = true;
+        writeStdout(wat);
       }
-      hasOutput = true;
     }
 
     // Write WebIDL
@@ -813,7 +814,6 @@ exports.main = function main(argv, options, callback) {
         writeStdout(idl);
         hasStdout = true;
       }
-      hasOutput = true;
     }
 
     // Write TypeScript definition
@@ -833,24 +833,23 @@ exports.main = function main(argv, options, callback) {
         writeStdout(tsd);
         hasStdout = true;
       }
-      hasOutput = true;
     }
 
-    // Write text (must be last)
-    if (args.textFile != null || !hasOutput) {
-      let wat;
-      if (args.textFile && args.textFile.length) {
+    // Write JS (modifies the binary, so must be last)
+    if (args.jsFile != null) {
+      let js;
+      if (args.jsFile.length) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          wat = module.toText();
+          js = module.toAsmjs();
         });
-        writeFile(args.textFile, wat, baseDir);
+        writeFile(args.jsFile, js, baseDir);
       } else if (!hasStdout) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          wat = module.toText();
+          js = module.toAsmjs();
         });
-        writeStdout(wat);
+        writeStdout(js);
       }
     }
   }


### PR DESCRIPTION
Reorders `asc`s various outputs so that `--jsFile` is always processed last, because conversion to JS can modify the original binary, previously leading to its artifacts being present in text format output (but not in binaries).

- [x] I've read the contributing guidelines