### PR TITLE
Merge oldest parent first

### DIFF
--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -56,7 +56,7 @@ export interface MemoryStream extends OutputStream {
 }
 
 /** Compiler options. */
-interface CompilerOptions {
+export interface CompilerOptions {
   /** Prints just the compiler's version and exits. */
   version?: boolean;
   /** Prints the help message and exits. */
@@ -146,7 +146,7 @@ interface CompilerOptions {
 }
 
 /** Compiler API options. */
-interface APIOptions {
+export interface APIOptions {
   /** Standard output stream to use. */
   stdout?: OutputStream;
   /** Standard error stream to use. */

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -193,8 +193,9 @@ exports.main = function main(argv, options, callback) {
   if (!stdout) throw Error("'options.stdout' must be specified");
   if (!stderr) throw Error("'options.stderr' must be specified");
 
-  const opts = optionsUtil.parse(argv, exports.options);
-  let args = opts.options;
+  const opts = optionsUtil.parse(argv, exports.options, false);
+  let args = optionsUtil.addDefaults(exports.options, opts.options);
+  let cliArgs = opts.options;
 
   argv = opts.arguments;
   if (args.noColors) {
@@ -302,6 +303,7 @@ exports.main = function main(argv, options, callback) {
   }
   let entries = new Set();
   asconfig = configs.shift();
+  let configArgs = {};
   while (asconfig) {
     // First merge options as the targets can overwrite them later
     if (asconfig.options) {
@@ -317,12 +319,12 @@ exports.main = function main(argv, options, callback) {
           return p;
         });
       }
-      args = optionsUtil.merge(exports.options, asconfig.options, args);
+      configArgs = optionsUtil.merge(exports.options, asconfig.options, configArgs);
     }
     
     // merge targets
     if (asconfig.targets && asconfig.targets[target]) {
-      args = optionsUtil.merge(exports.options, asconfig.targets[target], args);
+      configArgs = optionsUtil.merge(exports.options, asconfig.targets[target], configArgs);
     }
     // entries are added to the compilation
     if (asconfig.entries) {
@@ -337,7 +339,10 @@ exports.main = function main(argv, options, callback) {
     }
     asconfig = configs.shift();
   }
-
+  // Merge with defaults
+  args = optionsUtil.merge(exports.options, configArgs, args);
+  // Merge in cli args
+  args = optionsUtil.merge(exports.options, cliArgs, args);
   // Add entries
   argv = argv.concat(Array.from(entries));
 

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -284,7 +284,7 @@ exports.main = function main(argv, options, callback) {
   const configs = [asconfig];
 
   // First find all parent configs and add them each to the front
-  while (asconfig.extends) {
+  while (asconfig && asconfig.extends) {
     asconfigDir = path.isAbsolute(asconfig.extends)
       // absolute extension path means we know the exact directory and location
       ? path.dirname(asconfig.extends)

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -31,7 +31,7 @@ function parse(argv, config, propagateDefaults = true) {
       if (typeof option.alias === "string") aliases[option.alias] = key;
       else if (Array.isArray(option.alias)) option.alias.forEach(alias => aliases[alias] = key);
     }
-    if (option.default != null) options[key] = option.default;
+    if (option.default != null && propagateDefaults) options[key] = option.default;
   });
 
   // iterate over argv
@@ -87,7 +87,9 @@ function parse(argv, config, propagateDefaults = true) {
     } else unknown.push(arg);
   }
   while (i < k) trailing.push(argv[i++]); // trailing
-  if (propagateDefaults) addDefaults(config, options);
+  if (propagateDefaults) {
+    options = addDefaults(config, options);
+  }
 
   return { options, unknown, arguments: args, trailing };
 }
@@ -224,12 +226,17 @@ exports.merge = merge;
 
 /** Populates default values on a parsed options result. */
 function addDefaults(config, options) {
+  const newOptions = {};
   for (const [key, { default: defaultValue }] of Object.entries(config)) {
-    if (options[key] == null && defaultValue != null) {
-      options[key] = defaultValue;
+    if (options[key] == null) {
+      if (defaultValue != null) {
+        newOptions[key] = defaultValue;
+      }
+    } else {
+      newOptions[key] = options[key];
     }
   }
-  return options;
+  return newOptions;
 }
 
 exports.addDefaults = addDefaults;

--- a/tests/asconfig/complicated/assembly/index.ts
+++ b/tests/asconfig/complicated/assembly/index.ts
@@ -3,4 +3,4 @@ assert(ASC_SHRINK_LEVEL == 1);
 assert(ASC_FEATURE_SIMD);
 let size = memory.size();
 trace("size", 1, size);
-assert(size == 30);
+assert(size == 30, "expected 30 got " + size.toString());

--- a/tests/asconfig/complicated/assembly/index.ts
+++ b/tests/asconfig/complicated/assembly/index.ts
@@ -1,6 +1,6 @@
-assert(ASC_OPTIMIZE_LEVEL == 3);
-assert(ASC_SHRINK_LEVEL == 1);
-assert(ASC_FEATURE_SIMD);
+assert(ASC_OPTIMIZE_LEVEL == 3, "expected optimize level == 3");
+assert(ASC_SHRINK_LEVEL == 1, "expected shrink level == 1");
+assert(ASC_FEATURE_SIMD, "expected SIMD enabled");
 let size = memory.size();
 trace("size", 1, size);
 assert(size == 30, "expected 30 got " + size.toString());

--- a/tests/asconfig/extends/asconfig.json
+++ b/tests/asconfig/extends/asconfig.json
@@ -5,7 +5,9 @@
     }
   },
   "options": {
-    "enable": ["simd"]
+    "enable": ["simd"],
+    "runtime": "half",
+    "noEmit": false
   },
   "extends": "./extends.json"
 }

--- a/tests/asconfig/extends/expected.json
+++ b/tests/asconfig/extends/expected.json
@@ -1,0 +1,6 @@
+{
+  "runtime": "half",
+  "noEmit": false,
+  "noAssert": true,
+  "enable": ["simd"]
+}

--- a/tests/asconfig/extends/extends.json
+++ b/tests/asconfig/extends/extends.json
@@ -6,6 +6,8 @@
     }
   },
   "options": {
-    "disable": ["simd"]
+    "disable": ["simd"],
+    "noEmit": true,
+    "noAssert": true
   }
 }

