### PR TITLE
Fixed Incorrect Callback Return in CLI Module Validation

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -653,12 +653,16 @@ exports.main = function main(argv, options, callback) {
   // Validate the module if requested
   if (!args.noValidate) {
     stats.validateCount++;
+    let callbackErrorResponse;
     stats.validateTime += measure(() => {
       if (!module.validate()) {
         module.dispose();
-        return callback(Error("Validate error"));
+        callbackErrorResponse = callback(Error("Validate error"));
       }
     });
+    if (callbackErrorResponse) {
+      return callbackErrorResponse;
+    }
   }
 
   // Set Binaryen-specific options

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -653,15 +653,13 @@ exports.main = function main(argv, options, callback) {
   // Validate the module if requested
   if (!args.noValidate) {
     stats.validateCount++;
-    let callbackErrorResponse;
+    let isValid;
     stats.validateTime += measure(() => {
-      if (!module.validate()) {
-        module.dispose();
-        callbackErrorResponse = callback(Error("Validate error"));
-      }
+      isValid = module.validate();
     });
-    if (callbackErrorResponse) {
-      return callbackErrorResponse;
+    if (!isValid) {
+      module.dispose();
+      return callback(Error("validate error"));
     }
   }
 


### PR DESCRIPTION
relates to https://github.com/DuncanUszkay1/assemblyscript/pull/14

Please see the PR above for the context. But TL;DR I was working on closures, and the tests would hang when failing when validating the module. I think this return is meant to happen outside of the measure. 

With this fix, tests will not hang whenever a module cannot be validated correctly :smile: :+1: 

cc @dcodeIO @MaxGraey 