### PR TITLE
Fix assertion on exported interfaces

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -838,6 +838,7 @@ export class Compiler extends DiagnosticEmitter {
 
       // just traverse members below
       case ElementKind.ENUM:
+      case ElementKind.INTERFACE_PROTOTYPE:
       case ElementKind.NAMESPACE:
       case ElementKind.TYPEDEFINITION:
       case ElementKind.INDEXSIGNATURE: break;
@@ -907,6 +908,7 @@ export class Compiler extends DiagnosticEmitter {
         if (propertyInstance) this.compileProperty(propertyInstance);
         break;
       }
+      case ElementKind.INTERFACE_PROTOTYPE:
       case ElementKind.NAMESPACE:
       case ElementKind.TYPEDEFINITION:
       case ElementKind.ENUMVALUE:

--- a/tests/compiler/exports.ts
+++ b/tests/compiler/exports.ts
@@ -58,3 +58,9 @@ export namespace outer {
 }
 
 export {renamed_mul} from "./export"; 
+
+// interfaces (should not error)
+export interface Iface {}
+export namespace outer {
+  export interface Iface {}
+}


### PR DESCRIPTION
Fixes an unexpected assertion when an interface is exported (to the host) due to interfaces not yet being handled in `ensureModuleExport` respectively `compileElement`. Fixes #1599

- [x] I've read the contributing guidelines