### PR TITLE
fix: Fix binary util discarding bits when compiling to Wasm

### DIFF
--- a/src/util/binary.ts
+++ b/src/util/binary.ts
@@ -15,8 +15,8 @@ export function writeI8(value: i32, buffer: Uint8Array, offset: i32): void {
 
 /** Reads a 16-bit integer from the specified buffer. */
 export function readI16(buffer: Uint8Array, offset: i32): i32 {
-  return buffer[offset    ]
-       | buffer[offset + 1] << 8;
+  return i32(buffer[offset    ])
+       | i32(buffer[offset + 1]) << 8;
 }
 
 /** Writes a 16-bit integer to the specified buffer. */
@@ -27,10 +27,10 @@ export function writeI16(value: i32, buffer: Uint8Array, offset: i32): void {
 
 /** Reads a 32-bit integer from the specified buffer. */
 export function readI32(buffer: Uint8Array, offset: i32): i32 {
-  return buffer[offset    ]
-       | buffer[offset + 1] << 8
-       | buffer[offset + 2] << 16
-       | buffer[offset + 3] << 24;
+  return i32(buffer[offset    ])
+       | i32(buffer[offset + 1]) << 8
+       | i32(buffer[offset + 2]) << 16
+       | i32(buffer[offset + 3]) << 24;
 }
 
 /** Writes a 32-bit integer to the specified buffer. */


### PR DESCRIPTION
Another bug discovered in #1559 affecting static memory segment creation when reading back `rtSize`s larger than 255, but only in the Wasm target, where indexed access on `Uint8Array` yields actual `u8` values.

- [x] I've read the contributing guidelines