### PR TITLE
Make sure main start function is compiled last

### DIFF
--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -1347,9 +1347,6 @@
    unreachable
   end
  )
- (func $~start
-  call $start:do
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1443,5 +1440,8 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:do
  )
 )

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -2231,9 +2231,6 @@
    unreachable
   end
  )
- (func $~start
-  call $start:do
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -2339,6 +2336,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:do
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/exports-lazy.optimized.wat
+++ b/tests/compiler/exports-lazy.optimized.wat
@@ -7,8 +7,8 @@
  (global $exports-lazy/lazyGlobalUsed i32 (i32.const 1088))
  (export "memory" (memory $0))
  (export "lazyGlobalUsed" (global $exports-lazy/lazyGlobalUsed))
- (export "lazyFuncUsed" (func $~start))
- (func $~start
+ (export "lazyFuncUsed" (func $exports-lazy/lazyFuncUsed))
+ (func $exports-lazy/lazyFuncUsed
   nop
  )
 )

--- a/tests/compiler/exports-lazy.untouched.wat
+++ b/tests/compiler/exports-lazy.untouched.wat
@@ -16,10 +16,10 @@
   drop
   call $exports-lazy/lazyFuncUsed
  )
- (func $~start
-  call $start:exports-lazy
- )
  (func $exports-lazy/lazyFuncUsed
   nop
+ )
+ (func $~start
+  call $start:exports-lazy
  )
 )

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1718,9 +1718,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:extends-baseaggregate
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1885,6 +1882,9 @@
     end
    end
   end
+ )
+ (func $~start
+  call $start:extends-baseaggregate
  )
  (func $~lib/rt/pure/scanBlack (param $0 i32)
   local.get $0

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -3354,9 +3354,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:extends-baseaggregate
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -3585,6 +3582,9 @@
     i32.store offset=4
    end
   end
+ )
+ (func $~start
+  call $start:extends-baseaggregate
  )
  (func $~lib/rt/pure/markGray (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -1359,9 +1359,6 @@
    unreachable
   end
  )
- (func $~start
-  call $start:for
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1455,5 +1452,8 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:for
  )
 )

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -2276,9 +2276,6 @@
    unreachable
   end
  )
- (func $~start
-  call $start:for
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -2384,6 +2381,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:for
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/instanceof-class.optimized.wat
+++ b/tests/compiler/instanceof-class.optimized.wat
@@ -87,6 +87,36 @@
   i32.const 16
   i32.add
  )
+ (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=12
+  local.tee $0
+  i32.const 1104
+  i32.load
+  i32.le_u
+  if
+   loop $do-continue|0
+    local.get $0
+    local.get $1
+    i32.eq
+    if
+     i32.const 1
+     return
+    end
+    local.get $0
+    i32.const 3
+    i32.shl
+    i32.const 1108
+    i32.add
+    i32.load offset=4
+    local.tee $0
+    br_if $do-continue|0
+   end
+  end
+  i32.const 0
+ )
  (func $~start
   (local $0 i32)
   i32.const 1164
@@ -139,35 +169,5 @@
    call $~lib/builtins/abort
    unreachable
   end
- )
- (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.const 20
-  i32.sub
-  i32.load offset=12
-  local.tee $0
-  i32.const 1104
-  i32.load
-  i32.le_u
-  if
-   loop $do-continue|0
-    local.get $0
-    local.get $1
-    i32.eq
-    if
-     i32.const 1
-     return
-    end
-    local.get $0
-    i32.const 3
-    i32.shl
-    i32.const 1108
-    i32.add
-    i32.load offset=4
-    local.tee $0
-    br_if $do-continue|0
-   end
-  end
-  i32.const 0
  )
 )

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -254,9 +254,6 @@
   i32.eqz
   drop
  )
