### PR TITLE
Support .wast extention for --textFile

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -856,19 +856,22 @@ exports.main = function main(argv, options, callback) {
 
     // Write text (also fallback)
     if (opts.textFile != null || !hasOutput) {
-      let wat;
+      let out;
       if (opts.textFile != null && opts.textFile.length) {
+        // use superset text format when extension is `.wast`.
+        // Otherwise use official stack IR format (wat).
+        let watFormat = !opts.textFile.endsWith('.wast');
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          wat = module.toText();
+          out = module.toText(watFormat);
         });
-        writeFile(opts.textFile, wat, baseDir);
+        writeFile(opts.textFile, out, baseDir);
       } else if (!hasStdout) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          wat = module.toText();
+          out = module.toText();
         });
-        writeStdout(wat);
+        writeStdout(out);
       }
     }
 

--- a/src/glue/binaryen.js
+++ b/src/glue/binaryen.js
@@ -9,12 +9,16 @@ module.exports = binaryen;
 
 const { Module } = require("../module");
 
-Module.prototype.toText = function toText() {
-  // NOTE: Conversion to StackIR can yield conversion artifacts like sequences
-  // of unreachable statements not actually emitted by the compiler. Optimizing
-  // StackIR removes these again, but may also suppress useless code emitted by
-  // the compiler that's then no longer visible in tests. Both not ideal.
-  return binaryen.wrapModule(this.ref).emitStackIR(/* optimize-stack-ir */ true);
+Module.prototype.toText = function toText(watFormat = true) {
+  if (watFormat) {
+    // NOTE: Conversion to StackIR can yield conversion artifacts like sequences
+    // of unreachable statements not actually emitted by the compiler. Optimizing
+    // StackIR removes these again, but may also suppress useless code emitted by
+    // the compiler that's then no longer visible in tests. Both not ideal.
+    return binaryen.wrapModule(this.ref).emitStackIR(/* optimize-stack-ir */ true);
+  } else {
+    return binaryen.wrapModule(this.ref).emitText();
+  }
 };
 
 Module.prototype.toAsmjs = function toAsmjs() {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1705,7 +1705,7 @@ export class Module {
     return binary;
   }
 
-  toText(): string {
+  toText(watFormat: bool = true): string {
     throw new Error("not implemented"); // JS glue overrides this
   }
 


### PR DESCRIPTION
this add ability print `.wast` (superset text format) as well. 

@dcodeIO Sometimes this preferable. Especially useful for producing binaryen's test cases.

This shouldn't break any backward compatibility.

- [x] I've read the contributing guidelines