### PR TITLE
Support more options for providing Transforms to compiler frontend API

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,6 +29,7 @@ under the licensing terms detailed in LICENSE:
 * Valeria Viana Gusmao <valeria.viana.gusmao@gmail.com>
 * Gabor Greif <ggreif@gmail.com>
 * Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
+* Andrew Babin <code@andrewbab.in>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -4,6 +4,7 @@
  */
 
 import { OptionDescription } from "./util/options";
+import { Transform } from "./transform";
 export { OptionDescription };
 
 /** Ready promise resolved once/if the compiler is ready. */
@@ -157,10 +158,16 @@ export interface APIOptions {
   writeFile?: (filename: string, contents: Uint8Array, baseDir: string) => void;
   /** Lists all files within a directory. */
   listFiles?: (dirname: string, baseDir: string) => string[] | null;
+  /** Hook into the compilation process before, while and after the module is being compiled. */
+  transforms ?: Array<Transform | (new (...args : never[]) => Transform)>;
 }
 
 /** Convenience function that parses and compiles source strings directly. */
-export function compileString(sources: { [key: string]: string } | string, options?: CompilerOptions): {
+export function compileString(
+    sources: { [key: string]: string } | string,
+    options?: CompilerOptions,
+    transforms ?: Array<Transform | (new (...args : never[]) => Transform)>
+): {
   /** Standard output. */
   stdout: OutputStream,
   /** Standard error. */


### PR DESCRIPTION
Hi there!

This PR adds support for providing custom Transforms directly to the compiler frontend. A new optional parameter is added to `compileString` and a new prop is added to `APIOptions`, accepting an array of Transform constructors or instances. To keep it simple, the implementation avoids affecting any existing arg/option parsing. 

Configuration can be passed to the Transform, which can't be done trivially with dynamically imported modules.  

```javascript
class MyTransform extends Transform {
// ...
}

const output = compileString(source, opts, [MyTransform, new MyTransform()]);

// or

main(argv, {
  //...
  transforms: [MyTransform, new MyTransfrom()]
});
```

- [x] I've read the contributing guidelines