### PR TITLE
Respect outFile when detecting no output in asc

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -720,13 +720,6 @@ exports.main = function main(argv, options, callback) {
 
   // Prepare output
   if (!args.noEmit) {
-    let hasStdout = false;
-    let hasOutput = args.textFile != null
-                 || args.binaryFile != null
-                 || args.jsFile != null
-                 || args.tsdFile != null
-                 || args.idlFile != null;
-
     if (args.outFile != null) {
       if (/\.was?t$/.test(args.outFile) && args.textFile == null) {
         args.textFile = args.outFile;
@@ -736,6 +729,13 @@ exports.main = function main(argv, options, callback) {
         args.binaryFile = args.outFile;
       }
     }
+
+    let hasStdout = false;
+    let hasOutput = args.textFile != null
+                 || args.binaryFile != null
+                 || args.jsFile != null
+                 || args.tsdFile != null
+                 || args.idlFile != null;
 
     // Write binary
     if (args.binaryFile != null) {


### PR DESCRIPTION
Fixes a problem discovered in https://github.com/AssemblyScript/assemblyscript/pull/1238, where specifying `--outFile` would still emit text format to stdout, by reordering.

- [x] I've read the contributing guidelines