### PR TITLE
Add concat3 helper for string/util

### DIFF
--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -983,25 +983,25 @@ export function joinStringArray(dataStart: usize, length: i32, separator: string
     // @ts-ignore: type
     if (value !== null) estLen += value.length;
   }
-  var offset = 0;
-  var sepLen = separator.length;
-  var result = __alloc((estLen + sepLen * lastIndex) << 1, idof<string>());
+  var offset: usize = 0;
+  var sepLen = <usize>separator.length << 1;
+  var result = __alloc((estLen << 1) + sepLen * lastIndex, idof<string>());
   for (let i = 0; i < lastIndex; ++i) {
     value = load<string>(dataStart + (<usize>i << alignof<string>()));
     if (value !== null) {
-      let valueLen = value.length;
+      let valueLen = <usize>value.length << 1;
       memory.copy(
-        result + (<usize>offset << 1),
+        result + offset,
         changetype<usize>(value),
-        <usize>valueLen << 1
+        valueLen
       );
       offset += valueLen;
     }
     if (sepLen) {
       memory.copy(
-        result + (<usize>offset << 1),
+        result + offset,
         changetype<usize>(separator),
-        <usize>sepLen << 1
+        sepLen
       );
       offset += sepLen;
     }
@@ -1009,7 +1009,7 @@ export function joinStringArray(dataStart: usize, length: i32, separator: string
   value = load<string>(dataStart + (<usize>lastIndex << alignof<string>()));
   if (value !== null) {
     memory.copy(
-      result + (<usize>offset << 1),
+      result + offset,
       changetype<usize>(value),
       <usize>value.length << 1
     );

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -1,6 +1,5 @@
 import { itoa32, utoa32, itoa64, utoa64, dtoa, itoa_buffered, dtoa_buffered, MAX_DOUBLE_LENGTH } from "./number";
 import { ipow32 } from "../math";
-import { string } from "string";
 
 // All tables are stored as two staged lookup tables (static tries)
 // because the full range of Unicode symbols can't be efficiently
@@ -1022,8 +1021,7 @@ export function joinThreeStrings(a: string, b: string, c: string): string {
   var bytesLenA = <usize>a.length << 1;
   var bytesLenB = <usize>b.length << 1;
   var bytesLenC = <usize>c.length << 1;
-  var length = bytesLenA + bytesLenB + bytesLenC;
-  var result = __alloc(length, idof<string>());
+  var result = __alloc(bytesLenA + bytesLenB + bytesLenC, idof<string>());
   var offset: usize = 0;
   if (bytesLenA) {
     memory.copy(

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -1017,7 +1017,7 @@ export function joinStringArray(dataStart: usize, length: i32, separator: string
   return changetype<string>(result); // retains
 }
 
-export function joinThreeStrings(a: string, b: string, c: string): string {
+export function concat3(a: string, b: string, c: string): string {
   var bytesLenA = <usize>a.length << 1;
   var bytesLenB = <usize>b.length << 1;
   var bytesLenC = <usize>c.length << 1;

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -16072,14 +16072,16 @@
   local.set $10
   local.get $2
   call $~lib/string/String#get:length
+  i32.const 1
+  i32.shl
   local.set $11
   local.get $5
+  i32.const 1
+  i32.shl
   local.get $11
   local.get $3
   i32.mul
   i32.add
-  i32.const 1
-  i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   local.set $12
@@ -16117,16 +16119,14 @@
     if
      local.get $6
      call $~lib/string/String#get:length
+     i32.const 1
+     i32.shl
      local.set $9
      local.get $12
      local.get $10
-     i32.const 1
-     i32.shl
      i32.add
      local.get $6
      local.get $9
-     i32.const 1
-     i32.shl
      call $~lib/memory/memory.copy
      local.get $10
      local.get $9
@@ -16137,13 +16137,9 @@
     if
      local.get $12
      local.get $10
-     i32.const 1
-     i32.shl
      i32.add
      local.get $2
      local.get $11
-     i32.const 1
-     i32.shl
      call $~lib/memory/memory.copy
      local.get $10
      local.get $11
@@ -16182,8 +16178,6 @@
   if
    local.get $12
    local.get $10
-   i32.const 1
-   i32.shl
    i32.add
    local.get $6
    local.get $6


### PR DESCRIPTION
This helper concatenate / join three strings without extra allocations or creating temporal array and calling `concat3` in later. Only for internal using.

Could be helpful to #1427

+bonus: minor `joinStringArray` optimization

- [x] I've read the contributing guidelines