### PR TITLE
feat(loader): use TextDecoder for large strings

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -40,15 +40,7 @@ const BIGINT = typeof BigUint64Array !== "undefined";
 const THIS = Symbol();
 
 const STRING_DECODE_THRESHOLD = 32;
-
-let decoder;
-if (typeof process !== 'undefined' && typeof TextDecoder === 'undefined') {
-  // node.js
-  decoder = new (require('util').TextDecoder)('utf-16le');
-} else {
-  // browser
-  decoder = new TextDecoder('utf-16le');
-}
+const decoder = new TextDecoder('utf-16le');
 
 /** Gets a string from an U32 and an U16 view on a memory. */
 function getStringImpl(buffer, ptr) {

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -40,7 +40,15 @@ const BIGINT = typeof BigUint64Array !== "undefined";
 const THIS = Symbol();
 
 const STRING_DECODE_THRESHOLD = 32;
-const decoder = new TextDecoder('utf-16le');
+
+let decoder;
+if (typeof process !== 'undefined') {
+  // node.js
+  decoder = new (require('util').TextDecoder)('utf-16le');
+} else {
+  // browser
+  decoder = new TextDecoder('utf-16le');
+}
 
 /** Gets a string from an U32 and an U16 view on a memory. */
 function getStringImpl(buffer, ptr) {

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -42,7 +42,7 @@ const THIS = Symbol();
 const STRING_DECODE_THRESHOLD = 32;
 
 let decoder;
-if (typeof process !== 'undefined') {
+if (typeof process !== 'undefined' && typeof TextDecoder === 'undefined') {
   // node.js
   decoder = new (require('util').TextDecoder)('utf-16le');
 } else {

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -44,15 +44,12 @@ const decoder = new TextDecoder("utf-16le");
 
 /** Gets a string from an U32 and an U16 view on a memory. */
 function getStringImpl(buffer, ptr) {
-  const U32 = new Uint32Array(buffer);
-  const U16 = new Uint16Array(buffer);
-  const length = U32[ptr + SIZE_OFFSET >>> 2] >>> 1;
-  const offset = ptr >>> 1;
-  const data = U16.subarray(offset, offset + length);
-  if (length <= STRING_DECODE_THRESHOLD) {
-    return String.fromCharCode.apply(String, data);
+  const len = new Uint32Array(buffer)[ptr + SIZE_OFFSET >>> 2] >>> 1;
+  const arr = new Uint16Array(buffer, ptr, len);
+  if (len <= STRING_DECODE_THRESHOLD) {
+    return String.fromCharCode.apply(String, arr);
   }
-  return decoder.decode(data);
+  return decoder.decode(arr);
 }
 
 /** Prepares the base module prior to instantiation. */

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -40,7 +40,7 @@ const BIGINT = typeof BigUint64Array !== "undefined";
 const THIS = Symbol();
 
 const STRING_DECODE_THRESHOLD = 32;
-const decoder = new TextDecoder('utf-16le');
+const decoder = new TextDecoder("utf-16le");
 
 /** Gets a string from an U32 and an U16 view on a memory. */
 function getStringImpl(buffer, ptr) {

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -38,23 +38,21 @@ const ARRAY_SIZE = 16;
 
 const BIGINT = typeof BigUint64Array !== "undefined";
 const THIS = Symbol();
-const CHUNKSIZE = 1024;
+
+const STRING_DECODE_THRESHOLD = 32;
+const decoder = new TextDecoder('utf-16le');
 
 /** Gets a string from an U32 and an U16 view on a memory. */
 function getStringImpl(buffer, ptr) {
   const U32 = new Uint32Array(buffer);
   const U16 = new Uint16Array(buffer);
-  let length = U32[ptr + SIZE_OFFSET >>> 2] >>> 1;
-  let offset = ptr >>> 1;
-  if (length <= CHUNKSIZE) return String.fromCharCode.apply(String, U16.subarray(offset, offset + length));
-  let parts = '';
-  do {
-    const last = U16[offset + CHUNKSIZE - 1];
-    const size = last >= 0xD800 && last < 0xDC00 ? CHUNKSIZE - 1 : CHUNKSIZE;
-    parts += String.fromCharCode.apply(String, U16.subarray(offset, offset += size));
-    length -= size;
-  } while (length > CHUNKSIZE);
-  return parts + String.fromCharCode.apply(String, U16.subarray(offset, offset + length));
+  const length = U32[ptr + SIZE_OFFSET >>> 2] >>> 1;
+  const offset = ptr >>> 1;
+  const data = U16.subarray(offset, offset + length);
+  if (length <= STRING_DECODE_THRESHOLD) {
+    return String.fromCharCode.apply(String, data);
+  }
+  return decoder.decode(data);
 }
 
 /** Prepares the base module prior to instantiation. */

--- a/lib/loader/tests/index.js
+++ b/lib/loader/tests/index.js
@@ -24,9 +24,24 @@ function test(file) {
   // should be able to get an exported string
   assert.strictEqual(exports.__getString(exports.COLOR), "red");
 
-  // should be able to allocate and work with a new string
+  // should be able to allocate and work with a new small string
   {
     let str = "Hello world!𤭢";
+    let ref = exports.__retain(exports.__allocString(str));
+    assert.strictEqual(exports.__getString(ref), str);
+    assert.strictEqual(exports.strlen(ref), str.length);
+    exports.__release(ref);
+  }
+
+  // should be able to allocate and work with a new big string
+  {
+    let str = `
+      ∀ ∁ ∂ ∃ ∄ ∅ ∆ ∇ ∈ ∉ ∊ ∋ ∌ ∍ ∎ ∏ ∐ ∑ − ∓ ∔ ∕ ∖ ∗ ∘ ∙ √ ∛
+      ∜ ∝ ∞ ∟ ∠ ∡ ∢ ∣ ∤ ∥ ∦ ∧ ∨ ∩ ∪ ∫ ∬ ∭ ∮ ∯ ∰ ∱ ∲ ∳ ∴ ∵ ∶ ∷
+      ∸ ∹ ∺ ∻ ∼ ∽ ∾ ∿ ≀ ≁ ≂ ≃ ≄ ≅ ≆ ≇ ≈ ≉ ≊ ≋ ≌ ≍ ≎ ≏ ≐ ≑ ≒ ≓
+      ≔ ≕ ≖ ≗ ≘ ≙ ≚ ≛ ≜ ≝ ≞ ≟ ≠ ≡ ≢ ≣ ≤ ≥ ≦ ≧ ≨ ≩ ≪ ≫ ≬ ≭ ≮ ≯
+      ≰ ≱ ≲ ≳ ≴ ≵ ≶ ≷ ≸ ≹ ≺ ≻ ≼ ≽ ≾ ≿
+    `;
     let ref = exports.__retain(exports.__allocString(str));
     assert.strictEqual(exports.__getString(ref), str);
     assert.strictEqual(exports.strlen(ref), str.length);


### PR DESCRIPTION
Fix #1470

Since node.js `8.x` (LTS) have `util.TextDecoder`
Since node.js `11` (LTS) have `global.TextDecoder`

- [x] I've read the contributing guidelines