- (func $~start
-  call $start:instanceof-class
- )
  (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -320,5 +317,8 @@
   end
   i32.const 0
   return
+ )
+ (func $~start
+  call $start:instanceof-class
  )
 )

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -928,52 +928,6 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  local.tee $2
-  i32.const 1248
-  i32.store
-  local.get $2
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  local.set $3
-  local.get $0
-  i32.load
-  local.tee $1
-  i32.eqz
-  if
-   i32.const 1280
-   i32.const 1344
-   i32.const 8
-   i32.const 13
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load
-  local.tee $0
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $0
-   call $~lib/rt/pure/__release
-  end
-  local.get $3
-  local.get $1
-  i32.store
-  local.get $3
-  call $~lib/rt/pure/__release
-  local.get $2
-  call $~lib/rt/pure/__release
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1066,5 +1020,51 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.const 1248
+  i32.store
+  local.get $2
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  local.set $3
+  local.get $0
+  i32.load
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 1280
+   i32.const 1344
+   i32.const 8
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.load
+  local.tee $0
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $0
+   call $~lib/rt/pure/__release
+  end
+  local.get $3
+  local.get $1
+  i32.store
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
  )
 )

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -1563,9 +1563,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:issues/1095
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -1671,6 +1668,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:issues/1095
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/issues/1225.optimized.wat
+++ b/tests/compiler/issues/1225.optimized.wat
@@ -877,6 +877,100 @@
   global.get $issues/1225/x
   i32.load offset=4
  )
+ (func $~lib/rt/pure/decrement (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $2
+  i32.const 268435455
+  i32.and
+  local.set $1
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  if
+   i32.const 0
+   i32.const 1120
+   i32.const 122
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 1
+  i32.eq
+  if
+   block $__inlined_func$~lib/rt/__visit_members
+    block $invalid
+     block $~lib/arraybuffer/ArrayBufferView
+      local.get $0
+      i32.const 12
+      i32.add
+      i32.load
+      br_table $__inlined_func$~lib/rt/__visit_members $__inlined_func$~lib/rt/__visit_members $~lib/arraybuffer/ArrayBufferView $__inlined_func$~lib/rt/__visit_members $invalid
+     end
+     local.get $0
+     i32.load offset=20
+     local.tee $1
+     if
+      local.get $1
+      i32.const 1276
+      i32.ge_u
+      if
+       local.get $1
+       i32.const 20
+       i32.sub
+       call $~lib/rt/pure/decrement
+      end
+     end
+     br $__inlined_func$~lib/rt/__visit_members
+    end
+    unreachable
+   end
+   local.get $2
+   i32.const -2147483648
+   i32.and
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 126
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 1
+   i32.or
+   i32.store
+   global.get $~lib/rt/tlsf/ROOT
+   local.get $0
+   call $~lib/rt/tlsf/insertBlock
+  else
+   local.get $1
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 136
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.sub
+   local.get $2
+   i32.const -268435456
+   i32.and
+   i32.or
+   i32.store offset=4
+  end
+ )
  (func $~start
   (local $0 i32)
   (local $1 i32)
@@ -983,99 +1077,5 @@
   end
   i32.const 0
   global.set $issues/1225/x
- )
- (func $~lib/rt/pure/decrement (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  i32.load offset=4
-  local.tee $2
-  i32.const 268435455
-  i32.and
-  local.set $1
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.and
-  if
-   i32.const 0
-   i32.const 1120
-   i32.const 122
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  i32.const 1
-  i32.eq
-  if
-   block $__inlined_func$~lib/rt/__visit_members
-    block $invalid
-     block $~lib/arraybuffer/ArrayBufferView
-      local.get $0
-      i32.const 12
-      i32.add
-      i32.load
-      br_table $__inlined_func$~lib/rt/__visit_members $__inlined_func$~lib/rt/__visit_members $~lib/arraybuffer/ArrayBufferView $__inlined_func$~lib/rt/__visit_members $invalid
-     end
-     local.get $0
-     i32.load offset=20
-     local.tee $1
-     if
-      local.get $1
-      i32.const 1276
-      i32.ge_u
-      if
-       local.get $1
-       i32.const 20
-       i32.sub
-       call $~lib/rt/pure/decrement
-      end
-     end
-     br $__inlined_func$~lib/rt/__visit_members
-    end
-    unreachable
-   end
-   local.get $2
-   i32.const -2147483648
-   i32.and
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 126
-    i32.const 18
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $0
-   local.get $0
-   i32.load
-   i32.const 1
-   i32.or
-   i32.store
-   global.get $~lib/rt/tlsf/ROOT
-   local.get $0
-   call $~lib/rt/tlsf/insertBlock
-  else
-   local.get $1
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 136
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $0
-   local.get $1
-   i32.const 1
-   i32.sub
-   local.get $2
-   i32.const -268435456
-   i32.and
-   i32.or
-   i32.store offset=4
-  end
  )
 )

--- a/tests/compiler/issues/1225.untouched.wat
+++ b/tests/compiler/issues/1225.untouched.wat
@@ -1584,9 +1584,6 @@
   local.get $0
   global.set $issues/1225/x
  )
