### PR TITLE
Add CLI option: allow specifying --tsdModuleName for .d.ts

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -26,6 +26,7 @@ under the licensing terms detailed in LICENSE:
 * ncave <777696+ncave@users.noreply.github.com>
 * Andrew Davis <pulpdrew@gmail.com>
 * Maël Nison <nison.mael@gmail.com>
+* Wietse Wind <w.wind@ipublications.net>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -896,17 +896,21 @@ exports.main = function main(argv, options, callback) {
 
     // Write TypeScript definition
     if (opts.tsdFile != null) {
+      let moduleName;
       let tsd;
+      if (opts.tsdModuleName != null) {
+        moduleName = opts.tsdModuleName;
+      }
       if (opts.tsdFile.length) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          tsd = assemblyscript.buildTSD(program);
+          tsd = assemblyscript.buildTSD(program, moduleName);
         });
         writeFile(opts.tsdFile, tsd, baseDir);
       } else if (!hasStdout) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          tsd = assemblyscript.buildTSD(program);
+          tsd = assemblyscript.buildTSD(program, moduleName);
         });
         writeStdout(tsd);
         hasStdout = true;

--- a/cli/asc.json
+++ b/cli/asc.json
@@ -118,6 +118,12 @@
     "type": "s",
     "alias": "d"
   },
+  "tsdModuleName": {
+    "category": "Output",
+    "description": "Specifies the TypeScript definition output file module name.",
+    "type": "s",
+    "default": "ASModule"
+  },
 
   "sourceMap": {
     "category": "Debugging",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -373,16 +373,23 @@ export class IDLBuilder extends ExportsWalker {
 export class TSDBuilder extends ExportsWalker {
 
   /** Builds TypeScript definitions for the specified program. */
-  static build(program: Program): string {
-    return new TSDBuilder(program).build();
+  static build(program: Program, moduleName?: string): string {
+    return new TSDBuilder(program, false, moduleName).build();
   }
 
+  private moduleName: string = "ASModule";
   private sb: string[] = [];
   private indentLevel: i32 = 0;
 
   /** Constructs a new WebIDL builder. */
-  constructor(program: Program, includePrivate: bool = false) {
+  constructor(program: Program, includePrivate: bool = false, moduleName?: string) {
     super(program, includePrivate);
+
+    if (moduleName) {
+      if (moduleName.trim().match(/^[a-z0-9_]+$/i)) {
+        this.moduleName = moduleName.trim();
+      }
+    }
   }
 
   visitGlobal(name: string, element: Global): void {
@@ -592,7 +599,7 @@ export class TSDBuilder extends ExportsWalker {
   build(): string {
     var sb = this.sb;
     var isWasm64 = this.program.options.isWasm64;
-    sb.push("declare module ASModule {\n");
+    sb.push("declare module " + this.moduleName + " {\n");
     sb.push("  type i8 = number;\n");
     sb.push("  type i16 = number;\n");
     sb.push("  type i32 = number;\n");
@@ -618,7 +625,7 @@ export class TSDBuilder extends ExportsWalker {
     this.walk();
     --this.indentLevel;
     sb.push("}\n");
-    sb.push("export default ASModule;\n");
+    sb.push("export default " + this.moduleName + ";\n");
     return this.sb.join("");
   }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -373,23 +373,16 @@ export class IDLBuilder extends ExportsWalker {
 export class TSDBuilder extends ExportsWalker {
 
   /** Builds TypeScript definitions for the specified program. */
-  static build(program: Program, moduleName?: string): string {
-    return new TSDBuilder(program, false, moduleName).build();
+  static build(program: Program, moduleName: string = "ASModule"): string {
+    return new TSDBuilder(program).build(moduleName.trim());
   }
 
-  private moduleName: string = "ASModule";
   private sb: string[] = [];
   private indentLevel: i32 = 0;
 
   /** Constructs a new WebIDL builder. */
-  constructor(program: Program, includePrivate: bool = false, moduleName?: string) {
+  constructor(program: Program, includePrivate: bool = false) {
     super(program, includePrivate);
-
-    if (moduleName) {
-      if (moduleName.trim().match(/^[a-z0-9_]+$/i)) {
-        this.moduleName = moduleName.trim();
-      }
-    }
   }
 
   visitGlobal(name: string, element: Global): void {
@@ -596,10 +589,10 @@ export class TSDBuilder extends ExportsWalker {
     }
   }
 
-  build(): string {
+  build(moduleName: string): string {
     var sb = this.sb;
     var isWasm64 = this.program.options.isWasm64;
-    sb.push("declare module " + this.moduleName + " {\n");
+    sb.push("declare module " + moduleName + " {\n");
     sb.push("  type i8 = number;\n");
     sb.push("  type i16 = number;\n");
     sb.push("  type i32 = number;\n");
@@ -625,7 +618,7 @@ export class TSDBuilder extends ExportsWalker {
     this.walk();
     --this.indentLevel;
     sb.push("}\n");
-    sb.push("export default " + this.moduleName + ";\n");
+    sb.push("export default " + moduleName + ";\n");
     return this.sb.join("");
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,8 +253,8 @@ export function buildIDL(program: Program): string {
 }
 
 /** Builds TypeScript definitions for the specified program. */
-export function buildTSD(program: Program): string {
-  return TSDBuilder.build(program);
+export function buildTSD(program: Program, moduleName?: string): string {
+  return TSDBuilder.build(program, moduleName);
 }
 
 // Full API

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ export function buildIDL(program: Program): string {
 }
 
 /** Builds TypeScript definitions for the specified program. */
-export function buildTSD(program: Program, moduleName?: string): string {
+export function buildTSD(program: Program, moduleName: string = "ASModule"): string {
   return TSDBuilder.build(program, moduleName);
 }
 


### PR DESCRIPTION
[X] I've read the contributing guidelines

Currently, if the `-d` argument is added to the `asc` CLI command specifying a location to store a generated `.d.ts` (Typescript definition for the AssemblyScript being built) looks like:

```
declare module ASModule {
// ...
}
export default ASModule;
```

The module name `ASModule` is hardcoded:
https://github.com/AssemblyScript/assemblyscript/blob/master/src/definitions.ts#L363

It would be nice if the module name could be specified by eg. a CLI argument, which is why I added:
`--tsdModuleName`

When specified and matching `/^[a-z0-9_]$/i` instead of `ASModule` the specified value will be used in the generated .d.ts file:

```
declare module MyCustomModule {
// ...
}
export default MyCustomModule;
```

