### PR TITLE
Rename Int64/Uint64 DataView methods

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -30,6 +30,7 @@ under the licensing terms detailed in LICENSE:
 * Gabor Greif <ggreif@gmail.com>
 * Martin Fredriksson <martin.fredriksson@vikinganalytics.se>
 * forcepusher <bionitsoup@gmail.com>
+* 00ff0000red <65428781+00ff0000red@users.noreply.github.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly/dataview.ts
+++ b/std/assembly/dataview.ts
@@ -143,9 +143,7 @@ export class DataView {
     store<u32>(this.dataStart + <usize>byteOffset, littleEndian ? value : bswap<u32>(value));
   }
 
-  // Non-standard additions that make sense in WebAssembly, but won't work in JS:
-
-  getInt64(byteOffset: i32, littleEndian: boolean = false): i64 {
+  getBigInt64(byteOffset: i32, littleEndian: boolean = false): i64 {
     if (
       (byteOffset >>> 31) | i32(byteOffset + 8 > this.byteLength)
     ) throw new RangeError(E_INDEXOUTOFRANGE);
@@ -153,7 +151,7 @@ export class DataView {
     return littleEndian ? result : bswap<i64>(result);
   }
 
-  getUint64(byteOffset: i32, littleEndian: boolean = false): u64 {
+  getBigUint64(byteOffset: i32, littleEndian: boolean = false): u64 {
     if (
       (byteOffset >>> 31) | i32(byteOffset + 8 > this.byteLength)
     ) throw new RangeError(E_INDEXOUTOFRANGE);
@@ -161,18 +159,39 @@ export class DataView {
     return littleEndian ? result : bswap<u64>(result);
   }
 
-  setInt64(byteOffset: i32, value: i64, littleEndian: boolean = false): void {
+  setBigInt64(byteOffset: i32, value: i64, littleEndian: boolean = false): void {
     if (
       (byteOffset >>> 31) | i32(byteOffset + 8 > this.byteLength)
     ) throw new RangeError(E_INDEXOUTOFRANGE);
     store<i64>(this.dataStart + <usize>byteOffset, littleEndian ? value : bswap<i64>(value));
   }
 
-  setUint64(byteOffset: i32, value: u64, littleEndian: boolean = false): void {
+  setBigUint64(byteOffset: i32, value: u64, littleEndian: boolean = false): void {
     if (
       (byteOffset >>> 31) | i32(byteOffset + 8 > this.byteLength)
     ) throw new RangeError(E_INDEXOUTOFRANGE);
     store<u64>(this.dataStart + <usize>byteOffset, littleEndian ? value : bswap<u64>(value));
+  }
+
+  // Non-standard aliases, deprecate these
+  @inline
+  getInt64(byteOffset: i32, littleEndian: boolean = false): i64 {
+    return this.getBigInt64(byteOffset, littleEndian);
+  }
+
+  @inline
+  getUint64(byteOffset: i32, littleEndian: boolean = false): u64 {
+    return this.getBigUint64(byteOffset, littleEndian);
+  }
+
+  @inline
+  setInt64(byteOffset: i32, value: i64, littleEndian: boolean = false): void {
+    this.setBigInt64(byteOffset, value, littleEndian);
+  }
+
+  @inline
+  setUint64(byteOffset: i32, value: u64, littleEndian: boolean = false): void {
+    this.setBigUint64(byteOffset, value, littleEndian);
   }
 
   toString(): string {


### PR DESCRIPTION
- [x] I've read the contributing guidelines

In plain JavaScript, DataView offers two methods for reading integers of 64-bits at at time via DataView#{getBigInt64, setBigInt64}.

MDN documentation:
* [getBigInt64](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64)
* [setBigInt64](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigInt64)
* [getBigUint64](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64)
* [setBigUint64](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigUint64)

It seems that AS' non-standard DataView#{getInt64, setInt64} have the exact same semantics, the only difference being that the returned value isn't a genuine "bigint," but rather a sized u64/i64.

The fact that they don't yield real bigints technically breaks compatibility, but it's reasonable given AssemblyScript's current limitations.

For better compatibility with TS, I've renamed the non-standard methods into the JS DataView#{getBigInt64, setBigInt64, getBigUint64, setBigUint64}, and made the old methods into inlined aliases to maintain current code. The old methods should be deprecated and eventually removed.