### PR TITLE
Propagate mark after visiting pinned objects in minimal runtime

### DIFF
--- a/std/assembly/rt/itcms.ts
+++ b/std/assembly/rt/itcms.ts
@@ -153,8 +153,10 @@ function initLazy(space: Object): Object {
 /** Visits all objects considered to be program roots. */
 function visitRoots(cookie: u32): void {
   __visit_globals(cookie);
-  var iter = pinSpace.next;
-  while (iter != pinSpace) {
+  var pn = pinSpace;
+  var iter = pn.next;
+  while (iter != pn) {
+    if (DEBUG) assert(iter.color == transparent);
     __visit_members(changetype<usize>(iter) + TOTAL_OVERHEAD, cookie);
     iter = iter.next;
   }
@@ -204,8 +206,10 @@ function step(): usize {
         visitStack(VISIT_SCAN);
         obj = iter.next;
         while (obj != toSpace) {
-          obj.color = black;
-          __visit_members(changetype<usize>(obj) + TOTAL_OVERHEAD, VISIT_SCAN);
+          if (obj.color != black) {
+            obj.color = black;
+            __visit_members(changetype<usize>(obj) + TOTAL_OVERHEAD, VISIT_SCAN);
+          }
           obj = obj.next;
         }
         let from = fromSpace;

--- a/std/assembly/rt/tcms.ts
+++ b/std/assembly/rt/tcms.ts
@@ -206,7 +206,7 @@ export function __collect(): void {
   // Mark roots (add to toSpace)
   __visit_globals(VISIT_SCAN);
 
-  // Mark what's reachable from pinned objects (add to toSpace)
+  // Mark direct members of pinned objects (add to toSpace)
   var pn = pinSpace;
   var iter = pn.next;
   while (iter != pn) {

--- a/std/assembly/rt/tcms.ts
+++ b/std/assembly/rt/tcms.ts
@@ -203,24 +203,24 @@ export function __unpin(ptr: usize): void {
 export function __collect(): void {
   if (TRACE) trace("GC at", 1, total);
 
-  // Mark roots and add to toSpace
+  // Mark roots (add to toSpace)
   __visit_globals(VISIT_SCAN);
 
-  // Mark what's reachable from roots
-  var black = i32(!white);
-  var to = toSpace;
-  var iter = to.next;
-  while (iter != to) {
-    if (DEBUG) assert(iter.color == black);
+  // Mark what's reachable from pinned objects (add to toSpace)
+  var pn = pinSpace;
+  var iter = pn.next;
+  while (iter != pn) {
+    if (DEBUG) assert(iter.color == transparent);
     __visit_members(changetype<usize>(iter) + TOTAL_OVERHEAD, VISIT_SCAN);
     iter = iter.next;
   }
 
-  // Mark what's reachable from pinned objects
-  var pn = pinSpace;
-  iter = pn.next;
-  while (iter != pn) {
-    if (DEBUG) assert(iter.color == transparent);
+  // Mark what's reachable from toSpace
+  var black = i32(!white);
+  var to = toSpace;
+  iter = to.next;
+  while (iter != to) {
+    if (DEBUG) assert(iter.color == black);
     __visit_members(changetype<usize>(iter) + TOTAL_OVERHEAD, VISIT_SCAN);
     iter = iter.next;
   }

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -47,20 +47,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1296
   call $~lib/rt/itcms/__visit
   i32.const 1104
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1168
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -969,13 +985,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1022,7 +1046,7 @@
      if
       i32.const 0
       i32.const 1168
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1610,7 +1634,7 @@
   if
    i32.const 1104
    i32.const 1168
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -66,38 +66,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 144
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1435,13 +1453,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1487,7 +1511,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2285,7 +2309,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.optimized.wat
+++ b/tests/compiler/class-implements.optimized.wat
@@ -56,6 +56,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $class-implements/a
   local.tee $0
   if
@@ -73,15 +74,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -990,13 +1006,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1043,7 +1067,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/class-implements.untouched.wat
+++ b/tests/compiler/class-implements.untouched.wat
@@ -76,38 +76,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1445,13 +1463,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1497,7 +1521,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2295,7 +2319,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.optimized.wat
+++ b/tests/compiler/class-overloading.optimized.wat
@@ -70,6 +70,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $class-overloading/which
   local.tee $0
   if
@@ -111,15 +112,30 @@
   i32.const 1088
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1152
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1028,13 +1044,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1081,7 +1105,7 @@
      if
       i32.const 0
       i32.const 1152
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -82,38 +82,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 128
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1451,13 +1469,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1503,7 +1527,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2301,7 +2325,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -52,6 +52,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1456
@@ -59,15 +60,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -976,13 +992,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1029,7 +1053,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1617,7 +1641,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1717,7 +1741,7 @@
    if
     i32.const 0
     i32.const 1120
-    i32.const 290
+    i32.const 294
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -133,38 +133,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1502,13 +1520,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1554,7 +1578,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2352,7 +2376,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2411,7 +2435,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.optimized.wat
+++ b/tests/compiler/constructor.optimized.wat
@@ -55,6 +55,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $constructor/emptyCtor
   local.tee $0
   if
@@ -120,15 +121,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1037,13 +1053,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1090,7 +1114,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1678,7 +1702,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -76,38 +76,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1445,13 +1463,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1497,7 +1521,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2295,7 +2319,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -46,20 +46,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1280
   call $~lib/rt/itcms/__visit
   i32.const 1088
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1152
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -968,13 +984,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1021,7 +1045,7 @@
      if
       i32.const 0
       i32.const 1152
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -479,38 +479,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 128
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1848,13 +1866,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1900,7 +1924,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2698,7 +2722,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.optimized.wat
+++ b/tests/compiler/empty-exportruntime.optimized.wat
@@ -53,6 +53,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
@@ -62,15 +63,30 @@
   i32.const 1520
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -987,13 +1003,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1040,7 +1064,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1628,7 +1652,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1732,7 +1756,7 @@
    if
     i32.const 1456
     i32.const 1120
-    i32.const 333
+    i32.const 337
     i32.const 7
     call $~lib/builtins/abort
     unreachable
@@ -1764,7 +1788,7 @@
   if
    i32.const 1520
    i32.const 1120
-   i32.const 347
+   i32.const 351
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.untouched.wat
+++ b/tests/compiler/empty-exportruntime.untouched.wat
@@ -72,38 +72,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1441,13 +1459,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1493,7 +1517,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2291,7 +2315,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2349,7 +2373,7 @@
    if
     i32.const 432
     i32.const 96
-    i32.const 333
+    i32.const 337
     i32.const 7
     call $~lib/builtins/abort
     unreachable
@@ -2381,7 +2405,7 @@
   if
    i32.const 496
    i32.const 96
-   i32.const 347
+   i32.const 351
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.optimized.wat
+++ b/tests/compiler/empty-new.optimized.wat
@@ -42,20 +42,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -964,13 +980,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1017,7 +1041,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/empty-new.untouched.wat
+++ b/tests/compiler/empty-new.untouched.wat
@@ -65,38 +65,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1434,13 +1452,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1486,7 +1510,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2284,7 +2308,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -96,20 +96,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1018,13 +1034,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1071,7 +1095,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -129,38 +129,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1498,13 +1516,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1550,7 +1574,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2348,7 +2372,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.optimized.wat
+++ b/tests/compiler/exportstar-rereexport.optimized.wat
@@ -79,6 +79,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1296
   call $~lib/rt/itcms/__visit
   i32.const 1104
@@ -102,15 +103,30 @@
    call $~lib/rt/itcms/__visit
   end
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1168
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1019,13 +1035,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1072,7 +1096,7 @@
      if
       i32.const 0
       i32.const 1168
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/exportstar-rereexport.untouched.wat
+++ b/tests/compiler/exportstar-rereexport.untouched.wat
@@ -110,38 +110,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 144
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1479,13 +1497,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1531,7 +1555,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2329,7 +2353,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -55,6 +55,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1088
   call $~lib/rt/itcms/__visit
   i32.const 1168
@@ -66,15 +67,30 @@
   i32.const 1216
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1280
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -983,13 +999,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1036,7 +1060,7 @@
      if
       i32.const 0
       i32.const 1280
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1624,7 +1648,7 @@
   if
    i32.const 1216
    i32.const 1280
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1725,7 +1749,7 @@
   if
    i32.const 0
    i32.const 1280
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -74,38 +74,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 256
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1443,13 +1461,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1495,7 +1519,7 @@
     if
      i32.const 0
      i32.const 256
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2293,7 +2317,7 @@
   if
    i32.const 192
    i32.const 256
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2362,7 +2386,7 @@
   if
    i32.const 0
    i32.const 256
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.optimized.wat
+++ b/tests/compiler/extends-recursive.optimized.wat
@@ -49,20 +49,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -971,13 +987,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1024,7 +1048,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1424,7 +1448,7 @@
    if
     i32.const 0
     i32.const 1120
-    i32.const 290
+    i32.const 294
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -70,38 +70,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1439,13 +1457,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1491,7 +1515,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2289,7 +2313,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2348,7 +2372,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.optimized.wat
+++ b/tests/compiler/field-initialization.optimized.wat
@@ -65,6 +65,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1536
@@ -72,15 +73,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -989,13 +1005,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1042,7 +1066,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1630,7 +1654,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1730,7 +1754,7 @@
   if
    i32.const 0
    i32.const 1120
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.untouched.wat
+++ b/tests/compiler/field-initialization.untouched.wat
@@ -74,38 +74,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1443,13 +1461,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1495,7 +1519,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2293,7 +2317,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2362,7 +2386,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -46,20 +46,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1280
   call $~lib/rt/itcms/__visit
   i32.const 1088
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1152
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -968,13 +984,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1021,7 +1045,7 @@
      if
       i32.const 0
       i32.const 1152
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -492,38 +492,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 128
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1861,13 +1879,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1913,7 +1937,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2711,7 +2735,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.optimized.wat
+++ b/tests/compiler/function-call.optimized.wat
@@ -78,6 +78,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $function-call/foo
   local.tee $0
   if
@@ -89,15 +90,30 @@
   i32.const 1280
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1344
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1006,13 +1022,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1059,7 +1083,7 @@
      if
       i32.const 0
       i32.const 1344
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/function-call.untouched.wat
+++ b/tests/compiler/function-call.untouched.wat
@@ -101,38 +101,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 320
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1470,13 +1488,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1522,7 +1546,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2320,7 +2344,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -107,20 +107,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1792
   call $~lib/rt/itcms/__visit
   i32.const 1600
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1664
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1029,13 +1045,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1082,7 +1106,7 @@
      if
       i32.const 0
       i32.const 1664
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1784,7 +1808,7 @@
   if
    i32.const 0
    i32.const 1664
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -253,38 +253,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 640
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1622,13 +1640,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1674,7 +1698,7 @@
     if
      i32.const 0
      i32.const 640
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2472,7 +2496,7 @@
   if
    i32.const 576
    i32.const 640
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2531,7 +2555,7 @@
   if
    i32.const 0
    i32.const 640
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.optimized.wat
+++ b/tests/compiler/getter-call.optimized.wat
@@ -49,20 +49,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -971,13 +987,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1024,7 +1048,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -69,38 +69,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1438,13 +1456,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1490,7 +1514,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2288,7 +2312,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/implicit-getter-setter.optimized.wat
+++ b/tests/compiler/implicit-getter-setter.optimized.wat
@@ -55,20 +55,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -977,13 +993,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1030,7 +1054,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1430,7 +1454,7 @@
    if
     i32.const 0
     i32.const 1120
-    i32.const 290
+    i32.const 294
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -75,38 +75,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1444,13 +1462,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1496,7 +1520,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2294,7 +2318,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2362,7 +2386,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -80,6 +80,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1280
   call $~lib/rt/itcms/__visit
   i32.const 2000
@@ -87,15 +88,30 @@
   i32.const 1088
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1152
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1004,13 +1020,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1057,7 +1081,7 @@
      if
       i32.const 0
       i32.const 1152
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1645,7 +1669,7 @@
   if
    i32.const 1088
    i32.const 1152
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1919,7 +1943,7 @@
   if
    i32.const 0
    i32.const 1152
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -84,38 +84,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 128
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1453,13 +1471,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1505,7 +1529,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2303,7 +2327,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3630,7 +3654,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -58,20 +58,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1328
   call $~lib/rt/itcms/__visit
   i32.const 1136
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1200
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -980,13 +996,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1033,7 +1057,7 @@
      if
       i32.const 0
       i32.const 1200
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1621,7 +1645,7 @@
   if
    i32.const 1136
    i32.const 1200
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -277,38 +277,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 176
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1646,13 +1664,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1698,7 +1722,7 @@
     if
      i32.const 0
      i32.const 176
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2496,7 +2520,7 @@
   if
    i32.const 112
    i32.const 176
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof-class.optimized.wat
+++ b/tests/compiler/instanceof-class.optimized.wat
@@ -49,6 +49,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $instanceof-class/a
   local.tee $0
   if
@@ -66,15 +67,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -983,13 +999,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1036,7 +1060,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -68,38 +68,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1437,13 +1455,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1489,7 +1513,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2287,7 +2311,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -49,20 +49,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -971,13 +987,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1024,7 +1048,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1424,7 +1448,7 @@
    if
     i32.const 0
     i32.const 1120
-    i32.const 290
+    i32.const 294
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -68,38 +68,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1437,13 +1455,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1489,7 +1513,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2287,7 +2311,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2346,7 +2370,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.optimized.wat
+++ b/tests/compiler/issues/1225.optimized.wat
@@ -49,6 +49,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $issues/1225/x
   local.tee $0
   if
@@ -60,15 +61,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -977,13 +993,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1030,7 +1054,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/issues/1225.untouched.wat
+++ b/tests/compiler/issues/1225.untouched.wat
@@ -79,38 +79,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1448,13 +1466,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1500,7 +1524,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2298,7 +2322,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -46,20 +46,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1296
   call $~lib/rt/itcms/__visit
   i32.const 1104
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1168
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -968,13 +984,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1021,7 +1045,7 @@
      if
       i32.const 0
       i32.const 1168
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -91,38 +91,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 144
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1460,13 +1478,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1512,7 +1536,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2310,7 +2334,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -50,20 +50,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -972,13 +988,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1025,7 +1049,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -68,38 +68,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1437,13 +1455,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1489,7 +1513,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2287,7 +2311,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.optimized.wat
+++ b/tests/compiler/new.optimized.wat
@@ -47,6 +47,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $new/ref
   local.tee $0
   if
@@ -70,15 +71,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -987,13 +1003,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1040,7 +1064,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/new.untouched.wat
+++ b/tests/compiler/new.untouched.wat
@@ -68,38 +68,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1437,13 +1455,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1489,7 +1513,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2287,7 +2311,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -130,6 +130,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1472
   call $~lib/rt/itcms/__visit
   i32.const 1280
@@ -137,15 +138,30 @@
   i32.const 1680
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1344
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1054,13 +1070,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1107,7 +1131,7 @@
      if
       i32.const 0
       i32.const 1344
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1695,7 +1719,7 @@
   if
    i32.const 1280
    i32.const 1344
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -169,38 +169,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 320
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1538,13 +1556,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1590,7 +1614,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2388,7 +2412,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -205,7 +205,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -261,20 +261,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1200
   call $~lib/rt/itcms/__visit
   i32.const 1312
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1104
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1099,13 +1115,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1152,7 +1176,7 @@
      if
       i32.const 0
       i32.const 1104
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1705,7 +1729,7 @@
   if
    i32.const 1312
    i32.const 1104
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -269,7 +269,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -333,26 +333,44 @@
  (func $~lib/rt/itcms/visitRoots (param $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   call $~lib/rt/__visit_globals
   global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
   local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
   loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
    local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
    if
-    local.get $1
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 80
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
     i32.const 20
     i32.add
     local.get $0
     call $~lib/rt/__visit_members
-    local.get $1
+    local.get $2
     call $~lib/rt/itcms/Object#get:next
-    local.set $1
+    local.set $2
     br $while-continue|0
    end
   end
@@ -1527,13 +1545,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1579,7 +1603,7 @@
     if
      i32.const 0
      i32.const 80
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2377,7 +2401,7 @@
   if
    i32.const 288
    i32.const 80
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.optimized.wat
+++ b/tests/compiler/optional-typeparameters.optimized.wat
@@ -46,6 +46,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $optional-typeparameters/tConcrete
   local.tee $0
   if
@@ -63,15 +64,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -980,13 +996,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1033,7 +1057,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -74,38 +74,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1443,13 +1461,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1495,7 +1519,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2293,7 +2317,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -129,6 +129,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $reexport/car
   local.tee $0
   if
@@ -140,15 +141,30 @@
   i32.const 1104
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1168
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1057,13 +1073,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1110,7 +1134,7 @@
      if
       i32.const 0
       i32.const 1168
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -158,38 +158,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 144
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1527,13 +1545,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1579,7 +1603,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2377,7 +2401,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.optimized.wat
+++ b/tests/compiler/rereexport.optimized.wat
@@ -79,6 +79,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $rereexport/car
   local.tee $0
   if
@@ -102,15 +103,30 @@
    call $~lib/rt/itcms/__visit
   end
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1168
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1019,13 +1035,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1072,7 +1096,7 @@
      if
       i32.const 0
       i32.const 1168
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -110,38 +110,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 144
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1479,13 +1497,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1531,7 +1555,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2329,7 +2353,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -61,6 +61,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1280
   call $~lib/rt/itcms/__visit
   i32.const 1088
@@ -68,15 +69,30 @@
   i32.const 1760
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1152
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -985,13 +1001,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1038,7 +1062,7 @@
      if
       i32.const 0
       i32.const 1152
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1626,7 +1650,7 @@
   if
    i32.const 1088
    i32.const 1152
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2053,7 +2077,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 290
+    i32.const 294
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -84,38 +84,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 128
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1453,13 +1471,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1505,7 +1529,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2303,7 +2327,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3630,7 +3654,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -158,6 +158,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $resolve-binary/foo
   local.tee $0
   if
@@ -183,15 +184,30 @@
   i32.const 1840
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1504
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1100,13 +1116,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1153,7 +1177,7 @@
      if
       i32.const 0
       i32.const 1504
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1741,7 +1765,7 @@
   if
    i32.const 1440
    i32.const 1504
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -302,38 +302,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 480
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1671,13 +1689,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1723,7 +1747,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2521,7 +2545,7 @@
   if
    i32.const 416
    i32.const 480
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -98,6 +98,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $resolve-elementaccess/arr
   local.tee $0
   if
@@ -119,15 +120,30 @@
   i32.const 3168
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1232
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1036,13 +1052,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1089,7 +1113,7 @@
      if
       i32.const 0
       i32.const 1232
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1677,7 +1701,7 @@
   if
    i32.const 1168
    i32.const 1232
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1777,7 +1801,7 @@
    if
     i32.const 0
     i32.const 1232
-    i32.const 290
+    i32.const 294
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -107,38 +107,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 208
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1476,13 +1494,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1528,7 +1552,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2326,7 +2350,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2385,7 +2409,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -79,6 +79,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1648
   call $~lib/rt/itcms/__visit
   i32.const 1456
@@ -86,15 +87,30 @@
   i32.const 1856
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1520
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1003,13 +1019,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1056,7 +1080,7 @@
      if
       i32.const 0
       i32.const 1520
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1644,7 +1668,7 @@
   if
    i32.const 1456
    i32.const 1520
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -152,38 +152,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 496
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1521,13 +1539,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1573,7 +1597,7 @@
     if
      i32.const 0
      i32.const 496
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2371,7 +2395,7 @@
   if
    i32.const 432
    i32.const 496
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-nested.optimized.wat
+++ b/tests/compiler/resolve-nested.optimized.wat
@@ -55,20 +55,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -977,13 +993,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1030,7 +1054,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/resolve-nested.untouched.wat
+++ b/tests/compiler/resolve-nested.untouched.wat
@@ -90,38 +90,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1459,13 +1477,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1511,7 +1535,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2309,7 +2333,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.optimized.wat
+++ b/tests/compiler/resolve-new.optimized.wat
@@ -45,6 +45,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $resolve-new/foo
   local.tee $0
   if
@@ -56,15 +57,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -973,13 +989,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1026,7 +1050,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/resolve-new.untouched.wat
+++ b/tests/compiler/resolve-new.untouched.wat
@@ -66,38 +66,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1435,13 +1453,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1487,7 +1511,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2285,7 +2309,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -79,6 +79,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1472
   call $~lib/rt/itcms/__visit
   i32.const 1280
@@ -86,15 +87,30 @@
   i32.const 1680
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1344
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1003,13 +1019,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1056,7 +1080,7 @@
      if
       i32.const 0
       i32.const 1344
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1644,7 +1668,7 @@
   if
    i32.const 1280
    i32.const 1344
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -152,38 +152,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 320
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1521,13 +1539,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1573,7 +1597,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2371,7 +2395,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -125,6 +125,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1472
   call $~lib/rt/itcms/__visit
   i32.const 1280
@@ -132,15 +133,30 @@
   i32.const 1680
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1344
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1049,13 +1065,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1102,7 +1126,7 @@
      if
       i32.const 0
       i32.const 1344
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1690,7 +1714,7 @@
   if
    i32.const 1280
    i32.const 1344
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -160,38 +160,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 320
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1529,13 +1547,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1581,7 +1605,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2379,7 +2403,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -87,6 +87,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $resolve-unary/foo
   local.tee $0
   if
@@ -106,15 +107,30 @@
   i32.const 1680
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1344
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1023,13 +1039,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1076,7 +1100,7 @@
      if
       i32.const 0
       i32.const 1344
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1664,7 +1688,7 @@
   if
    i32.const 1280
    i32.const 1344
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -149,38 +149,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 320
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1518,13 +1536,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1570,7 +1594,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2368,7 +2392,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -49,20 +49,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1061,13 +1077,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1114,7 +1138,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -69,38 +69,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1458,13 +1476,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1510,7 +1534,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2308,7 +2332,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/instanceof.optimized.wat
+++ b/tests/compiler/rt/instanceof.optimized.wat
@@ -54,6 +54,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $rt/instanceof/animal
   local.tee $0
   if
@@ -95,15 +96,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1012,13 +1028,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1065,7 +1089,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -76,38 +76,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1445,13 +1463,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1497,7 +1521,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2295,7 +2319,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.optimized.wat
+++ b/tests/compiler/rt/runtime-incremental-export.optimized.wat
@@ -53,6 +53,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1056
@@ -62,15 +63,30 @@
   i32.const 1520
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -987,13 +1003,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1040,7 +1064,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1628,7 +1652,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1732,7 +1756,7 @@
    if
     i32.const 1456
     i32.const 1120
-    i32.const 333
+    i32.const 337
     i32.const 7
     call $~lib/builtins/abort
     unreachable
@@ -1764,7 +1788,7 @@
   if
    i32.const 1520
    i32.const 1120
-   i32.const 347
+   i32.const 351
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.untouched.wat
+++ b/tests/compiler/rt/runtime-incremental-export.untouched.wat
@@ -72,38 +72,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1441,13 +1459,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1493,7 +1517,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2291,7 +2315,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2349,7 +2373,7 @@
    if
     i32.const 432
     i32.const 96
-    i32.const 333
+    i32.const 337
     i32.const 7
     call $~lib/builtins/abort
     unreachable
@@ -2381,7 +2405,7 @@
   if
    i32.const 496
    i32.const 96
-   i32.const 347
+   i32.const 351
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-minimal-export.optimized.wat
+++ b/tests/compiler/rt/runtime-minimal-export.optimized.wat
@@ -1194,30 +1194,27 @@
   call $~lib/rt/tcms/__visit
   i32.const 1376
   call $~lib/rt/tcms/__visit
-  global.get $~lib/rt/tcms/white
-  i32.eqz
-  local.set $5
-  global.get $~lib/rt/tcms/toSpace
-  local.tee $6
+  global.get $~lib/rt/tcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   local.get $6
+   local.get $1
    i32.ne
    if
-    local.get $5
     local.get $0
     i32.load offset=4
     i32.const 3
     i32.and
+    i32.const 3
     i32.ne
     if
      i32.const 0
      i32.const 1120
-     i32.const 214
+     i32.const 213
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1234,22 +1231,25 @@
     br $while-continue|0
    end
   end
-  global.get $~lib/rt/tcms/pinSpace
-  local.tee $1
+  global.get $~lib/rt/tcms/white
+  i32.eqz
+  local.set $5
+  global.get $~lib/rt/tcms/toSpace
+  local.tee $6
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|1
    local.get $0
-   local.get $1
+   local.get $6
    i32.ne
    if
+    local.get $5
     local.get $0
     i32.load offset=4
     i32.const 3
     i32.and
-    i32.const 3
     i32.ne
     if
      i32.const 0

--- a/tests/compiler/rt/runtime-minimal-export.untouched.wat
+++ b/tests/compiler/rt/runtime-minimal-export.untouched.wat
@@ -1739,64 +1739,64 @@
   drop
   i32.const 0
   call $~lib/rt/__visit_globals
-  global.get $~lib/rt/tcms/white
-  i32.eqz
+  global.get $~lib/rt/tcms/pinSpace
   local.set $0
-  global.get $~lib/rt/tcms/toSpace
-  local.set $1
-  local.get $1
+  local.get $0
   call $~lib/rt/tcms/Object#get:next
-  local.set $2
+  local.set $1
   loop $while-continue|0
-   local.get $2
    local.get $1
+   local.get $0
    i32.ne
-   local.set $3
-   local.get $3
+   local.set $2
+   local.get $2
    if
     i32.const 1
     drop
-    local.get $2
+    local.get $1
     call $~lib/rt/tcms/Object#get:color
-    local.get $0
+    i32.const 3
     i32.eq
     i32.eqz
     if
      i32.const 0
      i32.const 96
-     i32.const 214
+     i32.const 213
      i32.const 16
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $1
     i32.const 20
     i32.add
     i32.const 0
     call $~lib/rt/__visit_members
-    local.get $2
+    local.get $1
     call $~lib/rt/tcms/Object#get:next
-    local.set $2
+    local.set $1
     br $while-continue|0
    end
   end
-  global.get $~lib/rt/tcms/pinSpace
+  global.get $~lib/rt/tcms/white
+  i32.eqz
+  local.set $3
+  global.get $~lib/rt/tcms/toSpace
   local.set $4
   local.get $4
   call $~lib/rt/tcms/Object#get:next
-  local.set $2
+  local.set $1
   loop $while-continue|1
-   local.get $2
+   local.get $1
    local.get $4
    i32.ne
-   local.set $3
-   local.get $3
+   local.set $2
+   local.get $2
    if
     i32.const 1
     drop
-    local.get $2
+    local.get $1
     call $~lib/rt/tcms/Object#get:color
-    i32.const 3
+    local.get $3
     i32.eq
     i32.eqz
     if
@@ -1807,14 +1807,14 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $1
     i32.const 20
     i32.add
     i32.const 0
     call $~lib/rt/__visit_members
-    local.get $2
+    local.get $1
     call $~lib/rt/tcms/Object#get:next
-    local.set $2
+    local.set $1
     br $while-continue|1
    end
   end
@@ -1822,17 +1822,17 @@
   local.set $5
   local.get $5
   call $~lib/rt/tcms/Object#get:next
-  local.set $2
+  local.set $1
   loop $while-continue|2
-   local.get $2
+   local.get $1
    local.get $5
    i32.ne
-   local.set $3
-   local.get $3
+   local.set $2
+   local.get $2
    if
     i32.const 1
     drop
-    local.get $2
+    local.get $1
     call $~lib/rt/tcms/Object#get:color
     global.get $~lib/rt/tcms/white
     i32.eq
@@ -1845,34 +1845,34 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $2
+    local.get $1
     call $~lib/rt/tcms/Object#get:next
     local.set $6
-    local.get $2
+    local.get $1
     global.get $~lib/memory/__heap_base
     i32.lt_u
     if
-     local.get $2
+     local.get $1
      i32.const 0
      call $~lib/rt/tcms/Object#set:nextWithColor
-     local.get $2
+     local.get $1
      i32.const 0
      call $~lib/rt/tcms/Object#set:prev
     else
      global.get $~lib/rt/tcms/total
-     local.get $2
+     local.get $1
      call $~lib/rt/tcms/Object#get:size
      i32.sub
      global.set $~lib/rt/tcms/total
      i32.const 0
      drop
-     local.get $2
+     local.get $1
      i32.const 4
      i32.add
      call $~lib/rt/tlsf/__free
     end
     local.get $6
-    local.set $2
+    local.set $1
     br $while-continue|2
    end
   end
@@ -1882,11 +1882,11 @@
   local.get $5
   local.get $5
   call $~lib/rt/tcms/Object#set:prev
-  local.get $1
+  local.get $4
   global.set $~lib/rt/tcms/fromSpace
   local.get $5
   global.set $~lib/rt/tcms/toSpace
-  local.get $0
+  local.get $3
   global.set $~lib/rt/tcms/white
   i32.const 0
   drop

--- a/tests/compiler/std-wasi/console.optimized.wat
+++ b/tests/compiler/std-wasi/console.optimized.wat
@@ -1833,6 +1833,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/console/timers
   local.tee $0
   if
@@ -1850,15 +1851,30 @@
   i32.const 5920
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 4880
+     i32.const 159
+     i32.const 16
+     call $~lib/wasi/index/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -2140,13 +2156,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -2193,7 +2217,7 @@
      if
       i32.const 0
       i32.const 4880
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/wasi/index/abort
       unreachable
@@ -2406,7 +2430,7 @@
   if
    i32.const 4288
    i32.const 4880
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -2501,7 +2525,7 @@
   if
    i32.const 0
    i32.const 4880
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/console.untouched.wat
+++ b/tests/compiler/std-wasi/console.untouched.wat
@@ -2676,38 +2676,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 3856
+     i32.const 159
+     i32.const 16
+     call $~lib/wasi/index/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -3074,13 +3092,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -3126,7 +3150,7 @@
     if
      i32.const 0
      i32.const 3856
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/wasi/index/abort
      unreachable
@@ -3440,7 +3464,7 @@
   if
    i32.const 3264
    i32.const 3856
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -3499,7 +3523,7 @@
   if
    i32.const 0
    i32.const 3856
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/crypto.optimized.wat
+++ b/tests/compiler/std-wasi/crypto.optimized.wat
@@ -447,6 +447,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $std-wasi/crypto/buf
   local.tee $0
   if
@@ -462,15 +463,30 @@
   i32.const 4928
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1232
+     i32.const 159
+     i32.const 16
+     call $~lib/wasi/index/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1431,13 +1447,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1484,7 +1508,7 @@
      if
       i32.const 0
       i32.const 1232
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/wasi/index/abort
       unreachable
@@ -2037,7 +2061,7 @@
   if
    i32.const 1168
    i32.const 1232
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -2131,7 +2155,7 @@
    if
     i32.const 0
     i32.const 1232
-    i32.const 290
+    i32.const 294
     i32.const 14
     call $~lib/wasi/index/abort
     unreachable

--- a/tests/compiler/std-wasi/crypto.untouched.wat
+++ b/tests/compiler/std-wasi/crypto.untouched.wat
@@ -458,38 +458,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 208
+     i32.const 159
+     i32.const 16
+     call $~lib/wasi/index/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1827,13 +1845,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1879,7 +1903,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/wasi/index/abort
      unreachable
@@ -2677,7 +2701,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -2736,7 +2760,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -1820,6 +1820,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 4336
   call $~lib/rt/itcms/__visit
   i32.const 4416
@@ -1867,15 +1868,30 @@
   i32.const 5664
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 4544
+     i32.const 159
+     i32.const 16
+     call $~lib/wasi/index/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -2157,13 +2173,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -2210,7 +2234,7 @@
      if
       i32.const 0
       i32.const 4544
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/wasi/index/abort
       unreachable
@@ -2423,7 +2447,7 @@
   if
    i32.const 4240
    i32.const 4544
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -2518,7 +2542,7 @@
   if
    i32.const 0
    i32.const 4544
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -3772,56 +3796,6 @@
   call $~lib/rt/tlsf/__free
   global.get $~lib/memory/__stack_pointer
   i32.const 16
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $0
- )
- (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $1
-  local.get $0
-  i32.load offset=12
-  i32.ge_u
-  if
-   i32.const 4672
-   i32.const 4496
-   i32.const 92
-   i32.const 42
-   call $~lib/wasi/index/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load
-  local.tee $0
-  i32.store offset=4
-  local.get $0
-  i32.eqz
-  if
-   i32.const 4912
-   i32.const 4496
-   i32.const 96
-   i32.const 40
-   call $~lib/wasi/index/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $0
@@ -5210,7 +5184,7 @@
   if
    i32.const 0
    i32.const 4816
-   i32.const 740
+   i32.const 749
    i32.const 7
    call $~lib/wasi/index/abort
    unreachable
@@ -5388,6 +5362,53 @@
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 4672
+   i32.const 4496
+   i32.const 92
+   i32.const 42
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.tee $0
+  i32.store
+  local.get $0
+  i32.eqz
+  if
+   i32.const 4912
+   i32.const 4496
+   i32.const 96
+   i32.const 40
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -2673,38 +2673,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 3520
+     i32.const 159
+     i32.const 16
+     call $~lib/wasi/index/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -3071,13 +3089,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -3123,7 +3147,7 @@
     if
      i32.const 0
      i32.const 3520
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/wasi/index/abort
      unreachable
@@ -3437,7 +3461,7 @@
   if
    i32.const 3216
    i32.const 3520
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -3496,7 +3520,7 @@
   if
    i32.const 0
    i32.const 3520
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -4955,15 +4979,6 @@
  (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
- )
- (func $~lib/array/Array<~lib/string/String>#__uget (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load
  )
  (func $~lib/map/Map<~lib/string/String,~lib/string/String>#set:buckets (param $0 i32) (param $1 i32)
   local.get $0
@@ -6683,63 +6698,6 @@
   global.set $~lib/memory/__stack_pointer
   local.get $12
  )
- (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $1
-  local.get $0
-  i32.load offset=12
-  i32.ge_u
-  if
-   i32.const 3648
-   i32.const 3472
-   i32.const 92
-   i32.const 42
-   call $~lib/wasi/index/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store
-  local.get $3
-  local.get $1
-  call $~lib/array/Array<~lib/string/String>#__uget
-  local.tee $2
-  i32.store offset=4
-  i32.const 1
-  drop
-  i32.const 0
-  i32.eqz
-  drop
-  local.get $2
-  i32.eqz
-  if
-   i32.const 3888
-   i32.const 3472
-   i32.const 96
-   i32.const 40
-   call $~lib/wasi/index/abort
-   unreachable
-  end
-  local.get $2
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $3
- )
  (func $~lib/string/String#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
@@ -8298,7 +8256,7 @@
   if
    i32.const 0
    i32.const 3792
-   i32.const 740
+   i32.const 749
    i32.const 7
    call $~lib/wasi/index/abort
    unreachable
@@ -8496,6 +8454,62 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $13
+ )
+ (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 3648
+   i32.const 3472
+   i32.const 92
+   i32.const 42
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.tee $2
+  i32.store
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  local.get $2
+  i32.eqz
+  if
+   i32.const 3888
+   i32.const 3472
+   i32.const 96
+   i32.const 40
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  local.get $2
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
  )
  (func $~lib/arraybuffer/ArrayBuffer#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -107,6 +107,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1088
   call $~lib/rt/itcms/__visit
   i32.const 1344
@@ -146,15 +147,30 @@
   i32.const 1472
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1536
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1063,13 +1079,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1116,7 +1140,7 @@
      if
       i32.const 0
       i32.const 1536
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1704,7 +1728,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1805,7 +1829,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -142,38 +142,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 512
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1511,13 +1529,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1563,7 +1587,7 @@
     if
      i32.const 0
      i32.const 512
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2361,7 +2385,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3688,7 +3712,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -667,6 +667,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $std/array/arr
   local.tee $0
   if
@@ -690,15 +691,30 @@
   i32.const 9152
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1216
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1659,13 +1675,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1712,7 +1736,7 @@
      if
       i32.const 0
       i32.const 1216
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -2280,7 +2304,7 @@
   if
    i32.const 1152
    i32.const 1216
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2376,7 +2400,7 @@
   if
    i32.const 0
    i32.const 1216
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -450,38 +450,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 192
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1819,13 +1837,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1871,7 +1895,7 @@
     if
      i32.const 0
      i32.const 192
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2669,7 +2693,7 @@
   if
    i32.const 128
    i32.const 192
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2728,7 +2752,7 @@
   if
    i32.const 0
    i32.const 192
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -57,6 +57,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1360
   call $~lib/rt/itcms/__visit
   i32.const 1056
@@ -64,15 +65,30 @@
   i32.const 1168
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1232
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -981,13 +997,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1034,7 +1058,7 @@
      if
       i32.const 0
       i32.const 1232
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1622,7 +1646,7 @@
   if
    i32.const 1168
    i32.const 1232
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1895,7 +1919,7 @@
   if
    i32.const 0
    i32.const 1232
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -72,38 +72,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 208
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1441,13 +1459,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1493,7 +1517,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2291,7 +2315,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3753,7 +3777,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -64,6 +64,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1360
   call $~lib/rt/itcms/__visit
   i32.const 1056
@@ -71,15 +72,30 @@
   i32.const 1168
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1232
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -988,13 +1004,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1041,7 +1065,7 @@
      if
       i32.const 0
       i32.const 1232
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1629,7 +1653,7 @@
   if
    i32.const 1168
    i32.const 1232
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1729,7 +1753,7 @@
    if
     i32.const 0
     i32.const 1232
-    i32.const 290
+    i32.const 294
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -79,38 +79,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 208
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1448,13 +1466,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1500,7 +1524,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2298,7 +2322,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2357,7 +2381,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -52,6 +52,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $std/date/date
   local.tee $0
   if
@@ -63,15 +64,30 @@
   i32.const 1104
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1168
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -980,13 +996,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1033,7 +1057,7 @@
      if
       i32.const 0
       i32.const 1168
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -81,38 +81,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 144
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1450,13 +1468,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1502,7 +1526,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2300,7 +2324,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -75,6 +75,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1456
@@ -84,15 +85,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1001,13 +1017,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1054,7 +1078,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1642,7 +1666,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1742,7 +1766,7 @@
   if
    i32.const 0
    i32.const 1120
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -90,38 +90,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1459,13 +1477,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1511,7 +1535,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2309,7 +2333,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2368,7 +2392,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -45,6 +45,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $std/new/aClass
   local.tee $0
   if
@@ -56,15 +57,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -973,13 +989,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1026,7 +1050,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -79,38 +79,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1448,13 +1466,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1500,7 +1524,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2298,7 +2322,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -113,17 +113,33 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   call $~lib/rt/__visit_globals
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1032,13 +1048,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1085,7 +1109,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -133,38 +133,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1502,13 +1520,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1554,7 +1578,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2352,7 +2376,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -68,6 +68,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1248
   call $~lib/rt/itcms/__visit
   i32.const 1456
@@ -75,15 +76,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -992,13 +1008,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1045,7 +1069,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1633,7 +1657,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1733,7 +1757,7 @@
   if
    i32.const 0
    i32.const 1120
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -85,38 +85,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1454,13 +1472,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1506,7 +1530,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2304,7 +2328,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2363,7 +2387,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -92,6 +92,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1088
   call $~lib/rt/itcms/__visit
   i32.const 1184
@@ -107,15 +108,30 @@
   i32.const 1632
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1696
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1024,13 +1040,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1077,7 +1101,7 @@
      if
       i32.const 0
       i32.const 1696
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1665,7 +1689,7 @@
   if
    i32.const 1632
    i32.const 1696
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2022,7 +2046,7 @@
      if
       i32.const 0
       i32.const 1696
-      i32.const 290
+      i32.const 294
       i32.const 14
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -121,38 +121,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 672
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1490,13 +1508,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1542,7 +1566,7 @@
     if
      i32.const 0
      i32.const 672
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2335,7 +2359,7 @@
   if
    i32.const 608
    i32.const 672
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3692,7 +3716,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -58,6 +58,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1056
   call $~lib/rt/itcms/__visit
   i32.const 1280
@@ -79,15 +80,30 @@
   i32.const 1344
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1408
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -996,13 +1012,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1049,7 +1073,7 @@
      if
       i32.const 0
       i32.const 1408
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1637,7 +1661,7 @@
   if
    i32.const 1344
    i32.const 1408
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1928,7 +1952,7 @@
    if
     i32.const 0
     i32.const 1408
-    i32.const 290
+    i32.const 294
     i32.const 14
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -93,38 +93,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 384
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1462,13 +1480,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1514,7 +1538,7 @@
     if
      i32.const 0
      i32.const 384
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2312,7 +2336,7 @@
   if
    i32.const 320
    i32.const 384
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3646,7 +3670,7 @@
   if
    i32.const 0
    i32.const 384
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -490,6 +490,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1280
   call $~lib/rt/itcms/__visit
   i32.const 1088
@@ -499,15 +500,30 @@
   i32.const 1488
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1152
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1416,13 +1432,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1469,7 +1493,7 @@
      if
       i32.const 0
       i32.const 1152
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -2057,7 +2081,7 @@
   if
    i32.const 1088
    i32.const 1152
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -255,38 +255,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 128
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1624,13 +1642,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1676,7 +1700,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2474,7 +2498,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -71,6 +71,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1056
   call $~lib/rt/itcms/__visit
   i32.const 1344
@@ -78,15 +79,30 @@
   i32.const 1152
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1216
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -995,13 +1011,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1048,7 +1072,7 @@
      if
       i32.const 0
       i32.const 1216
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1636,7 +1660,7 @@
   if
    i32.const 1152
    i32.const 1216
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -87,38 +87,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 192
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1456,13 +1474,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1508,7 +1532,7 @@
     if
      i32.const 0
      i32.const 192
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2306,7 +2330,7 @@
   if
    i32.const 128
    i32.const 192
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -1009,6 +1009,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $std/string/str
   local.tee $0
   if
@@ -1026,15 +1027,30 @@
   i32.const 15584
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1440
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1943,13 +1959,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1996,7 +2020,7 @@
      if
       i32.const 0
       i32.const 1440
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -2584,7 +2608,7 @@
   if
    i32.const 1376
    i32.const 1440
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3109,7 +3133,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -654,38 +654,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 416
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -2023,13 +2041,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -2075,7 +2099,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2873,7 +2897,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -4687,7 +4711,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -125,6 +125,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/symbol/stringToId
   local.tee $0
   if
@@ -170,15 +171,30 @@
   i32.const 1136
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1200
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1087,13 +1103,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1140,7 +1164,7 @@
      if
       i32.const 0
       i32.const 1200
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -1728,7 +1752,7 @@
   if
    i32.const 1136
    i32.const 1200
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1829,7 +1853,7 @@
   if
    i32.const 0
    i32.const 1200
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -125,38 +125,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 176
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1494,13 +1512,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1546,7 +1570,7 @@
     if
      i32.const 0
      i32.const 176
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2344,7 +2368,7 @@
   if
    i32.const 112
    i32.const 176
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2403,7 +2427,7 @@
   if
    i32.const 0
    i32.const 176
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -600,6 +600,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 6448
   call $~lib/rt/itcms/__visit
   i32.const 6912
@@ -625,15 +626,30 @@
   i32.const 7328
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1232
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1594,13 +1610,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1647,7 +1671,7 @@
      if
       i32.const 0
       i32.const 1232
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable
@@ -2215,7 +2239,7 @@
   if
    i32.const 1168
    i32.const 1232
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2310,7 +2334,7 @@
   if
    i32.const 0
    i32.const 1232
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -388,38 +388,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 208
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1757,13 +1775,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1809,7 +1833,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2607,7 +2631,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2666,7 +2690,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 290
+   i32.const 294
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.optimized.wat
+++ b/tests/compiler/super-inline.optimized.wat
@@ -46,6 +46,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   global.get $super-inline/foo
   local.tee $0
   if
@@ -63,15 +64,30 @@
   i32.const 1056
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -980,13 +996,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1033,7 +1057,7 @@
      if
       i32.const 0
       i32.const 1120
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/super-inline.untouched.wat
+++ b/tests/compiler/super-inline.untouched.wat
@@ -67,38 +67,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1436,13 +1454,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1488,7 +1512,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2286,7 +2310,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/throw.optimized.wat
+++ b/tests/compiler/throw.optimized.wat
@@ -22,8 +22,8 @@
  (data (i32.const 1288) "\01\00\00\00\06\00\00\004\005\006")
  (data (i32.const 1308) "\1c")
  (data (i32.const 1320) "\01\00\00\00\06\00\00\005\006\007")
- (data (i32.const 1404) "<")
- (data (i32.const 1416) "\01\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s")
+ (data (i32.const 1372) "<")
+ (data (i32.const 1384) "\01\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s")
  (data (i32.const 1468) "<")
  (data (i32.const 1480) "\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
  (data (i32.const 1532) ",")
@@ -57,18 +57,34 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1488
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1392
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -116,7 +132,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 1424
+    i32.const 1392
     i32.const 147
     i32.const 30
     call $~lib/builtins/abort
@@ -143,7 +159,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 1424
+     i32.const 1392
      i32.const 127
      i32.const 18
      call $~lib/builtins/abort
@@ -157,7 +173,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 1424
+    i32.const 1392
     i32.const 131
     i32.const 16
     call $~lib/builtins/abort
@@ -996,13 +1012,21 @@
       global.get $~lib/rt/itcms/toSpace
       i32.ne
       if
-       local.get $0
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
        local.get $0
-       i32.const 20
-       i32.add
-       call $~lib/rt/__visit_members
+       i32.load offset=4
+       i32.const 3
+       i32.and
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        i32.load offset=4
        i32.const -4
@@ -1048,8 +1072,8 @@
     i32.ne
     if
      i32.const 0
-     i32.const 1424
-     i32.const 224
+     i32.const 1392
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1169,7 +1193,7 @@
   i32.const 1344
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/pinSpace
-  i32.const 1376
+  i32.const 1440
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/toSpace
   i32.const 1584

--- a/tests/compiler/throw.untouched.wat
+++ b/tests/compiler/throw.untouched.wat
@@ -18,8 +18,8 @@
  (data (i32.const 252) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\06\00\00\004\005\006\00\00\00\00\00\00\00")
  (data (i32.const 284) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\06\00\00\005\006\007\00\00\00\00\00\00\00")
  (data (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 352) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 380) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 416) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 444) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00\00\00\00\00\00\00\00\00")
  (data (i32.const 508) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
  (data (i32.const 560) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -182,38 +182,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 368
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -263,7 +281,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 400
+    i32.const 368
     i32.const 127
     i32.const 18
     call $~lib/builtins/abort
@@ -280,7 +298,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 400
+   i32.const 368
    i32.const 131
    i32.const 16
    call $~lib/builtins/abort
@@ -369,7 +387,7 @@
    i32.eqz
    if (result i32)
     i32.const 0
-    i32.const 400
+    i32.const 368
     i32.const 147
     i32.const 30
     call $~lib/builtins/abort
@@ -1551,13 +1569,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1602,8 +1626,8 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 400
-     i32.const 224
+     i32.const 368
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1688,7 +1712,7 @@
   i32.const 320
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/pinSpace
-  i32.const 352
+  i32.const 416
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/toSpace
   i32.const 560

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -65,6 +65,7 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1264
   call $~lib/rt/itcms/__visit
   global.get $typeof/c
@@ -78,15 +79,30 @@
   i32.const 1360
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1424
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -995,13 +1011,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1048,7 +1072,7 @@
      if
       i32.const 0
       i32.const 1424
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -204,38 +204,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 400
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1573,13 +1591,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1625,7 +1649,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2423,7 +2447,7 @@
   if
    i32.const 336
    i32.const 400
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -135,20 +135,36 @@
  )
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
+  (local $1 i32)
   i32.const 1296
   call $~lib/rt/itcms/__visit
   i32.const 1104
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
   i32.load offset=4
   i32.const -4
   i32.and
   local.set $0
   loop $while-continue|0
    local.get $0
-   global.get $~lib/rt/itcms/pinSpace
+   local.get $1
    i32.ne
    if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1168
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
     local.get $0
     i32.const 20
     i32.add
@@ -1057,13 +1073,21 @@
        global.get $~lib/rt/itcms/toSpace
        i32.ne
        if
-        local.get $0
         local.get $1
-        call $~lib/rt/itcms/Object#set:color
         local.get $0
-        i32.const 20
-        i32.add
-        call $~lib/rt/__visit_members
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         call $~lib/rt/itcms/Object#set:color
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
         local.get $0
         i32.load offset=4
         i32.const -4
@@ -1110,7 +1134,7 @@
      if
       i32.const 0
       i32.const 1168
-      i32.const 224
+      i32.const 228
       i32.const 20
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -521,38 +521,56 @@
   i32.xor
   i32.and
  )
- (func $~lib/rt/itcms/visitRoots (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/__visit_globals
-  global.get $~lib/rt/itcms/pinSpace
-  call $~lib/rt/itcms/Object#get:next
-  local.set $1
-  loop $while-continue|0
-   local.get $1
-   global.get $~lib/rt/itcms/pinSpace
-   i32.ne
-   local.set $2
-   local.get $2
-   if
-    local.get $1
-    i32.const 20
-    i32.add
-    local.get $0
-    call $~lib/rt/__visit_members
-    local.get $1
-    call $~lib/rt/itcms/Object#get:next
-    local.set $1
-    br $while-continue|0
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
   local.get $0
   i32.load offset=4
   i32.const 3
   i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 144
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
  )
  (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
   local.get $0
@@ -1890,13 +1908,19 @@
       local.get $2
       if
        local.get $0
+       call $~lib/rt/itcms/Object#get:color
        local.get $1
-       call $~lib/rt/itcms/Object#set:color
-       local.get $0
-       i32.const 20
-       i32.add
-       i32.const 0
-       call $~lib/rt/__visit_members
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
        local.get $0
        call $~lib/rt/itcms/Object#get:next
        local.set $0
@@ -1942,7 +1966,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 224
+     i32.const 228
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2740,7 +2764,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 256
+   i32.const 260
    i32.const 31
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
The minimal runtime processed pinned object too late, leading to their members and other indirectly reachable objects to become collected prematurely.

fixes https://github.com/AssemblyScript/assemblyscript/issues/1646

- [x] I've read the contributing guidelines