### PR TITLE
asinit: Add WebAssembly text files to build/.gitignore

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,6 +29,7 @@ under the licensing terms detailed in LICENSE:
 * Valeria Viana Gusmao <valeria.viana.gusmao@gmail.com>
 * Gabor Greif <ggreif@gmail.com>
 * Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
+* Leonid Pospelov <pospelovlm@yandex.ru>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/bin/asinit
+++ b/bin/asinit
@@ -307,7 +307,8 @@ function ensureGitignore() {
     fs.writeFileSync(gitignoreFile, [
       "*.wasm",
       "*.wasm.map",
-      "*.asm.js"
+      "*.asm.js",
+      "*.wat"
     ].join("\n") + "\n");
     console.log(colors.green("  Created: ") + gitignoreFile);
   } else {


### PR DESCRIPTION
After running `asinit` and `npm run asbuild`, `optimized.wat` and `untouched.wat` has been generated. Since they are in the build directory they probably should not be versioned.