### PR TITLE
Support optional parameters in d.ts generation

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -459,11 +459,11 @@ export class TSDBuilder extends ExportsWalker {
     sb.push("(");
     var parameters = signature.parameterTypes;
     var numParameters = parameters.length;
-    // var requiredParameters = signature.requiredParameters;
+    var requiredParameters = signature.requiredParameters;
     for (let i = 0; i < numParameters; ++i) {
       if (i) sb.push(", ");
-      // if (i >= requiredParameters) sb.push("optional ");
       sb.push(element.getParameterName(i));
+      if (i >= requiredParameters) sb.push("?");
       sb.push(": ");
       sb.push(this.typeToString(parameters[i]));
     }


### PR DESCRIPTION
Turns out that optional parameters were not yet supported when generating a .d.ts for a module, so this PR adds the `?`.

fixes https://github.com/AssemblyScript/assemblyscript/issues/1644

- [x] I've read the contributing guidelines