### PR TITLE
Rebuild with known version before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "asinit": "bin/asinit"
   },
   "scripts": {
-    "build": "npm run build:bundle && npm run build:dts",
+    "build": "npm run build:bundle && npm run build:dts && node scripts/build-sdk",
     "build:bundle": "webpack --mode production --display-modules",
     "build:dts": "node scripts/build-dts && tsc --noEmit --target ESNEXT --module commonjs --experimentalDecorators tests/require/index-release",
     "build:sdk": "node scripts/build-sdk",
@@ -67,7 +67,7 @@
     "make": "npm run clean && npm test && npm run build && npm test",
     "all": "npm run check && npm run make",
     "docs": "typedoc --tsconfig tsconfig-docs.json --mode modules --name \"AssemblyScript Compiler API\" --out ./docs/api --ignoreCompilerErrors --excludeNotExported --excludePrivate --excludeExternals --exclude **/std/** --includeDeclarations --readme src/README.md",
-    "postversion": "node scripts/postversion && npm run build:sdk",
+    "postversion": "node scripts/postversion && npm run build",
     "prepublishOnly": "node scripts/prepublish",
     "postpublish": "node scripts/postpublish",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "asinit": "bin/asinit"
   },
   "scripts": {
-    "build": "npm run build:bundle && npm run build:dts && node scripts/build-sdk",
+    "build": "npm run build:bundle && npm run build:dts && npm run build:sdk",
     "build:bundle": "webpack --mode production --display-modules",
     "build:dts": "node scripts/build-dts && tsc --noEmit --target ESNEXT --module commonjs --experimentalDecorators tests/require/index-release",
     "build:sdk": "node scripts/build-sdk",


### PR DESCRIPTION
Fixes #1379 by forcing a rebuild of dist files after updating the release version during semantic release. Is a little dangerous because we are technically publishing something that hasn't been tested in this exact form, but since there's no better alternative and only the version string should differ in practice it's probably fine.

- [x] I've read the contributing guidelines