### PR TITLE
fix: reexport Source, Range and DiagnosticMessage from compiler's index.d.ts

### DIFF
--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -4,6 +4,8 @@
  */
 
 import { OptionDescription } from "./util/options";
+import { Source, Range, DiagnosticMessage } from "..";
+
 export { OptionDescription };
 
 /** Ready promise resolved once/if the compiler is ready. */
@@ -56,34 +58,13 @@ export interface MemoryStream extends OutputStream {
 }
 
 /** Relevant subset of the Source class for diagnostic reporting. */
-export interface Source {
-  /** Normalized path with file extension. */
-  normalizedPath: string;
-}
+export { Source }
 
 /** Relevant subset of the Range class for diagnostic reporting. */
-export interface Range {
-  /** Start offset within the source file. */
-  start: number;
-  /** End offset within the source file. */
-  end: number;
-  /** Respective source file. */
-  source: Source;
-}
+export { Range }
 
 /** Relevant subset of the DiagnosticMessage class for diagnostic reporting. */
-export interface DiagnosticMessage {
-  /** Message code. */
-  code: number;
-  /** Message category. */
-  category: number;
-  /** Message text. */
-  message: string;
-  /** Respective source range, if any. */
-  range: Range | null;
-  /** Related range, if any. */
-  relatedRange: Range | null;
-}
+export  { DiagnosticMessage }
 
 /** A function handling diagnostic messages. */
 type DiagnosticReporter = (diagnostic: DiagnosticMessage) => void;


### PR DESCRIPTION
This means any tool which imports the types from both, e.g. vistor-as there will be one source of truth.


