### PR TITLE
Make loader more compatible with plain ESM

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,6 +33,7 @@ under the licensing terms detailed in LICENSE:
 * Piotr Oleś <piotrek.oles@gmail.com>
 * Saúl Cabrera <saulecabrera@gmail.com>
 * Chance Snow <git@chancesnow.me>
+* Joe Pea <joe@trusktr.io>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/lib/loader/package.json
+++ b/lib/loader/package.json
@@ -29,7 +29,7 @@
       "import": "./index.js",
       "require": "./umd/index.js"
     },
-    "./index.js": "./index.js",
+    "./index.js": "./index.js"
   },
   "scripts": {
     "asbuild": "npm run asbuild:default && npm run asbuild:legacy",

--- a/lib/loader/package.json
+++ b/lib/loader/package.json
@@ -25,8 +25,11 @@
   "main": "index.js",
   "types": "index.d.ts",
   "exports": {
-    "import": "./index.js",
-    "require": "./umd/index.js"
+    ".": {
+      "import": "./index.js",
+      "require": "./umd/index.js"
+    },
+    "./index.js": "./index.js",
   },
   "scripts": {
     "asbuild": "npm run asbuild:default && npm run asbuild:legacy",


### PR DESCRIPTION
This makes it possible to also write `import {...} from "@assemblyscript/loader/index.js"`. Some people need to write this because some tools (for example TypeScript compiler) do not yet understand how to read the `exports` field from package.json. These tools that don't know `exports` will work fine with paths like `"@assemblyscript/loader/index.js"`, regardless if there's an `exports` field or not.

However, without adding this line, the same code that imports from `"@assemblyscript/loader/index.js"` will not work in a system that uses Node ESM (Node or Webpack) and they will throw an error that `index.js` exists but it is not exported therefore not importable.

TLDR: this allows us to write code that works in more places.

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈
⯈
⯈

- [ ] I've read the contributing guidelines