### PR TITLE
Substitute type arguments in 'new' only if prototypes match

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8442,8 +8442,10 @@ export class Compiler extends DiagnosticEmitter {
     if (
       !typeArguments &&
       (classReference = contextualType.classReference) !== null &&
+      classReference.prototype == classPrototype &&
       classReference.is(CommonFlags.GENERIC)
     ) {
+      // e.g. `arr: Array<T> = new Array()`
       classInstance = this.resolver.resolveClass(
         classPrototype,
         classReference.typeArguments,

--- a/tests/compiler/new.optimized.wat
+++ b/tests/compiler/new.optimized.wat
@@ -1,8 +1,8 @@
 (module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
@@ -18,8 +18,8 @@
  (data (i32.const 1304) "\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
  (data (i32.const 1372) "<")
  (data (i32.const 1384) "\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 1440) "\06\00\00\00 \00\00\00\00\00\00\00 ")
- (data (i32.const 1468) " \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 ")
+ (data (i32.const 1440) "\07\00\00\00 \00\00\00\00\00\00\00 ")
+ (data (i32.const 1468) " \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\04")
  (global $new/ref (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 1024))
@@ -33,7 +33,10 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $new/gen (mut i32) (i32.const 0))
  (global $new/ref2 (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 17876))
+ (global $new/genext (mut i32) (i32.const 0))
+ (global $new/genext2 (mut i32) (i32.const 0))
+ (global $new/genext3 (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 17884))
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/initLazy (param $0 i32) (result i32)
@@ -61,6 +64,24 @@
    call $~lib/rt/itcms/__visit
   end
   global.get $new/ref2
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/genext
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/genext2
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/genext3
   local.tee $0
   if
    local.get $0
@@ -180,7 +201,7 @@
    if
     i32.const 0
     local.get $0
-    i32.const 17876
+    i32.const 17884
     i32.lt_u
     local.get $0
     i32.load offset=8
@@ -980,7 +1001,7 @@
       local.set $0
       loop $while-continue|0
        local.get $0
-       i32.const 17876
+       i32.const 17884
        i32.lt_u
        if
         local.get $0
@@ -1070,7 +1091,7 @@
       unreachable
      end
      local.get $0
-     i32.const 17876
+     i32.const 17884
      i32.lt_u
      if
       local.get $0
@@ -1093,7 +1114,7 @@
       i32.const 4
       i32.add
       local.tee $1
-      i32.const 17876
+      i32.const 17884
       i32.ge_u
       if
        global.get $~lib/rt/tlsf/ROOT
@@ -1435,28 +1456,31 @@
  )
  (func $~lib/rt/__visit_members (param $0 i32)
   block $invalid
-   block $new/ns.Ref
-    block $new/Gen<i32>
-     block $new/Ref
-      block $~lib/arraybuffer/ArrayBufferView
-       block $~lib/string/String
-        block $~lib/arraybuffer/ArrayBuffer
-         local.get $0
-         i32.const 8
-         i32.sub
-         i32.load
-         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $new/Ref $new/Gen<i32> $new/ns.Ref $invalid
+   block $new/GenExt
+    block $new/ns.Ref
+     block $new/Gen<i32>
+      block $new/Ref
+       block $~lib/arraybuffer/ArrayBufferView
+        block $~lib/string/String
+         block $~lib/arraybuffer/ArrayBuffer
+          local.get $0
+          i32.const 8
+          i32.sub
+          i32.load
+          br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $new/Ref $new/Gen<i32> $new/ns.Ref $new/GenExt $invalid
+         end
+         return
         end
         return
        end
-       return
-      end
-      local.get $0
-      i32.load
-      local.tee $0
-      if
        local.get $0
-       call $~lib/rt/itcms/__visit
+       i32.load
+       local.tee $0
+       if
+        local.get $0
+        call $~lib/rt/itcms/__visit
+       end
+       return
       end
       return
      end
@@ -1498,8 +1522,13 @@
   i32.store
   local.get $0
   global.set $new/ref
+  i32.const 0
   call $new/Gen<i32>#constructor
   global.set $new/gen
+  i32.const 0
+  call $new/Gen<i32>#constructor
+  global.set $new/gen
+  i32.const 0
   call $new/Gen<i32>#constructor
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -1518,6 +1547,12 @@
   i32.store
   local.get $0
   global.set $new/ref2
+  call $new/GenExt#constructor
+  global.set $new/genext
+  call $new/GenExt#constructor
+  global.set $new/genext2
+  call $new/GenExt#constructor
+  global.set $new/genext3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add
@@ -1525,7 +1560,7 @@
  )
  (func $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i32.const 1492
+  i32.const 1500
   i32.lt_s
   if
    i32.const 17904
@@ -1535,6 +1570,35 @@
    call $~lib/builtins/abort
    unreachable
   end
+ )
+ (func $new/GenExt#constructor (result i32)
+  (local $0 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  call $new/Gen<i32>#constructor
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
  (func $new/Ref#constructor (result i32)
   (local $0 i32)
@@ -1557,8 +1621,7 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $new/Gen<i32>#constructor (result i32)
-  (local $0 i32)
+ (func $new/Gen<i32>#constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -1567,11 +1630,15 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  call $~lib/rt/itcms/__new
-  local.tee $0
-  i32.store
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+  end
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add

--- a/tests/compiler/new.ts
+++ b/tests/compiler/new.ts
@@ -12,6 +12,7 @@ class Gen<T> {
 }
 
 var gen: Gen<i32>;
+gen = new Gen();
 gen = new Gen<i32>();
 gen = new Gen<i32>().gen;
 
@@ -25,3 +26,10 @@ var ref2: ns.Ref;
 ref2 = new ns.Ref();
 ref2 = new ns.Ref;
 ref2 = new ns.Ref().ref;
+
+class GenExt extends Gen<i32> {
+}
+
+var genext = new GenExt();
+var genext2: GenExt = new GenExt();
+var genext3: Gen<i32> = new GenExt();

--- a/tests/compiler/new.untouched.wat
+++ b/tests/compiler/new.untouched.wat
@@ -18,7 +18,7 @@
  (data (i32.const 268) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
  (data (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 416) "\06\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00")
+ (data (i32.const 416) "\07\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\04\00\00\00")
  (table $0 1 funcref)
  (global $new/ref (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
@@ -35,10 +35,13 @@
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $new/gen (mut i32) (i32.const 0))
  (global $new/ref2 (mut i32) (i32.const 0))
+ (global $new/genext (mut i32) (i32.const 0))
+ (global $new/genext2 (mut i32) (i32.const 0))
+ (global $new/genext3 (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 416))
- (global $~lib/memory/__data_end i32 (i32.const 468))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 16852))
- (global $~lib/memory/__heap_base i32 (i32.const 16852))
+ (global $~lib/memory/__data_end i32 (i32.const 476))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 16860))
+ (global $~lib/memory/__heap_base i32 (i32.const 16860))
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $0 i32) (param $1 i32)
@@ -2386,6 +2389,27 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
+  global.get $new/genext
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/genext2
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $new/genext3
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   i32.const 224
   local.get $0
   call $~lib/rt/itcms/__visit
@@ -2406,25 +2430,28 @@
  )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid
-   block $new/ns.Ref
-    block $new/Gen<i32>
-     block $new/Ref
-      block $~lib/arraybuffer/ArrayBufferView
-       block $~lib/string/String
-        block $~lib/arraybuffer/ArrayBuffer
-         local.get $0
-         i32.const 8
-         i32.sub
-         i32.load
-         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $new/Ref $new/Gen<i32> $new/ns.Ref $invalid
+   block $new/GenExt
+    block $new/ns.Ref
+     block $new/Gen<i32>
+      block $new/Ref
+       block $~lib/arraybuffer/ArrayBufferView
+        block $~lib/string/String
+         block $~lib/arraybuffer/ArrayBuffer
+          local.get $0
+          i32.const 8
+          i32.sub
+          i32.load
+          br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $new/Ref $new/Gen<i32> $new/ns.Ref $new/GenExt $invalid
+         end
+         return
         end
         return
        end
+       local.get $0
+       local.get $1
+       call $~lib/arraybuffer/ArrayBufferView~visit
        return
       end
-      local.get $0
-      local.get $1
-      call $~lib/arraybuffer/ArrayBufferView~visit
       return
      end
      return
@@ -2450,6 +2477,44 @@
    call $~lib/builtins/abort
    unreachable
   end
+ )
+ (func $new/GenExt#constructor (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 6
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=4
+  local.get $1
+  call $new/Gen<i32>#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
  )
  (func $start:new
   (local $0 i32)
@@ -2490,6 +2555,9 @@
   global.set $new/gen
   i32.const 0
   call $new/Gen<i32>#constructor
+  global.set $new/gen
+  i32.const 0
+  call $new/Gen<i32>#constructor
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
@@ -2512,6 +2580,15 @@
   local.get $0
   call $new/ns.Ref#get:ref
   global.set $new/ref2
+  i32.const 0
+  call $new/GenExt#constructor
+  global.set $new/genext
+  i32.const 0
+  call $new/GenExt#constructor
+  global.set $new/genext2
+  i32.const 0
+  call $new/GenExt#constructor
+  global.set $new/genext3
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add


### PR DESCRIPTION
The code responsible to enable `arr: Array<i32> = new Array()` didn't check that both prototypes match before attempting to substitute type arguments, ultimately hitting an assertion that ensures that there's no unexpected "type argument count mismatch".

fixes https://github.com/AssemblyScript/assemblyscript/issues/1622

- [x] I've read the contributing guidelines