### PR TITLE
Rtrace shadow memory and instrumentation

### DIFF
--- a/lib/rtrace/README.md
+++ b/lib/rtrace/README.md
@@ -5,17 +5,34 @@ A tiny utility that records allocations, retains, releases and frees performed b
 Instructions
 ------------
 
-Compile your module that uses the full or half runtime with `-use ASC_RTRACE=1` and include an instance of this module as the import named `rtrace`.
+Compile your module that uses the full or half runtime with `-use ASC_RTRACE=1 --explicitStart` and include an instance of this module as the import named `rtrace`.
 
 ```js
-var rtr = rtrace(e => {
-  // handle error
+var rtrace = new Rtrace({
+  onerror(err, info) {
+    // handle error
+  },
+  oninfo(msg, info) {
+    // print info, optional
+  },
+  getMemory() {
+    // obtain the module's memory,
+    // e.g. with --explicitStart:
+    return instance.exports.memory;
+  }
 });
 
-WebAssembly.instantiate(..., { rtrace: rtr, ... });
+var { module, instance } = await WebAssembly.instantiate(..., {
+  rtrace,
+  env: Object.assign({ //
+    ...                // only required when instrumenting memory
+  }, rtrace.env),      //
+  ...
+});
+instance.exports._start();
 ...
 
-if (rtr.active) {
+if (rtrace.active) {
   let leakCount = rtr.check();
   if (leakCount) {
     // handle error

--- a/lib/rtrace/README.md
+++ b/lib/rtrace/README.md
@@ -12,8 +12,8 @@ var rtrace = new Rtrace({
   onerror(err, info) {
     // handle error
   },
-  oninfo(msg, info) {
-    // print info, optional
+  oninfo(msg) {
+    // print message, optional
   },
   getMemory() {
     // obtain the module's memory,

--- a/lib/rtrace/index.d.ts
+++ b/lib/rtrace/index.d.ts
@@ -1,63 +1,41 @@
-/** Creates a new `RTrace` instance, tracking allocations, frees and reference counts. */
-declare function rtrace(
-  /** Function being called when a problem is detected. */
-  onerror?: (error: Error) => void,
-  /** Function being called with information messages. */
-  oninfo?: (info: string) => void
-): rtrace.RTrace;
-
-declare namespace rtrace {
-  /** The rtrace instance used as the `rtrace` import to the Wasm module. */
-  export interface RTrace {
-    /** Number of allocations so far. */
-    allocCount: number;
-    /** Number of reallocations so far. */
-    reallocCount: number;
-    /** Number of frees so far. */
-    freeCount: number;
-    /** Number of RC increments (retains) so far. */
-    incrementCount: number;
-    /** Number of RC decrements (releases) so far. */
-    decrementCount: number;
-
-    /** Called when a new block is allocated. */
-    onalloc(
-      /** New block being allocated. */
-      block: number
-    ): void;
-
-    /** Called when a block is reallocated and must be moved. */
-    onrealloc(
-      /** Block being moved. */
-      oldBlock: number,
-      /** New block used from now on. */
-      newBlock: number
-    ): void;
-
-    /** Called when a block is freed, implicitly or explicitly. */
-    onfree(
-      /** Block being freed. */
-      block: number
-    ): void;
-
-    /** Called when a reference to a block is retained (RC incremented by one). */
-    onincrement(
-      /** Block a reference to is being retained. */
-      block: number
-    ): void;
-
-    /** Called when a reference to a block is released (RC decremented by one). */
-    ondecrement(
-      /** Block a reference to is being released. */
-      block: number
-    ): void;
-
-    /** Checks if rtrace is active, i.e. at least one event has occurred. */
-    readonly active: boolean;
-
-    /** Checks if there are any leaks and emits them via `oninfo`. Returns the number of live blocks. */
-    check(): number;
-  }
+/** Block information. */
+export declare interface BlockInfo {
+  /** Pointer to the block. */
+  ptr: number,
+  /** Block size. */
+  size: number,
+  /** Runtime header. */
+  header: {
+    /** Memory manager info bits. */
+    mmInfo: number,
+    /** Garbage collector info bits. */
+    gcInfo: number,
+    /** Runtime id. */
+    rtId: number,
+    /** Runtime size. */
+    rtSize: number
+  },
+  toString(): string
 }
 
-export = rtrace;
+export declare interface RtraceOptions {
+  /** Function being called when a problem is detected. */
+  onerror?: (error: Error, info: BlockInfo) => void,
+  /** Function being called with information messages. */
+  oninfo?: (msg: string) => void,
+  /** Obtains the module's memory instance. */
+  getMemory()
+}
+
+export declare class Rtrace {
+  [key: string]: unknown; // can be used as a Wasm import
+
+  /** Creates a new `RTrace` instance. */
+  constructor(options: RtraceOptions);
+
+  /** Checks if rtrace is active, i.e. at least one event has occurred. */
+  readonly active: boolean;
+
+  /** Checks if there are any leaks and emits them via `oninfo`. Returns the number of live blocks. */
+  check(): number;
+}

--- a/lib/rtrace/index.js
+++ b/lib/rtrace/index.js
@@ -1,94 +1,344 @@
-function rtrace(onerror, oninfo) {
-  if (!onerror) onerror = function() { /* nop */ };
-  if (!oninfo) oninfo = function() { /* nop */ };
-  var blocks = new Map();
-  var rtrace = {
+// WebAssembly pages are 65536 kb
+const PAGE_SIZE_BITS = 16;
+const PAGE_SIZE = 1 << PAGE_SIZE_BITS;
+const PAGE_MASK = PAGE_SIZE - 1;
 
-    allocCount: 0,
-    reallocCount: 0,
-    freeCount: 0,
-    incrementCount: 0,
-    decrementCount: 0,
+// Wasm32 pointer size is 4 bytes
+const PTR_SIZE_BITS = 2;
+const PTR_SIZE = 1 << PTR_SIZE_BITS;
+const PTR_MASK = PTR_SIZE - 1;
+const PTR_VIEW = Uint32Array;
 
-    onalloc: function(block) {
-      ++rtrace.allocCount;
-      if (blocks.has(block)) {
-        onerror(Error("duplicate alloc: " + block));
-      } else {
-        oninfo("ALLOC " + block);
-        blocks.set(block, 0);
-      }
-    },
+const BLOCK_OVERHEAD = 16;
 
-    onrealloc: function(oldBlock, newBlock) {
-      ++rtrace.reallocCount;
-      if (!blocks.has(oldBlock)) {
-        onerror(Error("orphaned realloc (old): " + oldBlock));
-      } else {
-        if (!blocks.has(newBlock)) {
-          onerror(Error("orphaned realloc (new): " + newBlock));
-        } else {
-          let newRc = blocks.get(newBlock);
-          if (newRc != 0) {
-            onerror(Error("invalid realloc: " + oldBlock + " -> " + newBlock + " @ " + newRc));
-          } else {
-            let oldRc = blocks.get(oldBlock);
-            oninfo("REALLOC " + oldBlock + " @ " + oldRc + " -> " + newBlock);
-            blocks.set(newBlock, oldRc);
-          }
-        }
-      }
-    },
-
-    onfree: function(block) {
-      ++rtrace.freeCount;
-      if (!blocks.has(block)) {
-        onerror(Error("orphaned free: " + block));
-      } else {
-        oninfo("FREE " + block + " @ " + blocks.get(block));
-        blocks.delete(block);
-      }
-    },
-
-    onincrement: function(block) {
-      ++rtrace.incrementCount;
-      if (!blocks.has(block)) {
-        onerror(Error("orphaned increment: " + block));
-      } else {
-        let rc = blocks.get(block);
-        oninfo("++ " + block + " @ " + rc + "->" + (rc + 1));
-        blocks.set(block, rc + 1);
-      }
-    },
-
-    ondecrement: function(block) {
-      ++rtrace.decrementCount;
-      if (!blocks.has(block)) {
-        onerror(Error("orphaned decrement: " + block));
-      } else {
-        let rc = blocks.get(block);
-        if (rc < 1) {
-          onerror(Error("invalid decrement: " + block + " @ " + rc));
-        } else {
-          oninfo("-- " + block + " @ " + rc + "->" + (rc - 1));
-          blocks.set(block, rc - 1);
-        }
-      }
-    },
-
-    get active() {
-      return Boolean(rtrace.allocCount || rtrace.reallocCount || rtrace.freeCount || rtrace.incrementCount || rtrace.decrementCount);
-    },
-
-    check() {
-      if (oninfo) {
-        for (let [block, rc ] of blocks) {
-          oninfo("LEAKING " + block + " @ " + rc);
-        }
-      }
-      return blocks.size;
-    }
-  };
-  return rtrace;
+function assert(x) {
+  if (!x) throw Error("assertion failed");
+  return x;
 }
-module.exports = rtrace;
+
+Error.stackTraceLimit = 50;
+
+function trimStacktrace(stack, levels) {
+  return stack.split(/\r?\n/).slice(1 + levels);
+}
+
+function isTLSF(stack) {
+  return stack[0].startsWith("    at ~lib/rt/tlsf/");
+}
+
+class Rtrace {
+
+  constructor(options) {
+    this.options = options || {};
+    this.onerror = this.options.onerror || function() { /* nop */ };
+    this.oninfo = this.options.oninfo || function() { /* nop */ };
+    this.memory = null;
+    this.shadow = null;
+    this.shadowStart = 0x100000000;
+    this.refCounts = new Map();
+    this.blocks = new Map();
+    this.allocSites = new Map();
+    this.allocCount = 0;
+    this.resizeCount = 0;
+    this.moveCount = 0;
+    this.freeCount = 0;
+    this.incrementCount = 0;
+    this.decrementCount = 0;
+
+    // The following hooks cannot just be on the prototype but must be
+    // bound so the Rtrace instance can be used as a WebAssembly import.
+    this.onalloc = this.onalloc.bind(this);
+    this.onresize = this.onresize.bind(this);
+    this.onmove = this.onmove.bind(this);
+    this.onfree = this.onfree.bind(this);
+    this.onincrement = this.onincrement.bind(this);
+    this.ondecrement = this.ondecrement.bind(this);
+    this.env = {
+      load_ptr: this.load_ptr.bind(this),
+      load_val_i32: this.load_val_i32.bind(this),
+      load_val_i64: this.load_val_i64.bind(this),
+      load_val_f32: this.load_val_f32.bind(this),
+      load_val_f64: this.load_val_f64.bind(this),
+      store_ptr: this.store_ptr.bind(this),
+      store_val_i32: this.store_val_i32.bind(this),
+      store_val_i64: this.store_val_i64.bind(this),
+      store_val_f32: this.store_val_f32.bind(this),
+      store_val_f64: this.store_val_f64.bind(this)
+    };
+  }
+
+  /** Synchronizes the shadow memory with the module's memory. */
+  syncShadow() {
+    if (!this.memory) {
+      this.memory = assert(this.options.getMemory());
+      this.shadow = new WebAssembly.Memory({
+        initial: ((this.memory.buffer.byteLength + PAGE_MASK) & ~PAGE_MASK) >>> PAGE_SIZE_BITS
+      });
+    } else {
+      var diff = this.memory.buffer.byteLength - this.shadow.buffer.byteLength;
+      if (diff > 0) this.shadow.grow(diff >>> 16);
+    }
+  }
+
+  /** Marks a block's presence in shadow memory. */
+  markShadow(info, oldSize = 0) {
+    assert(this.shadow && this.shadow.byteLength == this.memory.byteLength);
+    assert((info.size & PTR_MASK) == 0);
+    if (info.ptr < this.shadowStart) {
+      this.shadowStart = info.ptr;
+    }
+    var len = info.size >>> PTR_SIZE_BITS;
+    var view = new PTR_VIEW(this.shadow.buffer, info.ptr, len);
+    var errored = false;
+    var start = oldSize >>> PTR_SIZE_BITS;
+    for (let i = 0; i < start; ++i) {
+      if (view[i] != info.ptr && !errored) {
+        this.onerror(Error("shadow region mismatch: " + view[i] + " != " + info.ptr), info);
+        errored = true;
+      }
+    }
+    errored = false;
+    for (let i = start; i < len; ++i) {
+      if (view[i] != 0 && !errored) {
+        this.onerror(Error("shadow region already in use: " + view[i] + " != 0"), info);
+        errored = true;
+      }
+      view[i] = info.ptr;
+    }
+  }
+
+  /** Unmarks a block's presence in shadow memory. */
+  unmarkShadow(info, oldSize = info.size) {
+    assert(this.shadow && this.shadow.byteLength == this.memory.byteLength);
+    var len = oldSize >>> PTR_SIZE_BITS;
+    var view = new PTR_VIEW(this.shadow.buffer, info.ptr, len);
+    var errored = false;
+    var start = 0;
+    if (oldSize != info.size) {
+      assert(oldSize > info.size);
+      start = info.size >>> PTR_SIZE_BITS;
+    }
+    for (let i = 0; i < len; ++i) {
+      if (view[i] != info.ptr && !errored) {
+        this.onerror(Error("shadow region mismatch: " + view[i] + " != " + info.ptr), info);
+        errored = true;
+      }
+      if (i >= start) view[i] = 0;
+    }
+  }
+
+  /** Performs an access to shadow memory. */
+  accessShadow(ptr, size, isLoad) {
+    this.syncShadow();
+    if (ptr < this.shadowStart) return;
+    var value = new Uint32Array(this.shadow.buffer, ptr & ~PTR_MASK, 1)[0];
+    if (value != 0) return;
+    // FIXME: this is extremely slow
+    let stack = trimStacktrace(new Error().stack, 2);
+    if (!isTLSF(stack)) {
+      this.onerror(new Error("OOB " + (isLoad ? "load" : "store") + (8 * size) + " at address " + ptr + "\n" + stack.join("\n")));
+    }
+  }
+
+  /** Obtains information about a block. */
+  getBlockInfo(ptr) {
+    var header = new Uint32Array(this.memory.buffer, ptr, 4);
+    var mmInfo = header[0];
+    var gcInfo = header[1];
+    const mmTags = [ // 0│L│F
+      [],
+      ["FREE"],
+      ["LEFTFREE"],
+      ["FREE", "LEFTFREE"]
+    ];
+    const gcColor = [
+      "BLACK",
+      "GRAY",
+      "WHITE",
+      "PURPLE"
+    ];
+    var size = mmInfo & ~3;
+    return {
+      ptr,
+      size: BLOCK_OVERHEAD + size, // block size
+      header: {
+        mmInfo: {
+          tags: mmTags[mmInfo & 3],
+          size: size
+        },
+        gcInfo: {
+          buffered: (gcInfo >>> 31) === 1,
+          color: gcColor[gcInfo << 1 >>> 29],
+          rc: gcInfo << 4 >>> 4
+        },
+        rtId: header[2],
+        rtSize: header[3]
+      }
+    };
+  }
+
+  /** Checks if rtrace is active, i.e. at least one event has occurred. */
+  get active() {
+    return Boolean(this.allocCount || this.moveCount || this.freeCount || this.incrementCount || this.decrementCount);
+  }
+
+  /** Checks if there are any leaks and emits them via `oninfo`. Returns the number of live blocks. */
+  check() {
+    if (this.refCounts.size == 1) return 0; // purerc roots
+    if (this.oninfo) {
+      for (let [ptr, rc] of this.refCounts) {
+        this.oninfo("LEAKING " + ptr + " @ " + rc);
+      }
+    }
+    return this.refCounts.size;
+  }
+
+  // Runtime instrumentation
+
+  onalloc(ptr) {
+    this.syncShadow();
+    ++this.allocCount;
+    var info = this.getBlockInfo(ptr);
+    if (this.refCounts.has(ptr)) {
+      this.onerror(Error("duplicate alloc: " + ptr), info);
+    } else {
+      this.oninfo("ALLOC " + ptr + ".." + (ptr + info.size));
+      this.markShadow(info);
+      this.refCounts.set(ptr, 0);
+      this.blocks.set(ptr, Object.assign(info, {
+        allocStack: trimStacktrace(new Error().stack, /* onalloc */ 1)
+      }));
+    }
+  }
+  
+  onresize(ptr, oldSize) {
+    this.syncShadow();
+    ++this.resizeCount;
+    var info = this.getBlockInfo(ptr);
+    if (!this.refCounts.has(ptr)) {
+      this.onerror(Error("orphaned resize: " + ptr), info);
+    } else {
+      this.oninfo("RESIZE " + ptr + ".." + (ptr + info.size) + " (" +  oldSize + "->" + info.size + ")");
+      if (info.size > oldSize) {
+        this.markShadow(info, BLOCK_OVERHEAD + oldSize);
+      } else if (info.size < oldSize) {
+        this.unmarkShadow(info, BLOCK_OVERHEAD + oldSize);
+      }
+    }
+  }
+
+  onmove(oldPtr, newPtr) {
+    this.syncShadow();
+    ++this.moveCount;
+    var oldInfo = this.getBlockInfo(oldPtr);
+    var newInfo = this.getBlockInfo(newPtr);
+    if (!this.refCounts.has(oldPtr)) {
+      this.onerror(Error("orphaned move (old): " + oldPtr), oldInfo);
+    } else {
+      if (!this.refCounts.has(newPtr)) {
+        this.onerror(Error("orphaned move (new): " + newPtr), newInfo);
+      } else {
+        let newRc = this.refCounts.get(newPtr);
+        if (newRc != 0) {
+          this.onerror(Error("invalid realloc: " + oldPtr + " -> " + newPtr + " @ " + newRc), oldInfo);
+        } else {
+          let oldRc = this.refCounts.get(oldPtr);
+          this.oninfo("MOVE " + oldPtr + ".." + (oldPtr + oldInfo.size) + " @ " + oldRc + " -> " + newPtr + ".." + (newPtr + newInfo.size));
+          this.refCounts.set(newPtr, oldRc);
+          // calls new alloc before and old free after
+        }
+      }
+    }
+  }
+
+  onfree(ptr) {
+    this.syncShadow();
+    ++this.freeCount;
+    var info = this.getBlockInfo(ptr);
+    if (!this.refCounts.has(ptr)) {
+      this.onerror(Error("orphaned free: " + ptr), info);
+    } else {
+      this.oninfo("FREE " + ptr + ".." + (ptr + info.size) + " @ " + this.refCounts.get(ptr));
+      this.refCounts.delete(ptr);
+      this.unmarkShadow(info);
+      let block = this.blocks.get(ptr);
+      block.freeStack = trimStacktrace(new Error().stack, /* onfree */ 1);
+    }
+  }
+
+  onincrement(ptr) {
+    this.syncShadow();
+    ++this.incrementCount;
+    var info = this.getBlockInfo(ptr);
+    if (!this.refCounts.has(ptr)) {
+      this.onerror(Error("orphaned increment: " + ptr), info);
+    } else {
+      let rc = this.refCounts.get(ptr);
+      this.oninfo("++ " + ptr + " @ " + rc + "->" + (rc + 1));
+      this.refCounts.set(ptr, rc + 1);
+    }
+  }
+
+  ondecrement(ptr) {
+    this.syncShadow();
+    ++this.decrementCount;
+    var info = this.getBlockInfo(ptr);
+    if (!this.refCounts.has(ptr)) {
+      this.onerror(Error("orphaned decrement: " + ptr), info);
+    } else {
+      let rc = this.refCounts.get(ptr);
+      if (rc < 1) {
+        this.onerror(Error("invalid decrement: " + ptr + " @ " + rc), info);
+      } else {
+        this.oninfo("-- " + ptr + " @ " + rc + "->" + (rc - 1));
+        this.refCounts.set(ptr, rc - 1);
+      }
+    }
+  }
+
+  // Memory instrumentation
+
+  load_ptr(id, bytes, offset, address) {
+    this.accessShadow(address + offset, bytes, true);
+    return address;
+  }
+
+  load_val_i32(id, value) {
+    return value;
+  }
+
+  load_val_i64(id, value) {
+    return value;
+  }
+
+  load_val_f32(id, value) {
+    return value;
+  }
+
+  load_val_f64(id, value) {
+    return value;
+  }
+
+  store_ptr(id, bytes, offset, address) {
+    this.accessShadow(address + offset, bytes, false);
+    return address;
+  }
+
+  store_val_i32(id, value) {
+    return value;
+  }
+
+  store_val_i64(id, value) {
+    return value;
+  }
+
+  store_val_f32(id, value) {
+    return value;
+  }
+
+  store_val_f64(id, value) {
+    return value;
+  }
+}
+
+exports.Rtrace = Rtrace;

--- a/lib/rtrace/package.json
+++ b/lib/rtrace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@assemblyscript/rtrace",
   "types": "index.d.ts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "index.js"
 }

--- a/package.json
+++ b/package.json
@@ -71,8 +71,9 @@
     "prepublishOnly": "node scripts/prepublish",
     "postpublish": "node scripts/postpublish",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",
-    "asbuild:untouched": "node bin/asc src/glue/wasm/index.ts src/index.ts -t out/assemblyscript.untouched.wat -b out/assemblyscript.untouched.wasm -d out/assemblyscript.d.ts --debug --measure --runtime stub",
+    "asbuild:untouched": "node bin/asc src/glue/wasm/index.ts src/index.ts -t out/assemblyscript.untouched.wat -b out/assemblyscript.untouched.wasm -d out/assemblyscript.d.ts --debug --measure --runtime stub --explicitStart",
     "asbuild:optimized": "node bin/asc src/glue/wasm/index.ts src/index.ts -t out/assemblyscript.optimized.wat -b out/assemblyscript.optimized.wasm -O3 --measure --runtime stub",
+    "asbuild:rtraced": "node bin/asc src/glue/wasm/index.ts src/index.ts -t out/assemblyscript.rtraced.wat -b out/assemblyscript.rtraced.wasm --debug --measure --runtime full --explicitStart --use ASC_RTRACE=1 --runPasses instrument-memory",
     "astest": "ts-node tests/bootstrap"
   },
   "releaseFiles": [

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -582,6 +582,10 @@ export class TSDBuilder extends ExportsWalker {
       case TypeKind.F64: return "f64";
       case TypeKind.V128: return "v128";
       case TypeKind.VOID: return "void";
+      case TypeKind.FUNCREF: return "funcref";
+      case TypeKind.EXTERNREF: return "externref";
+      case TypeKind.EXNREF: return "exnref";
+      case TypeKind.ANYREF: return "anyref";
       default: {
         assert(false);
         return "any";

--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -1,7 +1,7 @@
 /// <reference path="./rt/index.d.ts" />
 
 import { HASH } from "./util/hash";
-import { E_KEYNOTFOUND } from "util/error";
+import { E_KEYNOTFOUND } from "./util/error";
 
 // A deterministic hash map based on CloseTable from https://github.com/jorendorff/dht
 

--- a/std/assembly/rt/pure.ts
+++ b/std/assembly/rt/pure.ts
@@ -184,12 +184,8 @@ function growRoots(): void {
   var oldSize = CUR - oldRoots;
   var newSize = max(oldSize * 2, 64 << alignof<usize>());
   var newRoots = __alloc(newSize, 0);
-  if (isDefined(ASC_RTRACE)) onfree(changetype<Block>(newRoots - BLOCK_OVERHEAD)); // neglect unmanaged
   memory.copy(newRoots, oldRoots, oldSize);
-  if (oldRoots) {
-    if (isDefined(ASC_RTRACE)) onalloc(changetype<Block>(oldRoots - BLOCK_OVERHEAD)); // neglect unmanaged
-    __free(oldRoots);
-  }
+  if (oldRoots) __free(oldRoots);
   ROOTS = newRoots;
   CUR = newRoots + oldSize;
   END = newRoots + newSize;

--- a/std/assembly/rt/pure.ts
+++ b/std/assembly/rt/pure.ts
@@ -1,7 +1,7 @@
 import { DEBUG, BLOCK_OVERHEAD } from "rt/common";
 import { Block, freeBlock, ROOT } from "rt/tlsf";
 import { TypeinfoFlags } from "shared/typeinfo";
-import { onincrement, ondecrement, onfree, onalloc } from "./rtrace";
+import { onincrement, ondecrement } from "./rtrace";
 
 // === A Pure Reference Counting Garbage Collector ===
 // see: https://researcher.watson.ibm.com/researcher/files/us-bacon/Bacon03Pure.pdf

--- a/std/assembly/rt/rtrace.ts
+++ b/std/assembly/rt/rtrace.ts
@@ -1,7 +1,8 @@
 import { BLOCK } from "./common";
 
 export declare function onalloc(s: BLOCK): void;
-export declare function onrealloc(sOld: BLOCK, sNew: BLOCK): void;
+export declare function onresize(s: BLOCK, oldSize: usize): void;
+export declare function onmove(sOld: BLOCK, sNew: BLOCK): void;
 export declare function onincrement(s: BLOCK): void;
 export declare function ondecrement(s: BLOCK): void;
 export declare function onfree(s: BLOCK): void;

--- a/tests/bootstrap/index.ts
+++ b/tests/bootstrap/index.ts
@@ -1,12 +1,14 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as v8 from "v8";
 import * as binaryen from "binaryen";
 import * as util from "util";
 import * as loader from "../../lib/loader";
+import { Rtrace } from "../../lib/rtrace";
 import * as find from "../../cli/util/find";
 import AssemblyScript from "../../out/assemblyscript";
 
-Error.stackTraceLimit = Infinity;
+v8.setFlagsFromString("--experimental-wasm-bigint");
 
 // Load stdlib
 const libDir = path.join(__dirname, "..", "..", "std", "assembly");
@@ -18,11 +20,27 @@ find.files(libDir, /^(?!.*\.d\.ts$).*\.ts$/).forEach((file: string) => {
 async function test(build: string): Promise<void> {
   await binaryen.ready;
 
+  const rtrace = new Rtrace({
+    onerror(err, info) {
+      console.log(err, info);
+    },
+    oninfo(msg) {
+      // console.log(msg);
+    },
+    getMemory() {
+      return asc.memory;
+    }
+  });
+
   const { exports: asc } = await loader.instantiate<typeof AssemblyScript>(
     fs.promises.readFile(`${ __dirname }/../../out/assemblyscript.${ build }.wasm`),
-    { binaryen }
+    {
+      binaryen,
+      rtrace,
+      env: rtrace.env
+    }
   );
-  console.log(util.inspect(asc, true));
+  if (asc._start) asc._start();
 
   const cachedStrings = new Map<string,number>();
   function cachedString(text: string): number {
@@ -59,8 +77,10 @@ async function test(build: string): Promise<void> {
   console.log("\nParsing backlog ...");
   var nextFilePtr = asc.nextFile(programPtr);
   while (nextFilePtr) {
-    const nextFile = asc.__getString(nextFilePtr);
-    if (!nextFile.startsWith("~lib/")) throw Error("unexpected file: " + nextFile);
+    let nextFile = asc.__getString(nextFilePtr);
+    if (!nextFile.startsWith("~lib/")) { // e.g. "rt/something"
+      nextFile = "~lib/" + nextFile;
+    }
     const text = libraryFiles[nextFile.substring(5)];
     if (text == null) throw Error("missing file: " + nextFile);
     const textPtr = cachedString(libraryFiles[nextFile.substring(5)]);

--- a/tests/bootstrap/index.ts
+++ b/tests/bootstrap/index.ts
@@ -2,7 +2,6 @@ import * as fs from "fs";
 import * as path from "path";
 import * as v8 from "v8";
 import * as binaryen from "binaryen";
-import * as util from "util";
 import * as loader from "../../lib/loader";
 import { Rtrace } from "../../lib/rtrace";
 import * as find from "../../cli/util/find";

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -317,7 +317,7 @@ function runTest(basename) {
         "--debug",
         "--use", "ASC_RTRACE=1",
         "--explicitStart",
-        "--runPasses", "instrument-memory"
+        // "--runPasses", "instrument-memory"
       ];
       if (asc_flags) {
         Array.prototype.push.apply(cmd, asc_flags);

--- a/tests/compiler/do.json
+++ b/tests/compiler/do.json
@@ -1,7 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\n\00\00\00\01\00\00\00\01\00\00\00\n\00\00\00d\00o\00.\00t\00s")
  (data (i32.const 1056) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
@@ -19,9 +15,8 @@
  (global $do/ran (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $do/testNested
   (local $0 i32)
   (local $1 i32)
@@ -972,8 +967,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $do/Ref#constructor (result i32)
   (local $0 i32)
@@ -983,14 +976,14 @@
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
-  local.tee $1
+  local.tee $0
   i32.const 1216
   i32.gt_u
   if
-   local.get $1
+   local.get $0
    i32.const 16
    i32.sub
-   local.tee $0
+   local.tee $1
    i32.load offset=4
    local.tee $2
    i32.const -268435456
@@ -1009,14 +1002,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
+   local.get $1
    local.get $2
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $0
-   call $~lib/rt/rtrace/onincrement
-   local.get $0
+   local.get $1
    i32.load
    i32.const 1
    i32.and
@@ -1029,7 +1020,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
  )
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
@@ -1388,13 +1379,6 @@
   end
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:do
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -1406,8 +1390,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1
@@ -1471,8 +1453,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $none_=>_none (func))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\n\00\00\00\01\00\00\00\01\00\00\00\n\00\00\00d\00o\00.\00t\00s\00")
  (data (i32.const 48) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
@@ -24,10 +20,9 @@
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~lib/gc/gc.auto (mut i32) (i32.const 1))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/heap/__heap_base i32 (i32.const 208))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $do/testSimple
   (local $0 i32)
   (local $1 i32)
@@ -1854,10 +1849,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1900,10 +1893,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -2264,13 +2255,6 @@
   end
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:do
  )
  (func $~lib/rt/pure/__collect
@@ -2288,13 +2272,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -2313,10 +2295,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1130,7 +1130,7 @@
   if
    i32.const 0
    i32.const 1136
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1326,6 +1326,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.tee $3
@@ -1334,6 +1335,7 @@
   local.tee $5
   i32.const -4
   i32.and
+  local.tee $4
   i32.le_u
   if
    local.get $0
@@ -1356,16 +1358,14 @@
   i32.add
   local.tee $6
   i32.load
-  local.tee $4
+  local.tee $7
   i32.const 1
   i32.and
   if
-   local.get $5
-   i32.const -4
-   i32.and
+   local.get $4
    i32.const 16
    i32.add
-   local.get $4
+   local.get $7
    i32.const -4
    i32.and
    i32.add

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -1603,7 +1603,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2873,11 +2873,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 0
-  drop
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -2886,18 +2886,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
   local.get $1
   i32.load
   local.set $4
-  local.get $3
   local.get $4
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
+  local.set $5
+  local.get $3
+  local.get $5
   i32.le_u
   if
    local.get $0
@@ -2907,55 +2910,53 @@
    local.get $1
    local.get $2
    i32.store offset=12
+   i32.const 0
+   drop
    local.get $1
    return
   end
   local.get $1
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.const 16
   i32.add
-  local.get $5
+  local.get $6
   i32.load
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
   i32.add
-  local.set $6
-  local.get $6
-  i32.load
   local.set $7
   local.get $7
+  i32.load
+  local.set $8
+  local.get $8
   i32.const 1
   i32.and
   if
-   local.get $4
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   local.get $5
    i32.const 16
    i32.add
-   local.get $7
+   local.get $8
    i32.const 3
    i32.const -1
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    local.get $3
    i32.ge_u
    if
     local.get $0
-    local.get $6
+    local.get $7
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $6
     i32.or
     i32.store
     local.get $1
@@ -2965,6 +2966,8 @@
     local.get $1
     local.get $3
     call $~lib/rt/tlsf/prepareBlock
+    i32.const 0
+    drop
     local.get $1
     return
    end
@@ -2974,12 +2977,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -2997,7 +3000,7 @@
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -3675,16 +3678,12 @@
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  i32.const 0
-  drop
   local.get $5
   local.get $0
   local.get $1
   call $~lib/memory/memory.copy
   local.get $0
   if
-   i32.const 0
-   drop
    local.get $0
    call $~lib/rt/tlsf/__free
   end

--- a/tests/compiler/for.json
+++ b/tests/compiler/for.json
@@ -1,7 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00f\00o\00r\00.\00t\00s")
  (data (i32.const 1056) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
@@ -19,9 +15,8 @@
  (global $for/ran (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $for/testNestedContinue
   (local $0 i32)
   (local $1 i32)
@@ -969,8 +964,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $for/Ref#constructor (result i32)
   (local $0 i32)
@@ -980,14 +973,14 @@
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
-  local.tee $1
+  local.tee $0
   i32.const 1216
   i32.gt_u
   if
-   local.get $1
+   local.get $0
    i32.const 16
    i32.sub
-   local.tee $0
+   local.tee $1
    i32.load offset=4
    local.tee $2
    i32.const -268435456
@@ -1006,14 +999,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
+   local.get $1
    local.get $2
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $0
-   call $~lib/rt/rtrace/onincrement
-   local.get $0
+   local.get $1
    i32.load
    i32.const 1
    i32.and
@@ -1026,7 +1017,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
  )
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
@@ -1398,13 +1389,6 @@
   end
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:for
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -1416,8 +1400,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1
@@ -1481,8 +1463,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $none_=>_none (func))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00f\00o\00r\00.\00t\00s\00")
  (data (i32.const 48) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
@@ -24,10 +20,9 @@
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~lib/gc/gc.auto (mut i32) (i32.const 1))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/heap/__heap_base i32 (i32.const 208))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $for/testInitExpression
   (local $0 i32)
   (local $1 i32)
@@ -1867,10 +1862,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1913,10 +1906,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -2309,13 +2300,6 @@
   end
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:for
  )
  (func $~lib/rt/pure/__collect
@@ -2333,13 +2317,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -2358,10 +2340,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/implicit-getter-setter.json
+++ b/tests/compiler/implicit-getter-setter.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime full",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime full"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/implicit-getter-setter.optimized.wat
+++ b/tests/compiler/implicit-getter-setter.optimized.wat
@@ -1,18 +1,14 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -1039,8 +1035,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1084,8 +1078,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1188,8 +1180,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -1252,8 +1242,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -1455,10 +1451,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1501,10 +1495,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1628,13 +1620,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1653,10 +1643,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/issues/1095.json
+++ b/tests/compiler/issues/1095.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -889,8 +885,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
@@ -926,8 +920,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1013,8 +1005,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -1077,8 +1067,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -1442,10 +1438,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1488,10 +1482,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1613,13 +1605,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1638,10 +1628,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/issues/1225.json
+++ b/tests/compiler/issues/1225.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/issues/1225.optimized.wat
+++ b/tests/compiler/issues/1225.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -890,8 +886,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $issues/1225/normal (result i32)
   global.get $issues/1225/x
@@ -940,8 +934,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1023,8 +1015,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -1087,8 +1077,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/issues/1225.untouched.wat
+++ b/tests/compiler/issues/1225.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -1443,10 +1439,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1489,10 +1483,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1633,13 +1625,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1658,10 +1648,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/logical.json
+++ b/tests/compiler/logical.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00l\00o\00g\00i\00c\00a\00l\00.\00t\00s")
  (data (i32.const 1072) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
@@ -887,8 +883,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
@@ -924,8 +918,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1008,8 +1000,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -1072,8 +1062,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
@@ -10,10 +10,6 @@
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00l\00o\00g\00i\00c\00a\00l\00.\00t\00s\00")
  (data (i32.const 64) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
@@ -1465,10 +1461,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1511,10 +1505,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -2163,13 +2155,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -2188,10 +2178,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/managed-cast.json
+++ b/tests/compiler/managed-cast.json
@@ -1,7 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -8,10 +8,6 @@
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -22,9 +18,8 @@
  (data (i32.const 1344) "\05\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\04\00\00\00 ")
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -891,8 +886,6 @@
    i32.store
   end
   local.get $2
-  call $~lib/rt/rtrace/onalloc
-  local.get $2
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -935,8 +928,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1147,13 +1138,6 @@
   call $~lib/rt/pure/__release
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:managed-cast
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -1165,8 +1149,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1
@@ -1230,8 +1212,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -26,11 +22,10 @@
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~lib/gc/gc.auto (mut i32) (i32.const 1))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 336))
  (global $~lib/heap/__heap_base i32 (i32.const 380))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1445,10 +1440,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1491,10 +1484,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1854,13 +1845,6 @@
   call $~lib/rt/pure/__release
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:managed-cast
  )
  (func $~lib/rt/pure/__collect
@@ -1878,13 +1862,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1903,10 +1885,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/object-literal.json
+++ b/tests/compiler/object-literal.json
@@ -1,7 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00h\00e\00l\00l\00o\00 \00w\00o\00r\00l\00d")
  (data (i32.const 1072) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
@@ -26,9 +22,8 @@
  (data (i32.const 1408) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\00b\00a\00z")
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1031,8 +1026,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1076,8 +1069,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1435,8 +1426,6 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $object-literal/testUnmanaged (param $0 i32)
   (local $1 i32)
@@ -1503,7 +1492,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2148,13 +2137,6 @@
   call $~lib/rt/pure/__release
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:object-literal
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -2166,8 +2148,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -10,10 +10,6 @@
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00h\00e\00l\00l\00o\00 \00w\00o\00r\00l\00d\00")
  (data (i32.const 64) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
@@ -31,10 +27,9 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~lib/gc/gc.auto (mut i32) (i32.const 1))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/heap/__heap_base i32 (i32.const 424))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1449,10 +1444,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1495,10 +1488,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -3215,7 +3206,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3232,13 +3223,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -3897,13 +3886,6 @@
   call $~lib/rt/pure/__release
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:object-literal
  )
  (func $~lib/rt/pure/__collect
@@ -3928,10 +3910,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/rc/global-init.json
+++ b/tests/compiler/rc/global-init.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/rc/global-init.untouched.wat
+++ b/tests/compiler/rc/global-init.untouched.wat
@@ -1,14 +1,11 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\00\00\00\00\01\00\00\00\01\00\00\00\00\00\00\00")
  (data (i32.const 32) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
@@ -55,10 +52,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -726,13 +721,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -751,10 +744,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/rc/local-init.json
+++ b/tests/compiler/rc/local-init.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/rc/local-init.optimized.wat
+++ b/tests/compiler/rc/local-init.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1028) "\01\00\00\00\01")
  (data (i32.const 1040) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
@@ -887,8 +883,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $~start
   (local $0 i32)
@@ -930,8 +924,6 @@
    i32.add
    i32.store offset=4
    local.get $1
-   call $~lib/rt/rtrace/onincrement
-   local.get $1
    i32.load
    i32.const 1
    i32.and
@@ -963,8 +955,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1
@@ -1028,8 +1018,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/rc/local-init.untouched.wat
+++ b/tests/compiler/rc/local-init.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\00\00\00\00\01\00\00\00\01\00\00\00\00\00\00\00")
  (data (i32.const 32) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
@@ -1454,10 +1450,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1500,10 +1494,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1574,13 +1566,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1599,10 +1589,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/rc/logical-and-mismatch.json
+++ b/tests/compiler/rc/logical-and-mismatch.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -887,8 +883,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
@@ -924,8 +918,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1006,8 +998,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -1070,8 +1060,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/rc/logical-and-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-and-mismatch.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -1440,10 +1436,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1486,10 +1480,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1619,13 +1611,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1644,10 +1634,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/rc/logical-or-mismatch.json
+++ b/tests/compiler/rc/logical-or-mismatch.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -887,8 +883,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
@@ -924,8 +918,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1006,8 +998,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -1070,8 +1060,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/rc/logical-or-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-or-mismatch.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -1440,10 +1436,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1486,10 +1480,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1619,13 +1611,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1644,10 +1634,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/rc/optimize.json
+++ b/tests/compiler/rc/optimize.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/rc/optimize.optimized.wat
+++ b/tests/compiler/rc/optimize.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -8,10 +8,6 @@
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
  (data (i32.const 1072) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
@@ -93,8 +89,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -977,8 +971,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $rc/optimize/getRef (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1148,8 +1140,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -1212,8 +1202,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/rc/optimize.untouched.wat
+++ b/tests/compiler/rc/optimize.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
  (data (i32.const 64) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
@@ -96,10 +92,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1543,10 +1537,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1871,13 +1863,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1896,10 +1886,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/rc/rereturn.untouched.wat
+++ b/tests/compiler/rc/rereturn.untouched.wat
@@ -1569,11 +1569,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 0
-  drop
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0

--- a/tests/compiler/rc/ternary-mismatch.json
+++ b/tests/compiler/rc/ternary-mismatch.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/rc/ternary-mismatch.optimized.wat
+++ b/tests/compiler/rc/ternary-mismatch.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -889,8 +885,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
@@ -926,8 +920,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1007,8 +999,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -1071,8 +1061,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/rc/ternary-mismatch.untouched.wat
+++ b/tests/compiler/rc/ternary-mismatch.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -1442,10 +1438,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1488,10 +1482,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1603,13 +1595,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -1628,10 +1618,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -2449,7 +2449,7 @@
    if
     i32.const 0
     i32.const 1040
-    i32.const 580
+    i32.const 585
     i32.const 3
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -4993,7 +4993,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -5010,11 +5010,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 0
-  drop
  )
  (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize

--- a/tests/compiler/retain-release-sanity.json
+++ b/tests/compiler/retain-release-sanity.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
@@ -9,11 +9,6 @@
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
  (data (i32.const 1072) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
@@ -1054,8 +1049,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1258,8 +1251,6 @@
    i32.add
    i32.store offset=4
    local.get $1
-   call $~lib/rt/rtrace/onincrement
-   local.get $1
    i32.load
    i32.const 1
    i32.and
@@ -1309,7 +1300,7 @@
   if
    i32.const 0
    i32.const 1136
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1499,14 +1490,13 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.tee $3
@@ -1515,6 +1505,7 @@
   local.tee $5
   i32.const -4
   i32.and
+  local.tee $4
   i32.le_u
   if
    local.get $0
@@ -1537,16 +1528,14 @@
   i32.add
   local.tee $6
   i32.load
-  local.tee $4
+  local.tee $7
   i32.const 1
   i32.and
   if
-   local.get $5
-   i32.const -4
-   i32.and
+   local.get $4
    i32.const 16
    i32.add
-   local.get $4
+   local.get $7
    i32.const -4
    i32.and
    i32.add
@@ -1596,9 +1585,6 @@
   i32.const 1652
   i32.ge_u
   if
-   local.get $1
-   local.get $3
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
@@ -2153,8 +2139,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -2266,19 +2250,11 @@
       i32.const 0
       call $~lib/rt/tlsf/__alloc
       local.tee $2
-      i32.const 16
-      i32.sub
-      call $~lib/rt/rtrace/onfree
-      local.get $2
       local.get $1
       local.get $3
       call $~lib/memory/memory.copy
       local.get $1
       if
-       local.get $1
-       i32.const 16
-       i32.sub
-       call $~lib/rt/rtrace/onalloc
        call $~lib/rt/tlsf/maybeInitialize
        local.get $1
        call $~lib/rt/tlsf/checkUsedBlock

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $i32_=>_none (func (param i32)))
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
@@ -9,11 +9,6 @@
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
  (data (i32.const 64) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
@@ -1467,10 +1462,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1726,10 +1719,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1880,7 +1871,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3150,13 +3141,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -3165,18 +3154,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
   local.get $1
   i32.load
   local.set $4
-  local.get $3
   local.get $4
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
+  local.set $5
+  local.get $3
+  local.get $5
   i32.le_u
   if
    local.get $0
@@ -3186,55 +3178,53 @@
    local.get $1
    local.get $2
    i32.store offset=12
+   i32.const 0
+   drop
    local.get $1
    return
   end
   local.get $1
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.const 16
   i32.add
-  local.get $5
+  local.get $6
   i32.load
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
   i32.add
-  local.set $6
-  local.get $6
-  i32.load
   local.set $7
   local.get $7
+  i32.load
+  local.set $8
+  local.get $8
   i32.const 1
   i32.and
   if
-   local.get $4
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   local.get $5
    i32.const 16
    i32.add
-   local.get $7
+   local.get $8
    i32.const 3
    i32.const -1
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    local.get $3
    i32.ge_u
    if
     local.get $0
-    local.get $6
+    local.get $7
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $6
     i32.or
     i32.store
     local.get $1
@@ -3244,6 +3234,8 @@
     local.get $1
     local.get $3
     call $~lib/rt/tlsf/prepareBlock
+    i32.const 0
+    drop
     local.get $1
     return
    end
@@ -3253,12 +3245,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -3270,16 +3262,13 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   i32.const 1
+   i32.const 0
    drop
-   local.get $1
-   local.get $8
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -4027,24 +4016,12 @@
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  i32.const 1
-  drop
-  local.get $5
-  i32.const 16
-  i32.sub
-  call $~lib/rt/rtrace/onfree
   local.get $5
   local.get $0
   local.get $1
   call $~lib/memory/memory.copy
   local.get $0
   if
-   i32.const 1
-   drop
-   local.get $0
-   i32.const 16
-   i32.sub
-   call $~lib/rt/rtrace/onalloc
    local.get $0
    call $~lib/rt/tlsf/__free
   end
@@ -4089,10 +4066,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/retain-return.untouched.wat
+++ b/tests/compiler/retain-return.untouched.wat
@@ -1725,11 +1725,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 0
-  drop
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -1813,7 +1813,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 580
+    i32.const 585
     i32.const 3
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -2188,11 +2188,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 0
-  drop
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 1
@@ -3524,7 +3524,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3567,16 +3567,12 @@
   i32.const 0
   call $~lib/rt/tlsf/__alloc
   local.set $5
-  i32.const 0
-  drop
   local.get $5
   local.get $0
   local.get $1
   call $~lib/memory/memory.copy
   local.get $0
   if
-   i32.const 0
-   drop
    local.get $0
    call $~lib/rt/tlsf/__free
   end

--- a/tests/compiler/runtime-full.untouched.wat
+++ b/tests/compiler/runtime-full.untouched.wat
@@ -1542,11 +1542,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 0
-  drop
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0

--- a/tests/compiler/std/array-literal.json
+++ b/tests/compiler/std/array-literal.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -9,10 +9,6 @@
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\03\00\00\00\01\00\00\00\00\00\00\00\03\00\00\00\00\01\02")
  (data (i32.const 1056) "\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00\10\04\00\00\10\04\00\00\03\00\00\00\03")
@@ -1077,8 +1073,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1122,8 +1116,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1553,8 +1545,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -1635,8 +1625,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -10,10 +10,6 @@
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\03\00\00\00\01\00\00\00\00\00\00\00\03\00\00\00\00\01\02")
  (data (i32.const 48) "\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00 \00\00\00 \00\00\00\03\00\00\00\03\00\00\00")
@@ -1528,10 +1524,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -2842,10 +2836,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -3375,13 +3367,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -3400,10 +3390,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/array.json
+++ b/tests/compiler/std/array.json
@@ -1,7 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -23,13 +23,8 @@
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "Math" "random" (func $~lib/bindings/Math/random (result f64)))
  (import "env" "seed" (func $~lib/builtins/seed (result f64)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
  (data (i32.const 1072) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
@@ -310,11 +305,9 @@
  (global $~lib/util/number/_K (mut i32) (i32.const 0))
  (global $~lib/util/number/_frc_pow (mut i64) (i64.const 0))
  (global $~lib/util/number/_exp_pow (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
  (global $std/array/ArrayU32 i32 (i32.const 40))
  (global $std/array/ArrayU8 i32 (i32.const 41))
  (global $std/array/ArrayStr i32 (i32.const 42))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "ArrayU32" (global $std/array/ArrayU32))
  (export "ArrayU32#constructor" (func $~lib/array/Array<u32>#constructor@varargs))
@@ -395,6 +388,7 @@
  (export "ArrayStr#flat" (func $~lib/array/Array<u32>#flat))
  (export "ArrayStr#toString" (func $~lib/array/Array<~lib/string/String|null>#toString))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
+ (start $~start)
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 11928
@@ -1412,8 +1406,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1630,8 +1622,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -2306,7 +2296,7 @@
   if
    i32.const 0
    i32.const 1136
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2323,14 +2313,13 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.tee $3
@@ -2339,6 +2328,7 @@
   local.tee $5
   i32.const -4
   i32.and
+  local.tee $4
   i32.le_u
   if
    local.get $0
@@ -2361,16 +2351,14 @@
   i32.add
   local.tee $6
   i32.load
-  local.tee $4
+  local.tee $7
   i32.const 1
   i32.and
   if
-   local.get $5
-   i32.const -4
-   i32.and
+   local.get $4
    i32.const 16
    i32.add
-   local.get $4
+   local.get $7
    i32.const -4
    i32.and
    i32.add
@@ -2420,9 +2408,6 @@
   i32.const 11928
   i32.ge_u
   if
-   local.get $1
-   local.get $3
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
@@ -19901,13 +19886,6 @@
   call $~lib/rt/pure/__retain
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/array
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -19921,8 +19899,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -29,13 +29,8 @@
  (type $f64_=>_i32 (func (param f64) (result i32)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "Math" "random" (func $~lib/bindings/Math/random (result f64)))
  (import "env" "seed" (func $~lib/builtins/seed (result f64)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
  (data (i32.const 64) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
@@ -319,12 +314,10 @@
  (global $~lib/util/number/_exp_pow (mut i32) (i32.const 0))
  (global $~lib/builtins/u32.MAX_VALUE i32 (i32.const -1))
  (global $~lib/builtins/i64.MAX_VALUE i64 (i64.const 9223372036854775807))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/heap/__heap_base i32 (i32.const 12360))
  (global $std/array/ArrayU32 i32 (i32.const 40))
  (global $std/array/ArrayU8 i32 (i32.const 41))
  (global $std/array/ArrayStr i32 (i32.const 42))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "ArrayU32" (global $std/array/ArrayU32))
  (export "ArrayU32#constructor" (func $~lib/array/Array<u32>#constructor@varargs))
@@ -405,6 +398,7 @@
  (export "ArrayStr#flat" (func $~lib/array/Array<~lib/string/String>#flat))
  (export "ArrayStr#toString" (func $~lib/array/Array<~lib/string/String>#toString))
  (export "__setArgumentsLength" (func $~setArgumentsLength))
+ (start $~start)
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
@@ -1830,10 +1824,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -2089,10 +2081,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -4189,7 +4179,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4206,13 +4196,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -4221,18 +4209,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
   local.get $1
   i32.load
   local.set $4
-  local.get $3
   local.get $4
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
+  local.set $5
+  local.get $3
+  local.get $5
   i32.le_u
   if
    local.get $0
@@ -4242,55 +4233,53 @@
    local.get $1
    local.get $2
    i32.store offset=12
+   i32.const 0
+   drop
    local.get $1
    return
   end
   local.get $1
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.const 16
   i32.add
-  local.get $5
+  local.get $6
   i32.load
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
   i32.add
-  local.set $6
-  local.get $6
-  i32.load
   local.set $7
   local.get $7
+  i32.load
+  local.set $8
+  local.get $8
   i32.const 1
   i32.and
   if
-   local.get $4
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   local.get $5
    i32.const 16
    i32.add
-   local.get $7
+   local.get $8
    i32.const 3
    i32.const -1
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    local.get $3
    i32.ge_u
    if
     local.get $0
-    local.get $6
+    local.get $7
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $6
     i32.or
     i32.store
     local.get $1
@@ -4300,6 +4289,8 @@
     local.get $1
     local.get $3
     call $~lib/rt/tlsf/prepareBlock
+    i32.const 0
+    drop
     local.get $1
     return
    end
@@ -4309,12 +4300,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -4326,16 +4317,13 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   i32.const 1
+   i32.const 0
    drop
-   local.get $1
-   local.get $8
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -30834,13 +30822,6 @@
   call $~lib/rt/pure/__visit
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/array
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
@@ -30860,10 +30841,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/arraybuffer.json
+++ b/tests/compiler/std/arraybuffer.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -9,10 +9,6 @@
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
  (data (i32.const 1072) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
@@ -1039,8 +1035,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1242,8 +1236,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1947,8 +1939,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -2010,8 +2000,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1,19 +1,15 @@
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
  (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
@@ -1458,10 +1454,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1717,10 +1711,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -4069,13 +4061,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -4094,10 +4084,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/dataview.json
+++ b/tests/compiler/std/dataview.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -1,10 +1,10 @@
 (module
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
@@ -16,10 +16,6 @@
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
  (data (i32.const 1072) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
@@ -1047,8 +1043,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1092,8 +1086,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -3431,8 +3423,6 @@
   i32.and
   local.set $1
   local.get $0
-  call $~lib/rt/rtrace/ondecrement
-  local.get $0
   i32.load
   i32.const 1
   i32.and
@@ -3495,8 +3485,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -1,11 +1,11 @@
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i64_i32_=>_none (func (param i32 i32 i64 i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
@@ -17,10 +17,6 @@
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
  (type $i32_i32_i32_=>_f64 (func (param i32 i32 i32) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
  (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
@@ -1466,10 +1462,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1725,10 +1719,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -4547,13 +4539,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -4572,10 +4562,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/map.json
+++ b/tests/compiler/std/map.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -4,8 +4,8 @@
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
@@ -24,11 +24,6 @@
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -1050,8 +1045,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1095,8 +1088,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1804,14 +1795,13 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.tee $3
@@ -1820,6 +1810,7 @@
   local.tee $5
   i32.const -4
   i32.and
+  local.tee $4
   i32.le_u
   if
    local.get $0
@@ -1842,16 +1833,14 @@
   i32.add
   local.tee $6
   i32.load
-  local.tee $4
+  local.tee $7
   i32.const 1
   i32.and
   if
-   local.get $5
-   i32.const -4
-   i32.and
+   local.get $4
    i32.const 16
    i32.add
-   local.get $4
+   local.get $7
    i32.const -4
    i32.and
    i32.add
@@ -1901,9 +1890,6 @@
   i32.const 1556
   i32.ge_u
   if
-   local.get $1
-   local.get $3
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
@@ -1973,7 +1959,7 @@
    if
     i32.const 0
     i32.const 1040
-    i32.const 580
+    i32.const 585
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -13026,8 +13012,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -3,8 +3,8 @@
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
@@ -25,11 +25,6 @@
  (type $i32_f64_f64_=>_i32 (func (param i32 f64 f64) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -1464,10 +1459,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1510,10 +1503,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -2378,7 +2369,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3648,13 +3639,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -3663,18 +3652,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
   local.get $1
   i32.load
   local.set $4
-  local.get $3
   local.get $4
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
+  local.set $5
+  local.get $3
+  local.get $5
   i32.le_u
   if
    local.get $0
@@ -3684,55 +3676,53 @@
    local.get $1
    local.get $2
    i32.store offset=12
+   i32.const 0
+   drop
    local.get $1
    return
   end
   local.get $1
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.const 16
   i32.add
-  local.get $5
+  local.get $6
   i32.load
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
   i32.add
-  local.set $6
-  local.get $6
-  i32.load
   local.set $7
   local.get $7
+  i32.load
+  local.set $8
+  local.get $8
   i32.const 1
   i32.and
   if
-   local.get $4
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   local.get $5
    i32.const 16
    i32.add
-   local.get $7
+   local.get $8
    i32.const 3
    i32.const -1
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    local.get $3
    i32.ge_u
    if
     local.get $0
-    local.get $6
+    local.get $7
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $6
     i32.or
     i32.store
     local.get $1
@@ -3742,6 +3732,8 @@
     local.get $1
     local.get $3
     call $~lib/rt/tlsf/prepareBlock
+    i32.const 0
+    drop
     local.get $1
     return
    end
@@ -3751,12 +3743,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -3768,16 +3760,13 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   i32.const 1
+   i32.const 0
    drop
-   local.get $1
-   local.get $8
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -20897,10 +20886,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/set.json
+++ b/tests/compiler/std/set.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -4,8 +4,8 @@
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
@@ -23,11 +23,6 @@
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1072) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -1047,8 +1042,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1092,8 +1085,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1789,14 +1780,13 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.tee $3
@@ -1805,6 +1795,7 @@
   local.tee $5
   i32.const -4
   i32.and
+  local.tee $4
   i32.le_u
   if
    local.get $0
@@ -1827,16 +1818,14 @@
   i32.add
   local.tee $6
   i32.load
-  local.tee $4
+  local.tee $7
   i32.const 1
   i32.and
   if
-   local.get $5
-   i32.const -4
-   i32.and
+   local.get $4
    i32.const 16
    i32.add
-   local.get $4
+   local.get $7
    i32.const -4
    i32.and
    i32.add
@@ -1886,9 +1875,6 @@
   i32.const 1444
   i32.ge_u
   if
-   local.get $1
-   local.get $3
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
@@ -1958,7 +1944,7 @@
    if
     i32.const 0
     i32.const 1040
-    i32.const 580
+    i32.const 585
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9357,8 +9343,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -2,8 +2,8 @@
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
@@ -22,11 +22,6 @@
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
  (data (i32.const 64) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
@@ -1459,10 +1454,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1505,10 +1498,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -2314,7 +2305,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3584,13 +3575,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -3599,18 +3588,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
   local.get $1
   i32.load
   local.set $4
-  local.get $3
   local.get $4
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
+  local.set $5
+  local.get $3
+  local.get $5
   i32.le_u
   if
    local.get $0
@@ -3620,55 +3612,53 @@
    local.get $1
    local.get $2
    i32.store offset=12
+   i32.const 0
+   drop
    local.get $1
    return
   end
   local.get $1
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.const 16
   i32.add
-  local.get $5
+  local.get $6
   i32.load
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
   i32.add
-  local.set $6
-  local.get $6
-  i32.load
   local.set $7
   local.get $7
+  i32.load
+  local.set $8
+  local.get $8
   i32.const 1
   i32.and
   if
-   local.get $4
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   local.get $5
    i32.const 16
    i32.add
-   local.get $7
+   local.get $8
    i32.const 3
    i32.const -1
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    local.get $3
    i32.ge_u
    if
     local.get $0
-    local.get $6
+    local.get $7
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $6
     i32.or
     i32.store
     local.get $1
@@ -3678,6 +3668,8 @@
     local.get $1
     local.get $3
     call $~lib/rt/tlsf/prepareBlock
+    i32.const 0
+    drop
     local.get $1
     return
    end
@@ -3687,12 +3679,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -3704,16 +3696,13 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   i32.const 1
+   i32.const 0
    drop
-   local.get $1
-   local.get $8
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -14724,10 +14713,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/staticarray.json
+++ b/tests/compiler/std/staticarray.json
@@ -1,7 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\0c\00\00\00\01\00\00\00\03\00\00\00\0c\00\00\00\01\00\00\00\02\00\00\00\03")
  (data (i32.const 1056) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
@@ -27,9 +23,8 @@
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $std/staticarray/arr3 (mut i32) (i32.const 0))
  (global $std/staticarray/arr4 (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/staticarray/StaticArray<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
@@ -1077,8 +1072,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1309,8 +1302,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1563,13 +1554,6 @@
   global.set $std/staticarray/arr4
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/staticarray
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -1583,8 +1567,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1
@@ -1674,8 +1656,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
@@ -9,10 +9,6 @@
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\0c\00\00\00\01\00\00\00\03\00\00\00\0c\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00")
  (data (i32.const 48) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
@@ -33,10 +29,9 @@
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $std/staticarray/arr3 (mut i32) (i32.const 0))
  (global $std/staticarray/arr4 (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/heap/__heap_base i32 (i32.const 464))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/staticarray/StaticArray<i32>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
@@ -1518,10 +1513,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -2832,10 +2825,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -3145,13 +3136,6 @@
   global.set $std/staticarray/arr4
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/staticarray
  )
  (func $~lib/rt/pure/__collect
@@ -3169,13 +3153,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -3194,10 +3176,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/string-casemapping.json
+++ b/tests/compiler/std/string-casemapping.json
@@ -1,7 +1,5 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
+    "--runtime half"
   ]
 }

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -1,24 +1,19 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f64_f64_f64_f64_f64_=>_none (func (param i32 i32 f64 f64 f64 f64 f64)))
  (type $none_=>_i32 (func (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "string_casemapping" "toLowerCaseFromIndex" (func $std/string-casemapping/toLowerCaseFromIndex (param i32 i32) (result i32)))
  (import "string_casemapping" "toUpperCaseFromIndex" (func $std/string-casemapping/toUpperCaseFromIndex (param i32 i32) (result i32)))
  (import "env" "trace" (func $~lib/builtins/trace (param i32 i32 f64 f64 f64 f64 f64)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 1028) "\01\00\00\00\01")
  (data (i32.const 1040) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
@@ -305,9 +300,8 @@
  (data (i32.const 18848) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00 \00e\00x\00p\00e\00c\00t\00U\00p\00p\00e\00r\00C\00o\00d\00e\00 \00=\00 ")
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
@@ -350,8 +344,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1373,8 +1365,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1718,14 +1708,13 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.tee $3
@@ -1734,6 +1723,7 @@
   local.tee $5
   i32.const -4
   i32.and
+  local.tee $4
   i32.le_u
   if
    local.get $0
@@ -1756,16 +1746,14 @@
   i32.add
   local.tee $6
   i32.load
-  local.tee $4
+  local.tee $7
   i32.const 1
   i32.and
   if
-   local.get $5
-   i32.const -4
-   i32.and
+   local.get $4
    i32.const 16
    i32.add
-   local.get $4
+   local.get $7
    i32.const -4
    i32.and
    i32.add
@@ -1815,9 +1803,6 @@
   i32.const 18904
   i32.ge_u
   if
-   local.get $1
-   local.get $3
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
@@ -1861,7 +1846,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4863,13 +4848,6 @@
   call $~lib/rt/pure/__release
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/string-casemapping
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -4881,8 +4859,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -15,14 +15,9 @@
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "string_casemapping" "toLowerCaseFromIndex" (func $std/string-casemapping/toLowerCaseFromIndex (param i32 i32) (result i32)))
  (import "string_casemapping" "toUpperCaseFromIndex" (func $std/string-casemapping/toUpperCaseFromIndex (param i32 i32) (result i32)))
  (import "env" "trace" (func $~lib/builtins/trace (param i32 i32 f64 f64 f64 f64 f64)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\00\00\00\00\01\00\00\00\01\00\00\00\00\00\00\00")
  (data (i32.const 32) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
@@ -206,10 +201,9 @@
  (global $~lib/util/casemap/SPECIALS_UPPER i32 (i32.const 208))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $~lib/builtins/u32.MAX_VALUE i32 (i32.const -1))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/heap/__heap_base i32 (i32.const 19592))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/string/String#get:length (param $0 i32) (result i32)
   local.get $0
   i32.const 16
@@ -250,10 +244,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1697,10 +1689,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1950,7 +1940,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3220,13 +3210,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -3235,18 +3223,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
   local.get $1
   i32.load
   local.set $4
-  local.get $3
   local.get $4
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
+  local.set $5
+  local.get $3
+  local.get $5
   i32.le_u
   if
    local.get $0
@@ -3256,55 +3247,53 @@
    local.get $1
    local.get $2
    i32.store offset=12
+   i32.const 0
+   drop
    local.get $1
    return
   end
   local.get $1
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.const 16
   i32.add
-  local.get $5
+  local.get $6
   i32.load
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
   i32.add
-  local.set $6
-  local.get $6
-  i32.load
   local.set $7
   local.get $7
+  i32.load
+  local.set $8
+  local.get $8
   i32.const 1
   i32.and
   if
-   local.get $4
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   local.get $5
    i32.const 16
    i32.add
-   local.get $7
+   local.get $8
    i32.const 3
    i32.const -1
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    local.get $3
    i32.ge_u
    if
     local.get $0
-    local.get $6
+    local.get $7
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $6
     i32.or
     i32.store
     local.get $1
@@ -3314,6 +3303,8 @@
     local.get $1
     local.get $3
     call $~lib/rt/tlsf/prepareBlock
+    i32.const 0
+    drop
     local.get $1
     return
    end
@@ -3323,12 +3314,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -3340,16 +3331,13 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   i32.const 1
+   i32.const 0
    drop
-   local.get $1
-   local.get $8
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -7191,13 +7179,6 @@
   call $~lib/rt/pure/__release
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/string-casemapping
  )
  (func $~lib/rt/pure/__collect
@@ -7222,10 +7203,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/string-encoding.json
+++ b/tests/compiler/std/string-encoding.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -1,19 +1,14 @@
 (module
  (type $none_=>_none (func))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00\01\d87\dch\00i\00R\d8b\df")
  (data (i32.const 1056) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s")
@@ -69,8 +64,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1113,8 +1106,6 @@
   local.get $3
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
-  local.get $3
-  call $~lib/rt/rtrace/onalloc
   local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -2405,14 +2396,13 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.tee $3
@@ -2421,6 +2411,7 @@
   local.tee $5
   i32.const -4
   i32.and
+  local.tee $4
   i32.le_u
   if
    local.get $0
@@ -2443,16 +2434,14 @@
   i32.add
   local.tee $6
   i32.load
-  local.tee $4
+  local.tee $7
   i32.const 1
   i32.and
   if
-   local.get $5
-   i32.const -4
-   i32.and
+   local.get $4
    i32.const 16
    i32.add
-   local.get $4
+   local.get $7
    i32.const -4
    i32.and
    i32.add
@@ -2502,9 +2491,6 @@
   i32.const 22060
   i32.ge_u
   if
-   local.get $1
-   local.get $3
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
@@ -2728,7 +2714,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3227,8 +3213,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -1,9 +1,9 @@
 (module
  (type $none_=>_none (func))
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
@@ -11,11 +11,6 @@
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00\01\d87\dch\00i\00R\d8b\df")
  (data (i32.const 48) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
@@ -75,10 +70,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -1562,10 +1555,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -4211,7 +4202,7 @@
   if
    i32.const 0
    i32.const 176
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4228,13 +4219,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -4243,18 +4232,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
   local.get $1
   i32.load
   local.set $4
-  local.get $3
   local.get $4
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
+  local.set $5
+  local.get $3
+  local.get $5
   i32.le_u
   if
    local.get $0
@@ -4264,55 +4256,53 @@
    local.get $1
    local.get $2
    i32.store offset=12
+   i32.const 0
+   drop
    local.get $1
    return
   end
   local.get $1
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.const 16
   i32.add
-  local.get $5
+  local.get $6
   i32.load
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
   i32.add
-  local.set $6
-  local.get $6
-  i32.load
   local.set $7
   local.get $7
+  i32.load
+  local.set $8
+  local.get $8
   i32.const 1
   i32.and
   if
-   local.get $4
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   local.get $5
    i32.const 16
    i32.add
-   local.get $7
+   local.get $8
    i32.const 3
    i32.const -1
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    local.get $3
    i32.ge_u
    if
     local.get $0
-    local.get $6
+    local.get $7
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $6
     i32.or
     i32.store
     local.get $1
@@ -4322,6 +4312,8 @@
     local.get $1
     local.get $3
     call $~lib/rt/tlsf/prepareBlock
+    i32.const 0
+    drop
     local.get $1
     return
    end
@@ -4331,12 +4323,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -4348,16 +4340,13 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   i32.const 1
+   i32.const 0
    drop
-   local.get $1
-   local.get $8
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -5045,10 +5034,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/string.json
+++ b/tests/compiler/std/string.json
@@ -1,7 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -2,9 +2,9 @@
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
@@ -21,11 +21,6 @@
  (type $i32_=>_i64 (func (param i32) (result i64)))
  (type $f64_i32_=>_f64 (func (param f64 i32) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 1024) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00h\00i\00,\00 \00I\00\'\00m\00 \00a\00 \00s\00t\00r\00i\00n\00g")
  (data (i32.const 1072) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00s\00t\00d\00/\00s\00t\00r\00i\00n\00g\00.\00t\00s")
@@ -462,10 +457,9 @@
  (global $~lib/util/number/_K (mut i32) (i32.const 0))
  (global $~lib/util/number/_frc_pow (mut i64) (i64.const 0))
  (global $~lib/util/number/_exp_pow (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "getString" (func $std/string/getString))
+ (start $~start)
  (func $~lib/rt/pure/__retain (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
@@ -500,8 +494,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -1700,8 +1692,6 @@
   local.get $3
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
-  local.get $3
-  call $~lib/rt/rtrace/onalloc
   local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -4648,7 +4638,7 @@
   if
    i32.const 0
    i32.const 1360
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -4665,14 +4655,13 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.tee $3
@@ -4681,6 +4670,7 @@
   local.tee $5
   i32.const -4
   i32.and
+  local.tee $4
   i32.le_u
   if
    local.get $0
@@ -4703,16 +4693,14 @@
   i32.add
   local.tee $6
   i32.load
-  local.tee $4
+  local.tee $7
   i32.const 1
   i32.and
   if
-   local.get $5
-   i32.const -4
-   i32.and
+   local.get $4
    i32.const 16
    i32.add
-   local.get $4
+   local.get $7
    i32.const -4
    i32.and
    i32.add
@@ -4762,9 +4750,6 @@
   i32.const 21992
   i32.ge_u
   if
-   local.get $1
-   local.get $3
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
@@ -17097,13 +17082,6 @@
   call $~lib/rt/pure/__retain
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/string
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -17117,8 +17095,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -2,9 +2,9 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
@@ -23,11 +23,6 @@
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
  (type $f64_i32_=>_f64 (func (param f64 i32) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 16) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00h\00i\00,\00 \00I\00\'\00m\00 \00a\00 \00s\00t\00r\00i\00n\00g\00")
  (data (i32.const 64) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00s\00t\00d\00/\00s\00t\00r\00i\00n\00g\00.\00t\00s\00")
@@ -484,11 +479,10 @@
  (global $~lib/util/number/_K (mut i32) (i32.const 0))
  (global $~lib/util/number/_frc_pow (mut i64) (i64.const 0))
  (global $~lib/util/number/_exp_pow (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/heap/__heap_base i32 (i32.const 22424))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
  (export "getString" (func $std/string/getString))
+ (start $~start)
  (func $~lib/rt/pure/increment (param $0 i32)
   (local $1 i32)
   local.get $0
@@ -521,10 +515,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -2222,10 +2214,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -7449,7 +7439,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -7466,13 +7456,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/reallocateBlock (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -7481,18 +7469,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
   local.get $1
   i32.load
   local.set $4
-  local.get $3
   local.get $4
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
+  local.set $5
+  local.get $3
+  local.get $5
   i32.le_u
   if
    local.get $0
@@ -7502,55 +7493,53 @@
    local.get $1
    local.get $2
    i32.store offset=12
+   i32.const 0
+   drop
    local.get $1
    return
   end
   local.get $1
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.const 16
   i32.add
-  local.get $5
+  local.get $6
   i32.load
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
   i32.add
-  local.set $6
-  local.get $6
-  i32.load
   local.set $7
   local.get $7
+  i32.load
+  local.set $8
+  local.get $8
   i32.const 1
   i32.and
   if
-   local.get $4
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   local.get $5
    i32.const 16
    i32.add
-   local.get $7
+   local.get $8
    i32.const 3
    i32.const -1
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    local.get $3
    i32.ge_u
    if
     local.get $0
-    local.get $6
+    local.get $7
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $6
     i32.or
     i32.store
     local.get $1
@@ -7560,6 +7549,8 @@
     local.get $1
     local.get $3
     call $~lib/rt/tlsf/prepareBlock
+    i32.const 0
+    drop
     local.get $1
     return
    end
@@ -7569,12 +7560,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -7586,16 +7577,13 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   i32.const 1
+   i32.const 0
    drop
-   local.get $1
-   local.get $8
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -21277,13 +21265,6 @@
   call $~lib/rt/pure/__retain
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/string
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
@@ -21303,10 +21284,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/std/typedarray.json
+++ b/tests/compiler/std/typedarray.json
@@ -1,7 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -42,12 +42,7 @@
  (type $f32_=>_f32 (func (param f32) (result f32)))
  (type $f64_=>_f64 (func (param f64) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
  (import "env" "trace" (func $~lib/builtins/trace (param i32 i32 f64 f64 f64 f64 f64)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
  (data (i32.const 1072) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
@@ -326,9 +321,8 @@
  (global $~lib/util/number/_K (mut i32) (i32.const 0))
  (global $~lib/util/number/_frc_pow (mut i64) (i64.const 0))
  (global $~lib/util/number/_exp_pow (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   i32.const 12524
@@ -1346,8 +1340,6 @@
   local.get $4
   call $~lib/rt/tlsf/prepareBlock
   local.get $3
-  call $~lib/rt/rtrace/onalloc
-  local.get $3
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -1564,8 +1556,6 @@
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $1
-   call $~lib/rt/rtrace/onincrement
    local.get $1
    i32.load
    i32.const 1
@@ -2584,7 +2574,7 @@
   if
    i32.const 0
    i32.const 1152
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2601,8 +2591,6 @@
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/util/sort/weakHeapSort<f64> (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -5537,6 +5525,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.tee $3
@@ -5545,6 +5534,7 @@
   local.tee $5
   i32.const -4
   i32.and
+  local.tee $4
   i32.le_u
   if
    local.get $0
@@ -5567,16 +5557,14 @@
   i32.add
   local.tee $6
   i32.load
-  local.tee $4
+  local.tee $7
   i32.const 1
   i32.and
   if
-   local.get $5
-   i32.const -4
-   i32.and
+   local.get $4
    i32.const 16
    i32.add
-   local.get $4
+   local.get $7
    i32.const -4
    i32.and
    i32.add
@@ -5626,9 +5614,6 @@
   i32.const 12524
   i32.ge_u
   if
-   local.get $1
-   local.get $3
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
@@ -36060,13 +36045,6 @@
   unreachable
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/typedarray
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -36078,8 +36056,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -9,8 +9,8 @@
  (type $i64_i32_i32_=>_i32 (func (param i64 i32 i32) (result i32)))
  (type $f32_i32_i32_=>_i32 (func (param f32 i32 i32) (result i32)))
  (type $f64_i32_i32_=>_i32 (func (param f64 i32 i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i64_i64_i32_i32_=>_i64 (func (param i64 i64 i32 i32) (result i64)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
@@ -47,12 +47,7 @@
  (type $f32_f32_=>_f32 (func (param f32 f32) (result f32)))
  (type $f64_f64_=>_f64 (func (param f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
- (import "rtrace" "onrealloc" (func $~lib/rt/rtrace/onrealloc (param i32 i32)))
  (import "env" "trace" (func $~lib/builtins/trace (param i32 i32 f64 f64 f64 f64 f64)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
  (data (i32.const 64) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
@@ -347,10 +342,9 @@
  (global $std/typedarray/setSource2 (mut i32) (i32.const 8992))
  (global $std/typedarray/setSource3 (mut i32) (i32.const 9072))
  (global $std/typedarray/setSource7 (mut i32) (i32.const 9136))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/heap/__heap_base i32 (i32.const 12956))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
   global.get $~lib/heap/__heap_base
@@ -1776,10 +1770,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -2035,10 +2027,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -3346,7 +3336,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 580
+   i32.const 585
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -3363,13 +3353,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/tlsf/__free (param $0 i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -11150,18 +11138,21 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/tlsf/prepareSize
   local.set $3
   local.get $1
   i32.load
   local.set $4
-  local.get $3
   local.get $4
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
+  local.set $5
+  local.get $3
+  local.get $5
   i32.le_u
   if
    local.get $0
@@ -11171,55 +11162,53 @@
    local.get $1
    local.get $2
    i32.store offset=12
+   i32.const 0
+   drop
    local.get $1
    return
   end
   local.get $1
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.const 16
   i32.add
-  local.get $5
+  local.get $6
   i32.load
   i32.const 3
   i32.const -1
   i32.xor
   i32.and
   i32.add
-  local.set $6
-  local.get $6
-  i32.load
   local.set $7
   local.get $7
+  i32.load
+  local.set $8
+  local.get $8
   i32.const 1
   i32.and
   if
-   local.get $4
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   local.get $5
    i32.const 16
    i32.add
-   local.get $7
+   local.get $8
    i32.const 3
    i32.const -1
    i32.xor
    i32.and
    i32.add
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    local.get $3
    i32.ge_u
    if
     local.get $0
-    local.get $6
+    local.get $7
     call $~lib/rt/tlsf/removeBlock
     local.get $1
     local.get $4
     i32.const 3
     i32.and
-    local.get $5
+    local.get $6
     i32.or
     i32.store
     local.get $1
@@ -11229,6 +11218,8 @@
     local.get $1
     local.get $3
     call $~lib/rt/tlsf/prepareBlock
+    i32.const 0
+    drop
     local.get $1
     return
    end
@@ -11238,12 +11229,12 @@
   local.get $1
   i32.load offset=8
   call $~lib/rt/tlsf/allocateBlock
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   local.get $1
   i32.load offset=4
   i32.store offset=4
-  local.get $8
+  local.get $9
   i32.const 16
   i32.add
   local.get $1
@@ -11255,16 +11246,13 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   i32.const 1
+   i32.const 0
    drop
-   local.get $1
-   local.get $8
-   call $~lib/rt/rtrace/onrealloc
    local.get $0
    local.get $1
    call $~lib/rt/tlsf/freeBlock
   end
-  local.get $8
+  local.get $9
  )
  (func $~lib/rt/tlsf/__realloc (param $0 i32) (param $1 i32) (result i32)
   call $~lib/rt/tlsf/maybeInitialize
@@ -57472,13 +57460,6 @@
   call $~lib/rt/pure/__release
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:std/typedarray
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
@@ -57498,10 +57479,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/throw.json
+++ b/tests/compiler/throw.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/throw.untouched.wat
+++ b/tests/compiler/throw.untouched.wat
@@ -4,8 +4,6 @@
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\001\002\003\00")
  (data (i32.const 48) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\002\003\004\00")
@@ -719,13 +717,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -744,10 +740,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/while.json
+++ b/tests/compiler/while.json
@@ -1,7 +1,6 @@
 {
   "asc_flags": [
-    "--runtime half",
-    "--explicitStart",
-    "--use ASC_RTRACE=1"
-  ]
+    "--runtime half"
+  ],
+  "asc_rtrace": true
 }

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -1,16 +1,12 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 1024) "\10\00\00\00\01\00\00\00\01\00\00\00\10\00\00\00w\00h\00i\00l\00e\00.\00t\00s")
  (data (i32.const 1056) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
@@ -19,9 +15,8 @@
  (global $while/ran (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $while/testNested
   (local $0 i32)
   (local $1 i32)
@@ -977,8 +972,6 @@
    i32.store
   end
   local.get $1
-  call $~lib/rt/rtrace/onalloc
-  local.get $1
  )
  (func $while/Ref#constructor (result i32)
   (local $0 i32)
@@ -988,14 +981,14 @@
   call $~lib/rt/tlsf/allocateBlock
   i32.const 16
   i32.add
-  local.tee $1
+  local.tee $0
   i32.const 1216
   i32.gt_u
   if
-   local.get $1
+   local.get $0
    i32.const 16
    i32.sub
-   local.tee $0
+   local.tee $1
    i32.load offset=4
    local.tee $2
    i32.const -268435456
@@ -1014,14 +1007,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
+   local.get $1
    local.get $2
    i32.const 1
    i32.add
    i32.store offset=4
-   local.get $0
-   call $~lib/rt/rtrace/onincrement
-   local.get $0
+   local.get $1
    i32.load
    i32.const 1
    i32.and
@@ -1034,7 +1025,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $0
  )
  (func $~lib/rt/pure/__release (param $0 i32)
   local.get $0
@@ -1446,13 +1437,6 @@
   global.set $while/ran
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:while
  )
  (func $~lib/rt/pure/decrement (param $0 i32)
@@ -1464,8 +1448,6 @@
   i32.const 268435455
   i32.and
   local.set $1
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   local.get $0
   i32.load
   i32.const 1
@@ -1529,8 +1511,6 @@
    global.get $~lib/rt/tlsf/ROOT
    local.get $0
    call $~lib/rt/tlsf/insertBlock
-   local.get $0
-   call $~lib/rt/rtrace/onfree
   else
    local.get $1
    i32.const 0

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $none_=>_none (func))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
@@ -9,10 +9,6 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
- (import "rtrace" "onincrement" (func $~lib/rt/rtrace/onincrement (param i32)))
- (import "rtrace" "ondecrement" (func $~lib/rt/rtrace/ondecrement (param i32)))
- (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (memory $0 1)
  (data (i32.const 16) "\10\00\00\00\01\00\00\00\01\00\00\00\10\00\00\00w\00h\00i\00l\00e\00.\00t\00s\00")
  (data (i32.const 48) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
@@ -24,10 +20,9 @@
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~lib/gc/gc.auto (mut i32) (i32.const 1))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/heap/__heap_base i32 (i32.const 208))
- (export "_start" (func $~start))
  (export "memory" (memory $0))
+ (start $~start)
  (func $while/testSimple
   (local $0 i32)
   (local $1 i32)
@@ -1896,10 +1891,8 @@
   local.get $4
   local.get $3
   call $~lib/rt/tlsf/prepareBlock
-  i32.const 1
+  i32.const 0
   drop
-  local.get $4
-  call $~lib/rt/rtrace/onalloc
   local.get $4
  )
  (func $~lib/rt/tlsf/__alloc (param $0 i32) (param $1 i32) (result i32)
@@ -1942,10 +1935,8 @@
   i32.const 1
   i32.add
   i32.store offset=4
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/onincrement
   i32.const 1
   drop
   local.get $0
@@ -2398,13 +2389,6 @@
   end
  )
  (func $~start
-  global.get $~started
-  if
-   return
-  else
-   i32.const 1
-   global.set $~started
-  end
   call $start:while
  )
  (func $~lib/rt/pure/__collect
@@ -2422,13 +2406,11 @@
   i32.const 1
   i32.or
   i32.store
+  i32.const 0
+  drop
   local.get $0
   local.get $1
   call $~lib/rt/tlsf/insertBlock
-  i32.const 1
-  drop
-  local.get $1
-  call $~lib/rt/rtrace/onfree
  )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
@@ -2447,10 +2429,8 @@
   i32.const 268435455
   i32.and
   local.set $2
-  i32.const 1
+  i32.const 0
   drop
-  local.get $0
-  call $~lib/rt/rtrace/ondecrement
   i32.const 1
   drop
   local.get $0


### PR DESCRIPTION
Adds a shadow memory, keeping track of alloc, resize, move and free ranges, and the option to instrument loads and stores to detect OOB accesses.

Doesn't find any problems in our tests, which is good, but hits OOB accesses in the bootstrapped compiler during PureRC's collection phase, indicating that something is off there. Will be helpful to debug, though. Also note that memory instrumentation is extremely slow currently due to having to look at stack traces to tell legit TLSF bookkeeping apart from actual OOB block accesses, but it's a start.

- [x] I've read the contributing guidelines