- (func $~start
-  call $start:issues/1225
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -1692,6 +1689,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:issues/1225
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -926,49 +926,6 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  call $~lib/rt/pure/__release
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 87
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  local.set $2
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  call $~lib/rt/pure/__release
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 92
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  call $~lib/rt/pure/__release
-  local.get $2
-  call $~lib/rt/pure/__release
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1062,5 +1019,48 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 87
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  local.set $2
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  call $~lib/rt/pure/__release
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 92
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
  )
 )

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -2113,9 +2113,6 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:logical
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -2221,6 +2218,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:logical
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -1112,9 +1112,6 @@
   local.get $9
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:managed-cast
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1208,5 +1205,8 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:managed-cast
  )
 )

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -1820,9 +1820,6 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:managed-cast
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -1928,6 +1925,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:managed-cast
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -2121,9 +2121,6 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:object-literal
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2272,6 +2269,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:object-literal
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -3857,9 +3857,6 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:object-literal
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -3952,6 +3949,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:object-literal
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/rc/global-init.untouched.wat
+++ b/tests/compiler/rc/global-init.untouched.wat
@@ -130,9 +130,6 @@
   local.get $1
   global.set $rc/global-init/b
  )
- (func $~start
-  call $start:rc/global-init
- )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -816,6 +813,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:rc/global-init
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/rc/local-init.optimized.wat
+++ b/tests/compiler/rc/local-init.optimized.wat
@@ -866,65 +866,6 @@
   i32.const 16
   i32.add
  )
- (func $~start
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  call $~lib/rt/pure/__new
-  local.tee $0
-  i32.const 1260
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   local.tee $2
-   i32.const -268435456
-   i32.and
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.const -268435456
-   i32.and
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 109
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.const 1
-   i32.add
-   i32.store offset=4
-   local.get $1
-   i32.load
-   i32.const 1
-   i32.and
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 112
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-  end
-  local.get $0
-  i32.const 1260
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   call $~lib/rt/pure/decrement
-  end
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1017,6 +958,65 @@
    i32.and
    i32.or
    i32.store offset=4
+  end
+ )
+ (func $~start
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  call $~lib/rt/pure/__new
+  local.tee $0
+  i32.const 1260
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   local.tee $1
+   i32.load offset=4
+   local.tee $2
+   i32.const -268435456
+   i32.and
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.const -268435456
+   i32.and
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 109
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.store offset=4
+   local.get $1
+   i32.load
+   i32.const 1
+   i32.and
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 112
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $0
+  i32.const 1260
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   call $~lib/rt/pure/decrement
   end
  )
 )

