### PR TITLE
Fix handling of boolean sourceMap option

### DIFF
--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -149,7 +149,10 @@ function sanitizeValue(value, type) {
       case "b": return Boolean(value);
       case "i": return Math.trunc(value) || 0;
       case "f": return Number(value) || 0;
-      case "s": return String(value);
+      case "s": {
+        if (value === true) return "";
+        return String(value);
+      }
       case "I": {
         if (!Array.isArray(value)) value = [ value ];
         return value.map(v => Math.trunc(v) || 0);

--- a/tests/asconfig/complicated/asconfig.json
+++ b/tests/asconfig/complicated/asconfig.json
@@ -6,7 +6,8 @@
       "initialMemory": 30,
       "explicitStart": true,
       "measure": true,
-      "pedantic": true
+      "pedantic": true,
+      "sourceMap": true
     }
   },
   "options": {

--- a/tests/asconfig/index.js
+++ b/tests/asconfig/index.js
@@ -8,6 +8,8 @@ asc.main(["assembly/index.ts", "--outFile", "output.wasm", "--explicitStart", ..
   writeFile(name, contents) {
     if (name === "output.wasm") {
       binary = contents;
+    } else if (name !== "output.wasm.map") {
+      throw Error("Unexpected output file: " + name);
     }
   }
 }, (err) => {


### PR DESCRIPTION
Fixes #1400 by recognizing `true` as a special value of string options, substituting it with the empty string. Now matches the behavior of string options given without arguments on the command line.

- [x] I've read the contributing guidelines