### PR TITLE
fix: read stream signature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,7 @@ jobs:
       env:
         ASC_FEATURES: mutable-globals,threads,reference-types,bigint-integration,gc
       run: |
-        npm run test:compiler rt/flags features/js-bigint-integration features/reference-types features/threads
+        npm run test:compiler rt/flags features/js-bigint-integration features/reference-types features/threads std-wasi/process std-wasi/crypto
   test-runtimes:
     name: "Runtimes"
     runs-on: ubuntu-latest

--- a/std/assembly/process.ts
+++ b/std/assembly/process.ts
@@ -133,7 +133,7 @@ abstract class WritableStream extends Stream {
 abstract class ReadableStream extends Stream {
   read(buffer: ArrayBuffer, offset: usize = 0): i32 {
     var end = <usize>buffer.byteLength;
-    if (offset < 0 || offset > end) {
+    if (offset > end) {
       throw new Error(E_INDEXOUTOFRANGE);
     }
     store<usize>(iobuf, changetype<usize>(buffer) + offset);

--- a/std/assembly/process.ts
+++ b/std/assembly/process.ts
@@ -131,7 +131,7 @@ abstract class WritableStream extends Stream {
 
 @unmanaged
 abstract class ReadableStream extends Stream {
-  read(buffer: ArrayBuffer, offset: isize = 0): i32 {
+  read(buffer: ArrayBuffer, offset: usize = 0): i32 {
     var end = <usize>buffer.byteLength;
     if (offset < 0 || offset > end) {
       throw new Error(E_INDEXOUTOFRANGE);

--- a/std/assembly/process.ts
+++ b/std/assembly/process.ts
@@ -131,9 +131,9 @@ abstract class WritableStream extends Stream {
 
 @unmanaged
 abstract class ReadableStream extends Stream {
-  read(buffer: ArrayBuffer, offset: usize = 0): i32 {
+  read(buffer: ArrayBuffer, offset: isize = 0): i32 {
     var end = <usize>buffer.byteLength;
-    if (offset > end) {
+    if (offset < 0 || <usize>offset > end) {
       throw new Error(E_INDEXOUTOFRANGE);
     }
     store<usize>(iobuf, changetype<usize>(buffer) + offset);

--- a/tests/compiler/std-wasi/crypto.optimized.wat
+++ b/tests/compiler/std-wasi/crypto.optimized.wat
@@ -201,16 +201,14 @@
  (data (i32.const 4984) "\01\00\00\00H\00\00\000\001\002\003\004\005\006\007\008\009\00a\00b\00c\00d\00e\00f\00g\00h\00i\00j\00k\00l\00m\00n\00o\00p\00q\00r\00s\00t\00u\00v\00w\00x\00y\00z")
  (data (i32.const 5068) "\1c")
  (data (i32.const 5080) "\01\00\00\00\02\00\00\00,")
- (data (i32.const 5100) "\1c")
- (data (i32.const 5112) "\01\00\00\00\08\00\00\00n\00u\00l\00l")
- (data (i32.const 5164) "<")
- (data (i32.const 5176) "\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00p\00r\00o\00c\00e\00s\00s\00.\00t\00s")
- (data (i32.const 5228) "\1c")
- (data (i32.const 5240) "\01\00\00\00\02\00\00\00\n")
- (data (i32.const 5260) "<")
- (data (i32.const 5272) "\01\00\00\00$\00\00\00s\00t\00d\00-\00w\00a\00s\00i\00/\00c\00r\00y\00p\00t\00o\00.\00t\00s")
- (data (i32.const 5328) "\04\00\00\00 \00\00\00\00\00\00\00 ")
- (data (i32.const 5356) "A\00\00\00\02")
+ (data (i32.const 5132) "<")
+ (data (i32.const 5144) "\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00p\00r\00o\00c\00e\00s\00s\00.\00t\00s")
+ (data (i32.const 5196) "\1c")
+ (data (i32.const 5208) "\01\00\00\00\02\00\00\00\n")
+ (data (i32.const 5228) "<")
+ (data (i32.const 5240) "\01\00\00\00$\00\00\00s\00t\00d\00-\00w\00a\00s\00i\00/\00c\00r\00y\00p\00t\00o\00.\00t\00s")
+ (data (i32.const 5296) "\04\00\00\00 \00\00\00\00\00\00\00 ")
+ (data (i32.const 5324) "A\00\00\00\02")
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
@@ -225,7 +223,7 @@
  (global $std-wasi/crypto/buf (mut i32) (i32.const 0))
  (global $std-wasi/crypto/b1 (mut i32) (i32.const 0))
  (global $std-wasi/crypto/b2 (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 21748))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 21716))
  (global $~started (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
@@ -722,7 +720,7 @@
    if
     i32.const 0
     local.get $0
-    i32.const 21748
+    i32.const 21716
     i32.lt_u
     local.get $0
     i32.load offset=8
@@ -768,7 +766,7 @@
    i32.const 1
   else
    local.get $1
-   i32.const 5328
+   i32.const 5296
    i32.load
    i32.gt_u
    if
@@ -782,7 +780,7 @@
    local.get $1
    i32.const 3
    i32.shl
-   i32.const 5332
+   i32.const 5300
    i32.add
    i32.load
    i32.const 32
@@ -1387,10 +1385,10 @@
   if
    unreachable
   end
-  i32.const 21760
+  i32.const 21728
   i32.const 0
   i32.store
-  i32.const 23328
+  i32.const 23296
   i32.const 0
   i32.store
   loop $for-loop|0
@@ -1401,7 +1399,7 @@
     local.get $1
     i32.const 2
     i32.shl
-    i32.const 21760
+    i32.const 21728
     i32.add
     i32.const 0
     i32.store offset=4
@@ -1419,7 +1417,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 21760
+      i32.const 21728
       i32.add
       i32.const 0
       i32.store offset=96
@@ -1437,20 +1435,20 @@
     br $for-loop|0
    end
   end
-  i32.const 21760
-  i32.const 23332
+  i32.const 21728
+  i32.const 23300
   memory.size
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 21760
+  i32.const 21728
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/tlsf/__free (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
-  i32.const 21748
+  i32.const 21716
   i32.lt_u
   if
    return
@@ -1574,7 +1572,7 @@
       local.set $0
       loop $while-continue|0
        local.get $0
-       i32.const 21748
+       i32.const 21716
        i32.lt_u
        if
         local.get $0
@@ -1664,7 +1662,7 @@
       unreachable
      end
      local.get $0
-     i32.const 21748
+     i32.const 21716
      i32.lt_u
      if
       local.get $0
@@ -2919,6 +2917,71 @@
    end
   end
  )
+ (func $~lib/string/String.__concat (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  block $__inlined_func$~lib/string/String#concat
+   local.get $0
+   local.tee $1
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 1
+   i32.shr_u
+   i32.const 1
+   i32.shl
+   local.tee $3
+   i32.const 4652
+   i32.load
+   i32.const 1
+   i32.shr_u
+   i32.const 1
+   i32.shl
+   local.tee $2
+   i32.add
+   local.tee $0
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    i32.const 4736
+    local.set $0
+    br $__inlined_func$~lib/string/String#concat
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   local.get $0
+   i32.const 4656
+   local.get $2
+   call $~lib/memory/memory.copy
+   local.get $0
+   local.get $2
+   i32.add
+   local.get $1
+   local.get $3
+   call $~lib/memory/memory.copy
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+  end
+  local.get $0
+ )
  (func $~lib/process/writeString (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2971,10 +3034,10 @@
     i32.const 128
     i32.ge_u
     br_if $break|0
-    i32.const 5136
-    i32.const 5144
+    i32.const 5104
+    i32.const 5112
     i32.store
-    i32.const 5140
+    i32.const 5108
     local.get $3
     i32.const -1
     i32.ne
@@ -2989,7 +3052,7 @@
     i32.ne
     i32.add
     i32.store
-    i32.const 5144
+    i32.const 5112
     local.get $2
     local.get $3
     i32.const 8
@@ -3005,9 +3068,9 @@
     i32.or
     i32.store
     i32.const 1
-    i32.const 5136
+    i32.const 5104
     i32.const 1
-    i32.const 5148
+    i32.const 5116
     call $~lib/bindings/wasi_snapshot_preview1/fd_write
     local.tee $0
     i32.const 65535
@@ -3015,7 +3078,7 @@
     if
      local.get $0
      call $~lib/bindings/wasi_snapshot_preview1/errnoToString
-     i32.const 5184
+     i32.const 5152
      i32.const 178
      i32.const 16
      call $~lib/wasi/index/abort
@@ -3118,22 +3181,22 @@
   i32.ne
   if
    i32.const 0
-   i32.const 5184
+   i32.const 5152
    i32.const 184
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
   end
-  i32.const 5136
+  i32.const 5104
   local.get $1
   i32.store
-  i32.const 5140
+  i32.const 5108
   local.get $2
   i32.store
   i32.const 1
-  i32.const 5136
+  i32.const 5104
   i32.const 1
-  i32.const 5144
+  i32.const 5112
   call $~lib/bindings/wasi_snapshot_preview1/fd_write
   local.set $0
   local.get $1
@@ -3144,7 +3207,7 @@
   if
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
-   i32.const 5184
+   i32.const 5152
    i32.const 189
    i32.const 12
    call $~lib/wasi/index/abort
@@ -3214,11 +3277,11 @@
  )
  (func $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i32.const 5364
+  i32.const 5332
   i32.lt_s
   if
-   i32.const 21776
-   i32.const 21824
+   i32.const 21744
+   i32.const 21792
    i32.const 1
    i32.const 1
    call $~lib/wasi/index/abort
@@ -3247,94 +3310,6 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/string/String.__concat (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4656
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  block $__inlined_func$~lib/string/String#concat
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 5120
-    i32.store
-    i32.const 5120
-    local.set $0
-   end
-   local.get $0
-   i32.const 20
-   i32.sub
-   i32.load offset=16
-   i32.const 1
-   i32.shr_u
-   i32.const 1
-   i32.shl
-   local.tee $3
-   i32.const 4652
-   i32.load
-   i32.const 1
-   i32.shr_u
-   i32.const 1
-   i32.shl
-   local.tee $2
-   i32.add
-   local.tee $1
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    i32.const 4736
-    local.set $1
-    br $__inlined_func$~lib/string/String#concat
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $1
-   i32.store offset=4
-   local.get $1
-   i32.const 4656
-   local.get $2
-   call $~lib/memory/memory.copy
-   local.get $1
-   local.get $2
-   i32.add
-   local.get $0
-   local.get $3
-   call $~lib/memory/memory.copy
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $1
- )
  (func $~lib/console/console.log (param $0 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3347,9 +3322,9 @@
   local.get $0
   call $~lib/process/writeString
   global.get $~lib/memory/__stack_pointer
-  i32.const 5248
+  i32.const 5216
   i32.store
-  i32.const 5248
+  i32.const 5216
   call $~lib/process/writeString
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3374,7 +3349,7 @@
   memory.size
   i32.const 16
   i32.shl
-  i32.const 21748
+  i32.const 21716
   i32.sub
   i32.const 1
   i32.shr_u
@@ -3530,7 +3505,7 @@
     i32.ne
     if
      i32.const 0
-     i32.const 5280
+     i32.const 5248
      i32.const 17
      i32.const 3
      call $~lib/wasi/index/abort
@@ -3571,7 +3546,7 @@
     i32.ne
     if
      i32.const 0
-     i32.const 5280
+     i32.const 5248
      i32.const 20
      i32.const 3
      call $~lib/wasi/index/abort

--- a/tests/compiler/std-wasi/crypto.untouched.wat
+++ b/tests/compiler/std-wasi/crypto.untouched.wat
@@ -115,12 +115,11 @@
  (data (i32.const 4348) "\1c\04\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\04\00\000\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\000\00a\000\00b\000\00c\000\00d\000\00e\000\00f\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\001\00a\001\00b\001\00c\001\00d\001\00e\001\00f\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\002\00a\002\00b\002\00c\002\00d\002\00e\002\00f\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\003\00a\003\00b\003\00c\003\00d\003\00e\003\00f\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\004\00a\004\00b\004\00c\004\00d\004\00e\004\00f\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\005\00a\005\00b\005\00c\005\00d\005\00e\005\00f\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\006\00a\006\00b\006\00c\006\00d\006\00e\006\00f\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\007\00a\007\00b\007\00c\007\00d\007\00e\007\00f\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\008\00a\008\00b\008\00c\008\00d\008\00e\008\00f\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\009\00a\009\00b\009\00c\009\00d\009\00e\009\00f\00a\000\00a\001\00a\002\00a\003\00a\004\00a\005\00a\006\00a\007\00a\008\00a\009\00a\00a\00a\00b\00a\00c\00a\00d\00a\00e\00a\00f\00b\000\00b\001\00b\002\00b\003\00b\004\00b\005\00b\006\00b\007\00b\008\00b\009\00b\00a\00b\00b\00b\00c\00b\00d\00b\00e\00b\00f\00c\000\00c\001\00c\002\00c\003\00c\004\00c\005\00c\006\00c\007\00c\008\00c\009\00c\00a\00c\00b\00c\00c\00c\00d\00c\00e\00c\00f\00d\000\00d\001\00d\002\00d\003\00d\004\00d\005\00d\006\00d\007\00d\008\00d\009\00d\00a\00d\00b\00d\00c\00d\00d\00d\00e\00d\00f\00e\000\00e\001\00e\002\00e\003\00e\004\00e\005\00e\006\00e\007\00e\008\00e\009\00e\00a\00e\00b\00e\00c\00e\00d\00e\00e\00e\00f\00f\000\00f\001\00f\002\00f\003\00f\004\00f\005\00f\006\00f\007\00f\008\00f\009\00f\00a\00f\00b\00f\00c\00f\00d\00f\00e\00f\00f\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 5404) "\\\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00H\00\00\000\001\002\003\004\005\006\007\008\009\00a\00b\00c\00d\00e\00f\00g\00h\00i\00j\00k\00l\00m\00n\00o\00p\00q\00r\00s\00t\00u\00v\00w\00x\00y\00z\00\00\00\00\00")
  (data (i32.const 5500) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00,\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 5532) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00n\00u\00l\00l\00\00\00\00\00")
- (data (i32.const 5568) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 5596) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00p\00r\00o\00c\00e\00s\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 5660) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00\n\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 5692) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00s\00t\00d\00-\00w\00a\00s\00i\00/\00c\00r\00y\00p\00t\00o\00.\00t\00s\00\00\00\00\00\00\00\00\00")
- (data (i32.const 5760) "\04\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00A\00\00\00\02\00\00\00")
+ (data (i32.const 5536) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 5564) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00p\00r\00o\00c\00e\00s\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 5628) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00\n\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 5660) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00s\00t\00d\00-\00w\00a\00s\00i\00/\00c\00r\00y\00p\00t\00o\00.\00t\00s\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 5728) "\04\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00A\00\00\00\02\00\00\00")
  (table $0 1 funcref)
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -137,15 +136,15 @@
  (global $std-wasi/crypto/ab (mut i32) (i32.const 0))
  (global $std-wasi/crypto/buf (mut i32) (i32.const 0))
  (global $~lib/process/process.stdout i32 (i32.const 1))
- (global $~lib/process/iobuf i32 (i32.const 5568))
+ (global $~lib/process/iobuf i32 (i32.const 5536))
  (global $~lib/builtins/i32.MAX_VALUE i32 (i32.const 2147483647))
  (global $std-wasi/crypto/b1 (mut i32) (i32.const 0))
  (global $std-wasi/crypto/b2 (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 5760))
- (global $~lib/memory/__data_end i32 (i32.const 5796))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 22180))
- (global $~lib/memory/__heap_base i32 (i32.const 22180))
+ (global $~lib/rt/__rtti_base i32 (i32.const 5728))
+ (global $~lib/memory/__data_end i32 (i32.const 5764))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 22148))
+ (global $~lib/memory/__heap_base i32 (i32.const 22148))
  (global $~started (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
@@ -5329,6 +5328,11 @@
   local.get $1
   call $~lib/util/string/joinIntegerArray<u8>
  )
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  call $~lib/string/String#concat
+ )
  (func $~lib/string/String.UTF8.byteLength (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -5571,7 +5575,7 @@
     if
      local.get $6
      call $~lib/bindings/wasi_snapshot_preview1/errnoToString
-     i32.const 5616
+     i32.const 5584
      i32.const 178
      i32.const 16
      call $~lib/wasi/index/abort
@@ -5598,7 +5602,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 5616
+   i32.const 5584
    i32.const 184
    i32.const 3
    call $~lib/wasi/index/abort
@@ -5628,7 +5632,7 @@
   if
    local.get $9
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
-   i32.const 5616
+   i32.const 5584
    i32.const 189
    i32.const 12
    call $~lib/wasi/index/abort
@@ -5807,8 +5811,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 22208
-   i32.const 22256
+   i32.const 22176
+   i32.const 22224
    i32.const 1
    i32.const 1
    call $~lib/wasi/index/abort
@@ -5840,36 +5844,6 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 5552
-  local.get $0
-  i32.const 0
-  i32.ne
-  select
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store
-  local.get $2
-  local.get $1
-  call $~lib/string/String#concat
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $2
- )
  (func $~lib/console/console.log (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5887,7 +5861,7 @@
   local.get $0
   call $~lib/process/WritableStream#write<~lib/string/String>
   local.get $1
-  i32.const 5680
+  i32.const 5648
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -6080,7 +6054,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 5712
+     i32.const 5680
      i32.const 17
      i32.const 3
      call $~lib/wasi/index/abort
@@ -6124,7 +6098,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 5712
+     i32.const 5680
      i32.const 20
      i32.const 3
      call $~lib/wasi/index/abort
@@ -6752,22 +6726,13 @@
   (local $5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $1
   i32.const 0
-  i32.eq
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5552
-   local.tee $1
-   i32.store
-  end
+  i32.store
   local.get $0
   call $~lib/string/String#get:length
   i32.const 1
@@ -6789,7 +6754,7 @@
    i32.const 3712
    local.set $6
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $6
@@ -6800,7 +6765,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $5
-  i32.store offset=4
+  i32.store
   local.get $5
   local.get $0
   local.get $2
@@ -6814,7 +6779,7 @@
   local.get $5
   local.set $6
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $6

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -7,8 +7,8 @@
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
@@ -19,6 +19,7 @@
  (import "wasi_snapshot_preview1" "environ_sizes_get" (func $~lib/bindings/wasi_snapshot_preview1/environ_sizes_get (param i32 i32) (result i32)))
  (import "wasi_snapshot_preview1" "environ_get" (func $~lib/bindings/wasi_snapshot_preview1/environ_get (param i32 i32) (result i32)))
  (import "wasi_snapshot_preview1" "clock_time_get" (func $~lib/bindings/wasi_snapshot_preview1/clock_time_get (param i32 i64 i32) (result i32)))
+ (import "wasi_snapshot_preview1" "fd_read" (func $~lib/bindings/wasi_snapshot_preview1/fd_read (param i32 i32 i32 i32) (result i32)))
  (memory $0 1)
  (data (i32.const 1036) ",")
  (data (i32.const 1048) "\01\00\00\00\14\00\00\00=\00=\00 \00a\00r\00c\00h\00 \00=\00=")
@@ -4637,6 +4638,43 @@
   call $~lib/console/console.log
   i32.const 42
   call $~lib/bindings/wasi_snapshot_preview1/proc_exit
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  local.set $1
+  i32.const 1088
+  local.get $0
+  i32.store
+  i32.const 1092
+  local.get $1
+  i32.store
+  i32.const 0
+  i32.const 1088
+  i32.const 1
+  i32.const 1096
+  call $~lib/bindings/wasi_snapshot_preview1/fd_read
+  local.tee $0
+  i32.const 65535
+  i32.and
+  if
+   local.get $0
+   call $~lib/bindings/wasi_snapshot_preview1/errnoToString
+   i32.const 4112
+   i32.const 142
+   i32.const 14
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  i32.const 1096
+  i32.load
+  drop
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
@@ -4736,7 +4774,7 @@
   if
    i32.const 0
    i32.const 4816
-   i32.const 749
+   i32.const 746
    i32.const 7
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.ts
+++ b/tests/compiler/std-wasi/process.ts
@@ -31,3 +31,5 @@ console.log(process.hrtime().toString());
 
 console.log("== exit ==");
 process.exit(42);
+
+process.stdin.read(new ArrayBuffer(0));

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -8,8 +8,8 @@
  (type $none_=>_none (func))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $none_=>_i64 (func (result i64)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
@@ -23,6 +23,7 @@
  (import "wasi_snapshot_preview1" "environ_sizes_get" (func $~lib/bindings/wasi_snapshot_preview1/environ_sizes_get (param i32 i32) (result i32)))
  (import "wasi_snapshot_preview1" "environ_get" (func $~lib/bindings/wasi_snapshot_preview1/environ_get (param i32 i32) (result i32)))
  (import "wasi_snapshot_preview1" "clock_time_get" (func $~lib/bindings/wasi_snapshot_preview1/clock_time_get (param i32 i64 i32) (result i32)))
+ (import "wasi_snapshot_preview1" "fd_read" (func $~lib/bindings/wasi_snapshot_preview1/fd_read (param i32 i32 i32 i32) (result i32)))
  (memory $0 1)
  (data (i32.const 12) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\00=\00=\00 \00a\00r\00c\00h\00 \00=\00=\00\00\00\00\00\00\00\00\00")
  (data (i32.const 64) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -164,6 +165,7 @@
  (global $std-wasi/process/env (mut i32) (i32.const 0))
  (global $std-wasi/process/envKeys (mut i32) (i32.const 0))
  (global $~lib/builtins/u32.MAX_VALUE i32 (i32.const -1))
+ (global $~lib/process/process.stdin i32 (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 6272))
  (global $~lib/memory/__data_end i32 (i32.const 6316))
  (global $~lib/memory/__stack_pointer (mut i32) (i32.const 22700))
@@ -6683,6 +6685,71 @@
   local.get $0
   call $~lib/bindings/wasi_snapshot_preview1/proc_exit
  )
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (param $0 i32) (result i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+ )
+ (func $~lib/process/ReadableStream#read (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.set $3
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if (result i32)
+   i32.const 1
+  else
+   local.get $2
+   local.get $3
+   i32.gt_u
+  end
+  if
+   i32.const 3648
+   i32.const 3088
+   i32.const 137
+   i32.const 7
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  global.get $~lib/process/iobuf
+  local.get $1
+  local.get $2
+  i32.add
+  i32.store
+  global.get $~lib/process/iobuf
+  local.get $3
+  local.get $2
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  global.get $~lib/process/iobuf
+  i32.const 1
+  global.get $~lib/process/iobuf
+  i32.const 2
+  i32.const 4
+  i32.mul
+  i32.add
+  call $~lib/bindings/wasi_snapshot_preview1/fd_read
+  local.set $4
+  local.get $4
+  i32.const 65535
+  i32.and
+  if
+   local.get $4
+   call $~lib/bindings/wasi_snapshot_preview1/errnoToString
+   i32.const 3088
+   i32.const 142
+   i32.const 14
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  global.get $~lib/process/iobuf
+  i32.load offset=8
+ )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
   global.get $~lib/process/process.arch
@@ -7561,6 +7628,18 @@
   call $~lib/console/console.log
   i32.const 42
   call $~lib/process/process.exit
+  global.get $~lib/process/process.stdin
+  i32.const 0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $4
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.store offset=4
+  local.get $4
+  i32.const 0
+  call $~lib/process/ReadableStream#read
+  drop
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
@@ -7680,7 +7759,7 @@
   if
    i32.const 0
    i32.const 3792
-   i32.const 749
+   i32.const 746
    i32.const 7
    call $~lib/wasi/index/abort
    unreachable


### PR DESCRIPTION
It is compared to a usize later and used as one later.

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->


- [x] I've read the contributing guidelines