### PR TITLE
Add package exports fallback for the CLI, dist files, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,12 @@
       "import": "./lib/rtrace/index.js",
       "require": "./lib/rtrace/umd/index.js"
     },
-    "./*": "./*.js"
+    "./*": "./*.js",
+    "./cli/asc": "./cli/asc.js",
+    "./cli/transform": "./cli/transform.js",
+    "./cli/util/options": "./cli/util/options.js",
+    "./dist/assemblyscript": "./dist/assemblyscript.js",
+    "./dist/asc": "./dist/asc.js"
   },
   "bin": {
     "asc": "bin/asc",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "./lib/rtrace": {
       "import": "./lib/rtrace/index.js",
       "require": "./lib/rtrace/umd/index.js"
-    }
+    },
+    "./*": "./*.js"
   },
   "bin": {
     "asc": "bin/asc",


### PR DESCRIPTION
With the fallback, legacy cases like

```ts
import asc from "assemblyscript/cli/asc";
import options from "assemblyscript/cli/util/options";
import distAsc from "assemblyscript/dist/asc";
```

including others we haven't though of yet are covered by always resolving `./* -> ./*.js`. Fixes https://github.com/AssemblyScript/assemblyscript/pull/1522

At some point we'll most likely want to break this, either to pull packages out of the main packages or make nicer entry points like just `/loader`, but this gives us sufficient backwards compatibility (on node >= 15, need to check 14) for now so is good to do :)

**Edit:** According to the node 14 docs, the fallback should work there as well.

- [x] I've read the contributing guidelines