### PR TITLE
Fix premature collect of backing buffers in loader's __newArray

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -180,7 +180,9 @@ function postInstantiate(extendedExports, instance) {
     if (info & STATICARRAY) {
       result = buf;
     } else {
+      __pin(buf);
       const arr = __new(info & ARRAY ? ARRAY_SIZE : ARRAYBUFFERVIEW_SIZE, id);
+      __unpin(buf);
       const U32 = new Uint32Array(memory.buffer);
       U32[arr + ARRAYBUFFERVIEW_BUFFER_OFFSET >>> 2] = buf;
       U32[arr + ARRAYBUFFERVIEW_DATASTART_OFFSET >>> 2] = buf;

--- a/lib/loader/umd/index.js
+++ b/lib/loader/umd/index.js
@@ -227,7 +227,11 @@ var loader = (function(exports) {
       if (info & STATICARRAY) {
         result = buf;
       } else {
+        __pin(buf);
+  
         const arr = __new(info & ARRAY ? ARRAY_SIZE : ARRAYBUFFERVIEW_SIZE, id);
+  
+        __unpin(buf);
   
         const U32 = new Uint32Array(memory.buffer);
         U32[arr + ARRAYBUFFERVIEW_BUFFER_OFFSET >>> 2] = buf;


### PR DESCRIPTION
This problem has been brought up in Discord recently iirc, and is one of these use-after-free kind of bugs (`__new` may step the GC) the docs warn about, yet I apparently forgot to account for in the loader itself.

- [x] I've read the contributing guidelines