### PR TITLE
Infer the right package manager per the environment

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -25,6 +25,7 @@ under the licensing terms detailed in LICENSE:
 * Guido Zuidhof <me@guido.io>
 * ncave <777696+ncave@users.noreply.github.com>
 * Andrew Davis <pulpdrew@gmail.com>
+* Maël Nison <nison.mael@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/bin/asinit
+++ b/bin/asinit
@@ -27,10 +27,13 @@ const commands = {
 };
 
 let pm = "npm";
-if (process.env.npm_config_user_agent.test(/\byarn\//))
-  pm = "yarn";
-else if (process.env.npm_config_user_agent.test(/\bpnpm\//))
-  pm = "pnpm";
+if (typeof process.env.npm_config_user_agent === "string") {
+  if (process.env.npm_config_user_agent.test(/\byarn\//)) {
+    pm = "yarn";
+  } else if (process.env.npm_config_user_agent.test(/\bpnpm\//)) {
+    pm = "pnpm";
+  }
+}
 
 const asinitOptions = {
   "help": {

--- a/bin/asinit
+++ b/bin/asinit
@@ -27,9 +27,9 @@ const commands = {
 };
 
 let pm = "npm";
-if (process.env.npm_config_user_agent.match(/\byarn\//))
+if (process.env.npm_config_user_agent.test(/\byarn\//))
   pm = "yarn";
-else if (process.env.npm_config_user_agent.match(/\bpnpm\//))
+else if (process.env.npm_config_user_agent.test(/\bpnpm\//))
   pm = "pnpm";
 
 const asinitOptions = {

--- a/bin/asinit
+++ b/bin/asinit
@@ -8,6 +8,30 @@ const colors = require("../cli/util/colors");
 const version = require("../package.json").version;
 const options = require("../cli/util/options");
 
+const commands = {
+  "npm": {
+    install: "npm install",
+    run: "npm run",
+    test: "npm test"
+  },
+  "yarn": {
+    install: "yarn install",
+    run: "yarn",
+    test: "yarn test"
+  },
+  "pnpm": {
+    install: "pnpm install",
+    run: "pnpm run",
+    test: "pnpm test"
+  }
+};
+
+let pm = "npm";
+if (process.env.npm_config_user_agent.match(/\byarn\//))
+  pm = "yarn";
+else if (process.env.npm_config_user_agent.match(/\bpnpm\//))
+  pm = "pnpm";
+
 const asinitOptions = {
   "help": {
     "category": "General",
@@ -118,14 +142,14 @@ function createProject(answer) {
     "",
     "Don't forget to install dependencies before you start:",
     "",
-    colors.white("  npm install"),
+    colors.white("  " + commands[pm].install),
     "",
     "To edit the entry file, open '" + colors.cyan("assembly/index.ts") + "' in your editor of choice.",
     "Create as many additional files as necessary and use them as imports.",
     "",
     "To build the entry file to WebAssembly when you are ready, run:",
     "",
-    colors.white("  npm run asbuild"),
+    colors.white("  " + commands[pm].run + " asbuild"),
     "",
     "Running the command above creates the following binaries incl. their respective",
     "text format representations and source maps:",
@@ -146,7 +170,7 @@ function createProject(answer) {
     "",
     "To run the tests, do:",
     "",
-    colors.white("  npm test"),
+    colors.white("  " + commands[pm].test),
     "",
     "The AssemblyScript documentation covers all the details:",
     "",
@@ -289,7 +313,7 @@ function ensurePackageJson() {
   const entryPath = path.relative(projectDir, entryFile).replace(/\\/g, "/");
   const buildUntouched = "asc " + entryPath + " --target debug";
   const buildOptimized = "asc " + entryPath + " --target release";
-  const buildAll = "npm run asbuild:untouched && npm run asbuild:optimized";
+  const buildAll = commands[pm].run + " asbuild:untouched && " + commands[pm].run + " asbuild:optimized";
   if (!fs.existsSync(packageFile)) {
     fs.writeFileSync(packageFile, JSON.stringify({
       "scripts": {

--- a/bin/asinit
+++ b/bin/asinit
@@ -28,9 +28,9 @@ const commands = {
 
 let pm = "npm";
 if (typeof process.env.npm_config_user_agent === "string") {
-  if (process.env.npm_config_user_agent.test(/\byarn\//)) {
+  if (/\byarn\//.test(process.env.npm_config_user_agent)) {
     pm = "yarn";
-  } else if (process.env.npm_config_user_agent.test(/\bpnpm\//)) {
+  } else if (/\bpnpm\//.test(process.env.npm_config_user_agent)) {
     pm = "pnpm";
   }
 }


### PR DESCRIPTION
- [x] I've read the contributing guidelines

This diff improves the user experience when using other package managers than npm, by referencing the right commands. This is important, because as I described in https://github.com/AssemblyScript/assemblyscript/issues/495#issuecomment-675142864 the package manager install artifacts aren't strictly compatible, especially in the more modern setups.

Fixes https://github.com/AssemblyScript/assemblyscript/issues/495