### PR TITLE
Preliminary path.relative workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,8 @@ jobs:
           exit 1
         fi
         npm test
+    - name: Test browser build
+      run: node tests/browser-asc
   test-windows:
     name: "Compiler (Windows, node current)"
     runs-on: windows-latest
@@ -87,6 +89,8 @@ jobs:
       run: npm run build
     - name: Test distribution
       run: npm test
+    - name: Test browser build
+      run: node tests/browser-asc
   test-macos:
     name: "Compiler (MacOS, node current)"
     runs-on: macos-latest
@@ -106,6 +110,8 @@ jobs:
       run: npm run build
     - name: Test distribution
       run: npm test
+    - name: Test browser build
+      run: node tests/browser-asc
   test-features:
     name: "Features"
     runs-on: ubuntu-latest

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -351,8 +351,11 @@ exports.main = function main(argv, options, callback) {
 
   // returns a relative path from baseDir
   function makeRelative(arg) {
+    // FIXME: see https://github.com/AssemblyScript/assemblyscript/issues/1398
+    if (baseDir === ".") return arg;
     return path.relative(baseDir, arg);
   }
+
   // postprocess we need to get absolute file locations argv
   argv = unique(argv.map(resolveBasedir)).map(makeRelative);
 


### PR DESCRIPTION
This is a relatively stupid workaround for https://github.com/AssemblyScript/assemblyscript/issues/1398 so we can get the editor on the website working again. Only works because baseDir in browsers is `.`. We'll still need a real fix but it's still unclear what's actually going on there.

- [x] I've read the contributing guidelines