### PR TITLE
Fix assertion when declaring a const v128

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -8,3 +8,4 @@ export * from "./collections";
 export * from "./math";
 export * from "./path";
 export * from "./text";
+export * from "./vector";

--- a/src/util/vector.ts
+++ b/src/util/vector.ts
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview Various vector utility.
+ * @license Apache-2.0
+ */
+
+/** v128 zero constant. */
+export const v128_zero = new Uint8Array(16);

--- a/tests/compiler/features/simd.ts
+++ b/tests/compiler/features/simd.ts
@@ -683,6 +683,11 @@ function test_v64x2(): void {
   // }
 }
 
+function test_const(): v128 {
+  const one = i32x4.splat(1); // should precompute
+  return one;                 // should not inline
+}
+
 if (ASC_FEATURE_SIMD) {
   test_v128();
   test_i8x16();
@@ -695,4 +700,5 @@ if (ASC_FEATURE_SIMD) {
   test_v16x8();
   test_v32x4();
   test_v64x2();
+  test_const();
 }

--- a/tests/compiler/features/simd.untouched.wat
+++ b/tests/compiler/features/simd.untouched.wat
@@ -3,6 +3,7 @@
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $none_=>_v128 (func (result v128)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00s\00t\00u\00b\00.\00t\00s\00")
@@ -2989,6 +2990,12 @@
  (func $features/simd/test_v64x2
   nop
  )
+ (func $features/simd/test_const (result v128)
+  (local $0 v128)
+  v128.const i32x4 0x00000001 0x00000001 0x00000001 0x00000001
+  local.set $0
+  local.get $0
+ )
  (func $start:features/simd
   global.get $~lib/heap/__heap_base
   i32.const 15
@@ -3013,6 +3020,8 @@
   call $features/simd/test_v16x8
   call $features/simd/test_v32x4
   call $features/simd/test_v64x2
+  call $features/simd/test_const
+  drop
  )
  (func $~start
   call $start:features/simd


### PR DESCRIPTION
This is a suggestion to fix https://github.com/AssemblyScript/assemblyscript/issues/1409 by keeping precompute intact but disabling inlining of `const` `v128`s. In the given case

```ts
const one = i32x4.splat(1);
```

will precompute the value to a `v128.const` (initializer might be arbitrarily complex), but will not attempt to inline an eventual constant in subsequent code and instead leave the decision to do so to Binaryen.

- [x] I've read the contributing guidelines