### PR TITLE
fix: avoid overflows during computation factors via mul+div in Map/Set

### DIFF
--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -123,7 +123,7 @@ export class Map<K,V> {
       // check if rehashing is necessary
       if (this.entriesOffset == this.entriesCapacity) {
         this.rehash(
-          this.entriesCount * FREE_FACTOR_D < this.entriesCapacity * FREE_FACTOR_N
+          <u64>this.entriesCount * FREE_FACTOR_D < <u64>this.entriesCapacity * FREE_FACTOR_N
             ?  this.bucketsMask           // just rehash if 1/4+ entries are empty
             : (this.bucketsMask << 1) | 1 // grow capacity to next 2^N
         );
@@ -158,7 +158,7 @@ export class Map<K,V> {
     var halfBucketsMask = this.bucketsMask >> 1;
     if (
       halfBucketsMask + 1 >= max<u32>(INITIAL_CAPACITY, this.entriesCount) &&
-      this.entriesCount * FREE_FACTOR_D < this.entriesCapacity * FREE_FACTOR_N
+      <u64>this.entriesCount * FREE_FACTOR_D < <u64>this.entriesCapacity * FREE_FACTOR_N
     ) this.rehash(halfBucketsMask);
     return true;
   }

--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -123,7 +123,7 @@ export class Map<K,V> {
       // check if rehashing is necessary
       if (this.entriesOffset == this.entriesCapacity) {
         this.rehash(
-          this.entriesCount < this.entriesCapacity * FREE_FACTOR_N / FREE_FACTOR_D
+          this.entriesCount * FREE_FACTOR_D < this.entriesCapacity * FREE_FACTOR_N
             ?  this.bucketsMask           // just rehash if 1/4+ entries are empty
             : (this.bucketsMask << 1) | 1 // grow capacity to next 2^N
         );
@@ -158,7 +158,7 @@ export class Map<K,V> {
     var halfBucketsMask = this.bucketsMask >> 1;
     if (
       halfBucketsMask + 1 >= max<u32>(INITIAL_CAPACITY, this.entriesCount) &&
-      this.entriesCount < this.entriesCapacity * FREE_FACTOR_N / FREE_FACTOR_D
+      this.entriesCount * FREE_FACTOR_D < this.entriesCapacity * FREE_FACTOR_N
     ) this.rehash(halfBucketsMask);
     return true;
   }
@@ -166,7 +166,7 @@ export class Map<K,V> {
   private rehash(newBucketsMask: u32): void {
     var newBucketsCapacity = <i32>(newBucketsMask + 1);
     var newBuckets = new ArrayBuffer(newBucketsCapacity * <i32>BUCKET_SIZE);
-    var newEntriesCapacity = newBucketsCapacity * FILL_FACTOR_N / FILL_FACTOR_D;
+    var newEntriesCapacity = <i32>(<u64>newBucketsCapacity * FILL_FACTOR_N / FILL_FACTOR_D);
     var newEntries = new ArrayBuffer(newEntriesCapacity * <i32>ENTRY_SIZE<K,V>());
 
     // copy old entries to new entries

--- a/std/assembly/set.ts
+++ b/std/assembly/set.ts
@@ -103,7 +103,7 @@ export class Set<T> {
       // check if rehashing is necessary
       if (this.entriesOffset == this.entriesCapacity) {
         this.rehash(
-          this.entriesCount < this.entriesCapacity * FREE_FACTOR_N / FREE_FACTOR_D
+          this.entriesCount * FREE_FACTOR_D < this.entriesCapacity * FREE_FACTOR_N
             ?  this.bucketsMask           // just rehash if 1/4+ entries are empty
             : (this.bucketsMask << 1) | 1 // grow capacity to next 2^N
         );
@@ -138,7 +138,7 @@ export class Set<T> {
     var halfBucketsMask = this.bucketsMask >> 1;
     if (
       halfBucketsMask + 1 >= max<u32>(INITIAL_CAPACITY, this.entriesCount) &&
-      this.entriesCount < this.entriesCapacity * FREE_FACTOR_N / FREE_FACTOR_D
+      this.entriesCount * FREE_FACTOR_D < this.entriesCapacity * FREE_FACTOR_N
     ) this.rehash(halfBucketsMask);
     return true;
   }
@@ -146,7 +146,7 @@ export class Set<T> {
   private rehash(newBucketsMask: u32): void {
     var newBucketsCapacity = <i32>(newBucketsMask + 1);
     var newBuckets = new ArrayBuffer(newBucketsCapacity * <i32>BUCKET_SIZE);
-    var newEntriesCapacity = newBucketsCapacity * FILL_FACTOR_N / FILL_FACTOR_D;
+    var newEntriesCapacity = <i32>(<u64>newBucketsCapacity * FILL_FACTOR_N / FILL_FACTOR_D);
     var newEntries = new ArrayBuffer(newEntriesCapacity * <i32>ENTRY_SIZE<T>());
 
     // copy old entries to new entries

--- a/std/assembly/set.ts
+++ b/std/assembly/set.ts
@@ -103,7 +103,7 @@ export class Set<T> {
       // check if rehashing is necessary
       if (this.entriesOffset == this.entriesCapacity) {
         this.rehash(
-          this.entriesCount * FREE_FACTOR_D < this.entriesCapacity * FREE_FACTOR_N
+          <u64>this.entriesCount * FREE_FACTOR_D < <u64>this.entriesCapacity * FREE_FACTOR_N
             ?  this.bucketsMask           // just rehash if 1/4+ entries are empty
             : (this.bucketsMask << 1) | 1 // grow capacity to next 2^N
         );
@@ -138,7 +138,7 @@ export class Set<T> {
     var halfBucketsMask = this.bucketsMask >> 1;
     if (
       halfBucketsMask + 1 >= max<u32>(INITIAL_CAPACITY, this.entriesCount) &&
-      this.entriesCount * FREE_FACTOR_D < this.entriesCapacity * FREE_FACTOR_N
+      <u64>this.entriesCount * FREE_FACTOR_D < <u64>this.entriesCapacity * FREE_FACTOR_N
     ) this.rehash(halfBucketsMask);
     return true;
   }

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1383,10 +1383,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 12
   i32.mul
@@ -1528,12 +1530,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -2408,10 +2410,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 3
   i32.shl
@@ -2592,12 +2596,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -2751,10 +2755,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 12
   i32.mul
@@ -2892,12 +2898,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -3009,12 +3015,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -3609,10 +3615,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 12
   i32.mul
@@ -3752,12 +3760,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -3973,10 +3981,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 3
   i32.shl
@@ -4155,12 +4165,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4270,12 +4280,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -4875,10 +4885,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 12
   i32.mul
@@ -5020,12 +5032,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -5297,10 +5309,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 3
   i32.shl
@@ -5481,12 +5495,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -5598,12 +5612,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -6167,10 +6181,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 12
   i32.mul
@@ -6310,12 +6326,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6535,10 +6551,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 3
   i32.shl
@@ -6717,12 +6735,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6832,12 +6850,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -7422,12 +7440,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -8615,10 +8633,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 4
   i32.shl
@@ -8756,12 +8776,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -9102,10 +9122,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 24
   i32.mul
@@ -9279,12 +9301,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -9393,12 +9415,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -10573,10 +10595,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 12
   i32.mul
@@ -10716,12 +10740,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -10974,10 +10998,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 12
   i32.mul
@@ -11117,12 +11143,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -11232,12 +11258,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -11805,10 +11831,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 4
   i32.shl
@@ -11948,12 +11976,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -12206,10 +12234,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $8
   i32.const 24
   i32.mul
@@ -12385,12 +12415,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -12500,12 +12530,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1530,13 +1530,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -2596,13 +2598,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -2898,13 +2902,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -3015,13 +3021,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -3760,13 +3768,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -4165,13 +4175,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -4280,13 +4292,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -5032,13 +5046,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -5495,13 +5511,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -5612,13 +5630,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -6326,13 +6346,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -6735,13 +6757,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -6850,13 +6874,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -7440,13 +7466,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -8776,13 +8804,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -9301,13 +9331,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -9415,13 +9447,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -10740,13 +10774,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -11143,13 +11179,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -11258,13 +11296,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -11976,13 +12016,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -12415,13 +12457,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -12530,13 +12574,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -2142,13 +2142,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -4600,13 +4602,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -4992,13 +4996,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -5145,13 +5151,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -6048,13 +6056,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -6775,13 +6785,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -6922,13 +6934,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -7843,13 +7857,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -8588,13 +8604,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -8741,13 +8759,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -9656,13 +9676,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -10395,13 +10417,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -10546,13 +10570,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -11383,13 +11409,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -12258,13 +12286,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -13003,13 +13033,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -13156,13 +13188,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -14133,13 +14167,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -14892,13 +14928,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -15050,13 +15088,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -15947,13 +15987,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -16706,13 +16748,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -16864,13 +16908,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -17728,13 +17774,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -18454,13 +18502,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -18601,13 +18651,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -19477,13 +19529,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -20215,13 +20269,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -20366,13 +20422,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -1948,10 +1948,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -2140,12 +2142,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4404,10 +4406,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -4596,12 +4600,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4782,10 +4786,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -4986,12 +4992,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -5139,12 +5145,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -5850,10 +5856,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -6040,12 +6048,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6575,10 +6583,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -6765,12 +6775,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6912,12 +6922,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -7631,10 +7641,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -7831,12 +7843,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -8374,10 +8386,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -8574,12 +8588,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -8727,12 +8741,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -9442,10 +9456,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -9640,12 +9656,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -10179,10 +10195,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -10377,12 +10395,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -10528,12 +10546,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -11365,12 +11383,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -12034,10 +12052,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -12238,12 +12258,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -12777,10 +12797,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -12981,12 +13003,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -13134,12 +13156,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -13896,10 +13918,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -14109,12 +14133,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -14653,10 +14677,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -14866,12 +14892,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -15024,12 +15050,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -15706,10 +15732,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -15919,12 +15947,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -16463,10 +16491,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -16676,12 +16706,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -16834,12 +16864,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -17505,10 +17535,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -17696,12 +17728,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -18229,10 +18261,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -18420,12 +18454,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -18567,12 +18601,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -19242,10 +19276,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -19441,12 +19477,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -19978,10 +20014,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -20177,12 +20215,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -20328,12 +20366,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1408,10 +1408,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
   local.get $4
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $7
   i32.const 3
   i32.shl
@@ -1544,12 +1546,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -2221,12 +2223,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -2643,10 +2645,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
   local.get $4
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $7
   i32.const 3
   i32.shl
@@ -2777,12 +2781,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -3016,12 +3020,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -3457,10 +3461,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
   local.get $4
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $7
   i32.const 3
   i32.shl
@@ -3593,12 +3599,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -3890,12 +3896,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -4279,10 +4285,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
   local.get $4
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $7
   i32.const 3
   i32.shl
@@ -4413,12 +4421,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4658,12 +4666,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -5109,10 +5117,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
   local.get $4
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $7
   i32.const 3
   i32.shl
@@ -5241,12 +5251,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -5534,12 +5544,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -6458,10 +6468,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
   local.get $4
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $7
   i32.const 4
   i32.shl
@@ -6590,12 +6602,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6884,12 +6896,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -7778,10 +7790,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
   local.get $4
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $7
   i32.const 3
   i32.shl
@@ -7912,12 +7926,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -8191,12 +8205,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -8605,10 +8619,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $6
   local.get $4
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $7
   i32.const 4
   i32.shl
@@ -8739,12 +8755,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -9018,12 +9034,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 2
+   i32.shl
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1546,13 +1546,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -2223,13 +2225,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -2781,13 +2785,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -3020,13 +3026,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -3599,13 +3607,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -3896,13 +3906,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -4421,13 +4433,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -4666,13 +4680,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -5251,13 +5267,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -5544,13 +5562,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -6602,13 +6622,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -6896,13 +6918,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -7926,13 +7950,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -8205,13 +8231,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -8755,13 +8783,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -9034,13 +9064,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 2
-   i32.shl
+   i64.extend_i32_s
+   i64.const 2
+   i64.shl
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -2127,13 +2127,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -4020,13 +4022,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -4760,13 +4764,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -5138,13 +5144,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -5910,13 +5918,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -6294,13 +6304,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -7046,13 +7058,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -7428,13 +7442,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -8220,13 +8236,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -8604,13 +8622,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -9342,13 +9362,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -9726,13 +9748,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -10566,13 +10590,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -10955,13 +10981,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -11708,13 +11736,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -12097,13 +12127,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -12817,13 +12849,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -13195,13 +13229,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end
@@ -13927,13 +13963,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -14309,13 +14347,15 @@
   if (result i32)
    local.get $0
    i32.load offset=20
-   i32.const 4
-   i32.mul
+   i64.extend_i32_s
+   i64.const 4
+   i64.mul
    local.get $0
    i32.load offset=12
-   i32.const 3
-   i32.mul
-   i32.lt_s
+   i64.extend_i32_s
+   i64.const 3
+   i64.mul
+   i64.lt_u
   else
    i32.const 0
   end

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -1943,10 +1943,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -2125,12 +2127,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4018,12 +4020,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -4576,10 +4578,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -4756,12 +4760,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -5134,12 +5138,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -5714,10 +5718,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -5904,12 +5910,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6288,12 +6294,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -6850,10 +6856,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -7038,12 +7046,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -7420,12 +7428,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -8016,10 +8024,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -8210,12 +8220,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -8594,12 +8604,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -9136,10 +9146,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -9330,12 +9342,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -9714,12 +9726,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -10349,10 +10361,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -10552,12 +10566,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -10941,12 +10955,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -11489,10 +11503,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -11692,12 +11708,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -12081,12 +12097,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -12618,10 +12634,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -12799,12 +12817,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -13177,12 +13195,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -13718,10 +13736,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -13907,12 +13927,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -14289,12 +14309,12 @@
   if (result i32)
    local.get $0
    i32.load offset=20
+   i32.const 4
+   i32.mul
    local.get $0
    i32.load offset=12
    i32.const 3
    i32.mul
-   i32.const 4
-   i32.div_s
    i32.lt_s
   else
    i32.const 0

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -538,10 +538,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $6
   i32.const 12
   i32.mul
@@ -652,12 +654,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -804,10 +806,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 3
+  i64.shl
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.tee $6
   i32.const 12
   i32.mul
@@ -925,12 +929,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 2
+    i32.shl
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -654,13 +654,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -929,13 +931,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 2
-    i32.shl
+    i64.extend_i32_s
+    i64.const 2
+    i64.shl
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -933,10 +933,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -1118,12 +1120,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -1309,10 +1311,12 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
+  i64.extend_i32_s
+  i64.const 8
+  i64.mul
+  i64.const 3
+  i64.div_u
+  i32.wrap_i64
   local.set $4
   i32.const 0
   local.get $4
@@ -1527,12 +1531,12 @@
     local.get $0
     local.get $0
     i32.load offset=20
+    i32.const 4
+    i32.mul
     local.get $0
     i32.load offset=12
     i32.const 3
     i32.mul
-    i32.const 4
-    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -1120,13 +1120,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4
@@ -1531,13 +1533,15 @@
     local.get $0
     local.get $0
     i32.load offset=20
-    i32.const 4
-    i32.mul
+    i64.extend_i32_s
+    i64.const 4
+    i64.mul
     local.get $0
     i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.lt_s
+    i64.extend_i32_s
+    i64.const 3
+    i64.mul
+    i64.lt_u
     if (result i32)
      local.get $0
      i32.load offset=4


### PR DESCRIPTION
composition `a * b / c` may overflow so avoid this.

- [x] I've read the contributing guidelines