### PR TITLE
Pedantic complains about bounds check in set.values()

### DIFF
--- a/std/assembly/set.ts
+++ b/std/assembly/set.ts
@@ -185,7 +185,7 @@ export class Set<T> {
     for (let i = 0; i < size; ++i) {
       let entry = changetype<SetEntry<T>>(start + <usize>i * ENTRY_SIZE<T>());
       if (!(entry.taggedNext & EMPTY)) {
-        values[length++] = entry.key;
+        unchecked(values[length++] = entry.key);
       }
     }
     values.length = length;


### PR DESCRIPTION
This should be pretty straightforward fix. Pedantic throws this warning whenever set.values() method is used.
```
PEDANTIC AS904: Indexed access may involve bounds checking.
         values[length++] = entry.key;
         ~~~~~~~~~~~~~~~~
 in ~lib/set.ts(188,9)
 ```
- [x] I've read the contributing guidelines