### PR TITLE
add index signature to ArrayLike

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,6 +29,8 @@ under the licensing terms detailed in LICENSE:
 * Valeria Viana Gusmao <valeria.viana.gusmao@gmail.com>
 * Gabor Greif <ggreif@gmail.com>
 * Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
+* Joe Pea (@trusktr) <trusktr@gmail.com>
+* Joe Pea (@trusktr) <joe@trusktr.io>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1434,7 +1434,7 @@ declare class DataView {
 
 interface ArrayLike<T> {
   length: i32;
-  // [key: number]: T;
+  [key: number]: T;
 }
 
 /** Interface for a typed view on an array buffer. */


### PR DESCRIPTION

- [x] I've read the contributing guidelines

Without this change, I get a type error in TypeScript and VS Code (not in AssemblyScript).

The error in TypeScript is:

```
Element implicitly has an 'any' type because expression of type 'number' can't be used to index type 'ArrayLike<N>'.
  No index signature with a parameter of type 'number' was found on type 'ArrayLike<N>'. ts(7053)
```