### PR TITLE
fix(compiler): Implement proper left / right cyclic builtin rotation for small integers

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1171,14 +1171,22 @@ function builtin_rotl(ctx: BuiltinContext): ExpressionRef {
   if (type.isValue) {
     let arg1 = compiler.compileExpression(operands[1], type, Constraints.CONV_IMPLICIT);
     switch (type.kind) {
+      case TypeKind.BOOL: return arg0;
       case TypeKind.I8:
       case TypeKind.I16:
       case TypeKind.U8:
-      case TypeKind.U16:
-      case TypeKind.BOOL: {
-        return compiler.ensureSmallIntegerWrap(
-          module.binary(BinaryOp.RotlI32, arg0, arg1),
-          type
+      case TypeKind.U16: {
+        // (value << (shift & mask)) | (value >>> ((0 - shift) & mask))
+        let mask   = module.i32(type.size - 1);
+        let shiftL = module.binary(BinaryOp.AndI32, arg1, mask);
+        let shiftR = module.binary(
+          BinaryOp.AndI32,
+          module.binary(BinaryOp.SubI32, module.i32(0), arg1),
+          mask
+        );
+        return module.binary(BinaryOp.OrI32,
+          module.binary(BinaryOp.ShlI32, arg0, shiftL),
+          module.binary(BinaryOp.ShrU32, arg0, shiftR)
         );
       }
       case TypeKind.I32:
@@ -1221,14 +1229,22 @@ function builtin_rotr(ctx: BuiltinContext): ExpressionRef {
   if (type.isValue) {
     let arg1 = compiler.compileExpression(operands[1], type, Constraints.CONV_IMPLICIT);
     switch (type.kind) {
+      case TypeKind.BOOL: return arg0;
       case TypeKind.I8:
       case TypeKind.I16:
       case TypeKind.U8:
-      case TypeKind.U16:
-      case TypeKind.BOOL: {
-        return compiler.ensureSmallIntegerWrap(
-          module.binary(BinaryOp.RotrI32, arg0, arg1),
-          type
+      case TypeKind.U16: {
+        // (value >>> (shift & mask)) | (value << ((0 - shift) & mask))
+        let mask   = module.i32(type.size - 1);
+        let shiftL = module.binary(BinaryOp.AndI32, arg1, mask);
+        let shiftR = module.binary(
+          BinaryOp.AndI32,
+          module.binary(BinaryOp.SubI32, module.i32(0), arg1),
+          mask
+        );
+        return module.binary(BinaryOp.OrI32,
+          module.binary(BinaryOp.ShrU32, arg0, shiftL),
+          module.binary(BinaryOp.ShlI32, arg0, shiftR)
         );
       }
       case TypeKind.I32:
@@ -2129,7 +2145,7 @@ function builtin_add(ctx: BuiltinContext): ExpressionRef {
       {
         op = BinaryOp.AddI32;
         break;
-      }       
+      }
       case TypeKind.I64:
       case TypeKind.U64: {
         op = BinaryOp.AddI64;
@@ -2220,7 +2236,7 @@ function builtin_sub(ctx: BuiltinContext): ExpressionRef {
       {
         op = BinaryOp.SubI32;
         break;
-      }       
+      }
       case TypeKind.I64:
       case TypeKind.U64: {
         op = BinaryOp.SubI64;
@@ -2311,7 +2327,7 @@ function builtin_mul(ctx: BuiltinContext): ExpressionRef {
       {
         op = BinaryOp.MulI32;
         break;
-      }       
+      }
       case TypeKind.I64:
       case TypeKind.U64: {
         op = BinaryOp.MulI64;
@@ -3041,7 +3057,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
       case TypeKind.EXTERNREF:
       case TypeKind.EXNREF:
       case TypeKind.ANYREF: return module.if(module.ref_is_null(arg0), abort);
-          
+
     }
   } else {
     compiler.currentType = type.nonNullableType;

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1126,8 +1126,8 @@ function builtin_popcnt(ctx: BuiltinContext): ExpressionRef {
   var type = compiler.currentType;
   if (type.isValue) {
     switch (compiler.currentType.kind) {
-      case TypeKind.BOOL: // not wrapped
-      case TypeKind.I8:
+      case TypeKind.BOOL: return arg0;
+      case TypeKind.I8: // not wrapped
       case TypeKind.U8:
       case TypeKind.I16:
       case TypeKind.U16:

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1177,16 +1177,21 @@ function builtin_rotl(ctx: BuiltinContext): ExpressionRef {
       case TypeKind.U8:
       case TypeKind.U16: {
         // (value << (shift & mask)) | (value >>> ((0 - shift) & mask))
-        let mask   = module.i32(type.size - 1);
-        let shiftL = module.binary(BinaryOp.AndI32, arg1, mask);
-        let shiftR = module.binary(
-          BinaryOp.AndI32,
-          module.binary(BinaryOp.SubI32, module.i32(0), arg1),
-          mask
-        );
         return module.binary(BinaryOp.OrI32,
-          module.binary(BinaryOp.ShlI32, arg0, shiftL),
-          module.binary(BinaryOp.ShrU32, arg0, shiftR)
+          module.binary(
+            BinaryOp.ShlI32,
+            arg0,
+            module.binary(BinaryOp.AndI32, arg1, module.i32(type.size - 1))
+          ),
+          module.binary(
+            BinaryOp.ShrU32,
+            arg0,
+            module.binary(
+              BinaryOp.AndI32,
+              module.binary(BinaryOp.SubI32, module.i32(0), arg1),
+              module.i32(type.size - 1)
+            )
+          )
         );
       }
       case TypeKind.I32:
@@ -1235,16 +1240,21 @@ function builtin_rotr(ctx: BuiltinContext): ExpressionRef {
       case TypeKind.U8:
       case TypeKind.U16: {
         // (value >>> (shift & mask)) | (value << ((0 - shift) & mask))
-        let mask   = module.i32(type.size - 1);
-        let shiftL = module.binary(BinaryOp.AndI32, arg1, mask);
-        let shiftR = module.binary(
-          BinaryOp.AndI32,
-          module.binary(BinaryOp.SubI32, module.i32(0), arg1),
-          mask
-        );
         return module.binary(BinaryOp.OrI32,
-          module.binary(BinaryOp.ShrU32, arg0, shiftL),
-          module.binary(BinaryOp.ShlI32, arg0, shiftR)
+          module.binary(
+            BinaryOp.ShrU32,
+            arg0,
+            module.binary(BinaryOp.AndI32, arg1, module.i32(type.size - 1))
+          ),
+          module.binary(
+            BinaryOp.ShlI32,
+            arg0,
+            module.binary(
+              BinaryOp.AndI32,
+              module.binary(BinaryOp.SubI32, module.i32(0), arg1),
+              module.i32(type.size - 1)
+            )
+          )
         );
       }
       case TypeKind.I32:

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -503,7 +503,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 294
+   i32.const 299
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -518,7 +518,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 295
+   i32.const 300
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -530,7 +530,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 296
+   i32.const 301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -542,7 +542,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 299
+   i32.const 304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -621,7 +621,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 475
+   i32.const 480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -633,7 +633,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 476
+   i32.const 481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -645,7 +645,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 477
+   i32.const 482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -655,7 +655,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 478
+   i32.const 483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -667,7 +667,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 479
+   i32.const 484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -677,7 +677,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 480
+   i32.const 485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -687,7 +687,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 481
+   i32.const 486
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -707,73 +707,13 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 498
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1328
-  i32.const 1328
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 499
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1360
-  i32.const 1360
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 500
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1392
-  i32.const 1392
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 501
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1424
-  i32.const 1424
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 502
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1456
-  i32.const 1456
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
    i32.const 503
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1488
-  i32.const 1488
+  i32.const 1328
+  i32.const 1328
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -784,8 +724,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1520
-  i32.const 1520
+  i32.const 1360
+  i32.const 1360
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -796,8 +736,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1552
-  i32.const 1552
+  i32.const 1392
+  i32.const 1392
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -808,8 +748,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1584
-  i32.const 1584
+  i32.const 1424
+  i32.const 1424
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -820,8 +760,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1616
-  i32.const 1616
+  i32.const 1456
+  i32.const 1456
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -832,8 +772,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1648
-  i32.const 1648
+  i32.const 1488
+  i32.const 1488
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -844,8 +784,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1680
-  i32.const 1680
+  i32.const 1520
+  i32.const 1520
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -856,8 +796,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1712
-  i32.const 1712
+  i32.const 1552
+  i32.const 1552
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -868,8 +808,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1744
-  i32.const 1744
+  i32.const 1584
+  i32.const 1584
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -880,8 +820,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1776
-  i32.const 1776
+  i32.const 1616
+  i32.const 1616
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -892,8 +832,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1808
-  i32.const 1808
+  i32.const 1648
+  i32.const 1648
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -904,8 +844,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1840
-  i32.const 1840
+  i32.const 1680
+  i32.const 1680
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -916,6 +856,66 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 1712
+  i32.const 1712
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1088
+   i32.const 516
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1744
+  i32.const 1744
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1088
+   i32.const 517
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1776
+  i32.const 1776
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1088
+   i32.const 518
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1808
+  i32.const 1808
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1088
+   i32.const 519
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1840
+  i32.const 1840
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1088
+   i32.const 520
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
   i32.const 1392
   i32.const 1392
   call $~lib/string/String.__eq
@@ -923,7 +923,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 516
+   i32.const 521
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -935,7 +935,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 517
+   i32.const 522
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -503,7 +503,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 299
+   i32.const 298
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -518,23 +518,23 @@
   if
    i32.const 0
    i32.const 1088
+   i32.const 299
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1040
+  i32.const 1040
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1088
    i32.const 300
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1040
-  i32.const 1040
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 301
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
   i32.const 1168
   i32.const 1168
   call $~lib/string/String.__eq
@@ -542,7 +542,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 304
+   i32.const 303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -621,7 +621,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 480
+   i32.const 479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -633,7 +633,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 481
+   i32.const 480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -645,7 +645,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 482
+   i32.const 481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -655,7 +655,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 483
+   i32.const 482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -667,7 +667,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 484
+   i32.const 483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -677,7 +677,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 485
+   i32.const 484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -687,7 +687,7 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 486
+   i32.const 485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -707,13 +707,25 @@
   if
    i32.const 0
    i32.const 1088
-   i32.const 503
+   i32.const 502
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1328
   i32.const 1328
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1088
+   i32.const 503
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1360
+  i32.const 1360
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -724,8 +736,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1360
-  i32.const 1360
+  i32.const 1392
+  i32.const 1392
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -736,8 +748,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1392
-  i32.const 1392
+  i32.const 1424
+  i32.const 1424
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -748,8 +760,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1424
-  i32.const 1424
+  i32.const 1456
+  i32.const 1456
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -760,8 +772,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1456
-  i32.const 1456
+  i32.const 1488
+  i32.const 1488
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -772,8 +784,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1488
-  i32.const 1488
+  i32.const 1520
+  i32.const 1520
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -784,8 +796,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1520
-  i32.const 1520
+  i32.const 1552
+  i32.const 1552
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -796,8 +808,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1552
-  i32.const 1552
+  i32.const 1584
+  i32.const 1584
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -808,8 +820,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1584
-  i32.const 1584
+  i32.const 1616
+  i32.const 1616
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -820,8 +832,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1616
-  i32.const 1616
+  i32.const 1648
+  i32.const 1648
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -832,8 +844,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1648
-  i32.const 1648
+  i32.const 1680
+  i32.const 1680
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -844,8 +856,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1680
-  i32.const 1680
+  i32.const 1712
+  i32.const 1712
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -856,8 +868,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1712
-  i32.const 1712
+  i32.const 1744
+  i32.const 1744
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -868,8 +880,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1744
-  i32.const 1744
+  i32.const 1776
+  i32.const 1776
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -880,8 +892,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1776
-  i32.const 1776
+  i32.const 1808
+  i32.const 1808
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -892,8 +904,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1808
-  i32.const 1808
+  i32.const 1840
+  i32.const 1840
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -904,8 +916,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1840
-  i32.const 1840
+  i32.const 1392
+  i32.const 1392
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -916,26 +928,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1392
-  i32.const 1392
+  i32.const 1328
+  i32.const 1328
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 1088
    i32.const 521
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1328
-  i32.const 1328
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 522
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/builtins.ts
+++ b/tests/compiler/builtins.ts
@@ -52,6 +52,10 @@ l = add<i8>(1, 2); assert(l == 3);
 l = sub<i8>(2, 1); assert(l == 1);
 l = mul<i8>(1, 2); assert(l == 2);
 
+var v: u8;
+v = rotl<u8>(<u8>0b10001111, 3); assert(v == 0b01111100);
+v = rotr<u8>(<u8>0b10101010, 1); assert(v == 0b01010101);
+
 // integers
 
 var i: i32;
@@ -149,9 +153,9 @@ abs<f64>(1.25);
 ceil<f64>(1.25);
 copysign<f64>(1.25, 2.5);
 floor<f64>(1.25);
-add<f64>(1.5, 2.5); 
-sub<f64>(2.5, 1.5); 
-mul<f64>(1.5, 2.0); 
+add<f64>(1.5, 2.5);
+sub<f64>(2.5, 1.5);
+mul<f64>(1.5, 2.0);
 max<f64>(1.25, 2.5);
 min<f64>(1.25, 2.5);
 nearest<f64>(1.25);

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -40,6 +40,7 @@
  (elem (i32.const 1) $start:builtins~anonymous|0 $start:builtins~anonymous|1 $start:builtins~anonymous|2)
  (global $builtins/b (mut i32) (i32.const 0))
  (global $builtins/l (mut i32) (i32.const 0))
+ (global $builtins/v (mut i32) (i32.const 0))
  (global $builtins/i (mut i32) (i32.const 0))
  (global $builtins/I (mut i64) (i64.const 0))
  (global $builtins/f (mut f32) (f32.const 0))
@@ -500,6 +501,62 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 143
+  i32.const 3
+  i32.const 7
+  i32.and
+  i32.shl
+  i32.const 143
+  i32.const 0
+  i32.const 3
+  i32.sub
+  i32.const 7
+  i32.and
+  i32.shr_u
+  i32.or
+  i32.const 255
+  i32.and
+  global.set $builtins/v
+  global.get $builtins/v
+  i32.const 124
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 80
+   i32.const 57
+   i32.const 34
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 170
+  i32.const 1
+  i32.const 7
+  i32.and
+  i32.shr_u
+  i32.const 170
+  i32.const 0
+  i32.const 1
+  i32.sub
+  i32.const 7
+  i32.and
+  i32.shl
+  i32.or
+  i32.const 255
+  i32.and
+  global.set $builtins/v
+  global.get $builtins/v
+  i32.const 85
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 80
+   i32.const 58
+   i32.const 34
+   call $~lib/builtins/abort
+   unreachable
+  end
   i32.const 1
   i32.clz
   drop
@@ -591,7 +648,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 76
+   i32.const 81
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -612,7 +669,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 77
+   i32.const 82
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -633,7 +690,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 78
+   i32.const 83
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -649,7 +706,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 79
+   i32.const 84
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -665,7 +722,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 80
+   i32.const 85
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -681,7 +738,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 81
+   i32.const 86
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -747,7 +804,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -768,7 +825,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 97
+   i32.const 102
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -789,7 +846,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 98
+   i32.const 103
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -805,7 +862,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 99
+   i32.const 104
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -821,7 +878,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 100
+   i32.const 105
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -837,7 +894,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 101
+   i32.const 106
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -955,7 +1012,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 131
+   i32.const 136
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -971,7 +1028,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 132
+   i32.const 137
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -987,7 +1044,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 133
+   i32.const 138
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1003,7 +1060,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 134
+   i32.const 139
    i32.const 26
    call $~lib/builtins/abort
    unreachable
@@ -1162,7 +1219,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 173
+   i32.const 178
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1178,7 +1235,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 174
+   i32.const 179
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1194,7 +1251,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 175
+   i32.const 180
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1517,7 +1574,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 294
+   i32.const 299
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -1533,7 +1590,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 295
+   i32.const 300
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -1547,7 +1604,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 296
+   i32.const 301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -1560,7 +1617,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 297
+   i32.const 302
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -1573,7 +1630,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 298
+   i32.const 303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -1587,7 +1644,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 299
+   i32.const 304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2111,7 +2168,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 475
+   i32.const 480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2124,7 +2181,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 476
+   i32.const 481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2137,7 +2194,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 477
+   i32.const 482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2150,7 +2207,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 478
+   i32.const 483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2163,7 +2220,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 479
+   i32.const 484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2176,7 +2233,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 480
+   i32.const 485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2189,7 +2246,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 481
+   i32.const 486
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2224,7 +2281,7 @@
   if
    i32.const 288
    i32.const 80
-   i32.const 491
+   i32.const 496
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2236,7 +2293,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 492
+   i32.const 497
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2248,7 +2305,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 493
+   i32.const 498
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2260,73 +2317,13 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 494
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 320
-  i32.const 320
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 80
-   i32.const 498
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 320
-  i32.const 320
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 80
    i32.const 499
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 352
-  i32.const 352
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 80
-   i32.const 500
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 384
-  i32.const 384
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 80
-   i32.const 501
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 416
-  i32.const 416
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 80
-   i32.const 502
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 448
-  i32.const 448
+  i32.const 320
+  i32.const 320
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2337,8 +2334,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 480
-  i32.const 480
+  i32.const 320
+  i32.const 320
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2349,8 +2346,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 512
-  i32.const 512
+  i32.const 352
+  i32.const 352
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2361,8 +2358,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 544
-  i32.const 544
+  i32.const 384
+  i32.const 384
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2373,8 +2370,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 576
-  i32.const 576
+  i32.const 416
+  i32.const 416
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2385,8 +2382,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 608
-  i32.const 608
+  i32.const 448
+  i32.const 448
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2397,8 +2394,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 640
-  i32.const 640
+  i32.const 480
+  i32.const 480
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2409,8 +2406,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 672
-  i32.const 672
+  i32.const 512
+  i32.const 512
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2421,8 +2418,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 704
-  i32.const 704
+  i32.const 544
+  i32.const 544
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2433,8 +2430,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 736
-  i32.const 736
+  i32.const 576
+  i32.const 576
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2445,8 +2442,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 768
-  i32.const 768
+  i32.const 608
+  i32.const 608
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2457,8 +2454,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 800
-  i32.const 800
+  i32.const 640
+  i32.const 640
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2469,8 +2466,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 832
-  i32.const 832
+  i32.const 672
+  i32.const 672
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2481,6 +2478,66 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 704
+  i32.const 704
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 80
+   i32.const 516
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 736
+  i32.const 736
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 80
+   i32.const 517
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 768
+  i32.const 768
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 80
+   i32.const 518
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 800
+  i32.const 800
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 80
+   i32.const 519
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 832
+  i32.const 832
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 80
+   i32.const 520
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
   i32.const 384
   i32.const 384
   call $~lib/string/String.__eq
@@ -2488,7 +2545,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 516
+   i32.const 521
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2500,7 +2557,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 517
+   i32.const 522
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -524,7 +524,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 57
+   i32.const 56
    i32.const 34
    call $~lib/builtins/abort
    unreachable
@@ -552,7 +552,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 58
+   i32.const 57
    i32.const 34
    call $~lib/builtins/abort
    unreachable
@@ -648,7 +648,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 81
+   i32.const 80
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -669,7 +669,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 82
+   i32.const 81
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -690,7 +690,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 83
+   i32.const 82
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -706,7 +706,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 84
+   i32.const 83
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -722,7 +722,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 85
+   i32.const 84
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -738,7 +738,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 86
+   i32.const 85
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -804,7 +804,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 101
+   i32.const 100
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -825,7 +825,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 102
+   i32.const 101
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -846,7 +846,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 103
+   i32.const 102
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -862,7 +862,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 104
+   i32.const 103
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -878,7 +878,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 105
+   i32.const 104
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -894,7 +894,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 106
+   i32.const 105
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -1012,7 +1012,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 136
+   i32.const 135
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1028,7 +1028,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 137
+   i32.const 136
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1044,7 +1044,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 138
+   i32.const 137
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1060,7 +1060,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 139
+   i32.const 138
    i32.const 26
    call $~lib/builtins/abort
    unreachable
@@ -1219,7 +1219,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 178
+   i32.const 177
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1235,7 +1235,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 179
+   i32.const 178
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1251,7 +1251,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 180
+   i32.const 179
    i32.const 25
    call $~lib/builtins/abort
    unreachable
@@ -1574,7 +1574,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 299
+   i32.const 298
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -1590,7 +1590,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 300
+   i32.const 299
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -1600,6 +1600,19 @@
   local.tee $0
   i32.const 32
   call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 80
+   i32.const 300
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $builtins/fn
+  call $~lib/function/Function<%28i32%2Ci32%29=>i32>#get:length
+  i32.const 2
+  i32.eq
   i32.eqz
   if
    i32.const 0
@@ -1623,19 +1636,6 @@
    unreachable
   end
   global.get $builtins/fn
-  call $~lib/function/Function<%28i32%2Ci32%29=>i32>#get:length
-  i32.const 2
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 80
-   i32.const 303
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $builtins/fn
   call $~lib/function/Function<%28i32%2Ci32%29=>i32>#toString
   local.tee $1
   i32.const 160
@@ -1644,7 +1644,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 304
+   i32.const 303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2168,7 +2168,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 480
+   i32.const 479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2181,7 +2181,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 481
+   i32.const 480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2194,7 +2194,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 482
+   i32.const 481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2207,7 +2207,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 483
+   i32.const 482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2220,7 +2220,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 484
+   i32.const 483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2233,7 +2233,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 485
+   i32.const 484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2246,7 +2246,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 486
+   i32.const 485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -2281,7 +2281,7 @@
   if
    i32.const 288
    i32.const 80
-   i32.const 496
+   i32.const 495
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2293,7 +2293,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 497
+   i32.const 496
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2305,7 +2305,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 498
+   i32.const 497
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2317,7 +2317,19 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 499
+   i32.const 498
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 320
+  i32.const 320
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 80
+   i32.const 502
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2334,8 +2346,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 320
-  i32.const 320
+  i32.const 352
+  i32.const 352
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2346,8 +2358,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 352
-  i32.const 352
+  i32.const 384
+  i32.const 384
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2358,8 +2370,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 384
-  i32.const 384
+  i32.const 416
+  i32.const 416
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2370,8 +2382,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 416
-  i32.const 416
+  i32.const 448
+  i32.const 448
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2382,8 +2394,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 448
-  i32.const 448
+  i32.const 480
+  i32.const 480
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2394,8 +2406,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 480
-  i32.const 480
+  i32.const 512
+  i32.const 512
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2406,8 +2418,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 512
-  i32.const 512
+  i32.const 544
+  i32.const 544
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2418,8 +2430,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 544
-  i32.const 544
+  i32.const 576
+  i32.const 576
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2430,8 +2442,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 576
-  i32.const 576
+  i32.const 608
+  i32.const 608
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2442,8 +2454,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 608
-  i32.const 608
+  i32.const 640
+  i32.const 640
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2454,8 +2466,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 640
-  i32.const 640
+  i32.const 672
+  i32.const 672
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2466,8 +2478,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 672
-  i32.const 672
+  i32.const 704
+  i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2478,8 +2490,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 704
-  i32.const 704
+  i32.const 736
+  i32.const 736
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2490,8 +2502,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 736
-  i32.const 736
+  i32.const 768
+  i32.const 768
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2502,8 +2514,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 768
-  i32.const 768
+  i32.const 800
+  i32.const 800
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2514,8 +2526,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 800
-  i32.const 800
+  i32.const 832
+  i32.const 832
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2526,8 +2538,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 832
-  i32.const 832
+  i32.const 384
+  i32.const 384
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2538,26 +2550,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 384
-  i32.const 384
+  i32.const 320
+  i32.const 320
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 80
    i32.const 521
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 320
-  i32.const 320
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 80
-   i32.const 522
    i32.const 3
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
Fix #1492

- [x] I've read the contributing guidelines