### PR TITLE
Simplify Math.signbit. Don't ignore sign bit for NaNs

### DIFF
--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1435,9 +1435,7 @@ export namespace NativeMath {
   // @ts-ignore: decorator
   @inline
   export function signbit(x: f64): bool {
-    // In ECMAScript all NaN values are indistinguishable from each other
-    // so we need handle NaN and negative NaN in similar way
-    return <bool>(<i32>(reinterpret<u64>(x) >>> 63) & i32(x == x));
+    return <bool>(reinterpret<u64>(x) >>> 63);
   }
 
   export function sin(x: f64): f64 { // see: musl/src/math/sin.c
@@ -2714,8 +2712,7 @@ export namespace NativeMathf {
   // @ts-ignore: decorator
   @inline
   export function signbit(x: f32): bool {
-    // @ts-ignore: type
-    return <bool>((reinterpret<u32>(x) >>> 31) & (x == x));
+    return <bool>(reinterpret<u32>(x) >>> 31);
   }
 
   export function sin(x: f32): f32 { // see: musl/src/math/sinf.c

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -325,7 +325,7 @@ Object.defineProperties(globalScope["JSMath"], {
   sincos_cos: { value: 0.0, writable: true },
   signbit: {
     value: function signbit(x) {
-      F64[0] = x; return Boolean((U64[1] >>> 31) & (x == x));
+      F64[0] = x; return Boolean(U64[1] >>> 31);
     }
   },
   sincos: {

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -187,22 +187,16 @@
    i64.reinterpret_f64
    i64.const 63
    i64.shr_u
-   i32.wrap_i64
-   local.get $0
-   local.get $0
-   f64.eq
-   i32.and
+   i64.const 0
+   i64.ne
    i32.const 0
    i32.ne
    local.get $1
    i64.reinterpret_f64
    i64.const 63
    i64.shr_u
-   i32.wrap_i64
-   local.get $1
-   local.get $1
-   f64.eq
-   i32.and
+   i64.const 0
+   i64.ne
    i32.const 0
    i32.ne
    i32.eq
@@ -382,20 +376,12 @@
    i32.reinterpret_f32
    i32.const 31
    i32.shr_u
-   local.get $0
-   local.get $0
-   f32.eq
-   i32.and
    i32.const 0
    i32.ne
    local.get $1
    i32.reinterpret_f32
    i32.const 31
    i32.shr_u
-   local.get $1
-   local.get $1
-   f32.eq
-   i32.and
    i32.const 0
    i32.ne
    i32.eq

--- a/tests/compiler/std/math.ts
+++ b/tests/compiler/std/math.ts
@@ -3129,7 +3129,7 @@ assert(NativeMath.signbit(-0.0) == true);
 assert(NativeMath.signbit(1.0)  == false);
 assert(NativeMath.signbit(-1.0) == true);
 assert(NativeMath.signbit(+NaN) == false);
-assert(NativeMath.signbit(-NaN) == false);
+assert(NativeMath.signbit(-NaN) == true);
 assert(NativeMath.signbit(+Infinity) == false);
 assert(NativeMath.signbit(-Infinity) == true);
 
@@ -3142,7 +3142,7 @@ assert(NativeMathf.signbit(-0.0) == true);
 assert(NativeMathf.signbit(1.0)  == false);
 assert(NativeMathf.signbit(-1.0) == true);
 assert(NativeMathf.signbit(+NaN) == false);
-assert(NativeMathf.signbit(-NaN) == false);
+assert(NativeMathf.signbit(-NaN) == true);
 assert(NativeMathf.signbit(+Infinity) == false);
 assert(NativeMathf.signbit(-Infinity) == true);
 

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -269,11 +269,8 @@
    i64.reinterpret_f64
    i64.const 63
    i64.shr_u
-   i32.wrap_i64
-   local.get $3
-   local.get $3
-   f64.eq
-   i32.and
+   i64.const 0
+   i64.ne
    i32.const 0
    i32.ne
    local.get $1
@@ -282,11 +279,8 @@
    i64.reinterpret_f64
    i64.const 63
    i64.shr_u
-   i32.wrap_i64
-   local.get $3
-   local.get $3
-   f64.eq
-   i32.and
+   i64.const 0
+   i64.ne
    i32.const 0
    i32.ne
    i32.eq
@@ -503,10 +497,6 @@
    i32.reinterpret_f32
    i32.const 31
    i32.shr_u
-   local.get $3
-   local.get $3
-   f32.eq
-   i32.and
    i32.const 0
    i32.ne
    local.get $1
@@ -515,10 +505,6 @@
    i32.reinterpret_f32
    i32.const 31
    i32.shr_u
-   local.get $3
-   local.get $3
-   f32.eq
-   i32.and
    i32.const 0
    i32.ne
    i32.eq
@@ -48467,11 +48453,8 @@
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $0
-  local.get $0
-  f64.eq
-  i32.and
+  i64.const 0
+  i64.ne
   i32.const 0
   i32.ne
   i32.const 0
@@ -48483,11 +48466,8 @@
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $0
-  local.get $0
-  f64.eq
-  i32.and
+  i64.const 0
+  i64.ne
   i32.const 0
   i32.ne
   i32.const 1
@@ -48499,11 +48479,8 @@
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $0
-  local.get $0
-  f64.eq
-  i32.and
+  i64.const 0
+  i64.ne
   i32.const 0
   i32.ne
   i32.const 0
@@ -48515,11 +48492,8 @@
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $0
-  local.get $0
-  f64.eq
-  i32.and
+  i64.const 0
+  i64.ne
   i32.const 0
   i32.ne
   i32.const 1
@@ -48531,11 +48505,8 @@
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $0
-  local.get $0
-  f64.eq
-  i32.and
+  i64.const 0
+  i64.ne
   i32.const 0
   i32.ne
   i32.const 0
@@ -48548,14 +48519,11 @@
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $0
-  local.get $0
-  f64.eq
-  i32.and
+  i64.const 0
+  i64.ne
   i32.const 0
   i32.ne
-  i32.const 0
+  i32.const 1
   i32.eq
   drop
   f64.const inf
@@ -48564,11 +48532,8 @@
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $0
-  local.get $0
-  f64.eq
-  i32.and
+  i64.const 0
+  i64.ne
   i32.const 0
   i32.ne
   i32.const 0
@@ -48581,11 +48546,8 @@
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $0
-  local.get $0
-  f64.eq
-  i32.and
+  i64.const 0
+  i64.ne
   i32.const 0
   i32.ne
   i32.const 1
@@ -48597,10 +48559,6 @@
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
-  f32.eq
-  i32.and
   i32.const 0
   i32.ne
   i32.const 0
@@ -48612,10 +48570,6 @@
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
-  f32.eq
-  i32.and
   i32.const 0
   i32.ne
   i32.const 1
@@ -48627,10 +48581,6 @@
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
-  f32.eq
-  i32.and
   i32.const 0
   i32.ne
   i32.const 0
@@ -48642,10 +48592,6 @@
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
-  f32.eq
-  i32.and
   i32.const 0
   i32.ne
   i32.const 1
@@ -48657,10 +48603,6 @@
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
-  f32.eq
-  i32.and
   i32.const 0
   i32.ne
   i32.const 0
@@ -48673,13 +48615,9 @@
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
-  f32.eq
-  i32.and
   i32.const 0
   i32.ne
-  i32.const 0
+  i32.const 1
   i32.eq
   drop
   f32.const inf
@@ -48688,10 +48626,6 @@
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
-  f32.eq
-  i32.and
   i32.const 0
   i32.ne
   i32.const 0
@@ -48704,10 +48638,6 @@
   i32.reinterpret_f32
   i32.const 31
   i32.shr_u
-  local.get $4
-  local.get $4
-  f32.eq
-  i32.and
   i32.const 0
   i32.ne
   i32.const 1

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -9249,16 +9249,10 @@
   i32.const 3008
   i32.const 0
   call $~lib/string/parseInt
-  local.tee $3
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $3
-  local.get $3
-  f64.eq
-  i32.and
-  i32.eqz
+  i64.eqz
   if
    i32.const 0
    i32.const 1088

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -13147,11 +13147,8 @@
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
-  i32.wrap_i64
-  local.get $32
-  local.get $32
-  f64.eq
-  i32.and
+  i64.const 0
+  i64.ne
   i32.const 0
   i32.ne
   i32.eqz


### PR DESCRIPTION
I don't think we should ignore sign for NaNs due to signed `-NaN` is actually valid and canonical.

- [x] I've read the contributing guidelines