### PR TITLE
Emit a diagnostic when an expression only refers to a static element

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7682,7 +7682,10 @@ export class Compiler extends DiagnosticEmitter {
           : module.i32(i64_low(offset));
       }
     }
-    assert(false);
+    this.error(
+      DiagnosticCode.Expression_refers_to_a_static_element_that_does_not_compile_to_a_value_at_runtime,
+      expression.range
+    );
     return this.module.unreachable();
   }
 

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -50,6 +50,7 @@ export enum DiagnosticCode {
   A_class_with_a_constructor_explicitly_returning_something_else_than_this_must_be_final = 231,
   Exported_generic_function_or_class_has_no_concrete_instances = 232,
   Property_0_is_always_assigned_before_being_used = 233,
+  Expression_refers_to_a_static_element_that_does_not_compile_to_a_value_at_runtime = 234,
   Importing_the_table_disables_some_indirect_call_optimizations = 901,
   Exporting_the_table_disables_some_indirect_call_optimizations = 902,
   Expression_compiles_to_a_dynamic_check_at_runtime = 903,
@@ -228,6 +229,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 231: return "A class with a constructor explicitly returning something else than 'this' must be '@final'.";
     case 232: return "Exported generic function or class has no concrete instances.";
     case 233: return "Property '{0}' is always assigned before being used.";
+    case 234: return "Expression refers to a static element that does not compile to a value at runtime.";
     case 901: return "Importing the table disables some indirect call optimizations.";
     case 902: return "Exporting the table disables some indirect call optimizations.";
     case 903: return "Expression compiles to a dynamic check at runtime.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -43,6 +43,7 @@
   "A class with a constructor explicitly returning something else than 'this' must be '@final'.": 231,
   "Exported generic function or class has no concrete instances.": 232,
   "Property '{0}' is always assigned before being used.": 233,
+  "Expression refers to a static element that does not compile to a value at runtime.": 234,
 
   "Importing the table disables some indirect call optimizations.": 901,
   "Exporting the table disables some indirect call optimizations.": 902,


### PR DESCRIPTION
When a static element that has no runtime representation in AS was accessed, the compiler only had an assertion assuming that would never happen, but should print a diagnostic instead because it can happen.

fixes https://github.com/AssemblyScript/assemblyscript/issues/1654

- [x] I've read the contributing guidelines