--- a/tests/compiler/rc/local-init.untouched.wat
+++ b/tests/compiler/rc/local-init.untouched.wat
@@ -1530,9 +1530,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:rc/local-init
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -1638,6 +1635,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:rc/local-init
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -926,48 +926,6 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start
-  (local $0 i32)
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  global.set $rc/logical-and-mismatch/gloRef
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  if (result i32)
-   local.get $0
-   call $~lib/rt/pure/__release
-   global.get $rc/logical-and-mismatch/gloRef
-   call $~lib/rt/pure/__retain
-  else
-   local.get $0
-  end
-  call $~lib/rt/pure/__release
-  global.get $rc/logical-and-mismatch/gloRef
-  local.tee $0
-  if (result i32)
-   call $~lib/rt/pure/__new
-   call $~lib/rt/pure/__retain
-  else
-   local.get $0
-   call $~lib/rt/pure/__retain
-  end
-  call $~lib/rt/pure/__release
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  if (result i32)
-   local.get $0
-   call $~lib/rt/pure/__release
-   call $~lib/rt/pure/__new
-   call $~lib/rt/pure/__retain
-  else
-   local.get $0
-  end
-  call $~lib/rt/pure/__release
-  global.get $rc/logical-and-mismatch/gloRef
-  call $~lib/rt/pure/__release
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1061,5 +1019,47 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  (local $0 i32)
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  global.set $rc/logical-and-mismatch/gloRef
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  if (result i32)
+   local.get $0
+   call $~lib/rt/pure/__release
+   global.get $rc/logical-and-mismatch/gloRef
+   call $~lib/rt/pure/__retain
+  else
+   local.get $0
+  end
+  call $~lib/rt/pure/__release
+  global.get $rc/logical-and-mismatch/gloRef
+  local.tee $0
+  if (result i32)
+   call $~lib/rt/pure/__new
+   call $~lib/rt/pure/__retain
+  else
+   local.get $0
+   call $~lib/rt/pure/__retain
+  end
+  call $~lib/rt/pure/__release
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  if (result i32)
+   local.get $0
+   call $~lib/rt/pure/__release
+   call $~lib/rt/pure/__new
+   call $~lib/rt/pure/__retain
+  else
+   local.get $0
+  end
+  call $~lib/rt/pure/__release
+  global.get $rc/logical-and-mismatch/gloRef
+  call $~lib/rt/pure/__release
  )
 )

--- a/tests/compiler/rc/logical-and-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-and-mismatch.untouched.wat
@@ -1570,9 +1570,6 @@
   global.get $rc/logical-and-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:rc/logical-and-mismatch
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -1678,6 +1675,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:rc/logical-and-mismatch
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -926,48 +926,6 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start
-  (local $0 i32)
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  global.set $rc/logical-or-mismatch/gloRef
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  if (result i32)
-   local.get $0
-  else
-   local.get $0
-   call $~lib/rt/pure/__release
-   global.get $rc/logical-or-mismatch/gloRef
-   call $~lib/rt/pure/__retain
-  end
-  call $~lib/rt/pure/__release
-  global.get $rc/logical-or-mismatch/gloRef
-  local.tee $0
-  if (result i32)
-   local.get $0
-   call $~lib/rt/pure/__retain
-  else
-   call $~lib/rt/pure/__new
-   call $~lib/rt/pure/__retain
-  end
-  call $~lib/rt/pure/__release
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  if (result i32)
-   local.get $0
-  else
-   local.get $0
-   call $~lib/rt/pure/__release
-   call $~lib/rt/pure/__new
-   call $~lib/rt/pure/__retain
-  end
-  call $~lib/rt/pure/__release
-  global.get $rc/logical-or-mismatch/gloRef
-  call $~lib/rt/pure/__release
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1061,5 +1019,47 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  (local $0 i32)
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  global.set $rc/logical-or-mismatch/gloRef
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  if (result i32)
+   local.get $0
+  else
+   local.get $0
+   call $~lib/rt/pure/__release
+   global.get $rc/logical-or-mismatch/gloRef
+   call $~lib/rt/pure/__retain
+  end
+  call $~lib/rt/pure/__release
+  global.get $rc/logical-or-mismatch/gloRef
+  local.tee $0
+  if (result i32)
+   local.get $0
+   call $~lib/rt/pure/__retain
+  else
+   call $~lib/rt/pure/__new
+   call $~lib/rt/pure/__retain
+  end
+  call $~lib/rt/pure/__release
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  if (result i32)
+   local.get $0
+  else
+   local.get $0
+   call $~lib/rt/pure/__release
+   call $~lib/rt/pure/__new
+   call $~lib/rt/pure/__retain
+  end
+  call $~lib/rt/pure/__release
+  global.get $rc/logical-or-mismatch/gloRef
+  call $~lib/rt/pure/__release
  )
 )

