### PR TITLE
Add a node representing an omitted expression

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -59,6 +59,7 @@ export enum NodeKind {
   LITERAL,
   NEW,
   NULL,
+  OMITTED,
   PARENTHESIZED,
   PROPERTYACCESS,
   TERNARY,
@@ -209,7 +210,7 @@ export abstract class Node {
   }
 
   static createArrayLiteralExpression(
-    elementExpressions: (Expression | null)[],
+    elementExpressions: Expression[],
     range: Range
   ): ArrayLiteralExpression {
     return new ArrayLiteralExpression(elementExpressions, range);
@@ -324,6 +325,12 @@ export abstract class Node {
     range: Range
   ): ObjectLiteralExpression {
     return new ObjectLiteralExpression(names, values, range);
+  }
+
+  static createOmittedExpression(
+    range: Range
+  ): OmittedExpression {
+    return new OmittedExpression(range);
   }
 
   static createParenthesizedExpression(
@@ -1101,7 +1108,7 @@ export abstract class LiteralExpression extends Expression {
 export class ArrayLiteralExpression extends LiteralExpression {
   constructor(
     /** Nested element expressions. */
-    public elementExpressions: (Expression | null)[],
+    public elementExpressions: Expression[],
     /** Source range. */
     range: Range
   ) {
@@ -1344,6 +1351,16 @@ export class ObjectLiteralExpression extends LiteralExpression {
     range: Range
   ) {
     super(LiteralKind.OBJECT, range);
+  }
+}
+
+/** Represents an omitted expression, e.g. within an array literal. */
+export class OmittedExpression extends Expression {
+  constructor(
+    /** Source range. */
+    range: Range
+  ) {
+    super(NodeKind.OMITTED, range);
   }
 }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8795,11 +8795,11 @@ export class Compiler extends DiagnosticEmitter {
     var expressions = expression.elementExpressions;
     var length = expressions.length;
     var values = new Array<ExpressionRef>(length);
-    var isStatic = true;
+    var isStatic = !elementType.is(TypeFlags.HOST);
     var nativeElementType = elementType.toNativeType();
     for (let i = 0; i < length; ++i) {
       let elementExpression = expressions[i];
-      if (elementExpression) {
+      if (elementExpression.kind != NodeKind.OMITTED) {
         let expr = this.compileExpression(<Expression>elementExpression, elementType,
           Constraints.CONV_IMPLICIT | Constraints.WILL_RETAIN
         );
@@ -8811,7 +8811,7 @@ export class Compiler extends DiagnosticEmitter {
         }
         values[i] = expr;
       } else {
-        values[i] = this.makeZero(elementType, expression);
+        values[i] = this.makeZero(elementType, elementExpression);
       }
     }
 
@@ -8966,10 +8966,10 @@ export class Compiler extends DiagnosticEmitter {
     var length = expressions.length;
     var values = new Array<ExpressionRef>(length);
     var nativeElementType = elementType.toNativeType();
-    var isStatic = true;
+    var isStatic = !elementType.is(TypeFlags.HOST);
     for (let i = 0; i < length; ++i) {
       let elementExpression = expressions[i];
-      if (elementExpression) {
+      if (elementExpression.kind != NodeKind.OMITTED) {
         let expr = this.compileExpression(elementExpression, elementType,
           Constraints.CONV_IMPLICIT | Constraints.WILL_RETAIN
         );
@@ -8981,7 +8981,7 @@ export class Compiler extends DiagnosticEmitter {
         }
         values[i] = expr;
       } else {
-        values[i] = this.makeZero(elementType, expression);
+        values[i] = this.makeZero(elementType, elementExpression);
       }
     }
 
@@ -10670,7 +10670,7 @@ export class Compiler extends DiagnosticEmitter {
         this.error(
           DiagnosticCode.Not_implemented_0,
           reportNode.range,
-          "ref.null<externref>"
+          "ref.null"
         );
         return module.unreachable();
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3668,11 +3668,11 @@ export class Parser extends DiagnosticEmitter {
       }
       // ArrayLiteralExpression
       case Token.OPENBRACKET: {
-        let elementExpressions = new Array<Expression | null>();
+        let elementExpressions = new Array<Expression>();
         while (!tn.skip(Token.CLOSEBRACKET)) {
           let expr: Expression | null;
           if (tn.peek() == Token.COMMA) {
-            expr = null; // omitted
+            expr = Node.createOmittedExpression(tn.range(tn.pos));
           } else {
             expr = this.parseExpression(tn, Precedence.COMMA + 1);
             if (!expr) return null;


### PR DESCRIPTION
As a follow-up to https://github.com/AssemblyScript/assemblyscript/pull/1319#discussion_r455396101, this PR adds an `OmittedExpression` AST node with a proper range for use in diagnostics. Also makes sure that arrays of `externref`s are never considered static, in turn yielding the expected diagnostic:

```
  ERROR AS100: Not implemented: ref.null

   var a: externref[] = [ , ];
                         ^
```

(Note that the code above is still invalid for other reasons)

- [x] I've read the contributing guidelines