### PR TITLE
Remove unused tslint comments / replace deprecated deepEqual

### DIFF
--- a/bin/asc
+++ b/bin/asc
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-/* tslint:disable */
-
 const tailArgs = process.argv.indexOf("--");
 if (~tailArgs) {
   require("child_process").spawnSync(

--- a/bin/asinit
+++ b/bin/asinit
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-/* tslint:disable */
-
 const fs = require("fs");
 const path = require("path");
 const colors = require("../cli/util/colors");

--- a/scripts/build-diagnostics.js
+++ b/scripts/build-diagnostics.js
@@ -7,8 +7,6 @@ var header = `/**
  * @license Apache-2.0
  */
 
-/* tslint:disable:max-line-length */
-
 `.replace(/\r\n/g, "\n");
 
 var sb = [ header ];

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -3,8 +3,6 @@
  * @license Apache-2.0
  */
 
-/* tslint:disable:max-line-length */
-
 /** Enum of available diagnostic codes. */
 export enum DiagnosticCode {
   Not_implemented_0 = 100,

--- a/std/assembly/bindings/wasi_snapshot_preview1.ts
+++ b/std/assembly/bindings/wasi_snapshot_preview1.ts
@@ -1,8 +1,6 @@
 // Phase: wasi_snapshot_preview1
 // See: https://github.com/WebAssembly/WASI/tree/master/phases/snapshot/witx
 
-/* tslint:disable:max-line-length */
-
 // helper types to be more explicit
 type char = u8;
 type ptr<T> = usize; // all pointers are usize'd

--- a/std/assembly/bindings/wasi_unstable.ts
+++ b/std/assembly/bindings/wasi_unstable.ts
@@ -1,8 +1,6 @@
 // Phase: wasi_unstable / wasi_snapshot_preview0
 // See: https://github.com/WebAssembly/WASI/tree/master/phases/old/snapshot_0/witx
 
-/* tslint:disable:max-line-length */
-
 // helper types to be more explicit
 type char = u8;
 type ptr<T> = usize; // all pointers are usize'd

--- a/tests/cli/options.js
+++ b/tests/cli/options.js
@@ -18,32 +18,32 @@ const config = {
 
 // Present in both should concat
 var merged = optionsUtil.merge(config, { enable: ["a"] }, { enable: ["b"] });
-assert.deepEqual(merged.enable, ["a", "b"]);
+assert.deepStrictEqual(merged.enable, ["a", "b"]);
 
 merged = optionsUtil.merge(config, { enable: ["a"] }, { enable: ["a", "b"] });
-assert.deepEqual(merged.enable, ["a", "b"]);
+assert.deepStrictEqual(merged.enable, ["a", "b"]);
 
 // Mutually exclusive should exclude
 merged = optionsUtil.merge(config, { enable: ["a", "b"] }, { disable: ["a", "c"] });
-assert.deepEqual(merged.enable, ["a", "b"]);
-assert.deepEqual(merged.disable, ["c"]);
+assert.deepStrictEqual(merged.enable, ["a", "b"]);
+assert.deepStrictEqual(merged.disable, ["c"]);
 
 merged = optionsUtil.merge(config, { disable: ["a", "b"] }, { enable: ["a", "c"] });
-assert.deepEqual(merged.enable, ["c"]);
-assert.deepEqual(merged.disable, ["a", "b"]);
+assert.deepStrictEqual(merged.enable, ["c"]);
+assert.deepStrictEqual(merged.disable, ["a", "b"]);
 
 // Populating defaults should work after the fact
 merged = optionsUtil.addDefaults(config, {});
-assert.deepEqual(merged.other, ["x"]);
+assert.deepStrictEqual(merged.other, ["x"]);
 
 merged = optionsUtil.addDefaults(config, { other: ["y"] });
-assert.deepEqual(merged.other, ["y"]);
+assert.deepStrictEqual(merged.other, ["y"]);
 
 // Complete usage test
 var result = optionsUtil.parse(["--enable", "a", "--disable", "b"], config, false);
 merged = optionsUtil.merge(config, result.options, { enable: ["b", "c"] });
 merged = optionsUtil.merge(config, merged, { disable: ["a", "d"] });
 optionsUtil.addDefaults(config, merged);
-assert.deepEqual(merged.enable, ["a", "c"]);
-assert.deepEqual(merged.disable, ["b", "d"]);
-assert.deepEqual(merged.other, ["x"]);
+assert.deepStrictEqual(merged.enable, ["a", "c"]);
+assert.deepStrictEqual(merged.disable, ["b", "d"]);
+assert.deepStrictEqual(merged.other, ["x"]);

--- a/tests/compiler/import.ts
+++ b/tests/compiler/import.ts
@@ -1,5 +1,3 @@
-/* tslint:disable:no-duplicate-imports */
-
 import {
   add,
   sub as sub,


### PR DESCRIPTION
Fixes https://github.com/AssemblyScript/assemblyscript/pull/1585, sans merge conflicts.

- [x] I've read the contributing guidelines