--- a/tests/compiler/rc/logical-or-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-or-mismatch.untouched.wat
@@ -1570,9 +1570,6 @@
   global.get $rc/logical-or-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:rc/logical-or-mismatch
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -1678,6 +1675,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:rc/logical-or-mismatch
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/rc/rereturn.optimized.wat
+++ b/tests/compiler/rc/rereturn.optimized.wat
@@ -1460,12 +1460,6 @@
    call $~lib/rt/pure/decrement
   end
  )
- (func $~start
-  i32.const 0
-  i32.const 3
-  call $~lib/rt/pure/__new
-  drop
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1553,5 +1547,11 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  i32.const 0
+  i32.const 3
+  call $~lib/rt/pure/__new
+  drop
  )
 )

--- a/tests/compiler/rc/rereturn.untouched.wat
+++ b/tests/compiler/rc/rereturn.untouched.wat
@@ -3009,9 +3009,6 @@
   call $rc/rereturn/rereturnRef
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:rc/rereturn
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -3104,6 +3101,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:rc/rereturn
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/rc/ternary-mismatch.optimized.wat
+++ b/tests/compiler/rc/ternary-mismatch.optimized.wat
@@ -937,26 +937,6 @@
    call $~lib/rt/pure/__retain
   end
  )
- (func $~start
-  (local $0 i32)
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  global.set $rc/ternary-mismatch/gloRef
-  call $~lib/rt/pure/__new
-  drop
-  call $~lib/rt/pure/__new
-  drop
-  global.get $rc/ternary-mismatch/gloRef
-  local.tee $0
-  i32.const 1228
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   call $~lib/rt/pure/decrement
-  end
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1049,6 +1029,26 @@
    i32.and
    i32.or
    i32.store offset=4
+  end
+ )
+ (func $~start
+  (local $0 i32)
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  global.set $rc/ternary-mismatch/gloRef
+  call $~lib/rt/pure/__new
+  drop
+  call $~lib/rt/pure/__new
+  drop
+  global.get $rc/ternary-mismatch/gloRef
+  local.tee $0
+  i32.const 1228
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   call $~lib/rt/pure/decrement
   end
  )
 )

--- a/tests/compiler/rc/ternary-mismatch.untouched.wat
+++ b/tests/compiler/rc/ternary-mismatch.untouched.wat
@@ -1554,9 +1554,6 @@
   global.get $rc/ternary-mismatch/gloRef
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:rc/ternary-mismatch
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -1662,6 +1659,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:rc/ternary-mismatch
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -2560,9 +2560,6 @@
   i32.const 2864
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:resolve-ternary
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2649,6 +2646,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:resolve-ternary
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -5266,9 +5266,6 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:resolve-ternary
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -5361,6 +5358,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:resolve-ternary
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -2155,9 +2155,6 @@
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
  )
- (func $~start
-  call $start:retain-release-sanity
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2539,6 +2536,9 @@
   end
   local.get $1
   global.set $~lib/rt/pure/CUR
+ )
+ (func $~start
+  call $start:retain-release-sanity
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -3952,9 +3952,6 @@
   call $~lib/rt/pure/__release
   call $~lib/rt/pure/__collect
  )
