### PR TITLE
tests: Add tests for StaticArray

### DIFF
--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -1,13 +1,13 @@
 (module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 1036) "\1c")
@@ -30,8 +30,77 @@
  (data (i32.const 1528) "\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
  (data (i32.const 1596) "<")
  (data (i32.const 1608) "\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 1664) "\06\00\00\00 \00\00\00\00\00\00\00 ")
- (data (i32.const 1692) "$\t\00\00\00\00\00\00 \00\00\00\00\00\00\00\04A")
+ (data (i32.const 1660) ",")
+ (data (i32.const 1672) "\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 1708) ",")
+ (data (i32.const 1724) "\18\00\00\00\00\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00\05")
+ (data (i32.const 1756) ",")
+ (data (i32.const 1768) "\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
+ (data (i32.const 1804) "\1c")
+ (data (i32.const 1836) "\1c")
+ (data (i32.const 1848) "\03\00\00\00\08\00\00\00\01\00\00\00\02")
+ (data (i32.const 1868) "\1c")
+ (data (i32.const 1880) "\03\00\00\00\04\00\00\00\01")
+ (data (i32.const 1900) "\1c")
+ (data (i32.const 1912) "\03")
+ (data (i32.const 1932) "\1c")
+ (data (i32.const 1944) "\01\00\00\00\06\00\00\00a\00n\00t")
+ (data (i32.const 1964) "\1c")
+ (data (i32.const 1976) "\01\00\00\00\n\00\00\00b\00i\00s\00o\00n")
+ (data (i32.const 1996) "\1c")
+ (data (i32.const 2008) "\01\00\00\00\n\00\00\00c\00a\00m\00e\00l")
+ (data (i32.const 2028) "\1c")
+ (data (i32.const 2040) "\01\00\00\00\08\00\00\00d\00u\00c\00k")
+ (data (i32.const 2060) ",")
+ (data (i32.const 2072) "\01\00\00\00\10\00\00\00e\00l\00e\00p\00h\00a\00n\00t")
+ (data (i32.const 2108) ",")
+ (data (i32.const 2120) "\08\00\00\00\14\00\00\00\a0\07\00\00\c0\07\00\00\e0\07\00\00\00\08\00\00 \08")
+ (data (i32.const 2156) "|")
+ (data (i32.const 2168) "\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
+ (data (i32.const 2284) ",")
+ (data (i32.const 2296) "\08\00\00\00\14\00\00\00\a0\07\00\00\c0\07\00\00\e0\07\00\00\00\08\00\00 \08")
+ (data (i32.const 2332) "\1c")
+ (data (i32.const 2364) "\1c")
+ (data (i32.const 2376) "\01\00\00\00\06\00\00\00f\00o\00o")
+ (data (i32.const 2396) "\1c")
+ (data (i32.const 2412) "\04\00\00\00P\t")
+ (data (i32.const 2428) ",")
+ (data (i32.const 2440) "\08\00\00\00\14\00\00\00\a0\07\00\00\c0\07\00\00\e0\07\00\00\00\08\00\00 \08")
+ (data (i32.const 2476) "\1c")
+ (data (i32.const 2488) "\n\00\00\00\08")
+ (data (i32.const 2502) "\f8\7f")
+ (data (i32.const 2508) "\1c")
+ (data (i32.const 2520) "\0b\00\00\00\04\00\00\00\00\00\c0\7f")
+ (data (i32.const 2540) "\1c")
+ (data (i32.const 2552) "\03\00\00\00\0c\00\00\00\02\00\00\00\t\00\00\00\t")
+ (data (i32.const 2572) "\1c")
+ (data (i32.const 2584) "\01\00\00\00\08\00\00\00F\00i\00r\00e")
+ (data (i32.const 2604) "\1c")
+ (data (i32.const 2616) "\01\00\00\00\06\00\00\00A\00i\00r")
+ (data (i32.const 2636) "\1c")
+ (data (i32.const 2648) "\01\00\00\00\n\00\00\00W\00a\00t\00e\00r")
+ (data (i32.const 2668) "\1c")
+ (data (i32.const 2684) "\0c\00\00\00 \n\00\00@\n\00\00`\n")
+ (data (i32.const 2700) "\1c")
+ (data (i32.const 2712) "\01")
+ (data (i32.const 2732) "\1c")
+ (data (i32.const 2744) "\01\00\00\00\02\00\00\00,")
+ (data (i32.const 2764) ",")
+ (data (i32.const 2776) "\01\00\00\00\1c\00\00\00F\00i\00r\00e\00,\00A\00i\00r\00,\00W\00a\00t\00e\00r")
+ (data (i32.const 2812) ",")
+ (data (i32.const 2824) "\01\00\00\00\18\00\00\00F\00i\00r\00e\00A\00i\00r\00W\00a\00t\00e\00r")
+ (data (i32.const 2860) "\1c")
+ (data (i32.const 2872) "\01\00\00\00\02\00\00\00-")
+ (data (i32.const 2892) ",")
+ (data (i32.const 2904) "\01\00\00\00\1c\00\00\00F\00i\00r\00e\00-\00A\00i\00r\00-\00W\00a\00t\00e\00r")
+ (data (i32.const 2940) "\1c")
+ (data (i32.const 2952) "\01\00\00\00\06\00\00\00 \00+\00 ")
+ (data (i32.const 2972) "<")
+ (data (i32.const 2984) "\01\00\00\00$\00\00\00F\00i\00r\00e\00 \00+\00 \00A\00i\00r\00 \00+\00 \00W\00a\00t\00e\00r")
+ (data (i32.const 3036) ",")
+ (data (i32.const 3052) "\10\00\00\00\02\00\00\00\05\00\00\00\t\00\00\00\02")
+ (data (i32.const 3088) "\0c\00\00\00 \00\00\00\00\00\00\00 ")
+ (data (i32.const 3116) "$\t\00\00\00\00\00\00 \00\00\00\00\00\00\00\04A\00\00\00\00\00\00\02\t\00\00\00\00\00\00\02\01\00\00\00\00\00\00\04A\00\00\00\00\00\00\02A\00\00\00\00\00\00$\1a\00\00\00\00\00\00$\19")
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
@@ -44,7 +113,8 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $std/staticarray/arr3 (mut i32) (i32.const 0))
  (global $std/staticarray/arr4 (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 18100))
+ (global $~argumentsLength (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 19572))
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/staticarray/StaticArray<i32>#__get (param $0 i32) (param $1 i32) (result i32)
@@ -121,6 +191,10 @@
    call $~lib/rt/itcms/__visit
   end
   i32.const 1088
+  call $~lib/rt/itcms/__visit
+  i32.const 1680
+  call $~lib/rt/itcms/__visit
+  i32.const 2176
   call $~lib/rt/itcms/__visit
   i32.const 1344
   call $~lib/rt/itcms/__visit
@@ -234,7 +308,7 @@
    if
     i32.const 0
     local.get $0
-    i32.const 18100
+    i32.const 19572
     i32.lt_u
     local.get $0
     i32.load offset=8
@@ -280,7 +354,7 @@
    i32.const 1
   else
    local.get $1
-   i32.const 1664
+   i32.const 3088
    i32.load
    i32.gt_u
    if
@@ -294,7 +368,7 @@
    local.get $1
    i32.const 3
    i32.shl
-   i32.const 1668
+   i32.const 3092
    i32.add
    i32.load
    i32.const 32
@@ -899,10 +973,10 @@
   if
    unreachable
   end
-  i32.const 18112
+  i32.const 19584
   i32.const 0
   i32.store
-  i32.const 19680
+  i32.const 21152
   i32.const 0
   i32.store
   loop $for-loop|0
@@ -913,7 +987,7 @@
     local.get $1
     i32.const 2
     i32.shl
-    i32.const 18112
+    i32.const 19584
     i32.add
     i32.const 0
     i32.store offset=4
@@ -931,7 +1005,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 18112
+      i32.const 19584
       i32.add
       i32.const 0
       i32.store offset=96
@@ -949,13 +1023,13 @@
     br $for-loop|0
    end
   end
-  i32.const 18112
-  i32.const 19684
+  i32.const 19584
+  i32.const 21156
   memory.size
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 18112
+  i32.const 19584
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (result i32)
@@ -1034,7 +1108,7 @@
       local.set $0
       loop $while-continue|0
        local.get $0
-       i32.const 18100
+       i32.const 19572
        i32.lt_u
        if
         local.get $0
@@ -1124,7 +1198,7 @@
       unreachable
      end
      local.get $0
-     i32.const 18100
+     i32.const 19572
      i32.lt_u
      if
       local.get $0
@@ -1147,7 +1221,7 @@
       i32.const 4
       i32.add
       local.tee $1
-      i32.const 18100
+      i32.const 19572
       i32.ge_u
       if
        global.get $~lib/rt/tlsf/ROOT
@@ -1981,8 +2055,73 @@
   end
   local.get $1
  )
- (func $~lib/staticarray/StaticArray<std/staticarray/Ref>#__uset (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.eqz
+  if
+   return
+  end
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1408
+   i32.const 294
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/white
+  local.get $1
+  i32.const 20
+  i32.sub
+  local.tee $1
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.eq
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   local.tee $0
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   local.tee $3
+   local.set $4
+   local.get $3
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $2
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   else
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    i32.const 0
+    local.get $4
+    i32.const 3
+    i32.eq
+    select
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
+ (func $~lib/staticarray/StaticArray<std/staticarray/Ref>#__uset (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.const 2
@@ -1990,93 +2129,495 @@
   i32.add
   local.get $2
   i32.store
+  local.get $0
   local.get $2
+  i32.const 1
+  call $~lib/rt/itcms/__link
+ )
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $0
+  local.get $1
+  i32.eq
   if
+   i32.const 1
+   return
+  end
+  local.get $1
+  i32.eqz
+  i32.const 1
+  local.get $0
+  select
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  local.tee $2
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  i32.ne
+  if
+   i32.const 0
+   return
+  end
+  block $__inlined_func$~lib/util/string/compareImpl (result i32)
    local.get $0
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1408
-    i32.const 294
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/rt/itcms/white
-   local.get $2
-   i32.const 20
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   i32.const 3
+   local.tee $3
+   i32.const 7
    i32.and
-   i32.eq
+   local.get $1
+   i32.const 7
+   i32.and
+   i32.or
+   i32.eqz
+   i32.const 0
+   local.get $2
+   local.tee $0
+   i32.const 4
+   i32.ge_u
+   select
    if
-    local.get $0
-    i32.const 20
-    i32.sub
-    local.tee $0
-    i32.load offset=4
-    i32.const 3
-    i32.and
-    local.tee $2
-    local.set $3
-    local.get $2
-    global.get $~lib/rt/itcms/white
-    i32.eqz
-    i32.eq
-    if
-     local.get $0
-     call $~lib/rt/itcms/Object#makeGray
-    else
-     global.get $~lib/rt/itcms/state
-     i32.const 1
-     i32.eq
-     i32.const 0
+    loop $do-continue|0
      local.get $3
-     i32.const 3
-     i32.eq
-     select
+     i64.load
+     local.get $1
+     i64.load
+     i64.eq
      if
+      local.get $3
+      i32.const 8
+      i32.add
+      local.set $3
       local.get $1
-      call $~lib/rt/itcms/Object#makeGray
+      i32.const 8
+      i32.add
+      local.set $1
+      local.get $0
+      i32.const 4
+      i32.sub
+      local.tee $0
+      i32.const 4
+      i32.ge_u
+      br_if $do-continue|0
      end
     end
    end
+   loop $while-continue|1
+    local.get $0
+    local.tee $2
+    i32.const 1
+    i32.sub
+    local.set $0
+    local.get $2
+    if
+     local.get $3
+     i32.load16_u
+     local.tee $2
+     local.get $1
+     i32.load16_u
+     local.tee $4
+     i32.ne
+     if
+      local.get $2
+      local.get $4
+      i32.sub
+      br $__inlined_func$~lib/util/string/compareImpl
+     end
+     local.get $3
+     i32.const 2
+     i32.add
+     local.set $3
+     local.get $1
+     i32.const 2
+     i32.add
+     local.set $1
+     br $while-continue|1
+    end
+   end
+   i32.const 0
   end
+  i32.eqz
+ )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#includes (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  block $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf
+   local.get $2
+   local.get $0
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 2
+   i32.shr_u
+   local.tee $3
+   i32.ge_s
+   i32.const 1
+   local.get $3
+   select
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    i32.const -1
+    local.set $2
+    br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf
+   end
+   local.get $2
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $2
+    local.get $3
+    i32.add
+    local.tee $2
+    i32.const 0
+    local.get $2
+    i32.const 0
+    i32.gt_s
+    select
+    local.set $2
+   end
+   loop $while-continue|0
+    local.get $2
+    local.get $3
+    i32.lt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     local.get $2
+     i32.const 2
+     i32.shl
+     i32.add
+     i32.load
+     local.tee $4
+     i32.store
+     local.get $4
+     local.get $1
+     call $~lib/string/String.__eq
+     if
+      global.get $~lib/memory/__stack_pointer
+      i32.const 4
+      i32.add
+      global.set $~lib/memory/__stack_pointer
+      br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf
+     end
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $while-continue|0
+    end
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   i32.const -1
+   local.set $2
+  end
+  local.get $2
+  i32.const 0
+  i32.ge_s
+ )
+ (func $~lib/staticarray/StaticArray<i32>#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $2
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  local.tee $3
+  i32.ge_s
+  i32.const 1
+  local.get $3
+  select
+  if
+   i32.const -1
+   return
+  end
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $2
+   local.get $3
+   i32.add
+   local.tee $2
+   i32.const 0
+   local.get $2
+   i32.const 0
+   i32.gt_s
+   select
+   local.set $2
+  end
+  loop $while-continue|0
+   local.get $2
+   local.get $3
+   i32.lt_s
+   if
+    local.get $1
+    local.get $0
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    i32.eq
+    if
+     local.get $2
+     return
+    end
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  i32.const -1
+ )
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  block $__inlined_func$~lib/string/String#concat
+   local.get $1
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 1
+   i32.shr_u
+   i32.const 1
+   i32.shl
+   local.tee $4
+   local.get $0
+   local.tee $2
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 1
+   i32.shr_u
+   i32.const 1
+   i32.shl
+   local.tee $3
+   i32.add
+   local.tee $0
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    i32.const 2720
+    local.set $0
+    br $__inlined_func$~lib/string/String#concat
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   local.get $0
+   local.get $2
+   local.get $3
+   call $~lib/memory/memory.copy
+   local.get $0
+   local.get $3
+   i32.add
+   local.get $1
+   local.get $4
+   call $~lib/memory/memory.copy
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+  end
+  local.get $0
+ )
+ (func $~lib/array/Array<i32>#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load offset=12
+  local.tee $3
+  i32.eqz
+  if
+   i32.const -1
+   return
+  end
+  local.get $2
+  local.get $3
+  i32.add
+  local.get $3
+  i32.const 1
+  i32.sub
+  local.get $2
+  local.get $2
+  local.get $3
+  i32.ge_s
+  select
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  select
+  local.set $2
+  local.get $0
+  i32.load offset=4
+  local.set $0
+  loop $while-continue|0
+   local.get $2
+   i32.const 0
+   i32.ge_s
+   if
+    local.get $1
+    local.get $0
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    i32.eq
+    if
+     local.get $2
+     return
+    end
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  i32.const -1
+ )
+ (func $~lib/array/Array<i32>#lastIndexOf@varargs (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  block $1of1
+   block $0of1
+    block $outOfRange
+     global.get $~argumentsLength
+     i32.const 1
+     i32.sub
+     br_table $0of1 $1of1 $outOfRange
+    end
+    unreachable
+   end
+   local.get $0
+   i32.load offset=12
+   local.set $2
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i32>#lastIndexOf
  )
  (func $~lib/rt/__visit_members (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  block $invalid
-   block $~lib/staticarray/StaticArray<std/staticarray/Ref>
-    block $std/staticarray/Ref
-     block $~lib/staticarray/StaticArray<i32>
-      block $~lib/arraybuffer/ArrayBufferView
-       block $~lib/string/String
-        block $~lib/arraybuffer/ArrayBuffer
-         local.get $0
-         i32.const 8
-         i32.sub
-         i32.load
-         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/staticarray/StaticArray<i32> $std/staticarray/Ref $~lib/staticarray/StaticArray<std/staticarray/Ref> $invalid
+  (local $3 i32)
+  block $folding-inner1
+   block $folding-inner0
+    block $invalid
+     block $~lib/staticarray/StaticArray<f32>
+      block $~lib/staticarray/StaticArray<f64>
+       block $~lib/array/Array<~lib/string/String>
+        block $std/staticarray/Ref
+         block $~lib/staticarray/StaticArray<i32>
+          block $~lib/arraybuffer/ArrayBufferView
+           block $~lib/string/String
+            block $~lib/arraybuffer/ArrayBuffer
+             local.get $0
+             i32.const 8
+             i32.sub
+             i32.load
+             br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/staticarray/StaticArray<i32> $std/staticarray/Ref $folding-inner0 $folding-inner1 $folding-inner1 $folding-inner0 $~lib/array/Array<~lib/string/String> $~lib/staticarray/StaticArray<f64> $~lib/staticarray/StaticArray<f32> $invalid
+            end
+            return
+           end
+           return
+          end
+          local.get $0
+          i32.load
+          local.tee $0
+          if
+           local.get $0
+           call $~lib/rt/itcms/__visit
+          end
+          return
+         end
+         return
         end
         return
        end
-       return
-      end
-      local.get $0
-      i32.load
-      local.tee $0
-      if
        local.get $0
+       i32.load offset=4
+       local.tee $1
+       local.get $0
+       i32.load offset=12
+       i32.const 2
+       i32.shl
+       i32.add
+       local.set $2
+       loop $while-continue|0
+        local.get $1
+        local.get $2
+        i32.lt_u
+        if
+         local.get $1
+         i32.load
+         local.tee $3
+         if
+          local.get $3
+          call $~lib/rt/itcms/__visit
+         end
+         local.get $1
+         i32.const 4
+         i32.add
+         local.set $1
+         br $while-continue|0
+        end
+       end
+       local.get $0
+       i32.load
        call $~lib/rt/itcms/__visit
+       return
       end
       return
      end
      return
     end
-    return
+    unreachable
    end
    local.get $0
    local.get $0
@@ -2085,7 +2626,7 @@
    i32.load offset=16
    i32.add
    local.set $1
-   loop $while-continue|0
+   loop $while-continue|00
     local.get $0
     local.get $1
     i32.lt_u
@@ -2101,39 +2642,185 @@
      i32.const 4
      i32.add
      local.set $0
-     br $while-continue|0
+     br $while-continue|00
     end
    end
    return
   end
-  unreachable
+  local.get $0
+  i32.load
+  call $~lib/rt/itcms/__visit
  )
  (func $~start
   call $start:std/staticarray
  )
  (func $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i32.const 1716
+  i32.const 3188
   i32.lt_s
   if
-   i32.const 18128
-   i32.const 18176
+   i32.const 19600
+   i32.const 19648
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
  )
- (func $start:std/staticarray
-  (local $0 i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/string/String> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  local.get $1
+  i32.const 1
+  i32.sub
+  local.tee $3
+  i32.const 0
+  i32.lt_s
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   i32.const 2720
+   return
+  end
+  local.get $3
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.load
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.const 2720
+   local.get $0
+   select
+   return
+  end
+  i32.const 2720
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2720
+  i32.store offset=4
+  local.get $2
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  local.set $6
+  loop $for-loop|0
+   local.get $3
+   local.get $4
+   i32.gt_s
+   if
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.tee $5
+    i32.store
+    local.get $5
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $5
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     local.get $5
+     call $~lib/string/String.__concat
+     local.tee $1
+     i32.store offset=4
+    end
+    local.get $6
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     local.get $2
+     call $~lib/string/String.__concat
+     local.tee $1
+     i32.store offset=4
+    end
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
+    br $for-loop|0
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  local.get $3
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.tee $0
+  i32.store
+  local.get $0
+  if
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   local.get $0
+   call $~lib/string/String.__concat
+   local.tee $1
+   i32.store offset=4
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $start:std/staticarray
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 f64)
+  (local $6 f32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 28
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=16
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=24
   global.get $~lib/memory/__stack_pointer
   i32.const 1056
   i32.store
@@ -2259,7 +2946,7 @@
   memory.size
   i32.const 16
   i32.shl
-  i32.const 18100
+  i32.const 19572
   i32.sub
   i32.const 1
   i32.shr_u
@@ -2280,9 +2967,9 @@
   global.set $std/staticarray/arr3
   global.get $~lib/memory/__stack_pointer
   global.get $std/staticarray/arr3
-  local.tee $0
+  local.tee $1
   i32.store
-  local.get $0
+  local.get $1
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 5
@@ -2297,9 +2984,9 @@
   end
   global.get $~lib/memory/__stack_pointer
   global.get $std/staticarray/arr3
-  local.tee $0
+  local.tee $1
   i32.store
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 6
@@ -2314,9 +3001,9 @@
   end
   global.get $~lib/memory/__stack_pointer
   global.get $std/staticarray/arr3
-  local.tee $0
+  local.tee $1
   i32.store
-  local.get $0
+  local.get $1
   i32.const 2
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 7
@@ -2331,9 +3018,9 @@
   end
   global.get $~lib/memory/__stack_pointer
   global.get $std/staticarray/arr3
-  local.tee $0
+  local.tee $1
   i32.store
-  local.get $0
+  local.get $1
   i32.const 20
   i32.sub
   i32.load offset=16
@@ -2351,16 +3038,16 @@
   end
   global.get $~lib/memory/__stack_pointer
   global.get $std/staticarray/arr3
-  local.tee $0
+  local.tee $1
   i32.store
-  local.get $0
+  local.get $1
   i32.const 8
   call $~lib/staticarray/StaticArray<i32>#__set
   global.get $~lib/memory/__stack_pointer
   global.get $std/staticarray/arr3
-  local.tee $0
+  local.tee $1
   i32.store
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 8
@@ -2380,9 +3067,9 @@
   global.set $std/staticarray/arr3
   global.get $~lib/memory/__stack_pointer
   global.get $std/staticarray/arr3
-  local.tee $0
+  local.tee $1
   i32.store
-  local.get $0
+  local.get $1
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 6
@@ -2400,34 +3087,1217 @@
   i32.const 5
   i32.const 0
   call $~lib/rt/__newBuffer
-  local.tee $0
+  local.tee $1
   i32.store offset=4
-  local.get $0
+  local.get $1
   i32.const 0
   call $std/staticarray/Ref#constructor
   call $~lib/staticarray/StaticArray<std/staticarray/Ref>#__uset
-  local.get $0
+  local.get $1
   i32.const 1
   call $std/staticarray/Ref#constructor
   call $~lib/staticarray/StaticArray<std/staticarray/Ref>#__uset
-  local.get $0
+  local.get $1
   global.set $std/staticarray/arr4
   i32.const 0
   global.set $std/staticarray/arr3
   i32.const 0
   global.set $std/staticarray/arr4
-  i32.const 18100
+  global.get $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.const 3
+  call $~lib/rt/itcms/__new
+  local.tee $1
+  i32.store
+  local.get $1
+  i32.const 12
+  call $~lib/memory/memory.fill
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=4
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 44
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  loop $for-loop|0
+   local.get $0
+   local.get $1
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 2
+   i32.shr_u
+   i32.lt_s
+   if
+    local.get $1
+    local.get $0
+    call $~lib/staticarray/StaticArray<i32>#__get
+    if
+     i32.const 0
+     i32.const 1216
+     i32.const 46
+     i32.const 5
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    i32.const 1
+    i32.add
+    local.set $0
+    br $for-loop|0
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6
+  i32.const 6
+  i32.const 1728
+  call $~lib/rt/__newArray
+  local.tee $1
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  call $~lib/staticarray/StaticArray.fromArray<i32>
+  local.tee $2
+  i32.store offset=4
+  local.get $1
+  i32.load offset=12
+  local.get $2
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 56
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $for-loop|1
+   local.get $0
+   local.get $1
+   i32.load offset=12
+   i32.lt_s
+   if
+    local.get $2
+    local.get $0
+    call $~lib/staticarray/StaticArray<i32>#__get
+    local.get $0
+    local.get $1
+    i32.load offset=12
+    i32.ge_u
+    if
+     i32.const 1088
+     i32.const 1776
+     i32.const 92
+     i32.const 42
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    i32.load offset=4
+    local.get $0
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1216
+     i32.const 58
+     i32.const 5
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    i32.const 1
+    i32.add
+    local.set $0
+    br $for-loop|1
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 6
+  i32.const 1824
+  call $~lib/rt/__newArray
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  local.get $0
+  call $~lib/staticarray/StaticArray.fromArray<i32>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 61
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.const 3
+  i32.const 1856
+  call $~lib/rt/__newBuffer
+  local.tee $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.const 3
+  i32.const 1888
+  call $~lib/rt/__newBuffer
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  call $~lib/staticarray/StaticArray.concat<i32>
+  local.tee $1
+  i32.store offset=8
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 69
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 3
+  i32.const 1920
+  call $~lib/rt/__newBuffer
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  call $~lib/staticarray/StaticArray.concat<i32>
+  local.tee $1
+  i32.store offset=8
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 71
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 20
+  i32.const 8
+  i32.const 2128
+  call $~lib/rt/__newBuffer
+  local.tee $1
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 0
+  i32.const 2147483647
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $2
+  i32.store offset=4
+  local.get $2
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 78
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $for-loop|2
+   local.get $0
+   local.get $1
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 2
+   i32.shr_u
+   i32.lt_s
+   if
+    local.get $1
+    local.get $0
+    call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+    local.set $3
+    global.get $~lib/memory/__stack_pointer
+    local.get $3
+    i32.store
+    local.get $2
+    local.get $0
+    call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+    local.set $4
+    global.get $~lib/memory/__stack_pointer
+    local.get $4
+    i32.store offset=12
+    local.get $3
+    local.get $4
+    call $~lib/string/String.__eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1216
+     i32.const 81
+     i32.const 5
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    i32.const 1
+    i32.add
+    local.set $0
+    br $for-loop|2
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 1
+  i32.const 3
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 85
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1984
+  i32.store offset=12
+  local.get $2
+  i32.const 1984
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 86
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2016
+  i32.store offset=12
+  local.get $0
+  i32.const 2016
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 87
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 1
+  i32.const 2147483647
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.const 1
+  i32.sub
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 90
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 0
+  i32.const 50
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 93
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 100
+  i32.const 2147483647
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 96
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const -1
+  i32.const 2147483647
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 99
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2080
+  i32.store offset=12
+  local.get $0
+  i32.const 2080
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 100
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const -2
+  i32.const -2
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 103
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 2
+  i32.const -2
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 106
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2016
+  i32.store offset=12
+  local.get $0
+  i32.const 2016
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 107
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 20
+  i32.const 8
+  i32.const 2304
+  call $~lib/rt/__newBuffer
+  local.tee $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 9
+  i32.const 2352
+  call $~lib/rt/__newArray
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#concat
+  local.tee $1
+  i32.store offset=16
+  local.get $1
+  i32.load offset=12
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 115
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1
+  i32.const 9
+  i32.const 2416
+  call $~lib/rt/__newArray
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#concat
+  local.tee $1
+  i32.store offset=16
+  local.get $1
+  i32.load offset=12
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.const 1
+  i32.add
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 119
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 20
+  i32.const 8
+  i32.const 2448
+  call $~lib/rt/__newBuffer
+  local.tee $0
+  i32.store offset=16
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1984
+  i32.store offset=12
+  local.get $0
+  i32.const 1984
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#includes
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 126
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2384
+  i32.store offset=12
+  local.get $0
+  i32.const 2384
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#includes
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 127
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2080
+  i32.store offset=12
+  local.get $0
+  i32.const 2080
+  i32.const 5
+  call $~lib/staticarray/StaticArray<~lib/string/String>#includes
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 128
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2080
+  i32.store offset=12
+  local.get $0
+  i32.const 2080
+  i32.const -1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#includes
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 129
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 8
+  i32.const 10
+  i32.const 2496
+  call $~lib/rt/__newBuffer
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  block $__inlined_func$~lib/staticarray/StaticArray<f64>#includes (result i32)
+   i32.const 0
+   local.set $0
+   i32.const 0
+   local.get $1
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 3
+   i32.shr_u
+   local.tee $3
+   i32.eqz
+   i32.const 1
+   local.get $3
+   select
+   br_if $__inlined_func$~lib/staticarray/StaticArray<f64>#includes
+   drop
+   loop $while-continue|0
+    local.get $0
+    local.get $3
+    i32.lt_s
+    if
+     i32.const 1
+     i32.const 1
+     local.get $1
+     local.get $0
+     i32.const 3
+     i32.shl
+     i32.add
+     f64.load
+     local.tee $5
+     local.get $5
+     f64.ne
+     local.get $5
+     f64.const nan:0x8000000000000
+     f64.eq
+     select
+     br_if $__inlined_func$~lib/staticarray/StaticArray<f64>#includes
+     drop
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $while-continue|0
+    end
+   end
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 131
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 4
+  i32.const 11
+  i32.const 2528
+  call $~lib/rt/__newBuffer
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  block $__inlined_func$~lib/staticarray/StaticArray<f32>#includes (result i32)
+   i32.const 0
+   local.set $1
+   i32.const 0
+   local.get $0
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 2
+   i32.shr_u
+   local.tee $2
+   i32.eqz
+   i32.const 1
+   local.get $2
+   select
+   br_if $__inlined_func$~lib/staticarray/StaticArray<f32>#includes
+   drop
+   loop $while-continue|00
+    local.get $1
+    local.get $2
+    i32.lt_s
+    if
+     i32.const 1
+     i32.const 1
+     local.get $0
+     local.get $1
+     i32.const 2
+     i32.shl
+     i32.add
+     f32.load
+     local.tee $6
+     local.get $6
+     f32.ne
+     local.get $6
+     f32.const nan:0x400000
+     f32.eq
+     select
+     br_if $__inlined_func$~lib/staticarray/StaticArray<f32>#includes
+     drop
+     local.get $1
+     i32.const 1
+     i32.add
+     local.set $1
+     br $while-continue|00
+    end
+   end
+   i32.const 0
+  end
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 132
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.const 3
+  i32.const 2560
+  call $~lib/rt/__newBuffer
+  local.tee $0
+  i32.store offset=16
+  local.get $0
+  i32.const 2
+  i32.const 0
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 138
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 7
+  i32.const 0
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 139
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 9
+  i32.const 2
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 140
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 2
+  i32.const -1
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 141
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 2
+  i32.const -3
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 142
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3
+  i32.const 9
+  i32.const 2688
+  call $~lib/rt/__newArray
+  local.tee $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2752
+  i32.store offset=20
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=12
+  i32.const 2752
+  call $~lib/util/string/joinReferenceArray<~lib/string/String>
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2784
+  i32.store offset=12
+  local.get $1
+  i32.const 2784
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 148
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2720
+  i32.store offset=20
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=12
+  i32.const 2720
+  call $~lib/util/string/joinReferenceArray<~lib/string/String>
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2832
+  i32.store offset=12
+  local.get $1
+  i32.const 2832
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 149
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2880
+  i32.store offset=20
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=12
+  i32.const 2880
+  call $~lib/util/string/joinReferenceArray<~lib/string/String>
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2912
+  i32.store offset=12
+  local.get $1
+  i32.const 2912
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 150
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2960
+  i32.store offset=20
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=12
+  i32.const 2960
+  call $~lib/util/string/joinReferenceArray<~lib/string/String>
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2992
+  i32.store offset=12
+  local.get $1
+  i32.const 2992
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 151
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2752
+  i32.store offset=20
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=12
+  i32.const 2752
+  call $~lib/util/string/joinReferenceArray<~lib/string/String>
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2752
+  i32.store
+  local.get $0
+  i32.load offset=4
+  local.get $0
+  i32.load offset=12
+  i32.const 2752
+  call $~lib/util/string/joinReferenceArray<~lib/string/String>
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 152
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.const 6
+  i32.const 3056
+  call $~lib/rt/__newArray
+  local.tee $0
+  i32.store offset=24
+  i32.const 1
+  global.set $~argumentsLength
+  local.get $0
+  i32.const 2
+  call $~lib/array/Array<i32>#lastIndexOf@varargs
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 158
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  global.set $~argumentsLength
+  local.get $0
+  i32.const 7
+  call $~lib/array/Array<i32>#lastIndexOf@varargs
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 159
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 2
+  i32.const 3
+  call $~lib/array/Array<i32>#lastIndexOf
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 160
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 2
+  i32.const 2
+  call $~lib/array/Array<i32>#lastIndexOf
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 161
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 2
+  i32.const -2
+  call $~lib/array/Array<i32>#lastIndexOf
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 162
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 2
+  i32.const -1
+  call $~lib/array/Array<i32>#lastIndexOf
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 163
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 19572
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/rt/itcms/state
   i32.const 0
   i32.gt_s
   if
-   loop $while-continue|0
+   loop $while-continue|032
     global.get $~lib/rt/itcms/state
     if
      call $~lib/rt/itcms/step
      drop
-     br $while-continue|0
+     br $while-continue|032
     end
    end
   end
@@ -2452,7 +4322,7 @@
   i32.add
   global.set $~lib/rt/itcms/threshold
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 28
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -2477,5 +4347,441 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $0
+ )
+ (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.const 2
+  i32.shl
+  local.tee $3
+  i32.const 0
+  local.get $2
+  call $~lib/rt/__newBuffer
+  local.tee $2
+  i32.store
+  i32.const 16
+  local.get $1
+  call $~lib/rt/itcms/__new
+  local.tee $1
+  local.get $2
+  i32.store
+  local.get $1
+  local.get $2
+  i32.const 0
+  call $~lib/rt/itcms/__link
+  local.get $1
+  local.get $2
+  i32.store offset=4
+  local.get $1
+  local.get $3
+  i32.store offset=8
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $~lib/staticarray/StaticArray.fromArray<i32> (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.load offset=12
+  i32.const 2
+  i32.shl
+  local.tee $2
+  i32.const 3
+  call $~lib/rt/itcms/__new
+  local.tee $1
+  i32.store
+  local.get $1
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  call $~lib/memory/memory.copy
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $~lib/staticarray/StaticArray.concat<i32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.const 0
+  local.get $1
+  select
+  local.tee $3
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  local.tee $4
+  i32.add
+  local.tee $2
+  i32.const 268435455
+  i32.gt_u
+  if
+   i32.const 1680
+   i32.const 1152
+   i32.const 41
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.const 3
+  call $~lib/rt/itcms/__new
+  local.tee $2
+  i32.store
+  local.get $2
+  local.get $0
+  local.get $4
+  i32.const 2
+  i32.shl
+  local.tee $0
+  call $~lib/memory/memory.copy
+  local.get $0
+  local.get $2
+  i32.add
+  local.get $1
+  local.get $3
+  i32.const 2
+  i32.shl
+  call $~lib/memory/memory.copy
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
+ (func $~lib/staticarray/StaticArray.slice<~lib/string/String> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  local.set $3
+  local.get $1
+  i32.const 0
+  i32.lt_s
+  if (result i32)
+   local.get $1
+   local.get $3
+   i32.add
+   local.tee $1
+   i32.const 0
+   local.get $1
+   i32.const 0
+   i32.gt_s
+   select
+  else
+   local.get $1
+   local.get $3
+   local.get $1
+   local.get $3
+   i32.lt_s
+   select
+  end
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if (result i32)
+   local.get $2
+   local.get $3
+   i32.add
+   local.tee $2
+   i32.const 0
+   local.get $2
+   i32.const 0
+   i32.gt_s
+   select
+  else
+   local.get $2
+   local.get $3
+   local.get $2
+   local.get $3
+   i32.lt_s
+   select
+  end
+  local.get $1
+  i32.sub
+  local.tee $2
+  i32.const 0
+  local.get $2
+  i32.const 0
+  i32.gt_s
+  select
+  i32.const 2
+  i32.shl
+  local.tee $3
+  i32.const 8
+  call $~lib/rt/itcms/__new
+  local.tee $2
+  i32.store
+  local.get $0
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.set $1
+  i32.const 0
+  local.set $0
+  loop $while-continue|0
+   local.get $0
+   local.get $3
+   i32.lt_u
+   if
+    local.get $0
+    local.get $2
+    i32.add
+    local.get $0
+    local.get $1
+    i32.add
+    i32.load
+    local.tee $4
+    i32.store
+    local.get $2
+    local.get $4
+    i32.const 1
+    call $~lib/rt/itcms/__link
+    local.get $0
+    i32.const 4
+    i32.add
+    local.set $0
+    br $while-continue|0
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 1088
+   i32.const 1152
+   i32.const 113
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.tee $0
+  i32.store
+  local.get $0
+  i32.eqz
+  if
+   i32.const 2176
+   i32.const 1152
+   i32.const 117
+   i32.const 40
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $0
+ )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#concat (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  i32.load offset=12
+  i32.const 0
+  local.get $1
+  select
+  local.tee $6
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+  local.tee $2
+  i32.add
+  local.tee $3
+  i32.const 268435455
+  i32.gt_u
+  if
+   i32.const 1680
+   i32.const 1152
+   i32.const 183
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.const 9
+  i32.const 0
+  call $~lib/rt/__newArray
+  local.tee $3
+  i32.store
+  local.get $3
+  i32.load offset=4
+  local.set $5
+  local.get $2
+  i32.const 2
+  i32.shl
+  local.set $2
+  loop $for-loop|0
+   local.get $2
+   local.get $4
+   i32.gt_u
+   if
+    local.get $4
+    local.get $5
+    i32.add
+    local.get $0
+    local.get $4
+    i32.add
+    i32.load
+    local.tee $7
+    i32.store
+    local.get $3
+    local.get $7
+    i32.const 1
+    call $~lib/rt/itcms/__link
+    local.get $4
+    i32.const 4
+    i32.add
+    local.set $4
+    br $for-loop|0
+   end
+  end
+  local.get $2
+  local.get $5
+  i32.add
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.set $1
+  local.get $6
+  i32.const 2
+  i32.shl
+  local.set $5
+  i32.const 0
+  local.set $0
+  loop $for-loop|1
+   local.get $0
+   local.get $5
+   i32.lt_u
+   if
+    local.get $0
+    local.get $4
+    i32.add
+    local.get $0
+    local.get $1
+    i32.add
+    i32.load
+    local.tee $2
+    i32.store
+    local.get $3
+    local.get $2
+    i32.const 1
+    call $~lib/rt/itcms/__link
+    local.get $0
+    i32.const 4
+    i32.add
+    local.set $0
+    br $for-loop|1
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
  )
 )

--- a/tests/compiler/std/staticarray.ts
+++ b/tests/compiler/std/staticarray.ts
@@ -36,5 +36,132 @@ var arr4: StaticArray<Ref> = [ new Ref(), new Ref() ];
 arr3 = changetype<StaticArray<i32>>(0); // unleak
 arr4 = changetype<StaticArray<Ref>>(0);
 
+
+// constructor
+
+{
+  const source = new StaticArray<i32>(3);
+  assert(source.length == 3);
+  for (let i = 0; i < source.length; i++) {
+    assert(source[i] == 0);
+  }
+}
+
+
+// fromArray
+
+{
+  const source: i32[] = [0, 1, 1, 2, 3, 5];
+  let subject = StaticArray.fromArray(source);
+  assert(subject.length == source.length);
+  for (let i = 0; i < source.length; i++) {
+    assert(subject[i] == source[i]);
+  }
+  subject = StaticArray.fromArray<i32>([]);
+  assert(subject.length == 0);
+}
+
+// concat
+
+{
+  let source: StaticArray<i32> = [1, 2];
+  let result = StaticArray.concat(source, [1]);
+  assert(result.length == 3);
+  result = StaticArray.concat(source, []);
+  assert(result.length == source.length);
+}
+
+// slice
+{
+  const source: StaticArray<string> = ['ant', 'bison', 'camel', 'duck', 'elephant'];
+  let result = StaticArray.slice(source);
+  assert(result.length == source.length);
+
+  for(let i = 0; i < source.length; i++) {
+    assert(source[i] == result[i]);
+  }
+
+  result = StaticArray.slice(source, 1, 3);
+  assert(result.length == 2);
+  assert(result[0] == "bison");
+  assert(result[1] == "camel");
+
+  result = StaticArray.slice(source, 1);
+  assert(result.length == (source.length - 1));
+
+  result = StaticArray.slice(source, 0, 50);
+  assert(result.length == source.length);
+
+  result = StaticArray.slice(source, 100);
+  assert(result.length == 0);
+
+  result = StaticArray.slice(source, -1);
+  assert(result.length == 1);
+  assert(result[0] == "elephant");
+
+  result = StaticArray.slice(source, -2, -2);
+  assert(result.length == 0);
+
+  result = StaticArray.slice(source, 2, -2);
+  assert(result.length == 1);
+  assert(result[0] == "camel");
+}
+
+// concat
+{
+  const source: StaticArray<string> = ['ant', 'bison', 'camel', 'duck', 'elephant'];
+
+  let result = source.concat([]);
+  assert(result.length == source.length);
+  assert(isArray(result));
+
+  result = source.concat(["foo"]);
+  assert(result.length == (source.length + 1));
+  assert(isArray(result));
+}
+
+// includes
+{
+  const source: StaticArray<string> = ['ant', 'bison', 'camel', 'duck', 'elephant'];
+  assert(source.includes("bison") == true);
+  assert(source.includes("foo") == false);
+  assert(source.includes("elephant", 5) == false);
+  assert(source.includes("elephant", -1) == true);
+
+  assert(([NaN] as StaticArray<f64>).includes(NaN) == true);
+  assert(([NaN] as StaticArray<f32>).includes(NaN) == true);
+}
+
+// indexOf
+{
+  const array: StaticArray<i32> = [2, 9, 9];
+  assert(array.indexOf(2) == 0);
+  assert(array.indexOf(7) == -1);
+  assert(array.indexOf(9, 2) == 2);
+  assert(array.indexOf(2, -1) == -1);
+  assert(array.indexOf(2, -3) == 0);
+}
+
+// join + toString
+{
+  const elements = ['Fire', 'Air', 'Water'];
+  assert(elements.join() == "Fire,Air,Water");
+  assert(elements.join('') == "FireAirWater");
+  assert(elements.join('-') == "Fire-Air-Water");
+  assert(elements.join(' + ') == "Fire + Air + Water");
+  assert(elements.join() == elements.toString());
+}
+
+// lastIndexOf
+{
+  var numbers = [2, 5, 9, 2];
+  assert(numbers.lastIndexOf(2) == 3);
+  assert(numbers.lastIndexOf(7) == -1);
+  assert(numbers.lastIndexOf(2, 3) == 3);
+  assert(numbers.lastIndexOf(2, 2) == 0);
+  assert(numbers.lastIndexOf(2, -2) == 0);
+  assert(numbers.lastIndexOf(2, -1) == 3);
+}
+
 __stack_pointer = __heap_base;
 __collect();

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -1,13 +1,17 @@
 (module
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
+ (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 12) "\1c\00\00\00\00\00\00\00\00\00\00\00\03\00\00\00\0c\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00")
@@ -23,7 +27,42 @@
  (data (i32.const 492) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
  (data (i32.const 544) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 572) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 640) "\06\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00$\t\00\00\00\00\00\00 \00\00\00\00\00\00\00\04A\00\00\00\00\00\00")
+ (data (i32.const 636) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 684) ",\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\18\00\00\00\00\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00\05\00\00\00\00\00\00\00")
+ (data (i32.const 732) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
+ (data (i32.const 780) "\1c\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 812) "\1c\00\00\00\00\00\00\00\00\00\00\00\03\00\00\00\08\00\00\00\01\00\00\00\02\00\00\00\00\00\00\00")
+ (data (i32.const 844) "\1c\00\00\00\00\00\00\00\00\00\00\00\03\00\00\00\04\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 876) "\1c\00\00\00\00\00\00\00\00\00\00\00\03\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 908) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\06\00\00\00a\00n\00t\00\00\00\00\00\00\00")
+ (data (i32.const 940) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\n\00\00\00b\00i\00s\00o\00n\00\00\00")
+ (data (i32.const 972) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\n\00\00\00c\00a\00m\00e\00l\00\00\00")
+ (data (i32.const 1004) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00d\00u\00c\00k\00\00\00\00\00")
+ (data (i32.const 1036) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\10\00\00\00e\00l\00e\00p\00h\00a\00n\00t\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1084) ",\00\00\00\00\00\00\00\00\00\00\00\08\00\00\00\14\00\00\00\a0\03\00\00\c0\03\00\00\e0\03\00\00\00\04\00\00 \04\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1132) "|\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1260) ",\00\00\00\00\00\00\00\00\00\00\00\08\00\00\00\14\00\00\00\a0\03\00\00\c0\03\00\00\e0\03\00\00\00\04\00\00 \04\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1308) "\1c\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1340) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\06\00\00\00f\00o\00o\00\00\00\00\00\00\00")
+ (data (i32.const 1372) "\1c\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\04\00\00\00P\05\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1404) ",\00\00\00\00\00\00\00\00\00\00\00\08\00\00\00\14\00\00\00\a0\03\00\00\c0\03\00\00\e0\03\00\00\00\04\00\00 \04\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1452) "\1c\00\00\00\00\00\00\00\00\00\00\00\n\00\00\00\08\00\00\00\00\00\00\00\00\00\f8\7f\00\00\00\00")
+ (data (i32.const 1484) "\1c\00\00\00\00\00\00\00\00\00\00\00\0b\00\00\00\04\00\00\00\00\00\c0\7f\00\00\00\00\00\00\00\00")
+ (data (i32.const 1516) "\1c\00\00\00\00\00\00\00\00\00\00\00\03\00\00\00\0c\00\00\00\02\00\00\00\t\00\00\00\t\00\00\00")
+ (data (i32.const 1548) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00F\00i\00r\00e\00\00\00\00\00")
+ (data (i32.const 1580) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\06\00\00\00A\00i\00r\00\00\00\00\00\00\00")
+ (data (i32.const 1612) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\n\00\00\00W\00a\00t\00e\00r\00\00\00")
+ (data (i32.const 1644) "\1c\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\0c\00\00\00 \06\00\00@\06\00\00`\06\00\00")
+ (data (i32.const 1676) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1708) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00,\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1740) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1c\00\00\00F\00i\00r\00e\00,\00A\00i\00r\00,\00W\00a\00t\00e\00r\00")
+ (data (i32.const 1788) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\18\00\00\00F\00i\00r\00e\00A\00i\00r\00W\00a\00t\00e\00r\00\00\00\00\00")
+ (data (i32.const 1836) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00-\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 1868) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1c\00\00\00F\00i\00r\00e\00-\00A\00i\00r\00-\00W\00a\00t\00e\00r\00")
+ (data (i32.const 1916) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\06\00\00\00 \00+\00 \00\00\00\00\00\00\00")
+ (data (i32.const 1948) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00F\00i\00r\00e\00 \00+\00 \00A\00i\00r\00 \00+\00 \00W\00a\00t\00e\00r\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2012) ",\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\10\00\00\00\02\00\00\00\05\00\00\00\t\00\00\00\02\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2064) "\0c\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00$\t\00\00\00\00\00\00 \00\00\00\00\00\00\00\04A\00\00\00\00\00\00\02\t\00\00\00\00\00\00\02\01\00\00\00\00\00\00\04A\00\00\00\00\00\00\02A\00\00\00\00\00\00$\1a\00\00\00\00\00\00$\19\00\00\00\00\00\00")
  (table $0 1 funcref)
  (global $std/staticarray/arr1 i32 (i32.const 32))
  (global $std/staticarray/arr2 i32 (i32.const 256))
@@ -41,10 +80,12 @@
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $std/staticarray/arr3 (mut i32) (i32.const 0))
  (global $std/staticarray/arr4 (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 640))
- (global $~lib/memory/__data_end i32 (i32.const 692))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 17076))
- (global $~lib/memory/__heap_base i32 (i32.const 17076))
+ (global $~lib/builtins/i32.MAX_VALUE i32 (i32.const 2147483647))
+ (global $~argumentsLength (mut i32) (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 2064))
+ (global $~lib/memory/__data_end i32 (i32.const 2164))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 18548))
+ (global $~lib/memory/__heap_base i32 (i32.const 18548))
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/staticarray/StaticArray<i32>#get:length (param $0 i32) (result i32)
@@ -3780,6 +3821,572 @@
   i32.const 1
   call $~lib/rt/itcms/__link
  )
+ (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 64
+   i32.const 752
+   i32.const 92
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.set $2
+  i32.const 0
+  drop
+  local.get $2
+ )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#get:length (param $0 i32) (result i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+ )
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+ )
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.set $5
+  local.get $2
+  local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
+  local.set $6
+  i32.const 0
+  i32.const 2
+  i32.lt_s
+  drop
+  local.get $4
+  i32.const 4
+  i32.ge_u
+  if (result i32)
+   local.get $5
+   i32.const 7
+   i32.and
+   local.get $6
+   i32.const 7
+   i32.and
+   i32.or
+   i32.eqz
+  else
+   i32.const 0
+  end
+  if
+   block $do-break|0
+    loop $do-continue|0
+     local.get $5
+     i64.load
+     local.get $6
+     i64.load
+     i64.ne
+     if
+      br $do-break|0
+     end
+     local.get $5
+     i32.const 8
+     i32.add
+     local.set $5
+     local.get $6
+     i32.const 8
+     i32.add
+     local.set $6
+     local.get $4
+     i32.const 4
+     i32.sub
+     local.set $4
+     local.get $4
+     i32.const 4
+     i32.ge_u
+     local.set $7
+     local.get $7
+     br_if $do-continue|0
+    end
+   end
+  end
+  loop $while-continue|1
+   local.get $4
+   local.tee $7
+   i32.const 1
+   i32.sub
+   local.set $4
+   local.get $7
+   local.set $7
+   local.get $7
+   if
+    local.get $5
+    i32.load16_u
+    local.set $8
+    local.get $6
+    i32.load16_u
+    local.set $9
+    local.get $8
+    local.get $9
+    i32.ne
+    if
+     local.get $8
+     local.get $9
+     i32.sub
+     return
+    end
+    local.get $5
+    i32.const 2
+    i32.add
+    local.set $5
+    local.get $6
+    i32.const 2
+    i32.add
+    local.set $6
+    br $while-continue|1
+   end
+  end
+  i32.const 0
+ )
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  local.get $1
+  i32.eq
+  if
+   i32.const 1
+   return
+  end
+  local.get $0
+  i32.const 0
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   local.get $1
+   i32.const 0
+   i32.eq
+  end
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  call $~lib/string/String#get:length
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/string/String#get:length
+  i32.ne
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  i32.const 0
+  local.get $1
+  i32.const 0
+  local.get $2
+  call $~lib/util/string/compareImpl
+  i32.eqz
+ )
+ (func $~lib/array/Array<~lib/string/String>#get:length (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#includes (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  i32.const 0
+  drop
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/staticarray/StaticArray<~lib/string/String>#indexOf
+  i32.const 0
+  i32.ge_s
+  return
+ )
+ (func $~lib/staticarray/StaticArray<f64>#get:length (param $0 i32) (result i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 3
+  i32.shr_u
+ )
+ (func $~lib/staticarray/StaticArray<f64>#includes (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 f64)
+  i32.const 1
+  drop
+  local.get $0
+  call $~lib/staticarray/StaticArray<f64>#get:length
+  local.set $3
+  local.get $3
+  i32.const 0
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   local.get $2
+   local.get $3
+   i32.ge_s
+  end
+  if
+   i32.const 0
+   return
+  end
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $3
+   local.get $2
+   i32.add
+   local.tee $4
+   i32.const 0
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $2
+  end
+  loop $while-continue|0
+   local.get $2
+   local.get $3
+   i32.lt_s
+   local.set $4
+   local.get $4
+   if
+    local.get $0
+    local.get $2
+    i32.const 3
+    i32.shl
+    i32.add
+    f64.load
+    local.set $6
+    local.get $6
+    local.get $1
+    f64.eq
+    if (result i32)
+     i32.const 1
+    else
+     local.get $6
+     local.get $6
+     f64.ne
+     local.get $1
+     local.get $1
+     f64.ne
+     i32.and
+    end
+    if
+     i32.const 1
+     return
+    end
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  i32.const 0
+  return
+ )
+ (func $~lib/staticarray/StaticArray<f32>#get:length (param $0 i32) (result i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 2
+  i32.shr_u
+ )
+ (func $~lib/staticarray/StaticArray<f32>#includes (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 f32)
+  i32.const 1
+  drop
+  local.get $0
+  call $~lib/staticarray/StaticArray<f32>#get:length
+  local.set $3
+  local.get $3
+  i32.const 0
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   local.get $2
+   local.get $3
+   i32.ge_s
+  end
+  if
+   i32.const 0
+   return
+  end
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $3
+   local.get $2
+   i32.add
+   local.tee $4
+   i32.const 0
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $2
+  end
+  loop $while-continue|0
+   local.get $2
+   local.get $3
+   i32.lt_s
+   local.set $4
+   local.get $4
+   if
+    local.get $0
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    f32.load
+    local.set $6
+    local.get $6
+    local.get $1
+    f32.eq
+    if (result i32)
+     i32.const 1
+    else
+     local.get $6
+     local.get $6
+     f32.ne
+     local.get $1
+     local.get $1
+     f32.ne
+     i32.and
+    end
+    if
+     i32.const 1
+     return
+    end
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  i32.const 0
+  return
+ )
+ (func $~lib/staticarray/StaticArray<i32>#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  local.set $3
+  local.get $3
+  i32.const 0
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   local.get $2
+   local.get $3
+   i32.ge_s
+  end
+  if
+   i32.const -1
+   return
+  end
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $3
+   local.get $2
+   i32.add
+   local.tee $4
+   i32.const 0
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $2
+  end
+  loop $while-continue|0
+   local.get $2
+   local.get $3
+   i32.lt_s
+   local.set $4
+   local.get $4
+   if
+    local.get $0
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.get $1
+    i32.eq
+    if
+     local.get $2
+     return
+    end
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  i32.const -1
+ )
+ (func $~lib/array/Array<~lib/string/String>#join (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $2
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  i32.const 0
+  drop
+  i32.const 0
+  drop
+  i32.const 0
+  drop
+  i32.const 0
+  i32.const 1
+  i32.lt_s
+  drop
+  i32.const 1
+  drop
+  local.get $2
+  local.get $3
+  local.get $1
+  call $~lib/util/string/joinStringArray
+  return
+ )
+ (func $~lib/array/Array<i32>#lastIndexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $3
+  i32.const 0
+  i32.eq
+  if
+   i32.const -1
+   return
+  end
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $3
+   local.get $2
+   i32.add
+   local.set $2
+  else
+   local.get $2
+   local.get $3
+   i32.ge_s
+   if
+    local.get $3
+    i32.const 1
+    i32.sub
+    local.set $2
+   end
+  end
+  local.get $0
+  i32.load offset=4
+  local.set $4
+  loop $while-continue|0
+   local.get $2
+   i32.const 0
+   i32.ge_s
+   local.set $5
+   local.get $5
+   if
+    local.get $4
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.get $1
+    i32.eq
+    if
+     local.get $2
+     return
+    end
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  i32.const -1
+ )
+ (func $~lib/array/Array<i32>#lastIndexOf@varargs (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  block $1of1
+   block $0of1
+    block $outOfRange
+     global.get $~argumentsLength
+     i32.const 1
+     i32.sub
+     br_table $0of1 $1of1 $outOfRange
+    end
+    unreachable
+   end
+   local.get $0
+   i32.load offset=12
+   local.set $2
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i32>#lastIndexOf
+ )
  (func $~lib/rt/itcms/__collect
   (local $0 i32)
   i32.const 0
@@ -3868,6 +4475,12 @@
   i32.const 64
   local.get $0
   call $~lib/rt/itcms/__visit
+  i32.const 656
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 1152
+  local.get $0
+  call $~lib/rt/itcms/__visit
   i32.const 320
   local.get $0
   call $~lib/rt/itcms/__visit
@@ -3928,36 +4541,187 @@
   local.get $1
   call $~lib/staticarray/StaticArray<std/staticarray/Ref>#__visit
  )
