### PR TITLE
Add index signature to ArrayLike

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1431,8 +1431,8 @@ declare class DataView {
 }
 
 interface ArrayLike<T> {
+  [key: number]: T;
   length: i32;
-  // [key: number]: T;
 }
 
 /** Interface for a typed view on an array buffer. */


### PR DESCRIPTION
As noted on the original issue, this doesn't make much of a difference but is technically OK in that `isArrayLike` checks for the presence of an index access overload. So we can as well just add it and resolve the original issue fwiw.

fixes https://github.com/AssemblyScript/assemblyscript/pull/1547

- [x] I've read the contributing guidelines