### PR TITLE
Emit a diagnostic when 'super' is called in ctor of a non-derived class

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6155,7 +6155,14 @@ export class Compiler extends DiagnosticEmitter {
       let parent = assert(actualFunction.parent);
       assert(parent.kind == ElementKind.CLASS);
       let classInstance = <Class>parent;
-      let baseClassInstance = assert(classInstance.base);
+      let baseClassInstance = classInstance.base;
+      if (!baseClassInstance) {
+        this.error(
+          DiagnosticCode._super_can_only_be_referenced_in_a_derived_class,
+          expression.expression.range
+        );
+        return module.unreachable();
+      }
       let thisLocal = assert(flow.lookupLocal(CommonNames.this_));
       let nativeSizeType = this.options.nativeSizeType;
 


### PR DESCRIPTION
Calling `super` in the constructor of a non-derived class was hitting an assertion. Emit a diagnostic instead.

fixes https://github.com/AssemblyScript/assemblyscript/issues/1677

- [x] I've read the contributing guidelines