### PR TITLE
feat: Report a diagnostic when attempting to use a template literal

### DIFF
--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1070,6 +1070,15 @@ export class Tokenizer extends DiagnosticEmitter {
     var quote = text.charCodeAt(pos++);
     var start = pos;
     var result = "";
+
+    if (quote == CharCode.BACKTICK) {
+      this.warning(
+        DiagnosticCode.Not_implemented_0,
+        this.range(start - 1, end),
+        "Template Literals can only be used for multi-line strings. Interpolation is not supported."
+      );
+    }
+
     while (true) {
       if (pos >= end) {
         result += text.substring(start, pos);

--- a/tests/parser/literals.ts
+++ b/tests/parser/literals.ts
@@ -70,6 +70,7 @@
 7_;
 1.a;
 2.0b;
+`123`;
 
 // technically invalid, but not handled by AS yet, TS1005: ';' expected
 3 4;

--- a/tests/parser/literals.ts.fixture.ts
+++ b/tests/parser/literals.ts.fixture.ts
@@ -67,6 +67,7 @@ b;
 a;
 2;
 b;
+"123";
 3;
 4;
 5;
@@ -82,3 +83,4 @@ b;
 // ERROR 6188: "Numeric separators are not allowed here." in literals.ts(70,2+0)
 // ERROR 1351: "An identifier or keyword cannot immediately follow a numeric literal." in literals.ts(71,3+0)
 // ERROR 1351: "An identifier or keyword cannot immediately follow a numeric literal." in literals.ts(72,4+0)
+// WARNING 100: "Not implemented: Template Literals can only be used for multi-line strings. Interpolation is not supported." in literals.ts(73,1+102)


### PR DESCRIPTION
Fixes https://github.com/AssemblyScript/assemblyscript/issues/1615

I think it makes sense to report a diagnostic until https://github.com/AssemblyScript/assemblyscript/issues/466 is implemented. We discovered this by accident as it was causing an unexpected behavior in one of our sdks.

- [x] I've read the contributing guidelines