### PR TITLE
fix(compiler): wrap RHS shifting value by maximum size of type in bits for small integers

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5686,7 +5686,7 @@ export class Compiler extends DiagnosticEmitter {
     switch (type.kind) {
       case TypeKind.I8:
       case TypeKind.I16: {
-        // leftExpr >> (rightExpr & (7 | 15))
+        // leftExpr >> (rightExpr & (7|15))
         return module.binary(
           BinaryOp.ShrI32,
           this.ensureSmallIntegerWrap(leftExpr, type),
@@ -5714,7 +5714,7 @@ export class Compiler extends DiagnosticEmitter {
       }
       case TypeKind.U8:
       case TypeKind.U16: {
-        // leftExpr >>> (rightExpr & (7 | 15))
+        // leftExpr >>> (rightExpr & (7|15))
         return module.binary(
           BinaryOp.ShrU32,
           this.ensureSmallIntegerWrap(leftExpr, type),
@@ -5753,7 +5753,7 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.I16:
       case TypeKind.U8:
       case TypeKind.U16: {
-        // leftExpr >>> (rightExpr & (7 | 15))
+        // leftExpr >>> (rightExpr & (7|15))
         return module.binary(
           BinaryOp.ShrU32,
           this.ensureSmallIntegerWrap(leftExpr, type),

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5128,7 +5128,7 @@ export class Compiler extends DiagnosticEmitter {
           module.binary(BinaryOp.EqI8x16, leftExpr, rightExpr)
         );
       }
-      case TypeKind.FUNCREF: 
+      case TypeKind.FUNCREF:
       case TypeKind.EXTERNREF:
       case TypeKind.EXNREF:
       case TypeKind.ANYREF: {
@@ -5648,7 +5648,14 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.I8:
       case TypeKind.I16:
       case TypeKind.U8:
-      case TypeKind.U16:
+      case TypeKind.U16: {
+        // leftExpr << (rightExpr & (7|15))
+        return module.binary(
+          BinaryOp.ShlI32,
+          leftExpr,
+          module.binary(BinaryOp.AndI32, rightExpr, module.i32(type.size - 1))
+        );
+      }
       case TypeKind.I32:
       case TypeKind.U32: {
         return module.binary(BinaryOp.ShlI32, leftExpr, rightExpr);
@@ -5679,8 +5686,12 @@ export class Compiler extends DiagnosticEmitter {
     switch (type.kind) {
       case TypeKind.I8:
       case TypeKind.I16: {
-        leftExpr = this.ensureSmallIntegerWrap(leftExpr, type);
-        // falls through
+        // leftExpr >> (rightExpr & (7 | 15))
+        return module.binary(
+          BinaryOp.ShrI32,
+          this.ensureSmallIntegerWrap(leftExpr, type),
+          module.binary(BinaryOp.AndI32, rightExpr, module.i32(type.size - 1))
+        );
       }
       case TypeKind.I32: {
         return module.binary(BinaryOp.ShrI32, leftExpr, rightExpr);
@@ -5703,8 +5714,12 @@ export class Compiler extends DiagnosticEmitter {
       }
       case TypeKind.U8:
       case TypeKind.U16: {
-        leftExpr = this.ensureSmallIntegerWrap(leftExpr, type);
-        // falls through
+        // leftExpr >>> (rightExpr & (7 | 15))
+        return module.binary(
+          BinaryOp.ShrU32,
+          this.ensureSmallIntegerWrap(leftExpr, type),
+          module.binary(BinaryOp.AndI32, rightExpr, module.i32(type.size - 1))
+        );
       }
       case TypeKind.U32: {
         return module.binary(BinaryOp.ShrU32, leftExpr, rightExpr);
@@ -5738,8 +5753,12 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.I16:
       case TypeKind.U8:
       case TypeKind.U16: {
-        leftExpr = this.ensureSmallIntegerWrap(leftExpr, type);
-        // falls through
+        // leftExpr >>> (rightExpr & (7 | 15))
+        return module.binary(
+          BinaryOp.ShrU32,
+          this.ensureSmallIntegerWrap(leftExpr, type),
+          module.binary(BinaryOp.AndI32, rightExpr, module.i32(type.size - 1))
+        );
       }
       case TypeKind.I32:
       case TypeKind.U32: {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5641,10 +5641,7 @@ export class Compiler extends DiagnosticEmitter {
     // Cares about garbage bits on the RHS, but only for types smaller than 5 bits
     var module = this.module;
     switch (type.kind) {
-      case TypeKind.BOOL: {
-        rightExpr = this.ensureSmallIntegerWrap(rightExpr, type);
-        // falls through
-      }
+      case TypeKind.BOOL:
       case TypeKind.I8:
       case TypeKind.I16:
       case TypeKind.U8:
@@ -5693,6 +5690,16 @@ export class Compiler extends DiagnosticEmitter {
           module.binary(BinaryOp.AndI32, rightExpr, module.i32(type.size - 1))
         );
       }
+      case TypeKind.BOOL:
+      case TypeKind.U8:
+      case TypeKind.U16: {
+        // leftExpr >>> (rightExpr & (7|15))
+        return module.binary(
+          BinaryOp.ShrU32,
+          this.ensureSmallIntegerWrap(leftExpr, type),
+          module.binary(BinaryOp.AndI32, rightExpr, module.i32(type.size - 1))
+        );
+      }
       case TypeKind.I32: {
         return module.binary(BinaryOp.ShrI32, leftExpr, rightExpr);
       }
@@ -5706,19 +5713,6 @@ export class Compiler extends DiagnosticEmitter {
             : BinaryOp.ShrI32,
           leftExpr,
           rightExpr
-        );
-      }
-      case TypeKind.BOOL: {
-        rightExpr = this.ensureSmallIntegerWrap(rightExpr, type);
-        // falls through
-      }
-      case TypeKind.U8:
-      case TypeKind.U16: {
-        // leftExpr >>> (rightExpr & (7|15))
-        return module.binary(
-          BinaryOp.ShrU32,
-          this.ensureSmallIntegerWrap(leftExpr, type),
-          module.binary(BinaryOp.AndI32, rightExpr, module.i32(type.size - 1))
         );
       }
       case TypeKind.U32: {
@@ -5745,10 +5739,7 @@ export class Compiler extends DiagnosticEmitter {
     // Cares about garbage bits on the LHS, but on the RHS only for types smaller than 5 bits
     var module = this.module;
     switch (type.kind) {
-      case TypeKind.BOOL: {
-        rightExpr = this.ensureSmallIntegerWrap(rightExpr, type);
-        // falls through
-      }
+      case TypeKind.BOOL:
       case TypeKind.I8:
       case TypeKind.I16:
       case TypeKind.U8:

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5646,7 +5646,7 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.I16:
       case TypeKind.U8:
       case TypeKind.U16: {
-        // leftExpr << (rightExpr & (7|15))
+        // leftExpr << (rightExpr & (1|7|15))
         return module.binary(
           BinaryOp.ShlI32,
           leftExpr,
@@ -5693,7 +5693,7 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.BOOL:
       case TypeKind.U8:
       case TypeKind.U16: {
-        // leftExpr >>> (rightExpr & (7|15))
+        // leftExpr >>> (rightExpr & (1|7|15))
         return module.binary(
           BinaryOp.ShrU32,
           this.ensureSmallIntegerWrap(leftExpr, type),
@@ -5744,7 +5744,7 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.I16:
       case TypeKind.U8:
       case TypeKind.U16: {
-        // leftExpr >>> (rightExpr & (7|15))
+        // leftExpr >>> (rightExpr & (1|7|15))
         return module.binary(
           BinaryOp.ShrU32,
           this.ensureSmallIntegerWrap(leftExpr, type),

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5641,12 +5641,12 @@ export class Compiler extends DiagnosticEmitter {
     // Cares about garbage bits on the RHS, but only for types smaller than 5 bits
     var module = this.module;
     switch (type.kind) {
-      case TypeKind.BOOL:
+      case TypeKind.BOOL: return leftExpr;
       case TypeKind.I8:
       case TypeKind.I16:
       case TypeKind.U8:
       case TypeKind.U16: {
-        // leftExpr << (rightExpr & (1|7|15))
+        // leftExpr << (rightExpr & (7|15))
         return module.binary(
           BinaryOp.ShlI32,
           leftExpr,
@@ -5681,6 +5681,7 @@ export class Compiler extends DiagnosticEmitter {
     // and signedness
     var module = this.module;
     switch (type.kind) {
+      case TypeKind.BOOL: return leftExpr;
       case TypeKind.I8:
       case TypeKind.I16: {
         // leftExpr >> (rightExpr & (7|15))
@@ -5690,10 +5691,9 @@ export class Compiler extends DiagnosticEmitter {
           module.binary(BinaryOp.AndI32, rightExpr, module.i32(type.size - 1))
         );
       }
-      case TypeKind.BOOL:
       case TypeKind.U8:
       case TypeKind.U16: {
-        // leftExpr >>> (rightExpr & (1|7|15))
+        // leftExpr >>> (rightExpr & (7|15))
         return module.binary(
           BinaryOp.ShrU32,
           this.ensureSmallIntegerWrap(leftExpr, type),
@@ -5739,12 +5739,12 @@ export class Compiler extends DiagnosticEmitter {
     // Cares about garbage bits on the LHS, but on the RHS only for types smaller than 5 bits
     var module = this.module;
     switch (type.kind) {
-      case TypeKind.BOOL:
+      case TypeKind.BOOL: return leftExpr;
       case TypeKind.I8:
       case TypeKind.I16:
       case TypeKind.U8:
       case TypeKind.U16: {
-        // leftExpr >>> (rightExpr & (1|7|15))
+        // leftExpr >>> (rightExpr & (7|15))
         return module.binary(
           BinaryOp.ShrU32,
           this.ensureSmallIntegerWrap(leftExpr, type),

--- a/tests/compiler/abi.untouched.wat
+++ b/tests/compiler/abi.untouched.wat
@@ -88,6 +88,8 @@
    i32.const 24
    i32.shr_s
    i32.const 24
+   i32.const 7
+   i32.and
    i32.shr_s
    local.set $0
   else

--- a/tests/compiler/retain-i32.ts
+++ b/tests/compiler/retain-i32.ts
@@ -7,7 +7,7 @@ function test(a: u32, b: u32): void {
   assert(<i8>(a & b) == <i8>(<i8>a & <i8>b));
   assert(<i8>(a | b) == <i8>(<i8>a | <i8>b));
   assert(<i8>(a ^ b) == <i8>(<i8>a ^ <i8>b));
-  assert(<i8>(a << b) == <i8>(<i8>a << <i8>b));
+  assert(<i8>(a << (b & 7)) == <i8>(<i8>a << <i8>b));
 
   // unsigned
   assert(<u8>(a + b) == <u8>(<u8>a + <u8>b));
@@ -16,7 +16,7 @@ function test(a: u32, b: u32): void {
   assert(<u8>(a & b) == <u8>(<u8>a & <u8>b));
   assert(<u8>(a | b) == <u8>(<u8>a | <u8>b));
   assert(<u8>(a ^ b) == <u8>(<u8>a ^ <u8>b));
-  assert(<u8>(a << b) == <u8>(<u8>a << <u8>b));
+  assert(<u8>(a << (b & 7)) == <u8>(<u8>a << <u8>b));
 }
 
 // signed

--- a/tests/compiler/retain-i32.untouched.wat
+++ b/tests/compiler/retain-i32.untouched.wat
@@ -167,6 +167,8 @@
   end
   local.get $0
   local.get $1
+  i32.const 7
+  i32.and
   i32.shl
   i32.const 24
   i32.shl
@@ -174,6 +176,8 @@
   i32.shr_s
   local.get $0
   local.get $1
+  i32.const 7
+  i32.and
   i32.shl
   i32.const 24
   i32.shl
@@ -311,11 +315,15 @@
   end
   local.get $0
   local.get $1
+  i32.const 7
+  i32.and
   i32.shl
   i32.const 255
   i32.and
   local.get $0
   local.get $1
+  i32.const 7
+  i32.and
   i32.shl
   i32.const 255
   i32.and

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -2124,6 +2124,8 @@
   drop
   local.get $0
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shl
   local.get $0
   i32.const 16
@@ -2131,6 +2133,8 @@
   i32.const 16
   i32.shr_s
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shr_s
   i32.const 255
   i32.and
@@ -2344,11 +2348,15 @@
   drop
   local.get $0
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shl
   local.get $0
   i32.const 65535
   i32.and
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shr_u
   i32.const 255
   i32.and

--- a/tests/compiler/std/polyfills.untouched.wat
+++ b/tests/compiler/std/polyfills.untouched.wat
@@ -54,11 +54,15 @@
   drop
   local.get $0
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shl
   local.get $0
   i32.const 65535
   i32.and
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shr_u
   i32.const 255
   i32.and
@@ -74,6 +78,8 @@
   drop
   local.get $0
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shl
   local.get $0
   i32.const 16
@@ -81,6 +87,8 @@
   i32.const 16
   i32.shr_s
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shr_s
   i32.const 255
   i32.and
@@ -347,11 +355,15 @@
   drop
   local.get $0
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shl
   local.get $0
   i32.const 65535
   i32.and
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shr_u
   i32.const 255
   i32.and
@@ -374,6 +386,8 @@
   drop
   local.get $0
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shl
   local.get $0
   i32.const 16
@@ -381,6 +395,8 @@
   i32.const 16
   i32.shr_s
   i32.const 8
+  i32.const 15
+  i32.and
   i32.shr_s
   i32.const 255
   i32.and


### PR DESCRIPTION
Similar to #1494 we should wrap RHS shifting value by maximum size of type in bits.

For booleans we just return `leftExpr` due to `leftExpr <<>> rightExpr & (1 - 1)` -> `leftExpr <<>> 0` -> `leftExpr`
- [x] I've read the contributing guidelines