### PR TITLE
fix: Fix invalid and remove unnecessary string encoding arguments in asc

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -989,11 +989,7 @@ exports.main = function main(argv, options, callback) {
       writeStdout.used = true;
     }
     stats.writeTime += measure(() => {
-      if (typeof contents === "string") {
-        stdout.write(contents);
-      } else {
-        stdout.write(contents);
-      }
+      stdout.write(contents);
     });
   }
 };

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -945,7 +945,7 @@ exports.main = function main(argv, options, callback) {
       let text;
       stats.readCount++;
       stats.readTime += measure(() => {
-        text = fs.readFileSync(name, { encoding: "utf8" });
+        text = fs.readFileSync(name, "utf8");
       });
       return text;
     } catch (e) {
@@ -961,10 +961,7 @@ exports.main = function main(argv, options, callback) {
         filename = path.basename(filename);
         const outputFilePath = path.join(dirPath, filename);
         if (!fs.existsSync(dirPath)) mkdirp(dirPath);
-        fs.writeFileSync(
-          outputFilePath, contents,
-          typeof contents === "string" ? { encoding: "utf8" } : void 0
-        );
+        fs.writeFileSync(outputFilePath, contents);
       });
       return true;
     } catch (e) {
@@ -993,7 +990,7 @@ exports.main = function main(argv, options, callback) {
     }
     stats.writeTime += measure(() => {
       if (typeof contents === "string") {
-        stdout.write(contents, { encoding: "utf8" });
+        stdout.write(contents);
       } else {
         stdout.write(contents);
       }


### PR DESCRIPTION
Fixes one use of `{ encoding: "utf8" }` on `Stream#write`, which was incorrect (not an option argument, just encoding), and removes unnecessary encoding arguments where the default is already `"utf8"`, i.e. on `fs.writeFileSync` with a string argument.

- [x] I've read the contributing guidelines