+ (func $~lib/array/Array<i32>#__visit (param $0 i32) (param $1 i32)
+  i32.const 0
+  drop
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/array/Array<i32>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i32>#__visit
+ )
+ (func $~lib/array/Array<usize>#__visit (param $0 i32) (param $1 i32)
+  i32.const 0
+  drop
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/array/Array<usize>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<usize>#__visit
+ )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#__visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  i32.const 1
+  drop
+  local.get $0
+  local.set $2
+  local.get $2
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.add
+  local.set $3
+  loop $while-continue|0
+   local.get $2
+   local.get $3
+   i32.lt_u
+   local.set $4
+   local.get $4
+   if
+    local.get $2
+    i32.load
+    local.set $5
+    local.get $5
+    if
+     local.get $5
+     local.get $1
+     call $~lib/rt/itcms/__visit
+    end
+    local.get $2
+    i32.const 4
+    i32.add
+    local.set $2
+    br $while-continue|0
+   end
+  end
+ )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#__visit
+ )
+ (func $~lib/array/Array<~lib/string/String>#__visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  i32.const 1
+  drop
+  local.get $0
+  i32.load offset=4
+  local.set $2
+  local.get $2
+  local.get $0
+  i32.load offset=12
+  i32.const 2
+  i32.shl
+  i32.add
+  local.set $3
+  loop $while-continue|0
+   local.get $2
+   local.get $3
+   i32.lt_u
+   local.set $4
+   local.get $4
+   if
+    local.get $2
+    i32.load
+    local.set $5
+    local.get $5
+    if
+     local.get $5
+     local.get $1
+     call $~lib/rt/itcms/__visit
+    end
+    local.get $2
+    i32.const 4
+    i32.add
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/array/Array<~lib/string/String>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#__visit
+ )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid
-   block $~lib/staticarray/StaticArray<std/staticarray/Ref>
-    block $std/staticarray/Ref
-     block $~lib/staticarray/StaticArray<i32>
-      block $~lib/arraybuffer/ArrayBufferView
-       block $~lib/string/String
-        block $~lib/arraybuffer/ArrayBuffer
+   block $~lib/staticarray/StaticArray<f32>
+    block $~lib/staticarray/StaticArray<f64>
+     block $~lib/array/Array<~lib/string/String>
+      block $~lib/staticarray/StaticArray<~lib/string/String>
+       block $~lib/array/Array<usize>
+        block $~lib/array/Array<i32>
+         block $~lib/staticarray/StaticArray<std/staticarray/Ref>
+          block $std/staticarray/Ref
+           block $~lib/staticarray/StaticArray<i32>
+            block $~lib/arraybuffer/ArrayBufferView
+             block $~lib/string/String
+              block $~lib/arraybuffer/ArrayBuffer
+               local.get $0
+               i32.const 8
+               i32.sub
+               i32.load
+               br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/staticarray/StaticArray<i32> $std/staticarray/Ref $~lib/staticarray/StaticArray<std/staticarray/Ref> $~lib/array/Array<i32> $~lib/array/Array<usize> $~lib/staticarray/StaticArray<~lib/string/String> $~lib/array/Array<~lib/string/String> $~lib/staticarray/StaticArray<f64> $~lib/staticarray/StaticArray<f32> $invalid
+              end
+              return
+             end
+             return
+            end
+            local.get $0
+            local.get $1
+            call $~lib/arraybuffer/ArrayBufferView~visit
+            return
+           end
+           return
+          end
+          return
+         end
          local.get $0