--- a/tests/asconfig/extends/package.json
+++ b/tests/asconfig/extends/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "test": "node ../index.js"
+    "test": "node ../index.js --showConfig && node ../index.js"
   }
 }

--- a/tests/asconfig/index.js
+++ b/tests/asconfig/index.js
@@ -1,7 +1,11 @@
 const asc = require("../../cli/asc");
 const loader = require("../../lib/loader");
 const args = process.argv.slice(2);
+const path = require('path');
+const fs = require("fs");
 
+/** @type {string} */
+let stderr;
 /** @type {Uint8Array} */
 let binary;
 asc.main(["assembly/index.ts", "--outFile", "output.wasm", "--explicitStart", ...args], {
@@ -11,13 +15,51 @@ asc.main(["assembly/index.ts", "--outFile", "output.wasm", "--explicitStart", ..
     } else if (name !== "output.wasm.map") {
       throw Error("Unexpected output file: " + name);
     }
+  },
+  stderr: {
+    write(s) {
+      stderr = s;
+    }
   }
+
 }, (err) => {
   if (err) {
     console.error(err);
+    console.error(stderr);
     process.exit(1);
   }
 
+  const jsonPath = path.join(process.cwd(), "expected.json");
+  if (fs.existsSync(jsonPath) && stderr) {
+    const actual = JSON.parse(stderr);
+    const expected = require(jsonPath);
+    let errored = false;
+    for (let name of Object.getOwnPropertyNames(expected)) {
+      if (actual[name] !== expected[name]) {
+        // If object check just first level
+        if (typeof actual[name] === 'object' && typeof expected[name] === 'object') {
+          let error = false;
+          for (let field of Object.getOwnPropertyNames(actual[name])) {
+            if (actual[name][field] !== expected[name][field]) {
+              error = true;
+              break;
+            }
+          }
+          if (!error) {
+            continue;
+          }
+        }
+        console.error(name + ": " + actual[name] + " expected " + expected[name]);
+        errored = true;
+      }
+    }
+    if (errored) {
+      process.exit(1);
+    }
+    process.exit(0);
+  }
+
+  
   if (!binary) {
     console.error("No binary was generated for the asconfig test in " + process.cwd());
     process.exit(1);
@@ -29,6 +71,7 @@ asc.main(["assembly/index.ts", "--outFile", "output.wasm", "--explicitStart", ..
     theModule.exports._start();
   } catch (err) {
     console.error("The wasm module _start() function failed in " + process.cwd());
+    console.error(err);
     process.exit(1);
   }
   return 0;

--- a/tests/asconfig/package.json
+++ b/tests/asconfig/package.json
@@ -1,12 +1,13 @@
 {
   "private": true,
   "scripts": {
-    "test": "npm run test:use-consts && npm run test:target && npm run test:entry-points && npm run test:complicated",
+    "test": "npm run test:use-consts && npm run test:target && npm run test:entry-points && npm run test:complicated && npm run test:extends",
     "test:use-consts": "cd use-consts && npm run test",
     "test:entry-points": "cd entry-points && npm run test",
     "test:respect-inheritence": "cd respect-inheritence && npm run test",
     "test:target": "cd target && npm run test",
     "test:cyclical": "cd cyclical && npm run test",
-    "test:complicated": "cd complicated && npm run test"
+    "test:complicated": "cd complicated && npm run test",
+    "test:extends": "cd extends && npm run test"
   }
 }

--- a/tests/asconfig/target/asconfig.json
+++ b/tests/asconfig/target/asconfig.json
@@ -9,5 +9,7 @@
       "debug": true
     }
   },
-  "options": {}
+  "options": {
+    "runtime": "stub"
+  }
 }

--- a/tests/asconfig/target/assembly/index.ts
+++ b/tests/asconfig/target/assembly/index.ts
@@ -1,3 +1,3 @@
-assert(ASC_OPTIMIZE_LEVEL == 3);
-assert(ASC_SHRINK_LEVEL == 1);
-assert(ASC_FEATURE_SIMD);
+assert(ASC_OPTIMIZE_LEVEL == 3, "expected optimize level == 3");
+assert(ASC_SHRINK_LEVEL == 1, "expected shrink level == 1");
+assert(ASC_FEATURE_SIMD, "expected SIMD enabled");

--- a/tests/asconfig/target/expected.json
+++ b/tests/asconfig/target/expected.json
@@ -1,0 +1,3 @@
+{
+  "runtime": "none"
+}

--- a/tests/asconfig/target/package.json
+++ b/tests/asconfig/target/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "test": "node ../index.js"
+    "test": "node ../index.js --target && node ../index.js --showConfig --runtime none"
   }
 }


### PR DESCRIPTION
This adds more tests and changes the order of merges so that cli > target > options > parent.target ...

Now adding `expected.json`, which will be checked if `--showConfig` is passed to the test runner.

Changed `addDefaults` to return a new options object instead of editing the passed one.