### PR TITLE
Adding valueOf override to generated TS class definitions.

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -501,6 +501,8 @@ export class TSDBuilder extends ExportsWalker {
       sb.push("static wrap(ptr: usize): ");
       sb.push(name);
       sb.push(";\n");
+      indent(sb, this.indentLevel);
+      sb.push("valueOf(): usize;\n");
     }
     var staticMembers = element.prototype.members;
     if (staticMembers) {


### PR DESCRIPTION
This PR complements [this issue](https://github.com/AssemblyScript/website/issues/41). I've realized that part of the problem why I found that feature so late is because the TS definition doesn't come with valueOf() override that returns `usize` pointer instead of an `Object`.

- [x] I've read the contributing guidelines