### PR TITLE
Align comments of the new heap functions with docs

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1326,9 +1326,9 @@ declare namespace heap {
   export function alloc(size: usize): usize;
   /** Reallocates a chunk of memory to have at least the specified size. */
   export function realloc(ptr: usize, size: usize): usize;
-  /** Frees a chunk of memory. */
+  /** Frees a chunk of memory. Does hardly anything (most recent block only) with the stub/none runtime. */
   export function free(ptr: usize): void;
-  /** Resets the heap. Stub/none runtime only. */
+  /** Dangerously resets the entire heap. Specific to the stub/none runtime. */
   export function reset(): void;
 }
 

--- a/std/assembly/memory.ts
+++ b/std/assembly/memory.ts
@@ -86,13 +86,13 @@ export namespace heap {
     return __realloc(ptr, size);
   }
 
-  /** Frees a chunk of memory. */
+  /** Frees a chunk of memory. Does hardly anything (most recent block only) with the stub/none runtime. */
   // @ts-ignore: decorator
   @unsafe export function free(ptr: usize): void {
     __free(ptr);
   }
 
-  /** Resets the heap. Stub/none runtime only. */
+  /** Dangerously resets the entire heap. Specific to the stub/none runtime. */
   // @ts-ignore: decorator
   @unsafe export function reset(): void {
     __reset();


### PR DESCRIPTION
Updates a few comments to the same wording as is now used on the documentation.

- [x] I've read the contributing guidelines