- (func $~start
-  call $start:retain-release-sanity
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -4443,6 +4440,9 @@
   end
   local.get $0
   global.set $~lib/rt/pure/CUR
+ )
+ (func $~start
+  call $start:retain-release-sanity
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/compiler/retain-return.optimized.wat
+++ b/tests/compiler/retain-return.optimized.wat
@@ -947,84 +947,6 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~start
-  (local $0 i32)
-  global.get $~started
-  if
-   return
-  end
-  i32.const 1
-  global.set $~started
-  call $~lib/rt/pure/__new
-  drop
-  call $~lib/rt/pure/__new
-  drop
-  call $~lib/rt/pure/__new
-  drop
-  call $~lib/rt/pure/__new
-  drop
-  call $~lib/rt/pure/__new
-  call $~lib/rt/pure/__retain
-  global.set $retain-return/ref
-  i32.const 1248
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  i32.const 1248
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  global.get $retain-return/ref
-  i32.const 1280
-  i32.load
-  call_indirect (type $i32_=>_i32)
-  call $~lib/rt/pure/__release
-  global.get $retain-return/ref
-  i32.const 1280
-  i32.load
-  call_indirect (type $i32_=>_i32)
-  call $~lib/rt/pure/__release
-  i32.const 1312
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  i32.const 1312
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  i32.const 1344
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  i32.const 1344
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  i32.const 1376
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  i32.const 1376
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  i32.const 1408
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  i32.const 1408
-  i32.load
-  call_indirect (type $none_=>_i32)
-  call $~lib/rt/pure/__release
-  global.get $retain-return/ref
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/pure/__release
-  end
-  i32.const 0
-  global.set $retain-return/ref
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1116,6 +1038,84 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  (local $0 i32)
+  global.get $~started
+  if
+   return
+  end
+  i32.const 1
+  global.set $~started
+  call $~lib/rt/pure/__new
+  drop
+  call $~lib/rt/pure/__new
+  drop
+  call $~lib/rt/pure/__new
+  drop
+  call $~lib/rt/pure/__new
+  drop
+  call $~lib/rt/pure/__new
+  call $~lib/rt/pure/__retain
+  global.set $retain-return/ref
+  i32.const 1248
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  i32.const 1248
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  global.get $retain-return/ref
+  i32.const 1280
+  i32.load
+  call_indirect (type $i32_=>_i32)
+  call $~lib/rt/pure/__release
+  global.get $retain-return/ref
+  i32.const 1280
+  i32.load
+  call_indirect (type $i32_=>_i32)
+  call $~lib/rt/pure/__release
+  i32.const 1312
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  i32.const 1312
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  i32.const 1344
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  i32.const 1344
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  i32.const 1376
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  i32.const 1376
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  i32.const 1408
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  i32.const 1408
+  i32.load
+  call_indirect (type $none_=>_i32)
+  call $~lib/rt/pure/__release
+  global.get $retain-return/ref
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/pure/__release
+  end
+  i32.const 0
+  global.set $retain-return/ref
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/retain-return.untouched.wat
+++ b/tests/compiler/retain-return.untouched.wat
@@ -1677,15 +1677,6 @@
   local.get $0
   global.set $retain-return/ref
  )