-         i32.const 8
-         i32.sub
-         i32.load
-         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/staticarray/StaticArray<i32> $std/staticarray/Ref $~lib/staticarray/StaticArray<std/staticarray/Ref> $invalid
+         local.get $1
+         call $~lib/staticarray/StaticArray<std/staticarray/Ref>~visit
+         return
         end
+        local.get $0
+        local.get $1
+        call $~lib/array/Array<i32>~visit
         return
        end
+       local.get $0
+       local.get $1
+       call $~lib/array/Array<usize>~visit
        return
       end
       local.get $0
       local.get $1
-      call $~lib/arraybuffer/ArrayBufferView~visit
+      call $~lib/staticarray/StaticArray<~lib/string/String>~visit
       return
      end
+     local.get $0
+     local.get $1
+     call $~lib/array/Array<~lib/string/String>~visit
      return
     end
     return
    end
-   local.get $0
-   local.get $1
-   call $~lib/staticarray/StaticArray<std/staticarray/Ref>~visit
    return
   end
   unreachable
@@ -3970,31 +4734,166 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 17104
-   i32.const 17152
+   i32.const 18576
+   i32.const 18624
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
  )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  local.set $3
+  local.get $3
+  i32.const 0
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   local.get $2
+   local.get $3
+   i32.ge_s
+  end
+  if
+   i32.const -1
+   local.set $6
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $6
+   return
+  end
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $3
+   local.get $2
+   i32.add
+   local.tee $4
+   i32.const 0
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $2
+  end
+  loop $while-continue|0
+   local.get $2
+   local.get $3
+   i32.lt_s
+   local.set $4
+   local.get $4
+   if
+    local.get $0
+    local.get $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.set $6
+    global.get $~lib/memory/__stack_pointer
+    local.get $6
+    i32.store
+    local.get $6
+    local.get $1
+    call $~lib/string/String.__eq
+    if
+     local.get $2
+     local.set $6
+     global.get $~lib/memory/__stack_pointer
+     i32.const 4
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $6
+     return
+    end
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  i32.const -1
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $6
+ )
+ (func $~lib/array/Array<~lib/string/String>#toString (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 1728
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#join
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
  (func $start:std/staticarray
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 28
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $std/staticarray/arr1
-  local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  i64.const 0
+  i64.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=16
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=24
+  global.get $std/staticarray/arr1
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 2
@@ -4009,11 +4908,11 @@
    unreachable
   end
   global.get $std/staticarray/arr1
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.const 3
   i32.eq
@@ -4027,20 +4926,20 @@
    unreachable
   end
   global.get $std/staticarray/arr1
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   i32.const 4
   call $~lib/staticarray/StaticArray<i32>#__set
   global.get $std/staticarray/arr1
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 4
@@ -4070,11 +4969,11 @@
    unreachable
   end
   global.get $std/staticarray/arr2
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 2
@@ -4089,11 +4988,11 @@
    unreachable
   end
   global.get $std/staticarray/arr2
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.const 3
   i32.eq
@@ -4107,20 +5006,20 @@
    unreachable
   end
   global.get $std/staticarray/arr2
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   i32.const 4
   call $~lib/staticarray/StaticArray<i32>#__set
   global.get $std/staticarray/arr2
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 4
@@ -4154,11 +5053,11 @@
   call $std/staticarray/test
   global.set $std/staticarray/arr3
   global.get $std/staticarray/arr3
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 0
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 5
@@ -4173,11 +5072,11 @@
    unreachable
   end
   global.get $std/staticarray/arr3
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 6
@@ -4192,11 +5091,11 @@
    unreachable
   end
   global.get $std/staticarray/arr3
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 2
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 7
@@ -4211,11 +5110,11 @@
    unreachable
   end
   global.get $std/staticarray/arr3
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   call $~lib/staticarray/StaticArray<i32>#get:length
   i32.const 3
   i32.eq
@@ -4229,20 +5128,20 @@
    unreachable
   end
   global.get $std/staticarray/arr3
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   i32.const 8
   call $~lib/staticarray/StaticArray<i32>#__set
   global.get $std/staticarray/arr3
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 8
@@ -4259,11 +5158,11 @@
   call $std/staticarray/test
   global.set $std/staticarray/arr3
   global.get $std/staticarray/arr3
-  local.set $1
+  local.set $5
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $5
   i32.store
-  local.get $1
+  local.get $5
   i32.const 1
   call $~lib/staticarray/StaticArray<i32>#__get
   i32.const 6
@@ -4300,11 +5199,1063 @@
   global.set $std/staticarray/arr3
   i32.const 0
   global.set $std/staticarray/arr4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 3
+  call $~lib/staticarray/StaticArray<i32>#constructor
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 44
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $1
+  loop $for-loop|0
+   local.get $1
+   local.get $0
+   call $~lib/staticarray/StaticArray<i32>#get:length
+   i32.lt_s
+   local.set $2
+   local.get $2
+   if
+    local.get $0
+    local.get $1
+    call $~lib/staticarray/StaticArray<i32>#__get
+    i32.const 0
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 192
+     i32.const 46
+     i32.const 5
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6
+  i32.const 2
+  i32.const 6
+  i32.const 704
+  call $~lib/rt/__newArray
+  local.tee $1
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  call $~lib/staticarray/StaticArray.fromArray<i32>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  local.get $1
+  call $~lib/array/Array<i32>#get:length
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 56
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $2
+  loop $for-loop|1
+   local.get $2
+   local.get $1
+   call $~lib/array/Array<i32>#get:length
+   i32.lt_s
+   local.set $3
+   local.get $3
+   if
+    local.get $0
+    local.get $2
+    call $~lib/staticarray/StaticArray<i32>#__get
+    local.get $1
+    local.get $2
+    call $~lib/array/Array<i32>#__get
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 192
+     i32.const 58
+     i32.const 5
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|1
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 2
+  i32.const 6
+  i32.const 800
+  call $~lib/rt/__newArray
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  call $~lib/staticarray/StaticArray.fromArray<i32>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 61
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.const 3
+  i32.const 832
+  call $~lib/rt/__newBuffer
+  local.tee $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.const 4
+  i32.const 3
+  i32.const 864
+  call $~lib/rt/__newBuffer
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/staticarray/StaticArray.concat<i32>
+  local.tee $1
+  i32.store offset=8
+  local.get $1
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 69
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.const 0
+  i32.const 3
+  i32.const 896
+  call $~lib/rt/__newBuffer
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/staticarray/StaticArray.concat<i32>
+  local.tee $1
+  i32.store offset=8
+  local.get $1
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  local.get $0
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 71
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 20
+  i32.const 8
+  i32.const 1104
+  call $~lib/rt/__newBuffer
+  local.tee $1
+  i32.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 0
+  global.get $~lib/builtins/i32.MAX_VALUE
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  local.get $1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 78
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $3
+  loop $for-loop|2
+   local.get $3
+   local.get $1
+   call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+   i32.lt_s
+   local.set $2
+   local.get $2
+   if
+    local.get $1
+    local.get $3
+    call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store
+    local.get $5
+    local.get $0
+    local.get $3
+    call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+    local.set $5
+    global.get $~lib/memory/__stack_pointer
+    local.get $5
+    i32.store offset=12
+    local.get $5
+    call $~lib/string/String.__eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 192
+     i32.const 81
+     i32.const 5
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $for-loop|2
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 1
+  i32.const 3
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 85
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  i32.const 960
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 86
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  i32.const 992
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 87
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 1
+  global.get $~lib/builtins/i32.MAX_VALUE
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  local.get $1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.const 1
+  i32.sub
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 90
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 0
+  i32.const 50
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  local.get $1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 93
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 100
+  global.get $~lib/builtins/i32.MAX_VALUE
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 96
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const -1
+  global.get $~lib/builtins/i32.MAX_VALUE
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 99
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  i32.const 1056
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 100
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const -2
+  i32.const -2
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 103
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.const 2
+  i32.const -2
+  call $~lib/staticarray/StaticArray.slice<~lib/string/String>
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 106
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#__get
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  i32.const 992
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 107
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 20
+  i32.const 8
+  i32.const 1280
+  call $~lib/rt/__newBuffer
+  local.tee $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.const 0
+  i32.const 2
+  i32.const 9
+  i32.const 1328
+  call $~lib/rt/__newArray
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/staticarray/StaticArray<~lib/string/String>#concat
+  local.tee $3
+  i32.store offset=16
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:length
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 115
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  drop
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.const 1
+  i32.const 2
+  i32.const 9
+  i32.const 1392
+  call $~lib/rt/__newArray
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/staticarray/StaticArray<~lib/string/String>#concat
+  local.tee $3
+  i32.store offset=16
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#get:length
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.const 1
+  i32.add
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 119
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  drop
+  global.get $~lib/memory/__stack_pointer
+  i32.const 20
+  i32.const 8
+  i32.const 1424
+  call $~lib/rt/__newBuffer
+  local.tee $3
+  i32.store offset=16
+  local.get $3
+  i32.const 960
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#includes
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 126
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 1360
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  i32.const 0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#includes
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 127
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 1056
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  i32.const 5
+  call $~lib/staticarray/StaticArray<~lib/string/String>#includes
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 128
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 1056
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  i32.const -1
+  call $~lib/staticarray/StaticArray<~lib/string/String>#includes
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 129
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 8
+  i32.const 10
+  i32.const 1472
+  call $~lib/rt/__newBuffer
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  f64.const nan:0x8000000000000
+  i32.const 0
+  call $~lib/staticarray/StaticArray<f64>#includes
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 131
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 4
+  i32.const 11
+  i32.const 1504
+  call $~lib/rt/__newBuffer
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  f32.const nan:0x400000
+  i32.const 0
+  call $~lib/staticarray/StaticArray<f32>#includes
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 132
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.const 3
+  i32.const 1536
+  call $~lib/rt/__newBuffer
+  local.tee $3
+  i32.store offset=16
+  local.get $3
+  i32.const 2
+  i32.const 0
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 138
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 7
+  i32.const 0
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 139
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 9
+  i32.const 2
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 140
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 2
+  i32.const -1
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 141
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 2
+  i32.const -3
+  call $~lib/staticarray/StaticArray<i32>#indexOf
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 142
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3
+  i32.const 2
+  i32.const 9
+  i32.const 1664
+  call $~lib/rt/__newArray
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  i32.const 1728
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=20
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#join
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  i32.const 1760
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 148
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 1696
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=20
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#join
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  i32.const 1808
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 149
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 1856
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=20
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#join
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  i32.const 1888
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 150
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 1936
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=20
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#join
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  i32.const 1968
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 151
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 1728
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=20
+  local.get $5
+  call $~lib/array/Array<~lib/string/String>#join
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store
+  local.get $5
+  local.get $0
+  call $~lib/array/Array<~lib/string/String>#toString
+  local.set $5
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.store offset=12
+  local.get $5
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 152
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.const 2
+  i32.const 6
+  i32.const 2032
+  call $~lib/rt/__newArray
+  local.tee $4
+  i32.store offset=24
+  local.get $4
+  i32.const 2
+  i32.const 1
+  global.set $~argumentsLength
+  i32.const 0
+  call $~lib/array/Array<i32>#lastIndexOf@varargs
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 158
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 7
+  i32.const 1
+  global.set $~argumentsLength
+  i32.const 0
+  call $~lib/array/Array<i32>#lastIndexOf@varargs
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 159
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 2
+  i32.const 3
+  call $~lib/array/Array<i32>#lastIndexOf
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 160
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 2
+  i32.const 2
+  call $~lib/array/Array<i32>#lastIndexOf
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 161
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 2
+  i32.const -2
+  call $~lib/array/Array<i32>#lastIndexOf
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 162
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 2
+  i32.const -1
+  call $~lib/array/Array<i32>#lastIndexOf
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 192
+   i32.const 163
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
   global.get $~lib/memory/__heap_base
   global.set $~lib/memory/__stack_pointer
   call $~lib/rt/itcms/__collect
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 28
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -4335,5 +6286,777 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
+ )
+ (func $~lib/staticarray/StaticArray<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  i32.const 1073741820
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 656
+   i32.const 128
+   i32.const 88
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 2
+  i32.shl
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.const 3
+  call $~lib/rt/itcms/__new
+  local.tee $3
+  i32.store
+  local.get $3
+  i32.const 0
+  local.get $2
+  call $~lib/memory/memory.fill
+  local.get $3
+  local.set $4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $4
+ )
+ (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  local.get $1
+  i32.shl
+  local.set $4
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.const 0
+  local.get $3
+  call $~lib/rt/__newBuffer
+  local.tee $5
+  i32.store
+  i32.const 16
+  local.get $2
+  call $~lib/rt/itcms/__new
+  local.set $6
+  local.get $6
+  local.get $5
+  i32.store
+  local.get $6
+  local.get $5
+  i32.const 0
+  call $~lib/rt/itcms/__link
+  local.get $6
+  local.get $5
+  i32.store offset=4
+  local.get $6
+  local.get $4
+  i32.store offset=8
+  local.get $6
+  local.get $0
+  i32.store offset=12
+  local.get $6
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $7
+ )
+ (func $~lib/staticarray/StaticArray.fromArray<i32> (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  call $~lib/array/Array<i32>#get:length
+  local.set $1
+  local.get $1
+  i32.const 2
+  i32.shl
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.const 3
+  call $~lib/rt/itcms/__new
+  local.tee $3
+  i32.store
+  i32.const 0
+  drop
+  local.get $3
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  call $~lib/memory/memory.copy
+  local.get $3
+  local.set $4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $4
+ )
+ (func $~lib/staticarray/StaticArray.concat<i32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  local.set $2
+  i32.const 0
+  local.get $1
+  call $~lib/staticarray/StaticArray<i32>#get:length
+  local.get $1
+  i32.const 0
+  i32.eq
+  select
+  local.set $3
+  local.get $2
+  local.get $3
+  i32.add
+  local.set $4
+  local.get $4
+  i32.const 1073741820
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 656
+   i32.const 128
+   i32.const 41
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.const 2
+  i32.shl
+  i32.const 3
+  call $~lib/rt/itcms/__new
+  local.tee $5
+  i32.store
+  local.get $5
+  local.set $6
+  local.get $2
+  i32.const 2
+  i32.shl
+  local.set $7
+  i32.const 0
+  drop
+  local.get $6
+  local.get $0
+  local.get $7
+  call $~lib/memory/memory.copy
+  local.get $6
+  local.get $7
+  i32.add
+  local.get $1
+  local.get $3
+  i32.const 2
+  i32.shl
+  call $~lib/memory/memory.copy
+  local.get $5
+  local.set $8
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $8
+ )
+ (func $~lib/staticarray/StaticArray.slice<~lib/string/String> (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  local.set $3
+  local.get $1
+  i32.const 0
+  i32.lt_s
+  if (result i32)
+   local.get $1
+   local.get $3
+   i32.add
+   local.tee $4
+   i32.const 0
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+  else
+   local.get $1
+   local.tee $5
+   local.get $3
+   local.tee $4
+   local.get $5
+   local.get $4
+   i32.lt_s
+   select
+  end
+  local.set $1
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if (result i32)
+   local.get $2
+   local.get $3
+   i32.add
+   local.tee $4
+   i32.const 0
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+  else
+   local.get $2
+   local.tee $5
+   local.get $3
+   local.tee $4
+   local.get $5
+   local.get $4
+   i32.lt_s
+   select
+  end
+  local.set $2
+  local.get $2
+  local.get $1
+  i32.sub
+  local.tee $4
+  i32.const 0
+  local.tee $5
+  local.get $4
+  local.get $5
+  i32.gt_s
+  select
+  local.set $3
+  local.get $3
+  i32.const 2
+  i32.shl
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $6
+  i32.const 8
+  call $~lib/rt/itcms/__new
+  local.tee $7
+  i32.store
+  local.get $0
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.set $8
+  i32.const 1
+  drop
+  i32.const 0
+  local.set $4
+  loop $while-continue|0
+   local.get $4
+   local.get $6
+   i32.lt_u
+   local.set $5
+   local.get $5
+   if
+    local.get $8
+    local.get $4
+    i32.add
+    i32.load
+    local.set $9
+    local.get $7
+    local.get $4
+    i32.add
+    local.get $9
+    i32.store
+    local.get $7
+    local.get $9
+    i32.const 1
+    call $~lib/rt/itcms/__link
+    local.get $4
+    i32.const 4
+    i32.add
+    local.set $4
+    br $while-continue|0
+   end
+  end
+  local.get $7
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $10
+ )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  i32.ge_u
+  if
+   i32.const 64
+   i32.const 128
+   i32.const 113
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.tee $2
+  i32.store
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  local.get $2
+  i32.eqz
+  if
+   i32.const 1152
+   i32.const 128
+   i32.const 117
+   i32.const 40
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
+ )
+ (func $~lib/staticarray/StaticArray<~lib/string/String>#concat (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  call $~lib/staticarray/StaticArray<~lib/string/String>#get:length
+  local.set $2
+  i32.const 0
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#get:length
+  local.get $1
+  i32.const 0
+  i32.eq
+  select
+  local.set $3
+  local.get $2
+  local.get $3
+  i32.add
+  local.set $4
+  local.get $4
+  i32.const 1073741820
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 656
+   i32.const 128
+   i32.const 183
+   i32.const 60
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.const 2
+  i32.const 9
+  i32.const 0
+  call $~lib/rt/__newArray
+  local.tee $5
+  i32.store
+  local.get $5
+  i32.load offset=4
+  local.set $6
+  local.get $2
+  i32.const 2
+  i32.shl
+  local.set $7
+  i32.const 1
+  drop
+  local.get $0
+  local.set $8
+  i32.const 0
+  local.set $9
+  loop $for-loop|0
+   local.get $9
+   local.get $7
+   i32.lt_u
+   local.set $10
+   local.get $10
+   if
+    local.get $8
+    local.get $9
+    i32.add
+    i32.load
+    local.set $11
+    local.get $6
+    local.get $9
+    i32.add
+    local.get $11
+    i32.store
+    local.get $5
+    local.get $11
+    i32.const 1
+    call $~lib/rt/itcms/__link
+    local.get $9
+    i32.const 4
+    i32.add
+    local.set $9
+    br $for-loop|0
+   end
+  end
+  local.get $6
+  local.get $7
+  i32.add
+  local.set $6
+  local.get $1
+  i32.load offset=4
+  local.set $9
+  local.get $3
+  i32.const 2
+  i32.shl
+  local.set $10
+  i32.const 0
+  local.set $11
+  loop $for-loop|1
+   local.get $11
+   local.get $10
+   i32.lt_u
+   local.set $12
+   local.get $12
+   if
+    local.get $9
+    local.get $11
+    i32.add
+    i32.load
+    local.set $13
+    local.get $6
+    local.get $11
+    i32.add
+    local.get $13
+    i32.store
+    local.get $5
+    local.get $13
+    i32.const 1
+    call $~lib/rt/itcms/__link
+    local.get $11
+    i32.const 4
+    i32.add
+    local.set $11
+    br $for-loop|1
+   end
+  end
+  local.get $5
+  local.set $14
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $14
+ )
+ (func $~lib/util/string/joinStringArray (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  local.get $1
+  i32.const 1
+  i32.sub
+  local.set $3
+  local.get $3
+  i32.const 0
+  i32.lt_s
+  if
+   i32.const 1696
+   local.set $12
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $12
+   return
+  end
+  local.get $3
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.load
+   local.tee $4
+   i32.store
+   local.get $4
+   if (result i32)
+    local.get $4
+   else
+    i32.const 1696
+   end
+   local.set $12
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $12
+   return
+  end
+  i32.const 0
+  local.set $5
+  i32.const 0
+  local.set $4
+  loop $for-loop|0
+   local.get $4
+   local.get $1
+   i32.lt_s
+   local.set $7
+   local.get $7
+   if
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.tee $6
+    i32.store offset=4
+    local.get $6
+    i32.const 0
+    i32.ne
+    if
+     local.get $5
+     local.get $6
+     call $~lib/string/String#get:length
+     i32.add
+     local.set $5
+    end
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
+    br $for-loop|0
+   end
+  end
+  i32.const 0
+  local.set $8
+  local.get $2
+  call $~lib/string/String#get:length
+  local.set $9
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  local.get $9
+  local.get $3
+  i32.mul
+  i32.add
+  i32.const 1
+  i32.shl
+  i32.const 1
+  call $~lib/rt/itcms/__new
+  local.tee $10
+  i32.store offset=8
+  i32.const 0
+  local.set $4
+  loop $for-loop|1
+   local.get $4
+   local.get $3
+   i32.lt_s
+   local.set $7
+   local.get $7
+   if
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.tee $6
+    i32.store offset=4
+    local.get $6
+    i32.const 0
+    i32.ne
+    if
+     local.get $6
+     call $~lib/string/String#get:length
+     local.set $11
+     local.get $10
+     local.get $8
+     i32.const 1
+     i32.shl
+     i32.add
+     local.get $6
+     local.get $11
+     i32.const 1
+     i32.shl
+     call $~lib/memory/memory.copy
+     local.get $8
+     local.get $11
+     i32.add
+     local.set $8
+    end
+    local.get $9
+    if
+     local.get $10
+     local.get $8
+     i32.const 1
+     i32.shl
+     i32.add
+     local.get $2
+     local.get $9
+     i32.const 1
+     i32.shl
+     call $~lib/memory/memory.copy
+     local.get $8
+     local.get $9
+     i32.add
+     local.set $8
+    end
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
+    br $for-loop|1
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  local.get $3
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.tee $6
+  i32.store offset=4
+  local.get $6
+  i32.const 0
+  i32.ne
+  if
+   local.get $10
+   local.get $8
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $6
+   local.get $6
+   call $~lib/string/String#get:length
+   i32.const 1
+   i32.shl
+   call $~lib/memory/memory.copy
+  end
+  local.get $10
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $12
  )
 )


### PR DESCRIPTION
Adds the following missing tests for StaticArray:

- constructor
- fromArray
- concat (static)
- slice (static)
- concat (instance)
- includes
- indexOf
- join + toString

- [x] I've read the contributing guidelines