### PR TITLE
Fix emitting ASMJS

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -1037,13 +1037,13 @@ exports.main = function main(argv, options, callback) {
       if (opts.jsFile.length) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          js = module.toAsmjs();
+          js = module.emitAsmjs();
         });
         writeFile(opts.jsFile, js, baseDir);
       } else if (!hasStdout) {
         stats.emitCount++;
         stats.emitTime += measure(() => {
-          js = module.toAsmjs();
+          js = module.emitAsmjs();
         });
         writeStdout(js);
       }


### PR DESCRIPTION
As discovered in https://github.com/AssemblyScript/examples/pull/11, `asc` now always wraps the module in a Binaryen.js module instance, so the correct method to call here is `emitAsmjs`, not `toAsmjs`.

- [x] I've read the contributing guidelines