- (func $~start
-  global.get $~started
-  if
-   return
-  end
-  i32.const 1
-  global.set $~started
-  call $start:retain-return
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -1791,6 +1782,15 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  global.get $~started
+  if
+   return
+  end
+  i32.const 1
+  global.set $~started
+  call $start:retain-return
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -25,10 +25,10 @@
  (global $rt/finalize/expected (mut i32) (i32.const 0))
  (global $rt/finalize/expectedWriteIndex (mut i32) (i32.const 0))
  (global $rt/finalize/expectedReadIndex (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/rt/pure/CUR (mut i32) (i32.const 0))
  (global $~lib/rt/pure/END (mut i32) (i32.const 0))
  (global $~lib/rt/pure/ROOTS (mut i32) (i32.const 0))
+ (global $~started (mut i32) (i32.const 0))
  (export "_start" (func $~start))
  (export "memory" (memory $0))
  (func $~lib/rt/pure/__release (param $0 i32)
@@ -1503,15 +1503,6 @@
    unreachable
   end
  )
- (func $~start
-  global.get $~started
-  if
-   return
-  end
-  i32.const 1
-  global.set $~started
-  call $start:rt/finalize
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -2144,6 +2135,15 @@
   end
   local.get $1
   global.set $~lib/rt/pure/CUR
+ )
+ (func $~start
+  global.get $~started
+  if
+   return
+  end
+  i32.const 1
+  global.set $~started
+  call $start:rt/finalize
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -29,10 +29,10 @@
  (global $rt/finalize/expected (mut i32) (i32.const 0))
  (global $rt/finalize/expectedWriteIndex (mut i32) (i32.const 0))
  (global $rt/finalize/expectedReadIndex (mut i32) (i32.const 0))
- (global $~started (mut i32) (i32.const 0))
  (global $~lib/rt/pure/CUR (mut i32) (i32.const 0))
  (global $~lib/rt/pure/END (mut i32) (i32.const 0))
  (global $~lib/rt/pure/ROOTS (mut i32) (i32.const 0))
+ (global $~started (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 576))
  (global $~lib/memory/__heap_base i32 (i32.const 636))
  (export "_start" (func $~start))
@@ -2105,15 +2105,6 @@
    unreachable
   end
  )
- (func $~start
-  global.get $~started
-  if
-   return
-  end
-  i32.const 1
-  global.set $~started
-  call $start:rt/finalize
- )
  (func $~lib/staticarray/StaticArray<usize>#__uget (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
@@ -3948,6 +3939,15 @@
   end
   local.get $0
   global.set $~lib/rt/pure/CUR
+ )
+ (func $~start
+  global.get $~started
+  if
+   return
+  end
+  i32.const 1
+  global.set $~started
+  call $start:rt/finalize
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -1515,9 +1515,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:std/array-literal
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1645,6 +1642,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/array-literal
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -3325,9 +3325,6 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:std/array-literal
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -3433,6 +3430,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/array-literal
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -19643,9 +19643,6 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~start
-  call $start:std/array
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19778,6 +19775,9 @@
   i32.const 20
   i32.sub
   call $~lib/rt/pure/decrement
+ )
+ (func $~start
+  call $start:std/array
  )
  (func $~lib/array/Array<std/array/Ref>~visit (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -30834,9 +30834,6 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~start
-  call $start:std/array
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -30957,6 +30954,9 @@
   i32.const 20
   i32.sub
   call $~lib/rt/pure/decrement
+ )
+ (func $~start
+  call $start:std/array
  )
  (func $~lib/arraybuffer/ArrayBuffer~visit (param $0 i32) (param $1 i32)
   nop

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1908,9 +1908,6 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:std/arraybuffer
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2012,6 +2009,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/arraybuffer
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -4024,9 +4024,6 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:std/arraybuffer
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -4132,6 +4129,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/arraybuffer
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -3381,9 +3381,6 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:std/dataview
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3472,6 +3469,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/dataview
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32)
   local.get $0

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -4510,9 +4510,6 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:std/dataview
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -4618,6 +4615,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/dataview
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -13038,18 +13038,6 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $std/map/testNumeric<i8,i32>
-  call $std/map/testNumeric<u8,i32>
-  call $std/map/testNumeric<i16,i32>
-  call $std/map/testNumeric<u16,i32>
-  call $std/map/testNumeric<i32,i32>
-  call $std/map/testNumeric<u32,i32>
-  call $std/map/testNumeric<i64,i32>
-  call $std/map/testNumeric<u64,i32>
-  call $std/map/testNumeric<f32,i32>
-  call $std/map/testNumeric<f64,i32>
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13144,6 +13132,18 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $std/map/testNumeric<i8,i32>
+  call $std/map/testNumeric<u8,i32>
+  call $std/map/testNumeric<i16,i32>
+  call $std/map/testNumeric<u16,i32>
+  call $std/map/testNumeric<i32,i32>
+  call $std/map/testNumeric<u32,i32>
+  call $std/map/testNumeric<i64,i32>
+  call $std/map/testNumeric<u64,i32>
+  call $std/map/testNumeric<f32,i32>
+  call $std/map/testNumeric<f64,i32>
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -20944,9 +20944,6 @@
   call $std/map/testNumeric<f32,i32>
   call $std/map/testNumeric<f64,i32>
  )
- (func $~start
-  call $start:std/map
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -21039,6 +21036,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/map
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -9378,18 +9378,6 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $std/set/testNumeric<i8>
-  call $std/set/testNumeric<u8>
-  call $std/set/testNumeric<i16>
-  call $std/set/testNumeric<u16>
-  call $std/set/testNumeric<i32>
-  call $std/set/testNumeric<u32>
-  call $std/set/testNumeric<i64>
-  call $std/set/testNumeric<u64>
-  call $std/set/testNumeric<f32>
-  call $std/set/testNumeric<f64>
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9484,6 +9472,18 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $std/set/testNumeric<i8>
+  call $std/set/testNumeric<u8>
+  call $std/set/testNumeric<i16>
+  call $std/set/testNumeric<u16>
+  call $std/set/testNumeric<i32>
+  call $std/set/testNumeric<u32>
+  call $std/set/testNumeric<i64>
+  call $std/set/testNumeric<u64>
+  call $std/set/testNumeric<f32>
+  call $std/set/testNumeric<f64>
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -14735,9 +14735,6 @@
   call $std/set/testNumeric<f32>
   call $std/set/testNumeric<f64>
  )
- (func $~start
-  call $start:std/set
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -14830,6 +14827,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/set
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -1543,9 +1543,6 @@
   i32.const 0
   global.set $std/staticarray/arr4
  )
- (func $~start
-  call $start:std/staticarray
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1666,6 +1663,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/staticarray
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -3112,9 +3112,6 @@
   local.get $1
   global.set $std/staticarray/arr4
  )
- (func $~start
-  call $start:std/staticarray
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -3220,6 +3217,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/staticarray
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -4889,9 +4889,6 @@
   local.get $98
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:std/string-casemapping
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4979,5 +4976,8 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/string-casemapping
  )
 )

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -7212,9 +7212,6 @@
   local.get $85
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:std/string-casemapping
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -7307,6 +7304,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/string-casemapping
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -3239,9 +3239,6 @@
   i32.const 14784
   call $std/string-encoding/testLarge
  )
