### PR TITLE
ASUtil methods are not been exported on loader, such as __newString

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,6 +29,7 @@ under the licensing terms detailed in LICENSE:
 * Valeria Viana Gusmao <valeria.viana.gusmao@gmail.com>
 * Gabor Greif <ggreif@gmail.com>
 * Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
+* Kurt Lee <breath103@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/lib/loader/umd/index.js
+++ b/lib/loader/umd/index.js
@@ -371,7 +371,7 @@ var loader = (function(exports) {
   
   
   function demangle(exports, extendedExports = {}) {
-    extendedExports = Object.create(extendedExports);
+    extendedExports = { ...extendedExports };
     const setArgumentsLength = exports["__argumentsLength"] ? length => {
       exports["__argumentsLength"].value = length;
     } : exports["__setArgumentsLength"] || exports["__setargc"] || (() => {


### PR DESCRIPTION
- [x] I've read the contributing guidelines

Hi, since it seems like very straightforward bug (also serious one honestly). 
i'm just making straight up PR. 

# How to reproduce bug
1. some AS file
```
export function concat(a: string, b: string): string {
  return a.concat(b);
}
```
2. compile and load 
```
import * as fs from "fs";
import * as loader from "@assemblyscript/loader";

// this file is from "asc assembly/index.ts -d as.d.ts"
import ASModule from "../as"; 

const wasmModule =
  loader.instantiateSync<typeof ASModule>(fs.readFileSync(__dirname + "/build/optimized.wasm"), {});
console.log(wasmModule.exports);

export default wasmModule.exports;
```

this gives you output of
```
{
  memory: Memory [WebAssembly.Memory] {},
  __new: [Function (anonymous)] { original: [Function: 10] },
  __renew: [Function (anonymous)] { original: [Function: 15] },
  __retain: [Function (anonymous)] { original: [Function: 16] },
  __release: [Function (anonymous)] { original: [Function: 17] },
  __rtti_base: Global [WebAssembly.Global] {},
  concat: [Function (anonymous)] { original: [Function: 19] },
}
```
So all the ASUtil methods (such as **__newString**, which i was looking for in order to use concat method) are missing
this turns out to be problem of Object.create. first argument have to be prototype not properties


