### PR TITLE
Fix ASTBuilder for parameters

### DIFF
--- a/src/extra/ast.ts
+++ b/src/extra/ast.ts
@@ -1613,7 +1613,7 @@ export class ASTBuilder {
     var type = node.type;
     var initializer = node.initializer;
     if (type) {
-      if (kind == ParameterKind.OPTIONAL) sb.push("?");
+      if (kind == ParameterKind.OPTIONAL && !initializer) sb.push("?");
       if (!isTypeOmitted(type)) {
         sb.push(": ");
         this.visitTypeNode(type);

--- a/tests/parser/constructor.ts.fixture.ts
+++ b/tests/parser/constructor.ts.fixture.ts
@@ -4,5 +4,5 @@ class MyClass {
   constructor(a: i32, b: i32) {}
 }
 class MyClassImplicit {
-  constructor(public a: i32, private readonly b?: i32 = 2, c?: i32 = 3) {}
+  constructor(public a: i32, private readonly b: i32 = 2, c: i32 = 3) {}
 }

--- a/tests/parser/function.ts.fixture.ts
+++ b/tests/parser/function.ts.fixture.ts
@@ -1,5 +1,5 @@
 function simple(): void {}
-function typeparams<T, V extends T>(a?: V | null = null): void {}
+function typeparams<T, V extends T>(a: V | null = null): void {}
 @decorator()
 function withdecorator(): void {}
 function withthis(this: i32): i32 {

--- a/tests/parser/parameter-optional.ts
+++ b/tests/parser/parameter-optional.ts
@@ -1,0 +1,1 @@
+function optionalParam(a: string = ""): void {}

--- a/tests/parser/parameter-optional.ts.fixture.ts
+++ b/tests/parser/parameter-optional.ts.fixture.ts
@@ -1,0 +1,1 @@
+function optionalParam(a: string = ""): void {}

--- a/tests/parser/parameter-order.ts.fixture.ts
+++ b/tests/parser/parameter-order.ts.fixture.ts
@@ -2,7 +2,7 @@ function restValid(a: i32, ...b: Array<i32>): void {}
 function optionalValid(a: i32, b?: i32): void {}
 function restParameterMustBeLast(...a: Array<i32>, b: i32): void {}
 function optionalCannotPrecedeRequired(a?: i32, b: i32): void {}
-function optionalWithInitializerCannotPrecedeRequired(a?: i32 = 1, b: i32): void {}
+function optionalWithInitializerCannotPrecedeRequired(a: i32 = 1, b: i32): void {}
 // ERROR 1014: "A rest parameter must be last in a parameter list." in parameter-order.ts(5,37+1)
 // ERROR 1016: "A required parameter cannot follow an optional parameter." in parameter-order.ts(8,49+1)
 // ERROR 1016: "A required parameter cannot follow an optional parameter." in parameter-order.ts(11,67+1)

--- a/tests/parser/string-binding.ts.fixture.ts
+++ b/tests/parser/string-binding.ts.fixture.ts
@@ -1,7 +1,7 @@
 @binding(BindingCall.NEW, [BindingType.STRING], BindingType.OBJECT_HANDLE)
 export class ExternalString {
   @binding(BindingCall.FUNCTION, [BindingType.U32, BindingType.U32], BindingType.OBJECT_HANDLE)
-  static fromCharCode(char: u16, schar?: u16 = <u16>-1): String {
+  static fromCharCode(char: u16, schar: u16 = <u16>-1): String {
     return unreachable();
   }
   @binding(BindingCall.FUNCTION, [BindingType.U32], BindingType.OBJECT_HANDLE)


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

Avoids adding a "?" to optional parameter if it has an initializer and adds a new parser test.

- [x] I've read the contributing guidelines