### PR TITLE
Prevent webpack from detecting calls to `require` from `dyrequire`

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,6 +33,7 @@ under the licensing terms detailed in LICENSE:
 * Piotr Oleś <piotrek.oles@gmail.com>
 * Saúl Cabrera <saulecabrera@gmail.com>
 * Chance Snow <git@chancesnow.me>
+* Aurelien Ribon <aurelien.ribon@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:
@@ -58,6 +59,6 @@ the following terms:
   The 3-Clause BSD License (https://opensource.org/licenses/BSD-3-Clause)
 
 * Arm Optimized Routines: https://github.com/ARM-software/optimized-routines
-  
+
   Copyright (c) Arm Limited
   The MIT License (https://opensource.org/licenses/MIT)

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -47,7 +47,7 @@ const find = require("./util/find");
 const binaryen = global.binaryen || (global.binaryen = require("binaryen"));
 
 const dynrequire = typeof __webpack_require__ === "function"
-  ? __non_webpack_require__
+  ? eval('require')
   : require;
 
 const WIN = process.platform === "win32";

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -47,7 +47,7 @@ const find = require("./util/find");
 const binaryen = global.binaryen || (global.binaryen = require("binaryen"));
 
 const dynrequire = typeof __webpack_require__ === "function"
-  ? eval('require')
+  ? __non_webpack_require__
   : require;
 
 const WIN = process.platform === "win32";

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -47,7 +47,7 @@ const find = require("./util/find");
 const binaryen = global.binaryen || (global.binaryen = require("binaryen"));
 
 const dynrequire = typeof __webpack_require__ === "function"
-  ? __non_webpack_require__
+  ? () => module[`require`] // backticks required
   : require;
 
 const WIN = process.platform === "win32";

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -238,7 +238,7 @@ function merge(config, currentOptions, parentOptions, parentBaseDir) {
 exports.merge = merge;
 
 const dynrequire = typeof __webpack_require__ === "function"
-  ? __non_webpack_require__
+  ? () => module[`require`] // backticks required
   : require;
 
 /** Resolves a single possibly relative path. Keeps absolute paths, otherwise prepends baseDir. */

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -238,7 +238,7 @@ function merge(config, currentOptions, parentOptions, parentBaseDir) {
 exports.merge = merge;
 
 const dynrequire = typeof __webpack_require__ === "function"
-  ? __non_webpack_require__
+  ? eval('require')
   : require;
 
 /** Resolves a single possibly relative path. Keeps absolute paths, otherwise prepends baseDir. */

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -238,7 +238,7 @@ function merge(config, currentOptions, parentOptions, parentBaseDir) {
 exports.merge = merge;
 
 const dynrequire = typeof __webpack_require__ === "function"
-  ? eval('require')
+  ? __non_webpack_require__
   : require;
 
 /** Resolves a single possibly relative path. Keeps absolute paths, otherwise prepends baseDir. */


### PR DESCRIPTION
# ISSUE
Webpack is used to generate the bundle in `dist/` folder, that is included in the `npm` package. However, when users install the package in their project `npm install assemblyscript`, include ASC with `const asc = require('assemblyscript/dist/asc.js')`, and try to bundle their own project with Webpack, there are multiple warnings emitted, saying that calls to `require` are made in a way that prevents static analysis of dependencies.

This is caused by this code:
```js
// Original source code
const dynrequire = typeof __webpack_require__ === "function"
  ? __non_webpack_require__
  : require;

// Generated code from `npm run build:bundle` (without minification)
const dynrequire = true
  ? require // <--- that's our issue
  : 0;
```
When users call Webpack themselves in their project, it will detect that `dynrequire === require` (I was surprised it could do that, the constant condition `true` may help). Thus, that leads to many errors, from `ts-node` module is not found (we are in a web bundle...), to "require is called in a way that prevents static analysis".

![image](https://user-images.githubusercontent.com/1777005/108038109-c0345000-703a-11eb-85b0-a8cfbdb89d09.png)

# SOLUTION
The variable `require` must not be present in the distributed code when requiring Node-only stuff. `__non_webpack_require__` is replaced by webpack with `require`. Thus it should only be used by leaf projects, not by libraries, else that creates issues in leaf projects. The solution consists in just replacing that `__non_webpack_require__ ` by `eval('require')`, so that

- [x] I've read the contributing guidelines
