### PR TITLE
Bundle loader and rtrace with asc

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,9 +71,7 @@ const bin = {
   entry: [ "./asc.js" ],
   externals: [
     "binaryen",
-    "assemblyscript",
-    "../lib/loader/umd/index",
-    "../lib/rtrace/umd/index"
+    "assemblyscript"
   ],
   node: {
     global: true


### PR DESCRIPTION
Should fix editor breakage on the website. The issue was introduced by `asc` now needing the loader and rtrace for Wasm builds of the compiler, with the configuration to make these externals causing the issue apparently.

- [x] I've read the contributing guidelines