- (func $~start
-  call $start:std/string-encoding
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3329,5 +3326,8 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/string-encoding
  )
 )

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -5021,9 +5021,6 @@
   i32.const 13760
   call $std/string-encoding/testLarge
  )
- (func $~start
-  call $start:std/string-encoding
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -5116,6 +5113,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/string-encoding
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -17601,9 +17601,6 @@
   global.get $std/string/str
   call $~lib/rt/pure/__retain
  )
- (func $~start
-  call $start:std/string
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17726,6 +17723,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/string
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -21618,9 +21618,6 @@
   global.get $std/string/str
   call $~lib/rt/pure/__retain
  )
- (func $~start
-  call $start:std/string
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -21713,6 +21710,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/string
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -35821,9 +35821,6 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~start
-  call $start:std/typedarray
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -35925,6 +35922,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/typedarray
  )
  (func $~lib/rt/pure/__visit (param $0 i32)
   local.get $0

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -57446,9 +57446,6 @@
   local.get $20
   call $~lib/rt/pure/__release
  )
- (func $~start
-  call $start:std/typedarray
- )
  (func $~lib/rt/pure/finalize (param $0 i32)
   i32.const 0
   drop
@@ -57541,6 +57538,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:std/typedarray
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/throw.untouched.wat
+++ b/tests/compiler/throw.untouched.wat
@@ -126,9 +126,6 @@
   call $~lib/builtins/abort
   unreachable
  )
- (func $~start
-  call $start:throw
- )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -812,6 +809,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:throw
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -1418,9 +1418,6 @@
   i32.const 1
   global.set $while/ran
  )
- (func $~start
-  call $start:while
- )
  (func $~lib/rt/pure/decrement (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1514,5 +1511,8 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:while
  )
 )

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -2365,9 +2365,6 @@
    unreachable
   end
  )
- (func $~start
-  call $start:while
- )
  (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
   local.get $1
   local.get $1
@@ -2473,6 +2470,9 @@
    i32.or
    i32.store offset=4
   end
+ )
+ (func $~start
+  call $start:while
  )
  (func $~lib/rt/pure/__visit (param $0 i32) (param $1 i32)
   local.get $0


### PR DESCRIPTION
Another backport from the stw branch, fixing a problem with `@lazy` elements potentially never becoming initialized.

- [x] I've read the contributing guidelines