### PR TITLE
Add erf and erfc for NativeMath

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1914,6 +1914,10 @@ interface INativeMath<T> extends IMath<T> {
   sincos(x: T): void;
   /** Returns 2 raised to the given power x. Equivalent to 2 ** x. */
   exp2(x: T): T;
+  /** Returns the error function. */
+  erf(x: T): T;
+  /** Returns the complementary error function. */
+  erfc(x: T): T;
 }
 
 /** Double precision math imported from JavaScript. */

--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1883,7 +1883,8 @@ export namespace NativeMath {
       let r = pp0 + z * (pp1 + z * (pp2 + z * (pp3 + z * pp4)));
       let s = 1.0 + z * (qq1 + z * (qq2 + z * (qq3 + z * (qq4 + z * qq5))));
       let y = r / s;
-      if (sig || ux < 0x3FD00000) {  // x < 1/4
+      // @ts-ignore
+      if (sig | (ux < 0x3FD00000)) {  // x < 1 / 4
         return 1.0 - (x + x * y);
       }
       return 0.5 - (x - 0.5 + x * y);
@@ -3389,7 +3390,8 @@ export namespace NativeMathf {
       let r = pp0f   + z * (pp1f + z * (pp2f + z * (pp3f + z * pp4f)));
       let s = <f32>1 + z * (qq1f + z * (qq2f + z * (qq3f + z * (qq4f + z * qq5f))));
       let y = r / s;
-      if (sig || ux < 0x3E800000) { // x < 1 / 4
+      // @ts-ignore
+      if (sig | (ux < 0x3E800000)) { // x < 1 / 4
         return <f32>1 - (x + x * y);
       }
       return <f32>0.5 - (x - 0.5 + x * y);

--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1847,8 +1847,8 @@ export namespace NativeMath {
     if (ux >= 0x7FF00000) {
       return f64(sig | 1) + 1.0 / x; // erf(nan)=nan, erf(+-inf)=+-1
     }
-    if (ux < 0x3FEB0000) {  // |x| < 0.84375
-      if (ux < 0x3E300000) {  // |x| < 2**-28
+    if (ux < 0x3FEB0000) {    // |x| < 0.84375
+      if (ux < 0x3E300000) {  // |x| < 2 ** -28
         // avoid underflow
         return 0.125 * (8 * x + efx8 * x);
       }
@@ -3344,7 +3344,7 @@ export namespace NativeMathf {
 
   export function erf(x: f32): f32 { // see: musl/tree/src/math/erff.c
     const efx8 = reinterpret<f32>(0x3F8375D4); // 1.0270333290e+00
-    const Ox1p_120f: f32 = 0; // TODO: 0x1p-120f
+    const Ox1p_120f = reinterpret<f32>(0x03800000); // 0x1p-120f
 
     var ux  = reinterpret<u32>(x);
     var sig = (<i32>ux) >> 31;
@@ -3372,7 +3372,7 @@ export namespace NativeMathf {
   }
 
   export function erfc(x: f32): f32 { // see: musl/tree/src/math/erff.c
-    const Ox1p_120f: f32 = 0; // 0x1p-120f
+    const Ox1p_120f = reinterpret<f32>(0x03800000); // 0x1p-120f
 
     var ux  = reinterpret<u32>(x);
     var sig = ux >> 31;

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -4202,7 +4202,7 @@
   if
    i32.const 0
    i32.const 7264
-   i32.const 1399
+   i32.const 1499
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -4202,7 +4202,7 @@
   if
    i32.const 0
    i32.const 7264
-   i32.const 1417
+   i32.const 1517
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -6622,7 +6622,7 @@
   if
    i32.const 0
    i32.const 6240
-   i32.const 1399
+   i32.const 1499
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -6622,7 +6622,7 @@
   if
    i32.const 0
    i32.const 6240
-   i32.const 1417
+   i32.const 1517
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -11544,12 +11544,11 @@
    f64.add
    f64.div
    local.set $5
-   i32.const 1
+   local.get $1
    local.get $2
    i32.const 1070596096
    i32.lt_u
-   local.get $1
-   select
+   i32.or
    if
     f64.const 1
     local.get $0
@@ -12136,12 +12135,11 @@
    f32.add
    f32.div
    local.set $5
-   i32.const 1
+   local.get $1
    local.get $2
    i32.const 1048576000
    i32.lt_u
-   local.get $1
-   select
+   i32.or
    if
     f32.const 1
     local.get $0

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -7,6 +7,8 @@
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $f32_f32_=>_f32 (func (param f32 f32) (result f32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i64_i64_i64_=>_none (func (param i64 i64 i64)))
  (type $f32_f32_=>_i32 (func (param f32 f32) (result i32)))
  (type $f64_f64_f64_f64_=>_i32 (func (param f64 f64 f64 f64) (result i32)))
  (type $none_=>_f64 (func (result f64)))
@@ -8219,7 +8221,7 @@
   if
    i32.const 0
    i32.const 3648
-   i32.const 1399
+   i32.const 1499
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -10758,6 +10760,1888 @@
    call $std/math/check<f64>
    drop
   end
+ )
+ (func $~lib/math/NativeMath.erf (param $0 f64) (result f64)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 f64)
+  (local $5 f64)
+  (local $6 f64)
+  local.get $0
+  i64.reinterpret_f64
+  i64.const 32
+  i64.shr_u
+  i32.wrap_i64
+  local.tee $2
+  i32.const 31
+  i32.shr_s
+  local.set $1
+  local.get $2
+  i32.const 2147483647
+  i32.and
+  local.tee $2
+  i32.const 2146435072
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 1
+   i32.or
+   f64.convert_i32_s
+   f64.const 1
+   local.get $0
+   f64.div
+   f64.add
+   return
+  end
+  local.get $2
+  i32.const 1072365568
+  i32.lt_u
+  if
+   local.get $2
+   i32.const 1043333120
+   i32.lt_u
+   if
+    local.get $0
+    f64.const 8
+    f64.mul
+    local.get $0
+    f64.const 1.0270333367641007
+    f64.mul
+    f64.add
+    f64.const 0.125
+    f64.mul
+    return
+   end
+   local.get $0
+   local.get $0
+   local.get $0
+   local.get $0
+   f64.mul
+   local.tee $0
+   local.get $0
+   local.get $0
+   local.get $0
+   f64.const -2.3763016656650163e-05
+   f64.mul
+   f64.const -0.005770270296489442
+   f64.add
+   f64.mul
+   f64.const -0.02848174957559851
+   f64.add
+   f64.mul
+   f64.const -0.3250421072470015
+   f64.add
+   f64.mul
+   f64.const 0.12837916709551256
+   f64.add
+   local.get $0
+   local.get $0
+   local.get $0
+   local.get $0
+   local.get $0
+   f64.const -3.960228278775368e-06
+   f64.mul
+   f64.const 1.3249473800432164e-04
+   f64.add
+   f64.mul
+   f64.const 0.005081306281875766
+   f64.add
+   f64.mul
+   f64.const 0.0650222499887673
+   f64.add
+   f64.mul
+   f64.const 0.39791722395915535
+   f64.add
+   f64.mul
+   f64.const 1
+   f64.add
+   f64.div
+   f64.mul
+   f64.add
+   return
+  end
+  local.get $2
+  i32.const 1075314688
+  i32.lt_u
+  if (result f64)
+   f64.const 1
+   block $~lib/math/erfc2|inlined.0 (result f64)
+    local.get $2
+    local.tee $1
+    i32.const 1072955392
+    i32.lt_u
+    if
+     f64.const 0.15493708848953247
+     local.get $0
+     f64.abs
+     f64.const 1
+     f64.sub
+     local.tee $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f64.const -0.002166375594868791
+     f64.mul
+     f64.const 0.035478304325618236
+     f64.add
+     f64.mul
+     f64.const -0.11089469428239668
+     f64.add
+     f64.mul
+     f64.const 0.31834661990116175
+     f64.add
+     f64.mul
+     f64.const -0.3722078760357013
+     f64.add
+     f64.mul
+     f64.const 0.41485611868374833
+     f64.add
+     f64.mul
+     f64.const -2.3621185607526594e-03
+     f64.add
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f64.const 0.011984499846799107
+     f64.mul
+     f64.const 0.01363708391202905
+     f64.add
+     f64.mul
+     f64.const 0.12617121980876164
+     f64.add
+     f64.mul
+     f64.const 0.07182865441419627
+     f64.add
+     f64.mul
+     f64.const 0.540397917702171
+     f64.add
+     f64.mul
+     f64.const 0.10642088040084423
+     f64.add
+     f64.mul
+     f64.const 1
+     f64.add
+     f64.div
+     f64.sub
+     br $~lib/math/erfc2|inlined.0
+    end
+    f64.const 1
+    local.get $0
+    f64.abs
+    local.tee $5
+    local.get $5
+    f64.mul
+    f64.div
+    local.set $6
+    local.get $1
+    i32.const 1074191213
+    i32.lt_u
+    if (result f64)
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f64.const -0.0604244152148581
+     f64.mul
+     f64.const 6.570249770319282
+     f64.add
+     f64.mul
+     f64.const 108.63500554177944
+     f64.add
+     f64.mul
+     f64.const 429.00814002756783
+     f64.add
+     f64.mul
+     f64.const 645.3872717332679
+     f64.add
+     f64.mul
+     f64.const 434.56587747522923
+     f64.add
+     f64.mul
+     f64.const 137.65775414351904
+     f64.add
+     f64.mul
+     f64.const 19.651271667439257
+     f64.add
+     f64.mul
+     f64.const 1
+     f64.add
+     local.set $4
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f64.const -9.814329344169145
+     f64.mul
+     f64.const -81.2874355063066
+     f64.add
+     f64.mul
+     f64.const -184.60509290671104
+     f64.add
+     f64.mul
+     f64.const -162.39666946257347
+     f64.add
+     f64.mul
+     f64.const -62.375332450326006
+     f64.add
+     f64.mul
+     f64.const -10.558626225323291
+     f64.add
+     f64.mul
+     f64.const -0.6938585727071818
+     f64.add
+     f64.mul
+     f64.const -0.009864944034847148
+     f64.add
+    else
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f64.const -22.44095244658582
+     f64.mul
+     f64.const 474.52854120695537
+     f64.add
+     f64.mul
+     f64.const 2553.0504064331644
+     f64.add
+     f64.mul
+     f64.const 3199.8582195085955
+     f64.add
+     f64.mul
+     f64.const 1536.729586084437
+     f64.add
+     f64.mul
+     f64.const 325.7925129965739
+     f64.add
+     f64.mul
+     f64.const 30.33806074348246
+     f64.add
+     f64.mul
+     f64.const 1
+     f64.add
+     local.set $4
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f64.const -483.5191916086514
+     f64.mul
+     f64.const -1025.0951316110772
+     f64.add
+     f64.mul
+     f64.const -637.5664433683896
+     f64.add
+     f64.mul
+     f64.const -160.63638485582192
+     f64.add
+     f64.mul
+     f64.const -17.757954917754752
+     f64.add
+     f64.mul
+     f64.const -0.799283237680523
+     f64.add
+     f64.mul
+     f64.const -0.0098649429247001
+     f64.add
+    end
+    local.set $3
+    local.get $5
+    i64.reinterpret_f64
+    i64.const -4294967296
+    i64.and
+    f64.reinterpret_i64
+    local.tee $6
+    f64.neg
+    local.get $6
+    f64.mul
+    f64.const 0.5625
+    f64.sub
+    call $~lib/math/NativeMath.exp
+    local.get $6
+    local.get $5
+    f64.sub
+    local.get $6
+    local.get $5
+    f64.add
+    f64.mul
+    local.get $3
+    local.get $4
+    f64.div
+    f64.add
+    call $~lib/math/NativeMath.exp
+    f64.mul
+    local.get $5
+    f64.div
+   end
+   f64.sub
+  else
+   f64.const 1
+  end
+  local.get $0
+  f64.copysign
+ )
+ (func $std/math/test_erf (param $0 i64) (param $1 i64) (param $2 i64)
+  local.get $0
+  f64.reinterpret_i64
+  call $~lib/math/NativeMath.erf
+  local.get $1
+  f64.reinterpret_i64
+  local.get $2
+  f64.reinterpret_i64
+  call $std/math/check<f64>
+  drop
+ )
+ (func $~lib/math/NativeMathf.erf (param $0 f32) (result f32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 f32)
+  (local $5 f32)
+  (local $6 f32)
+  local.get $0
+  i32.reinterpret_f32
+  local.tee $2
+  i32.const 31
+  i32.shr_s
+  local.set $1
+  local.get $2
+  i32.const 2147483647
+  i32.and
+  local.tee $2
+  i32.const 2139095040
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 1
+   i32.or
+   f32.convert_i32_s
+   f32.const 1
+   local.get $0
+   f32.div
+   f32.add
+   return
+  end
+  local.get $2
+  i32.const 1062731776
+  i32.lt_u
+  if
+   local.get $2
+   i32.const 830472192
+   i32.lt_u
+   if
+    local.get $0
+    f32.const 8
+    f32.mul
+    local.get $0
+    f32.const 1.0270333290100098
+    f32.mul
+    f32.add
+    f32.const 0.125
+    f32.mul
+    return
+   end
+   local.get $0
+   local.get $0
+   local.get $0
+   local.get $0
+   f32.mul
+   local.tee $0
+   local.get $0
+   local.get $0
+   local.get $0
+   f32.const -2.3763017452438362e-05
+   f32.mul
+   f32.const -0.005770270247012377
+   f32.add
+   f32.mul
+   f32.const -0.028481749817728996
+   f32.add
+   f32.mul
+   f32.const -0.32504209876060486
+   f32.add
+   f32.mul
+   f32.const 0.12837916612625122
+   f32.add
+   local.get $0
+   local.get $0
+   local.get $0
+   local.get $0
+   local.get $0
+   f32.const -3.9602282413397916e-06
+   f32.mul
+   f32.const 1.324947370449081e-04
+   f32.add
+   f32.mul
+   f32.const 5.0813062116503716e-03
+   f32.add
+   f32.mul
+   f32.const 0.06502225250005722
+   f32.add
+   f32.mul
+   f32.const 0.3979172110557556
+   f32.add
+   f32.mul
+   f32.const 1
+   f32.add
+   f32.div
+   f32.mul
+   f32.add
+   return
+  end
+  local.get $2
+  i32.const 1086324736
+  i32.lt_u
+  if (result f32)
+   f32.const 1
+   block $~lib/math/erfc2f|inlined.0 (result f32)
+    local.get $2
+    local.tee $1
+    i32.const 1067450368
+    i32.lt_u
+    if
+     f32.const 0.15493708848953247
+     local.get $0
+     f32.abs
+     f32.const 1
+     f32.sub
+     local.tee $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f32.const -0.002166375517845154
+     f32.mul
+     f32.const 0.03547830507159233
+     f32.add
+     f32.mul
+     f32.const -0.11089469492435455
+     f32.add
+     f32.mul
+     f32.const 0.31834661960601807
+     f32.add
+     f32.mul
+     f32.const -0.3722078800201416
+     f32.add
+     f32.mul
+     f32.const 0.41485610604286194
+     f32.add
+     f32.mul
+     f32.const -2.3621185682713985e-03
+     f32.add
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f32.const 0.011984500102698803
+     f32.mul
+     f32.const 0.01363708358258009
+     f32.add
+     f32.mul
+     f32.const 0.12617121636867523
+     f32.add
+     f32.mul
+     f32.const 0.07182865589857101
+     f32.add
+     f32.mul
+     f32.const 0.5403979420661926
+     f32.add
+     f32.mul
+     f32.const 0.10642088204622269
+     f32.add
+     f32.mul
+     f32.const 1
+     f32.add
+     f32.div
+     f32.sub
+     br $~lib/math/erfc2f|inlined.0
+    end
+    f32.const 1
+    local.get $0
+    f32.abs
+    local.tee $5
+    local.get $5
+    f32.mul
+    f32.div
+    local.set $6
+    local.get $1
+    i32.const 1077336941
+    i32.lt_u
+    if (result f32)
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f32.const -0.06042441353201866
+     f32.mul
+     f32.const 6.570249557495117
+     f32.add
+     f32.mul
+     f32.const 108.63500213623047
+     f32.add
+     f32.mul
+     f32.const 429.0081481933594
+     f32.add
+     f32.mul
+     f32.const 645.3872680664062
+     f32.add
+     f32.mul
+     f32.const 434.5658874511719
+     f32.add
+     f32.mul
+     f32.const 137.6577606201172
+     f32.add
+     f32.mul
+     f32.const 19.65127182006836
+     f32.add
+     f32.mul
+     f32.const 1
+     f32.add
+     local.set $4
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f32.const -9.814329147338867
+     f32.mul
+     f32.const -81.28743743896484
+     f32.add
+     f32.mul
+     f32.const -184.60508728027344
+     f32.add
+     f32.mul
+     f32.const -162.39666748046875
+     f32.add
+     f32.mul
+     f32.const -62.37533187866211
+     f32.add
+     f32.mul
+     f32.const -10.558626174926758
+     f32.add
+     f32.mul
+     f32.const -0.6938585638999939
+     f32.add
+     f32.mul
+     f32.const -0.009864944033324718
+     f32.add
+    else
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f32.const -22.44095230102539
+     f32.mul
+     f32.const 474.5285339355469
+     f32.add
+     f32.mul
+     f32.const 2553.05029296875
+     f32.add
+     f32.mul
+     f32.const 3199.858154296875
+     f32.add
+     f32.mul
+     f32.const 1536.7296142578125
+     f32.add
+     f32.mul
+     f32.const 325.7925109863281
+     f32.add
+     f32.mul
+     f32.const 30.33806037902832
+     f32.add
+     f32.mul
+     f32.const 1
+     f32.add
+     local.set $4
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     local.get $6
+     f32.const -483.5191955566406
+     f32.mul
+     f32.const -1025.0950927734375
+     f32.add
+     f32.mul
+     f32.const -637.5664672851562
+     f32.add
+     f32.mul
+     f32.const -160.63638305664062
+     f32.add
+     f32.mul
+     f32.const -17.75795555114746
+     f32.add
+     f32.mul
+     f32.const -0.7992832660675049
+     f32.add
+     f32.mul
+     f32.const -0.009864943102002144
+     f32.add
+    end
+    local.set $3
+    local.get $5
+    i32.reinterpret_f32
+    i32.const -8192
+    i32.and
+    f32.reinterpret_i32
+    local.tee $6
+    f32.neg
+    local.get $6
+    f32.mul
+    f32.const 0.5625
+    f32.sub
+    call $~lib/math/NativeMathf.exp
+    local.get $6
+    local.get $5
+    f32.sub
+    local.get $6
+    local.get $5
+    f32.add
+    f32.mul
+    local.get $3
+    local.get $4
+    f32.div
+    f32.add
+    call $~lib/math/NativeMathf.exp
+    f32.mul
+    local.get $5
+    f32.div
+   end
+   f32.sub
+  else
+   f32.const 1
+  end
+  local.get $0
+  f32.copysign
+ )
+ (func $std/math/test_erff (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  f32.reinterpret_i32
+  call $~lib/math/NativeMathf.erf
+  local.get $1
+  f32.reinterpret_i32
+  local.get $2
+  f32.reinterpret_i32
+  call $std/math/check<f32>
+  drop
+ )
+ (func $~lib/math/NativeMath.erfc (param $0 f64) (result f64)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 f64)
+  (local $5 f64)
+  local.get $0
+  i64.reinterpret_f64
+  i64.const 32
+  i64.shr_u
+  i32.wrap_i64
+  local.tee $2
+  i32.const 31
+  i32.shr_u
+  local.set $1
+  local.get $2
+  i32.const 2147483647
+  i32.and
+  local.tee $2
+  i32.const 2146435072
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 1
+   i32.shl
+   f64.convert_i32_u
+   f64.const 1
+   local.get $0
+   f64.div
+   f64.add
+   return
+  end
+  local.get $2
+  i32.const 1072365568
+  i32.lt_u
+  if
+   local.get $2
+   i32.const 1013972992
+   i32.lt_u
+   if
+    f64.const 1
+    local.get $0
+    f64.sub
+    return
+   end
+   local.get $0
+   local.get $0
+   f64.mul
+   local.tee $5
+   local.get $5
+   local.get $5
+   local.get $5
+   f64.const -2.3763016656650163e-05
+   f64.mul
+   f64.const -0.005770270296489442
+   f64.add
+   f64.mul
+   f64.const -0.02848174957559851
+   f64.add
+   f64.mul
+   f64.const -0.3250421072470015
+   f64.add
+   f64.mul
+   f64.const 0.12837916709551256
+   f64.add
+   local.get $5
+   local.get $5
+   local.get $5
+   local.get $5
+   local.get $5
+   f64.const -3.960228278775368e-06
+   f64.mul
+   f64.const 1.3249473800432164e-04
+   f64.add
+   f64.mul
+   f64.const 0.005081306281875766
+   f64.add
+   f64.mul
+   f64.const 0.0650222499887673
+   f64.add
+   f64.mul
+   f64.const 0.39791722395915535
+   f64.add
+   f64.mul
+   f64.const 1
+   f64.add
+   f64.div
+   local.set $5
+   i32.const 1
+   local.get $2
+   i32.const 1070596096
+   i32.lt_u
+   local.get $1
+   select
+   if
+    f64.const 1
+    local.get $0
+    local.get $0
+    local.get $5
+    f64.mul
+    f64.add
+    f64.sub
+    return
+   end
+   f64.const 0.5
+   local.get $0
+   f64.const 0.5
+   f64.sub
+   local.get $0
+   local.get $5
+   f64.mul
+   f64.add
+   f64.sub
+   return
+  end
+  local.get $2
+  i32.const 1077673984
+  i32.lt_u
+  if
+   local.get $1
+   if (result f64)
+    f64.const 2
+    block $~lib/math/erfc2|inlined.1 (result f64)
+     local.get $2
+     local.tee $1
+     i32.const 1072955392
+     i32.lt_u
+     if
+      f64.const 0.15493708848953247
+      local.get $0
+      f64.abs
+      f64.const 1
+      f64.sub
+      local.tee $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -0.002166375594868791
+      f64.mul
+      f64.const 0.035478304325618236
+      f64.add
+      f64.mul
+      f64.const -0.11089469428239668
+      f64.add
+      f64.mul
+      f64.const 0.31834661990116175
+      f64.add
+      f64.mul
+      f64.const -0.3722078760357013
+      f64.add
+      f64.mul
+      f64.const 0.41485611868374833
+      f64.add
+      f64.mul
+      f64.const -2.3621185607526594e-03
+      f64.add
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const 0.011984499846799107
+      f64.mul
+      f64.const 0.01363708391202905
+      f64.add
+      f64.mul
+      f64.const 0.12617121980876164
+      f64.add
+      f64.mul
+      f64.const 0.07182865441419627
+      f64.add
+      f64.mul
+      f64.const 0.540397917702171
+      f64.add
+      f64.mul
+      f64.const 0.10642088040084423
+      f64.add
+      f64.mul
+      f64.const 1
+      f64.add
+      f64.div
+      f64.sub
+      br $~lib/math/erfc2|inlined.1
+     end
+     f64.const 1
+     local.get $0
+     f64.abs
+     local.tee $5
+     local.get $5
+     f64.mul
+     f64.div
+     local.set $0
+     local.get $1
+     i32.const 1074191213
+     i32.lt_u
+     if (result f64)
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -9.814329344169145
+      f64.mul
+      f64.const -81.2874355063066
+      f64.add
+      f64.mul
+      f64.const -184.60509290671104
+      f64.add
+      f64.mul
+      f64.const -162.39666946257347
+      f64.add
+      f64.mul
+      f64.const -62.375332450326006
+      f64.add
+      f64.mul
+      f64.const -10.558626225323291
+      f64.add
+      f64.mul
+      f64.const -0.6938585727071818
+      f64.add
+      f64.mul
+      f64.const -0.009864944034847148
+      f64.add
+      local.set $4
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -0.0604244152148581
+      f64.mul
+      f64.const 6.570249770319282
+      f64.add
+      f64.mul
+      f64.const 108.63500554177944
+      f64.add
+      f64.mul
+      f64.const 429.00814002756783
+      f64.add
+      f64.mul
+      f64.const 645.3872717332679
+      f64.add
+      f64.mul
+      f64.const 434.56587747522923
+      f64.add
+      f64.mul
+      f64.const 137.65775414351904
+      f64.add
+      f64.mul
+      f64.const 19.651271667439257
+      f64.add
+      f64.mul
+      f64.const 1
+      f64.add
+     else
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -483.5191916086514
+      f64.mul
+      f64.const -1025.0951316110772
+      f64.add
+      f64.mul
+      f64.const -637.5664433683896
+      f64.add
+      f64.mul
+      f64.const -160.63638485582192
+      f64.add
+      f64.mul
+      f64.const -17.757954917754752
+      f64.add
+      f64.mul
+      f64.const -0.799283237680523
+      f64.add
+      f64.mul
+      f64.const -0.0098649429247001
+      f64.add
+      local.set $4
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -22.44095244658582
+      f64.mul
+      f64.const 474.52854120695537
+      f64.add
+      f64.mul
+      f64.const 2553.0504064331644
+      f64.add
+      f64.mul
+      f64.const 3199.8582195085955
+      f64.add
+      f64.mul
+      f64.const 1536.729586084437
+      f64.add
+      f64.mul
+      f64.const 325.7925129965739
+      f64.add
+      f64.mul
+      f64.const 30.33806074348246
+      f64.add
+      f64.mul
+      f64.const 1
+      f64.add
+     end
+     local.set $3
+     local.get $5
+     i64.reinterpret_f64
+     i64.const -4294967296
+     i64.and
+     f64.reinterpret_i64
+     local.tee $0
+     f64.neg
+     local.get $0
+     f64.mul
+     f64.const 0.5625
+     f64.sub
+     call $~lib/math/NativeMath.exp
+     local.get $0
+     local.get $5
+     f64.sub
+     local.get $0
+     local.get $5
+     f64.add
+     f64.mul
+     local.get $4
+     local.get $3
+     f64.div
+     f64.add
+     call $~lib/math/NativeMath.exp
+     f64.mul
+     local.get $5
+     f64.div
+    end
+    f64.sub
+   else
+    block $~lib/math/erfc2|inlined.2 (result f64)
+     local.get $2
+     local.tee $1
+     i32.const 1072955392
+     i32.lt_u
+     if
+      f64.const 0.15493708848953247
+      local.get $0
+      f64.abs
+      f64.const 1
+      f64.sub
+      local.tee $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -0.002166375594868791
+      f64.mul
+      f64.const 0.035478304325618236
+      f64.add
+      f64.mul
+      f64.const -0.11089469428239668
+      f64.add
+      f64.mul
+      f64.const 0.31834661990116175
+      f64.add
+      f64.mul
+      f64.const -0.3722078760357013
+      f64.add
+      f64.mul
+      f64.const 0.41485611868374833
+      f64.add
+      f64.mul
+      f64.const -2.3621185607526594e-03
+      f64.add
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const 0.011984499846799107
+      f64.mul
+      f64.const 0.01363708391202905
+      f64.add
+      f64.mul
+      f64.const 0.12617121980876164
+      f64.add
+      f64.mul
+      f64.const 0.07182865441419627
+      f64.add
+      f64.mul
+      f64.const 0.540397917702171
+      f64.add
+      f64.mul
+      f64.const 0.10642088040084423
+      f64.add
+      f64.mul
+      f64.const 1
+      f64.add
+      f64.div
+      f64.sub
+      br $~lib/math/erfc2|inlined.2
+     end
+     f64.const 1
+     local.get $0
+     f64.abs
+     local.tee $5
+     local.get $5
+     f64.mul
+     f64.div
+     local.set $0
+     local.get $1
+     i32.const 1074191213
+     i32.lt_u
+     if (result f64)
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -0.0604244152148581
+      f64.mul
+      f64.const 6.570249770319282
+      f64.add
+      f64.mul
+      f64.const 108.63500554177944
+      f64.add
+      f64.mul
+      f64.const 429.00814002756783
+      f64.add
+      f64.mul
+      f64.const 645.3872717332679
+      f64.add
+      f64.mul
+      f64.const 434.56587747522923
+      f64.add
+      f64.mul
+      f64.const 137.65775414351904
+      f64.add
+      f64.mul
+      f64.const 19.651271667439257
+      f64.add
+      f64.mul
+      f64.const 1
+      f64.add
+      local.set $4
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -9.814329344169145
+      f64.mul
+      f64.const -81.2874355063066
+      f64.add
+      f64.mul
+      f64.const -184.60509290671104
+      f64.add
+      f64.mul
+      f64.const -162.39666946257347
+      f64.add
+      f64.mul
+      f64.const -62.375332450326006
+      f64.add
+      f64.mul
+      f64.const -10.558626225323291
+      f64.add
+      f64.mul
+      f64.const -0.6938585727071818
+      f64.add
+      f64.mul
+      f64.const -0.009864944034847148
+      f64.add
+     else
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -22.44095244658582
+      f64.mul
+      f64.const 474.52854120695537
+      f64.add
+      f64.mul
+      f64.const 2553.0504064331644
+      f64.add
+      f64.mul
+      f64.const 3199.8582195085955
+      f64.add
+      f64.mul
+      f64.const 1536.729586084437
+      f64.add
+      f64.mul
+      f64.const 325.7925129965739
+      f64.add
+      f64.mul
+      f64.const 30.33806074348246
+      f64.add
+      f64.mul
+      f64.const 1
+      f64.add
+      local.set $4
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f64.const -483.5191916086514
+      f64.mul
+      f64.const -1025.0951316110772
+      f64.add
+      f64.mul
+      f64.const -637.5664433683896
+      f64.add
+      f64.mul
+      f64.const -160.63638485582192
+      f64.add
+      f64.mul
+      f64.const -17.757954917754752
+      f64.add
+      f64.mul
+      f64.const -0.799283237680523
+      f64.add
+      f64.mul
+      f64.const -0.0098649429247001
+      f64.add
+     end
+     local.set $3
+     local.get $5
+     i64.reinterpret_f64
+     i64.const -4294967296
+     i64.and
+     f64.reinterpret_i64
+     local.tee $0
+     f64.neg
+     local.get $0
+     f64.mul
+     f64.const 0.5625
+     f64.sub
+     call $~lib/math/NativeMath.exp
+     local.get $0
+     local.get $5
+     f64.sub
+     local.get $0
+     local.get $5
+     f64.add
+     f64.mul
+     local.get $3
+     local.get $4
+     f64.div
+     f64.add
+     call $~lib/math/NativeMath.exp
+     f64.mul
+     local.get $5
+     f64.div
+    end
+   end
+   return
+  end
+  f64.const 2
+  f64.const 0
+  local.get $1
+  select
+ )
+ (func $std/math/test_erfc (param $0 i64) (param $1 i64) (param $2 i64)
+  local.get $0
+  f64.reinterpret_i64
+  call $~lib/math/NativeMath.erfc
+  local.get $1
+  f64.reinterpret_i64
+  local.get $2
+  f64.reinterpret_i64
+  call $std/math/check<f64>
+  drop
+ )
+ (func $~lib/math/NativeMathf.erfc (param $0 f32) (result f32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 f32)
+  (local $5 f32)
+  local.get $0
+  i32.reinterpret_f32
+  local.tee $2
+  i32.const 31
+  i32.shr_u
+  local.set $1
+  local.get $2
+  i32.const 2147483647
+  i32.and
+  local.tee $2
+  i32.const 2139095040
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 1
+   i32.shl
+   f32.convert_i32_u
+   f32.const 1
+   local.get $0
+   f32.div
+   f32.add
+   return
+  end
+  local.get $2
+  i32.const 1062731776
+  i32.lt_u
+  if
+   local.get $2
+   i32.const 595591168
+   i32.lt_u
+   if
+    f32.const 1
+    local.get $0
+    f32.sub
+    return
+   end
+   local.get $0
+   local.get $0
+   f32.mul
+   local.tee $5
+   local.get $5
+   local.get $5
+   local.get $5
+   f32.const -2.3763017452438362e-05
+   f32.mul
+   f32.const -0.005770270247012377
+   f32.add
+   f32.mul
+   f32.const -0.028481749817728996
+   f32.add
+   f32.mul
+   f32.const -0.32504209876060486
+   f32.add
+   f32.mul
+   f32.const 0.12837916612625122
+   f32.add
+   local.get $5
+   local.get $5
+   local.get $5
+   local.get $5
+   local.get $5
+   f32.const -3.9602282413397916e-06
+   f32.mul
+   f32.const 1.324947370449081e-04
+   f32.add
+   f32.mul
+   f32.const 5.0813062116503716e-03
+   f32.add
+   f32.mul
+   f32.const 0.06502225250005722
+   f32.add
+   f32.mul
+   f32.const 0.3979172110557556
+   f32.add
+   f32.mul
+   f32.const 1
+   f32.add
+   f32.div
+   local.set $5
+   i32.const 1
+   local.get $2
+   i32.const 1048576000
+   i32.lt_u
+   local.get $1
+   select
+   if
+    f32.const 1
+    local.get $0
+    local.get $0
+    local.get $5
+    f32.mul
+    f32.add
+    f32.sub
+    return
+   end
+   f32.const 0.5
+   local.get $0
+   f32.const 0.5
+   f32.sub
+   local.get $0
+   local.get $5
+   f32.mul
+   f32.add
+   f32.sub
+   return
+  end
+  local.get $2
+  i32.const 1105199104
+  i32.lt_u
+  if
+   local.get $1
+   if (result f32)
+    f32.const 2
+    block $~lib/math/erfc2f|inlined.1 (result f32)
+     local.get $2
+     local.tee $1
+     i32.const 1067450368
+     i32.lt_u
+     if
+      f32.const 0.15493708848953247
+      local.get $0
+      f32.abs
+      f32.const 1
+      f32.sub
+      local.tee $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -0.002166375517845154
+      f32.mul
+      f32.const 0.03547830507159233
+      f32.add
+      f32.mul
+      f32.const -0.11089469492435455
+      f32.add
+      f32.mul
+      f32.const 0.31834661960601807
+      f32.add
+      f32.mul
+      f32.const -0.3722078800201416
+      f32.add
+      f32.mul
+      f32.const 0.41485610604286194
+      f32.add
+      f32.mul
+      f32.const -2.3621185682713985e-03
+      f32.add
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const 0.011984500102698803
+      f32.mul
+      f32.const 0.01363708358258009
+      f32.add
+      f32.mul
+      f32.const 0.12617121636867523
+      f32.add
+      f32.mul
+      f32.const 0.07182865589857101
+      f32.add
+      f32.mul
+      f32.const 0.5403979420661926
+      f32.add
+      f32.mul
+      f32.const 0.10642088204622269
+      f32.add
+      f32.mul
+      f32.const 1
+      f32.add
+      f32.div
+      f32.sub
+      br $~lib/math/erfc2f|inlined.1
+     end
+     f32.const 1
+     local.get $0
+     f32.abs
+     local.tee $5
+     local.get $5
+     f32.mul
+     f32.div
+     local.set $0
+     local.get $1
+     i32.const 1077336941
+     i32.lt_u
+     if (result f32)
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -9.814329147338867
+      f32.mul
+      f32.const -81.28743743896484
+      f32.add
+      f32.mul
+      f32.const -184.60508728027344
+      f32.add
+      f32.mul
+      f32.const -162.39666748046875
+      f32.add
+      f32.mul
+      f32.const -62.37533187866211
+      f32.add
+      f32.mul
+      f32.const -10.558626174926758
+      f32.add
+      f32.mul
+      f32.const -0.6938585638999939
+      f32.add
+      f32.mul
+      f32.const -0.009864944033324718
+      f32.add
+      local.set $4
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -0.06042441353201866
+      f32.mul
+      f32.const 6.570249557495117
+      f32.add
+      f32.mul
+      f32.const 108.63500213623047
+      f32.add
+      f32.mul
+      f32.const 429.0081481933594
+      f32.add
+      f32.mul
+      f32.const 645.3872680664062
+      f32.add
+      f32.mul
+      f32.const 434.5658874511719
+      f32.add
+      f32.mul
+      f32.const 137.6577606201172
+      f32.add
+      f32.mul
+      f32.const 19.65127182006836
+      f32.add
+      f32.mul
+      f32.const 1
+      f32.add
+     else
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -483.5191955566406
+      f32.mul
+      f32.const -1025.0950927734375
+      f32.add
+      f32.mul
+      f32.const -637.5664672851562
+      f32.add
+      f32.mul
+      f32.const -160.63638305664062
+      f32.add
+      f32.mul
+      f32.const -17.75795555114746
+      f32.add
+      f32.mul
+      f32.const -0.7992832660675049
+      f32.add
+      f32.mul
+      f32.const -0.009864943102002144
+      f32.add
+      local.set $4
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -22.44095230102539
+      f32.mul
+      f32.const 474.5285339355469
+      f32.add
+      f32.mul
+      f32.const 2553.05029296875
+      f32.add
+      f32.mul
+      f32.const 3199.858154296875
+      f32.add
+      f32.mul
+      f32.const 1536.7296142578125
+      f32.add
+      f32.mul
+      f32.const 325.7925109863281
+      f32.add
+      f32.mul
+      f32.const 30.33806037902832
+      f32.add
+      f32.mul
+      f32.const 1
+      f32.add
+     end
+     local.set $3
+     local.get $5
+     i32.reinterpret_f32
+     i32.const -8192
+     i32.and
+     f32.reinterpret_i32
+     local.tee $0
+     f32.neg
+     local.get $0
+     f32.mul
+     f32.const 0.5625
+     f32.sub
+     call $~lib/math/NativeMathf.exp
+     local.get $0
+     local.get $5
+     f32.sub
+     local.get $0
+     local.get $5
+     f32.add
+     f32.mul
+     local.get $4
+     local.get $3
+     f32.div
+     f32.add
+     call $~lib/math/NativeMathf.exp
+     f32.mul
+     local.get $5
+     f32.div
+    end
+    f32.sub
+   else
+    block $~lib/math/erfc2f|inlined.2 (result f32)
+     local.get $2
+     local.tee $1
+     i32.const 1067450368
+     i32.lt_u
+     if
+      f32.const 0.15493708848953247
+      local.get $0
+      f32.abs
+      f32.const 1
+      f32.sub
+      local.tee $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -0.002166375517845154
+      f32.mul
+      f32.const 0.03547830507159233
+      f32.add
+      f32.mul
+      f32.const -0.11089469492435455
+      f32.add
+      f32.mul
+      f32.const 0.31834661960601807
+      f32.add
+      f32.mul
+      f32.const -0.3722078800201416
+      f32.add
+      f32.mul
+      f32.const 0.41485610604286194
+      f32.add
+      f32.mul
+      f32.const -2.3621185682713985e-03
+      f32.add
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const 0.011984500102698803
+      f32.mul
+      f32.const 0.01363708358258009
+      f32.add
+      f32.mul
+      f32.const 0.12617121636867523
+      f32.add
+      f32.mul
+      f32.const 0.07182865589857101
+      f32.add
+      f32.mul
+      f32.const 0.5403979420661926
+      f32.add
+      f32.mul
+      f32.const 0.10642088204622269
+      f32.add
+      f32.mul
+      f32.const 1
+      f32.add
+      f32.div
+      f32.sub
+      br $~lib/math/erfc2f|inlined.2
+     end
+     f32.const 1
+     local.get $0
+     f32.abs
+     local.tee $5
+     local.get $5
+     f32.mul
+     f32.div
+     local.set $0
+     local.get $1
+     i32.const 1077336941
+     i32.lt_u
+     if (result f32)
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -0.06042441353201866
+      f32.mul
+      f32.const 6.570249557495117
+      f32.add
+      f32.mul
+      f32.const 108.63500213623047
+      f32.add
+      f32.mul
+      f32.const 429.0081481933594
+      f32.add
+      f32.mul
+      f32.const 645.3872680664062
+      f32.add
+      f32.mul
+      f32.const 434.5658874511719
+      f32.add
+      f32.mul
+      f32.const 137.6577606201172
+      f32.add
+      f32.mul
+      f32.const 19.65127182006836
+      f32.add
+      f32.mul
+      f32.const 1
+      f32.add
+      local.set $4
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -9.814329147338867
+      f32.mul
+      f32.const -81.28743743896484
+      f32.add
+      f32.mul
+      f32.const -184.60508728027344
+      f32.add
+      f32.mul
+      f32.const -162.39666748046875
+      f32.add
+      f32.mul
+      f32.const -62.37533187866211
+      f32.add
+      f32.mul
+      f32.const -10.558626174926758
+      f32.add
+      f32.mul
+      f32.const -0.6938585638999939
+      f32.add
+      f32.mul
+      f32.const -0.009864944033324718
+      f32.add
+     else
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -22.44095230102539
+      f32.mul
+      f32.const 474.5285339355469
+      f32.add
+      f32.mul
+      f32.const 2553.05029296875
+      f32.add
+      f32.mul
+      f32.const 3199.858154296875
+      f32.add
+      f32.mul
+      f32.const 1536.7296142578125
+      f32.add
+      f32.mul
+      f32.const 325.7925109863281
+      f32.add
+      f32.mul
+      f32.const 30.33806037902832
+      f32.add
+      f32.mul
+      f32.const 1
+      f32.add
+      local.set $4
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      local.get $0
+      f32.const -483.5191955566406
+      f32.mul
+      f32.const -1025.0950927734375
+      f32.add
+      f32.mul
+      f32.const -637.5664672851562
+      f32.add
+      f32.mul
+      f32.const -160.63638305664062
+      f32.add
+      f32.mul
+      f32.const -17.75795555114746
+      f32.add
+      f32.mul
+      f32.const -0.7992832660675049
+      f32.add
+      f32.mul
+      f32.const -0.009864943102002144
+      f32.add
+     end
+     local.set $3
+     local.get $5
+     i32.reinterpret_f32
+     i32.const -8192
+     i32.and
+     f32.reinterpret_i32
+     local.tee $0
+     f32.neg
+     local.get $0
+     f32.mul
+     f32.const 0.5625
+     f32.sub
+     call $~lib/math/NativeMathf.exp
+     local.get $0
+     local.get $5
+     f32.sub
+     local.get $0
+     local.get $5
+     f32.add
+     f32.mul
+     local.get $3
+     local.get $4
+     f32.div
+     f32.add
+     call $~lib/math/NativeMathf.exp
+     f32.mul
+     local.get $5
+     f32.div
+    end
+   end
+   return
+  end
+  f32.const 2
+  f32.const 0
+  local.get $1
+  select
+ )
+ (func $std/math/test_erfcf (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  f32.reinterpret_i32
+  call $~lib/math/NativeMathf.erfc
+  local.get $1
+  f32.reinterpret_i32
+  local.get $2
+  f32.reinterpret_i32
+  call $std/math/check<f32>
+  drop
  )
  (func $~lib/math/dtoi32 (param $0 f64) (result i32)
   local.get $0
@@ -48673,6 +50557,250 @@
   i64.const 4605185968576882368
   i64.const 4599236402884902912
   call $std/math/test_sincos
+  i64.const -4602641186874283791
+  i64.const -4616189618054758400
+  i64.const -4822430703297757184
+  call $std/math/test_erf
+  i64.const 4616578323568966759
+  i64.const 4607182418792819341
+  i64.const 4595959478666395648
+  call $std/math/test_erf
+  i64.const -4602464091242371353
+  i64.const -4616189618054758400
+  i64.const -4856313964973260800
+  call $std/math/test_erf
+  i64.const -4604332007749985084
+  i64.const -4616189618054758400
+  i64.const -4675333723976105984
+  call $std/math/test_erf
+  i64.const 4621406507342668262
+  i64.const 4607182418800017408
+  i64.const 4264908847119859712
+  call $std/math/test_erf
+  i64.const 4604137858433287319
+  i64.const 4604037324040016550
+  i64.const 4600115794217533440
+  call $std/math/test_erf
+  i64.const -4622375691843501615
+  i64.const -4621869099206057201
+  i64.const -4625754138708279296
+  call $std/math/test_erf
+  i64.const 4603235101512779211
+  i64.const 4603336934479865465
+  i64.const 4587405971839516672
+  call $std/math/test_erf
+  i64.const 4605148163534189634
+  i64.const 4604718076478330597
+  i64.const 4582222713501777920
+  call $std/math/test_erf
+  i64.const -4619083057392940530
+  i64.const -4619225918560826409
+  i64.const -4626487030853926912
+  call $std/math/test_erf
+  i64.const 0
+  i64.const 0
+  i64.const 0
+  call $std/math/test_erf
+  i64.const 1152921504606846976
+  i64.const 1152921504606846976
+  i64.const 0
+  call $std/math/test_erf
+  i64.const 9218868437227405312
+  i64.const 4607182418800017408
+  i64.const 0
+  call $std/math/test_erf
+  i64.const -4503599627370496
+  i64.const -4616189618054758400
+  i64.const 0
+  call $std/math/test_erf
+  i64.const 9221120237041090560
+  i64.const 9221120237041090560
+  i64.const 0
+  call $std/math/test_erf
+  i32.const -1056894512
+  i32.const -1082130432
+  i32.const -1709554081
+  call $std/math/test_erff
+  i32.const 1082854452
+  i32.const 1065353216
+  i32.const 1004251905
+  call $std/math/test_erff
+  i32.const -1056564646
+  i32.const -1082130432
+  i32.const -1772666530
+  call $std/math/test_erff
+  i32.const -1060043912
+  i32.const -1082130432
+  i32.const -1435564515
+  call $std/math/test_erff
+  i32.const 1091847646
+  i32.const 1065353216
+  i32.const 184549376
+  call $std/math/test_erff
+  i32.const 1059682280
+  i32.const 1059495020
+  i32.const -1101644848
+  call $std/math/test_erff
+  i32.const -1093652892
+  i32.const -1092709290
+  i32.const 1050393313
+  call $std/math/test_erff
+  i32.const 1058000765
+  i32.const 1058190444
+  i32.const 1053212850
+  call $std/math/test_erff
+  i32.const 1061564120
+  i32.const 1060763021
+  i32.const 1055470256
+  call $std/math/test_erff
+  i32.const -1087519883
+  i32.const -1087785983
+  i32.const 1053987903
+  call $std/math/test_erff
+  i32.const 0
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erff
+  i32.const 268435456
+  i32.const 268435456
+  i32.const 0
+  call $std/math/test_erff
+  i32.const 2139095040
+  i32.const 1065353216
+  i32.const 0
+  call $std/math/test_erff
+  i32.const -8388608
+  i32.const -1082130432
+  i32.const 0
+  call $std/math/test_erff
+  i32.const 2143289344
+  i32.const 2143289344
+  i32.const 0
+  call $std/math/test_erff
+  i64.const -4602641186874283791
+  i64.const 4611686018427387904
+  i64.const 4396437733929648128
+  call $std/math/test_erfc
+  i64.const 4616578323568966759
+  i64.const 4470796096516416978
+  i64.const -4625010188632457216
+  call $std/math/test_erfc
+  i64.const -4602464091242371353
+  i64.const 4611686018427387904
+  i64.const 4362554471180402688
+  call $std/math/test_erfc
+  i64.const -4604332007749985084
+  i64.const 4611686018427387904
+  i64.const 4543534713251299328
+  call $std/math/test_erfc
+  i64.const 4621406507342668262
+  i64.const 4030905104282833751
+  i64.const -4621755121502519296
+  call $std/math/test_erfc
+  i64.const 4604137858433287319
+  i64.const 4599961809437907637
+  i64.const 4598797670365003776
+  call $std/math/test_erfc
+  i64.const -4622375691843501615
+  i64.const 4609140248232720580
+  i64.const 4599231454545707008
+  call $std/math/test_erfc
+  i64.const 4603235101512779211
+  i64.const 4601362588558209806
+  i64.const -4631462465387888640
+  call $std/math/test_erfc
+  i64.const 4605148163534189634
+  i64.const 4598600304561279542
+  i64.const -4636645723725627392
+  call $std/math/test_erfc
+  i64.const -4619083057392940530
+  i64.const 4610167868174353899
+  i64.const -4622622464378142720
+  call $std/math/test_erfc
+  i64.const 0
+  i64.const 4607182418800017408
+  i64.const 0
+  call $std/math/test_erfc
+  i64.const -9223372036854775808
+  i64.const 4607182418800017408
+  i64.const 0
+  call $std/math/test_erfc
+  i64.const 9218868437227405312
+  i64.const 0
+  i64.const 0
+  call $std/math/test_erfc
+  i64.const -4503599627370496
+  i64.const 4611686018427387904
+  i64.const 0
+  call $std/math/test_erfc
+  i64.const 9221120237041090560
+  i64.const 9221120237041090560
+  i64.const 0
+  call $std/math/test_erfc
+  i64.const 4608830954484908218
+  i64.const 4587852795391849103
+  i64.const 4600709147707572224
+  call $std/math/test_erfc
+  i32.const -1056894512
+  i32.const 1073741824
+  i32.const 429540959
+  call $std/math/test_erfcf
+  i32.const 1082854452
+  i32.const 811313921
+  i32.const -1096552700
+  call $std/math/test_erfcf
+  i32.const -1056564646
+  i32.const 1073741824
+  i32.const 366428508
+  call $std/math/test_erfcf
+  i32.const -1060043912
+  i32.const 1073741824
+  i32.const 703530525
+  call $std/math/test_erfcf
+  i32.const 1091847646
+  i32.const 2182553
+  i32.const -1090778605
+  call $std/math/test_erfcf
+  i32.const 1059682280
+  i32.const 1051903784
+  i32.const 1054227408
+  call $std/math/test_erfcf
+  i32.const -1093652892
+  i32.const 1068999958
+  i32.const 1054413128
+  call $std/math/test_erfcf
+  i32.const 1058000765
+  i32.const 1054512937
+  i32.const 1046805814
+  call $std/math/test_erfcf
+  i32.const 1061564120
+  i32.const 1049367783
+  i32.const 1035364990
+  call $std/math/test_erfcf
+  i32.const -1087519883
+  i32.const 1070914049
+  i32.const 1050064352
+  call $std/math/test_erfcf
+  i32.const 0
+  i32.const 1065353216
+  i32.const 0
+  call $std/math/test_erfcf
+  i32.const -2147483648
+  i32.const 1065353216
+  i32.const 0
+  call $std/math/test_erfcf
+  i32.const 2139095040
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erfcf
+  i32.const -8388608
+  i32.const 1073741824
+  i32.const 0
+  call $std/math/test_erfcf
+  i32.const 2143289344
+  i32.const 2143289344
+  i32.const 0
+  call $std/math/test_erfcf
   f64.const 2
   f64.const 4
   call $~lib/math/NativeMath.imul
@@ -48681,7 +50809,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4010
+   i32.const 4168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48694,7 +50822,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4011
+   i32.const 4169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48707,7 +50835,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4012
+   i32.const 4170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48720,7 +50848,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4013
+   i32.const 4171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48733,7 +50861,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4014
+   i32.const 4172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48746,7 +50874,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4015
+   i32.const 4173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48759,7 +50887,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4016
+   i32.const 4174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48772,7 +50900,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4017
+   i32.const 4175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48785,7 +50913,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4018
+   i32.const 4176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48798,7 +50926,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4019
+   i32.const 4177
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48811,7 +50939,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4020
+   i32.const 4178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48824,7 +50952,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4021
+   i32.const 4179
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48836,7 +50964,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4025
+   i32.const 4183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48848,7 +50976,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4026
+   i32.const 4184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48860,7 +50988,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4027
+   i32.const 4185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48872,7 +51000,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4028
+   i32.const 4186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48884,7 +51012,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4029
+   i32.const 4187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48896,7 +51024,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4030
+   i32.const 4188
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48908,7 +51036,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4031
+   i32.const 4189
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48920,7 +51048,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4032
+   i32.const 4190
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48932,7 +51060,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4033
+   i32.const 4191
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48944,7 +51072,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4034
+   i32.const 4192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48956,7 +51084,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4035
+   i32.const 4193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48968,7 +51096,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4036
+   i32.const 4194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48980,7 +51108,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4037
+   i32.const 4195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48992,7 +51120,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4038
+   i32.const 4196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49004,7 +51132,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4039
+   i32.const 4197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49016,7 +51144,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4040
+   i32.const 4198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49029,7 +51157,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4044
+   i32.const 4202
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49042,7 +51170,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4045
+   i32.const 4203
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49055,7 +51183,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4046
+   i32.const 4204
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49068,7 +51196,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4047
+   i32.const 4205
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49081,7 +51209,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4049
+   i32.const 4207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49094,7 +51222,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4050
+   i32.const 4208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49107,7 +51235,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4051
+   i32.const 4209
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49120,7 +51248,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4052
+   i32.const 4210
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49133,7 +51261,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4054
+   i32.const 4212
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49146,7 +51274,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4055
+   i32.const 4213
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49159,7 +51287,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4056
+   i32.const 4214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49172,7 +51300,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4057
+   i32.const 4215
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49185,7 +51313,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4059
+   i32.const 4217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49198,7 +51326,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4060
+   i32.const 4218
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49211,7 +51339,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4061
+   i32.const 4219
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49224,7 +51352,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4062
+   i32.const 4220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49237,7 +51365,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4064
+   i32.const 4222
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49250,7 +51378,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4065
+   i32.const 4223
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49263,7 +51391,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4066
+   i32.const 4224
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49276,7 +51404,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4067
+   i32.const 4225
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49289,7 +51417,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4069
+   i32.const 4227
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49302,7 +51430,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4070
+   i32.const 4228
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49315,7 +51443,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4071
+   i32.const 4229
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49328,7 +51456,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4072
+   i32.const 4230
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49341,7 +51469,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4073
+   i32.const 4231
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49354,7 +51482,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4075
+   i32.const 4233
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49367,7 +51495,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4076
+   i32.const 4234
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49380,7 +51508,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4077
+   i32.const 4235
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49393,7 +51521,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4078
+   i32.const 4236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49406,7 +51534,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4084
+   i32.const 4242
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49419,7 +51547,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4085
+   i32.const 4243
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49432,7 +51560,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4086
+   i32.const 4244
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49445,7 +51573,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4087
+   i32.const 4245
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49458,7 +51586,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4088
+   i32.const 4246
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49471,7 +51599,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4089
+   i32.const 4247
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49482,7 +51610,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4091
+   i32.const 4249
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49493,7 +51621,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4092
+   i32.const 4250
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49504,7 +51632,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4095
+   i32.const 4253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49517,7 +51645,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4097
+   i32.const 4255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49530,7 +51658,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4098
+   i32.const 4256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49543,7 +51671,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4101
+   i32.const 4259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49558,7 +51686,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4103
+   i32.const 4261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49573,7 +51701,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4104
+   i32.const 4262
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49588,7 +51716,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4105
+   i32.const 4263
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49601,7 +51729,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4106
+   i32.const 4264
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49616,7 +51744,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4107
+   i32.const 4265
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49629,7 +51757,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4109
+   i32.const 4267
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49642,7 +51770,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4110
+   i32.const 4268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49655,7 +51783,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4111
+   i32.const 4269
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49668,7 +51796,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4112
+   i32.const 4270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49681,7 +51809,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4113
+   i32.const 4271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49694,7 +51822,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4114
+   i32.const 4272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49707,7 +51835,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4115
+   i32.const 4273
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49720,7 +51848,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4116
+   i32.const 4274
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49733,7 +51861,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4117
+   i32.const 4275
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49752,7 +51880,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4119
+   i32.const 4277
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49769,7 +51897,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4120
+   i32.const 4278
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49782,7 +51910,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4122
+   i32.const 4280
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49795,7 +51923,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4123
+   i32.const 4281
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49808,7 +51936,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4124
+   i32.const 4282
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49821,7 +51949,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4125
+   i32.const 4283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49834,7 +51962,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4126
+   i32.const 4284
    i32.const 1
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -8221,7 +8221,7 @@
   if
    i32.const 0
    i32.const 3648
-   i32.const 1417
+   i32.const 1517
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.ts
+++ b/tests/compiler/std/math.ts
@@ -4005,6 +4005,164 @@ test_sincos(0x3FE1F9EF934745CB, 0x3FE10BAF3A5F550E, 0xBFD6B8FCE0000000, 0x3FEB15
 test_sincos(0x3FE8C5DB097F7442, 0x3FE65F1C5E591DB2, 0xBFDB5EFC20000000, 0x3FE6E164E427022B, 0xBFB5DB4C20000000, INEXACT);
 test_sincos(0xBFE5B86EA8118A0E, 0xBFE417318671B83D, 0xBFD87FFC00000000, 0x3FE8E83D35A366C0, 0x3FD3C52400000000, INEXACT);
 
+// Math.erf ////////////////////////////////////////////////////////////////////////////////
+
+function test_erf(value: u64, expected_erf: u64, error_erf: u64, flags: i32): bool {
+  var arg    = reinterpret<f64>(value);
+  var experf = reinterpret<f64>(expected_erf);
+  var errerf = reinterpret<f64>(error_erf);
+  return (check<f64>(NativeMath.erf(arg), experf, errerf, flags));
+}
+
+// sanity
+// -0x1.02239f3c6a8f1p+3,                 -0x1p+0, -0x1.348d36p-46
+//  0x1.161868e18bc67p+2,    0x1.fffffff922a8dp-1,   0x1.820cbap-3
+// -0x1.0c34b3e01e6e7p+3,                 -0x1p+0, -0x1.ae82dcp-54
+// -0x1.a206f0a19dcc4p+2,                 -0x1p+0, -0x1.de0bfcp-14
+//  0x1.288bbb0d6a1e6p+3,                  0x1p+0,         0x1p-76
+//  0x1.52efd0cd80497p-1,    0x1.4d38d900b92a6p-1,   0x1.6e4f14p-2
+// -0x1.a05cc754481d1p-2,   -0x1.bd28abf77e30fp-2,  -0x1.e051e8p-3
+//  0x1.1f9ef934745cbp-1,    0x1.2568d691ba679p-1,   0x1.9bd6d2p-5
+//  0x1.8c5db097f7442p-1,    0x1.73eb1974f96e5p-1,   0x1.75347cp-6
+// -0x1.5b86ea8118a0ep-1,   -0x1.5368032e78bd7p-1,  -0x1.b6a8ecp-3
+
+test_erf(0xC0202239F3C6A8F1, 0xBFF0000000000000, 0xBD1348D360000000, INEXACT);
+test_erf(0x401161868E18BC67, 0x3FEFFFFFFF922A8D, 0x3FC820CBA0000000, INEXACT);
+test_erf(0xC020C34B3E01E6E7, 0xBFF0000000000000, 0xBC9AE82DC0000000, INEXACT);
+test_erf(0xC01A206F0A19DCC4, 0xBFF0000000000000, 0xBF1DE0BFC0000000, INEXACT);
+test_erf(0x402288BBB0D6A1E6, 0x3FF0000000000000, 0x3B30000000000000, INEXACT);
+test_erf(0x3FE52EFD0CD80497, 0x3FE4D38D900B92A6, 0x3FD6E4F140000000, INEXACT);
+test_erf(0xBFDA05CC754481D1, 0xBFDBD28ABF77E30F, 0xBFCE051E80000000, INEXACT);
+test_erf(0x3FE1F9EF934745CB, 0x3FE2568D691BA679, 0x3FA9BD6D20000000, INEXACT);
+test_erf(0x3FE8C5DB097F7442, 0x3FE73EB1974F96E5, 0x3F975347C0000000, INEXACT);
+test_erf(0xBFE5B86EA8118A0E, 0xBFE5368032E78BD7, 0xBFCB6A8EC0000000, INEXACT);
+
+// special
+test_erf(0x0000000000000000, 0x0000000000000000, 0, 0); //  0.0,  0.0
+test_erf(0x1000000000000000, 0x1000000000000000, 0, 0); // -0.0, -0.0
+test_erf(0x7FF0000000000000, 0x3FF0000000000000, 0, 0); //  inf,  1.0
+test_erf(0xFFF0000000000000, 0xBFF0000000000000, 0, 0); // -inf, -1.0
+test_erf(0x7FF8000000000000, 0x7FF8000000000000, 0, 0); //  nan,  nan
+
+// Mathf.erf ////////////////////////////////////////////////////////////////////////////////
+
+function test_erff(value: u32, expected_erf: u32, error_erf: u32, flags: i32): bool {
+  var arg    = reinterpret<f32>(value);
+  var experf = reinterpret<f32>(expected_erf);
+  var errerf = reinterpret<f32>(error_erf);
+  return (check<f32>(NativeMathf.erf(arg), experf, errerf, flags));
+}
+
+// sanity
+//  -0x1.0223ap+3,         -0x1p+0, -0x1.348cbep-75
+//  0x1.161868p+2,          0x1p+0,   0x1.b75602p-8
+// -0x1.0c34b4p+3,         -0x1p+0, -0x1.ae82bcp-83
+//  -0x1.a206fp+2,         -0x1p+0, -0x1.de0c3ap-43
+//  0x1.288bbcp+3,          0x1p+0,        0x1p-105
+//   0x1.52efdp-1,   0x1.4d38d8p-1,   -0x1.ac77ap-3
+// -0x1.a05cc8p-2,  -0x1.bd28acp-2,   0x1.3775c2p-2
+//  0x1.1f9efap-1,   0x1.2568d8p-1,   0x1.8d8164p-2
+//   0x1.8c5dbp-1,   0x1.73eb1ap-1,    0x1.d2656p-2
+// -0x1.5b86eap-1,  -0x1.536802p-1,   0x1.a5287ep-2
+
+test_erff(0xC10111D0, 0xBF800000, 0x9A1A465F, INEXACT);
+test_erff(0x408B0C34, 0x3F800000, 0x3BDBAB01, INEXACT);
+test_erff(0xC1061A5A, 0xBF800000, 0x9657415E, INEXACT);
+test_erff(0xC0D10378, 0xBF800000, 0xAA6F061D, INEXACT);
+test_erff(0x411445DE, 0x3F800000, 0x0B000000, INEXACT);
+test_erff(0x3F2977E8, 0x3F269C6C, 0xBE563BD0, INEXACT);
+test_erff(0xBED02E64, 0xBEDE9456, 0x3E9BBAE1, INEXACT);
+test_erff(0x3F0FCF7D, 0x3F12B46C, 0x3EC6C0B2, INEXACT);
+test_erff(0x3F462ED8, 0x3F39F58D, 0x3EE932B0, INEXACT);
+test_erff(0xBF2DC375, 0xBF29B401, 0x3ED2943F, INEXACT);
+
+// special
+test_erff(0x00000000, 0x00000000, 0, 0); //  0.0,  0.0
+test_erff(0x10000000, 0x10000000, 0, 0); // -0.0, -0.0
+test_erff(0x7F800000, 0x3F800000, 0, 0); //  inf,  1.0
+test_erff(0xFF800000, 0xBF800000, 0, 0); // -inf, -1.0
+test_erff(0x7FC00000, 0x7FC00000, 0, 0); //  nan,  nan
+
+// Math.erfc ////////////////////////////////////////////////////////////////////////////////
+
+function test_erfc(value: u64, expected_erfc: u64, error_erfc: u64, flags: i32): bool {
+  var arg     = reinterpret<f64>(value);
+  var experfc = reinterpret<f64>(expected_erfc);
+  var errerfc = reinterpret<f64>(error_erfc);
+  return (check<f64>(NativeMath.erfc(arg), experfc, errerfc, flags));
+}
+
+// sanity
+// -0x1.02239f3c6a8f1p+3,                  0x1p+1,  0x1.348d36p-47
+//  0x1.161868e18bc67p+2,   0x1.b755ccc1065d2p-31,  -0x1.0a9bcep-2
+// -0x1.0c34b3e01e6e7p+3,                  0x1p+1,  0x1.ae82d8p-55
+// -0x1.a206f0a19dcc4p+2,                  0x1p+1,  0x1.de0bfcp-15
+//  0x1.288bbb0d6a1e6p+3,  0x1.0a6d5f0165357p-128,  -0x1.c3a344p-2
+//  0x1.52efd0cd80497p-1,    0x1.658e4dfe8dab5p-2,   0x1.2361dap-2
+// -0x1.a05cc754481d1p-2,    0x1.6f4a2afddf8c4p+0,   0x1.3c0a3ep-2
+//  0x1.1f9ef934745cbp-1,    0x1.b52e52dc8b30ep-2,  -0x1.9bd6d2p-4
+//  0x1.8c5db097f7442p-1,    0x1.1829cd160d236p-2,  -0x1.75347cp-5
+// -0x1.5b86ea8118a0ep-1,    0x1.a9b401973c5ebp+0,  -0x1.9255c4p-2
+
+test_erfc(0xC0202239F3C6A8F1, 0x4000000000000000, 0x3D0348D360000000, INEXACT);
+test_erfc(0x401161868E18BC67, 0x3E0B755CCC1065D2, 0xBFD0A9BCE0000000, INEXACT);
+test_erfc(0xC020C34B3E01E6E7, 0x4000000000000000, 0x3C8AE82D80000000, INEXACT);
+test_erfc(0xC01A206F0A19DCC4, 0x4000000000000000, 0x3F0DE0BFC0000000, INEXACT);
+test_erfc(0x402288BBB0D6A1E6, 0x37F0A6D5F0165357, 0xBFDC3A3440000000, INEXACT);
+test_erfc(0x3FE52EFD0CD80497, 0x3FD658E4DFE8DAB5, 0x3FD2361DA0000000, INEXACT);
+test_erfc(0xBFDA05CC754481D1, 0x3FF6F4A2AFDDF8C4, 0x3FD3C0A3E0000000, INEXACT);
+test_erfc(0x3FE1F9EF934745CB, 0x3FDB52E52DC8B30E, 0xBFB9BD6D20000000, INEXACT);
+test_erfc(0x3FE8C5DB097F7442, 0x3FD1829CD160D236, 0xBFA75347C0000000, INEXACT);
+test_erfc(0xBFE5B86EA8118A0E, 0x3FFA9B401973C5EB, 0xBFD9255C40000000, INEXACT);
+
+// special
+test_erfc(                 0, 0x3FF0000000000000,                  0,       0);
+test_erfc(0x8000000000000000, 0x3FF0000000000000,                  0,       0);
+test_erfc(0x7FF0000000000000,                  0,                  0,       0);
+test_erfc(0xFFF0000000000000, 0x4000000000000000,                  0,       0);
+test_erfc(0x7FF8000000000000, 0x7FF8000000000000,                  0,       0);
+test_erfc(0x3FF5DB559FE5C0BA, 0x3FAB53CF571D328F, 0x3FD9009820000000, INEXACT);
+
+
+// Mathf.erfc ////////////////////////////////////////////////////////////////////////////////
+
+function test_erfcf(value: u32, expected_erfcf: u32, error_erfcf: u32, flags: i32): bool {
+  var arg      = reinterpret<f32>(value);
+  var experfcf = reinterpret<f32>(expected_erfcf);
+  var errerfcf = reinterpret<f32>(error_erfcf);
+  return (check<f32>(NativeMathf.erfc(arg), experfcf, errerfcf, flags));
+}
+
+// sanity
+//  -0x1.0223ap+3,          0x1p+1,  0x1.348cbep-76
+//  0x1.161868p+2,  0x1.b75602p-31,  -0x1.47de08p-2
+// -0x1.0c34b4p+3,          0x1p+1,  0x1.ae82b8p-84
+//  -0x1.a206fp+2,          0x1p+1,  0x1.de0c3ap-44
+//  0x1.288bbcp+3, 0x1.0a6cc8p-128,  -0x1.f81426p-2
+//   0x1.52efdp-1,    0x1.658e5p-2,    0x1.ac77ap-2
+// -0x1.a05cc8p-2,   0x1.6f4a2cp+0,    0x1.b2229p-2
+//  0x1.1f9efap-1,   0x1.b52e52p-2,   0x1.c9fa6cp-3
+//   0x1.8c5dbp-1,   0x1.1829cep-2,   0x1.6cd4fcp-4
+// -0x1.5b86eap-1,   0x1.a9b402p+0,    0x1.2d6bcp-2
+
+test_erfcf(0xC10111D0, 0x40000000, 0x199A465F, INEXACT);
+test_erfcf(0x408B0C34, 0x305BAB01, 0xBEA3EF04, INEXACT);
+test_erfcf(0xC1061A5A, 0x40000000, 0x15D7415C, INEXACT);
+test_erfcf(0xC0D10378, 0x40000000, 0x29EF061D, INEXACT);
+test_erfcf(0x411445DE, 0x00214D99, 0xBEFC0A13, INEXACT | UNDERFLOW);
+test_erfcf(0x3F2977E8, 0x3EB2C728, 0x3ED63BD0, INEXACT);
+test_erfcf(0xBED02E64, 0x3FB7A516, 0x3ED91148, INEXACT);
+test_erfcf(0x3F0FCF7D, 0x3EDA9729, 0x3E64FD36, INEXACT);
+test_erfcf(0x3F462ED8, 0x3E8C14E7, 0x3DB66A7E, INEXACT);
+test_erfcf(0xBF2DC375, 0x3FD4DA01, 0x3E96B5E0, INEXACT);
+
+// special
+test_erfcf(         0, 0x3F800000, 0, 0);
+test_erfcf(0x80000000, 0x3F800000, 0, 0);
+test_erfcf(0x7F800000,          0, 0, 0);
+test_erfcf(0xFF800000, 0x40000000, 0, 0);
+test_erfcf(0x7FC00000, 0x7FC00000, 0, 0);
+
 // Math.imul //////////////////////////////////////////////////////////////////////////////////
 
 assert(NativeMath.imul(2, 4) == 8);

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -16724,13 +16724,10 @@
    f64.div
    local.set $6
    local.get $2
-   if (result i32)
-    i32.const 1
-   else
-    local.get $1
-    i32.const 1070596096
-    i32.lt_u
-   end
+   local.get $1
+   i32.const 1070596096
+   i32.lt_u
+   i32.or
    if
     f64.const 1
     local.get $0
@@ -17373,13 +17370,10 @@
    f32.div
    local.set $6
    local.get $2
-   if (result i32)
-    i32.const 1
-   else
-    local.get $1
-    i32.const 1048576000
-    i32.lt_u
-   end
+   local.get $1
+   i32.const 1048576000
+   i32.lt_u
+   i32.or
    if
     f32.const 1
     local.get $0

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -16349,7 +16349,7 @@
    return
   end
   f32.const 1
-  f32.const 0
+  f32.const 7.52316384526264e-37
   f32.sub
   local.set $6
   local.get $1
@@ -17898,11 +17898,11 @@
   local.get $2
   if (result f32)
    f32.const 2
-   f32.const 0
+   f32.const 7.52316384526264e-37
    f32.sub
   else
-   f32.const 0
-   f32.const 0
+   f32.const 7.52316384526264e-37
+   f32.const 7.52316384526264e-37
    f32.mul
   end
  )

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -11429,7 +11429,7 @@
   if
    i32.const 0
    i32.const 13376
-   i32.const 1417
+   i32.const 1517
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -10,6 +10,8 @@
  (type $none_=>_f64 (func (result f64)))
  (type $none_=>_none (func))
  (type $f64_=>_i32 (func (param f64) (result i32)))
+ (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i64_i64_i64_i32_=>_i32 (func (param i64 i64 i64 i32) (result i32)))
  (type $i64_=>_none (func (param i64)))
  (type $f64_=>_none (func (param f64)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
@@ -11427,7 +11429,7 @@
   if
    i32.const 0
    i32.const 13376
-   i32.const 1399
+   i32.const 1499
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -15847,6 +15849,2082 @@
   else
    i32.const 0
   end
+ )
+ (func $~lib/math/NativeMath.erf (param $0 f64) (result f64)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 f64)
+  (local $5 f64)
+  (local $6 f64)
+  (local $7 i32)
+  (local $8 f64)
+  (local $9 f64)
+  local.get $0
+  i64.reinterpret_f64
+  i64.const 32
+  i64.shr_u
+  i32.wrap_i64
+  local.set $1
+  local.get $1
+  i32.const 31
+  i32.shr_s
+  local.set $2
+  local.get $1
+  i32.const 2147483647
+  i32.and
+  local.set $1
+  local.get $1
+  i32.const 2146435072
+  i32.ge_u
+  if
+   local.get $2
+   i32.const 1
+   i32.or
+   f64.convert_i32_s
+   f64.const 1
+   local.get $0
+   f64.div
+   f64.add
+   return
+  end
+  local.get $1
+  i32.const 1072365568
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1043333120
+   i32.lt_u
+   if
+    f64.const 0.125
+    f64.const 8
+    local.get $0
+    f64.mul
+    f64.const 1.0270333367641007
+    local.get $0
+    f64.mul
+    f64.add
+    f64.mul
+    return
+   end
+   local.get $0
+   local.get $0
+   f64.mul
+   local.set $3
+   f64.const 0.12837916709551256
+   local.get $3
+   f64.const -0.3250421072470015
+   local.get $3
+   f64.const -0.02848174957559851
+   local.get $3
+   f64.const -0.005770270296489442
+   local.get $3
+   f64.const -2.3763016656650163e-05
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   local.set $4
+   f64.const 1
+   local.get $3
+   f64.const 0.39791722395915535
+   local.get $3
+   f64.const 0.0650222499887673
+   local.get $3
+   f64.const 0.005081306281875766
+   local.get $3
+   f64.const 1.3249473800432164e-04
+   local.get $3
+   f64.const -3.960228278775368e-06
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   local.set $5
+   local.get $4
+   local.get $5
+   f64.div
+   local.set $6
+   local.get $0
+   local.get $0
+   local.get $6
+   f64.mul
+   f64.add
+   return
+  end
+  f64.const 1
+  f64.const 2.2250738585072014e-308
+  f64.sub
+  local.set $6
+  local.get $1
+  i32.const 1075314688
+  i32.lt_u
+  if
+   f64.const 1
+   block $~lib/math/erfc2|inlined.0 (result f64)
+    local.get $1
+    local.set $7
+    local.get $0
+    local.set $3
+    local.get $7
+    i32.const 1072955392
+    i32.lt_u
+    if
+     local.get $3
+     local.set $4
+     local.get $4
+     f64.abs
+     f64.const 1
+     f64.sub
+     local.set $5
+     f64.const -2.3621185607526594e-03
+     local.get $5
+     f64.const 0.41485611868374833
+     local.get $5
+     f64.const -0.3722078760357013
+     local.get $5
+     f64.const 0.31834661990116175
+     local.get $5
+     f64.const -0.11089469428239668
+     local.get $5
+     f64.const 0.035478304325618236
+     local.get $5
+     f64.const -0.002166375594868791
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     local.set $8
+     f64.const 1
+     local.get $5
+     f64.const 0.10642088040084423
+     local.get $5
+     f64.const 0.540397917702171
+     local.get $5
+     f64.const 0.07182865441419627
+     local.get $5
+     f64.const 0.12617121980876164
+     local.get $5
+     f64.const 0.01363708391202905
+     local.get $5
+     f64.const 0.011984499846799107
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     local.set $9
+     f64.const 1
+     f64.const 0.8450629115104675
+     f64.sub
+     local.get $8
+     local.get $9
+     f64.div
+     f64.sub
+     br $~lib/math/erfc2|inlined.0
+    end
+    local.get $3
+    f64.abs
+    local.set $3
+    f64.const 1
+    local.get $3
+    local.get $3
+    f64.mul
+    f64.div
+    local.set $9
+    local.get $7
+    i32.const 1074191213
+    i32.lt_u
+    if
+     f64.const -0.009864944034847148
+     local.get $9
+     f64.const -0.6938585727071818
+     local.get $9
+     f64.const -10.558626225323291
+     local.get $9
+     f64.const -62.375332450326006
+     local.get $9
+     f64.const -162.39666946257347
+     local.get $9
+     f64.const -184.60509290671104
+     local.get $9
+     f64.const -81.2874355063066
+     local.get $9
+     f64.const -9.814329344169145
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     local.set $8
+     f64.const 1
+     local.get $9
+     f64.const 19.651271667439257
+     local.get $9
+     f64.const 137.65775414351904
+     local.get $9
+     f64.const 434.56587747522923
+     local.get $9
+     f64.const 645.3872717332679
+     local.get $9
+     f64.const 429.00814002756783
+     local.get $9
+     f64.const 108.63500554177944
+     local.get $9
+     f64.const 6.570249770319282
+     local.get $9
+     f64.const -0.0604244152148581
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     local.set $5
+    else
+     f64.const -0.0098649429247001
+     local.get $9
+     f64.const -0.799283237680523
+     local.get $9
+     f64.const -17.757954917754752
+     local.get $9
+     f64.const -160.63638485582192
+     local.get $9
+     f64.const -637.5664433683896
+     local.get $9
+     f64.const -1025.0951316110772
+     local.get $9
+     f64.const -483.5191916086514
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     local.set $8
+     f64.const 1
+     local.get $9
+     f64.const 30.33806074348246
+     local.get $9
+     f64.const 325.7925129965739
+     local.get $9
+     f64.const 1536.729586084437
+     local.get $9
+     f64.const 3199.8582195085955
+     local.get $9
+     f64.const 2553.0504064331644
+     local.get $9
+     f64.const 474.52854120695537
+     local.get $9
+     f64.const -22.44095244658582
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     f64.mul
+     f64.add
+     local.set $5
+    end
+    local.get $3
+    i64.reinterpret_f64
+    i64.const -4294967296
+    i64.and
+    f64.reinterpret_i64
+    local.set $4
+    local.get $4
+    f64.neg
+    local.get $4
+    f64.mul
+    f64.const 0.5625
+    f64.sub
+    call $~lib/math/NativeMath.exp
+    local.get $4
+    local.get $3
+    f64.sub
+    local.get $4
+    local.get $3
+    f64.add
+    f64.mul
+    local.get $8
+    local.get $5
+    f64.div
+    f64.add
+    call $~lib/math/NativeMath.exp
+    f64.mul
+    local.get $3
+    f64.div
+   end
+   f64.sub
+   local.set $6
+  end
+  local.get $6
+  local.get $0
+  f64.copysign
+ )
+ (func $std/math/test_erf (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i32) (result i32)
+  (local $4 f64)
+  (local $5 f64)
+  (local $6 f64)
+  local.get $0
+  f64.reinterpret_i64
+  local.set $4
+  local.get $1
+  f64.reinterpret_i64
+  local.set $5
+  local.get $2
+  f64.reinterpret_i64
+  local.set $6
+  local.get $4
+  call $~lib/math/NativeMath.erf
+  local.get $5
+  local.get $6
+  local.get $3
+  call $std/math/check<f64>
+ )
+ (func $~lib/math/NativeMathf.erf (param $0 f32) (result f32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 f32)
+  (local $5 f32)
+  (local $6 f32)
+  (local $7 i32)
+  (local $8 f32)
+  (local $9 f32)
+  local.get $0
+  i32.reinterpret_f32
+  local.set $1
+  local.get $1
+  i32.const 31
+  i32.shr_s
+  local.set $2
+  local.get $1
+  i32.const 2147483647
+  i32.and
+  local.set $1
+  local.get $1
+  i32.const 2139095040
+  i32.ge_u
+  if
+   local.get $2
+   i32.const 1
+   i32.or
+   f32.convert_i32_s
+   f32.const 1
+   local.get $0
+   f32.div
+   f32.add
+   return
+  end
+  local.get $1
+  i32.const 1062731776
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 830472192
+   i32.lt_u
+   if
+    f32.const 0.125
+    f32.const 8
+    local.get $0
+    f32.mul
+    f32.const 1.0270333290100098
+    local.get $0
+    f32.mul
+    f32.add
+    f32.mul
+    return
+   end
+   local.get $0
+   local.get $0
+   f32.mul
+   local.set $3
+   f32.const 0.12837916612625122
+   local.get $3
+   f32.const -0.32504209876060486
+   local.get $3
+   f32.const -0.028481749817728996
+   local.get $3
+   f32.const -0.005770270247012377
+   local.get $3
+   f32.const -2.3763017452438362e-05
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   local.set $4
+   f32.const 1
+   local.get $3
+   f32.const 0.3979172110557556
+   local.get $3
+   f32.const 0.06502225250005722
+   local.get $3
+   f32.const 5.0813062116503716e-03
+   local.get $3
+   f32.const 1.324947370449081e-04
+   local.get $3
+   f32.const -3.9602282413397916e-06
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   local.set $5
+   local.get $4
+   local.get $5
+   f32.div
+   local.set $6
+   local.get $0
+   local.get $0
+   local.get $6
+   f32.mul
+   f32.add
+   return
+  end
+  f32.const 1
+  f32.const 0
+  f32.sub
+  local.set $6
+  local.get $1
+  i32.const 1086324736
+  i32.lt_u
+  if
+   f32.const 1
+   block $~lib/math/erfc2f|inlined.0 (result f32)
+    local.get $1
+    local.set $7
+    local.get $0
+    local.set $3
+    local.get $7
+    i32.const 1067450368
+    i32.lt_u
+    if
+     local.get $3
+     local.set $4
+     local.get $4
+     f32.abs
+     f32.const 1
+     f32.sub
+     local.set $5
+     f32.const -2.3621185682713985e-03
+     local.get $5
+     f32.const 0.41485610604286194
+     local.get $5
+     f32.const -0.3722078800201416
+     local.get $5
+     f32.const 0.31834661960601807
+     local.get $5
+     f32.const -0.11089469492435455
+     local.get $5
+     f32.const 0.03547830507159233
+     local.get $5
+     f32.const -0.002166375517845154
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     local.set $8
+     f32.const 1
+     local.get $5
+     f32.const 0.10642088204622269
+     local.get $5
+     f32.const 0.5403979420661926
+     local.get $5
+     f32.const 0.07182865589857101
+     local.get $5
+     f32.const 0.12617121636867523
+     local.get $5
+     f32.const 0.01363708358258009
+     local.get $5
+     f32.const 0.011984500102698803
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     local.set $9
+     f32.const 1
+     f32.const 0.8450629115104675
+     f32.sub
+     local.get $8
+     local.get $9
+     f32.div
+     f32.sub
+     br $~lib/math/erfc2f|inlined.0
+    end
+    local.get $3
+    f32.abs
+    local.set $3
+    f32.const 1
+    local.get $3
+    local.get $3
+    f32.mul
+    f32.div
+    local.set $9
+    local.get $7
+    i32.const 1077336941
+    i32.lt_u
+    if
+     f32.const -0.009864944033324718
+     local.get $9
+     f32.const -0.6938585638999939
+     local.get $9
+     f32.const -10.558626174926758
+     local.get $9
+     f32.const -62.37533187866211
+     local.get $9
+     f32.const -162.39666748046875
+     local.get $9
+     f32.const -184.60508728027344
+     local.get $9
+     f32.const -81.28743743896484
+     local.get $9
+     f32.const -9.814329147338867
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     local.set $8
+     f32.const 1
+     local.get $9
+     f32.const 19.65127182006836
+     local.get $9
+     f32.const 137.6577606201172
+     local.get $9
+     f32.const 434.5658874511719
+     local.get $9
+     f32.const 645.3872680664062
+     local.get $9
+     f32.const 429.0081481933594
+     local.get $9
+     f32.const 108.63500213623047
+     local.get $9
+     f32.const 6.570249557495117
+     local.get $9
+     f32.const -0.06042441353201866
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     local.set $5
+    else
+     f32.const -0.009864943102002144
+     local.get $9
+     f32.const -0.7992832660675049
+     local.get $9
+     f32.const -17.75795555114746
+     local.get $9
+     f32.const -160.63638305664062
+     local.get $9
+     f32.const -637.5664672851562
+     local.get $9
+     f32.const -1025.0950927734375
+     local.get $9
+     f32.const -483.5191955566406
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     local.set $8
+     f32.const 1
+     local.get $9
+     f32.const 30.33806037902832
+     local.get $9
+     f32.const 325.7925109863281
+     local.get $9
+     f32.const 1536.7296142578125
+     local.get $9
+     f32.const 3199.858154296875
+     local.get $9
+     f32.const 2553.05029296875
+     local.get $9
+     f32.const 474.5285339355469
+     local.get $9
+     f32.const -22.44095230102539
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     f32.mul
+     f32.add
+     local.set $5
+    end
+    local.get $3
+    i32.reinterpret_f32
+    i32.const -8192
+    i32.and
+    f32.reinterpret_i32
+    local.set $4
+    local.get $4
+    f32.neg
+    local.get $4
+    f32.mul
+    f32.const 0.5625
+    f32.sub
+    call $~lib/math/NativeMathf.exp
+    local.get $4
+    local.get $3
+    f32.sub
+    local.get $4
+    local.get $3
+    f32.add
+    f32.mul
+    local.get $8
+    local.get $5
+    f32.div
+    f32.add
+    call $~lib/math/NativeMathf.exp
+    f32.mul
+    local.get $3
+    f32.div
+   end
+   f32.sub
+   local.set $6
+  end
+  local.get $6
+  local.get $0
+  f32.copysign
+ )
+ (func $std/math/test_erff (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 f32)
+  (local $5 f32)
+  (local $6 f32)
+  local.get $0
+  f32.reinterpret_i32
+  local.set $4
+  local.get $1
+  f32.reinterpret_i32
+  local.set $5
+  local.get $2
+  f32.reinterpret_i32
+  local.set $6
+  local.get $4
+  call $~lib/math/NativeMathf.erf
+  local.get $5
+  local.get $6
+  local.get $3
+  call $std/math/check<f32>
+ )
+ (func $~lib/math/NativeMath.erfc (param $0 f64) (result f64)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f64)
+  (local $4 f64)
+  (local $5 f64)
+  (local $6 f64)
+  (local $7 i32)
+  (local $8 f64)
+  local.get $0
+  i64.reinterpret_f64
+  i64.const 32
+  i64.shr_u
+  i32.wrap_i64
+  local.set $1
+  local.get $1
+  i32.const 31
+  i32.shr_u
+  local.set $2
+  local.get $1
+  i32.const 2147483647
+  i32.and
+  local.set $1
+  local.get $1
+  i32.const 2146435072
+  i32.ge_u
+  if
+   local.get $2
+   i32.const 1
+   i32.shl
+   f64.convert_i32_u
+   f64.const 1
+   local.get $0
+   f64.div
+   f64.add
+   return
+  end
+  local.get $1
+  i32.const 1072365568
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1013972992
+   i32.lt_u
+   if
+    f64.const 1
+    local.get $0
+    f64.sub
+    return
+   end
+   local.get $0
+   local.get $0
+   f64.mul
+   local.set $3
+   f64.const 0.12837916709551256
+   local.get $3
+   f64.const -0.3250421072470015
+   local.get $3
+   f64.const -0.02848174957559851
+   local.get $3
+   f64.const -0.005770270296489442
+   local.get $3
+   f64.const -2.3763016656650163e-05
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   local.set $4
+   f64.const 1
+   local.get $3
+   f64.const 0.39791722395915535
+   local.get $3
+   f64.const 0.0650222499887673
+   local.get $3
+   f64.const 0.005081306281875766
+   local.get $3
+   f64.const 1.3249473800432164e-04
+   local.get $3
+   f64.const -3.960228278775368e-06
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   f64.mul
+   f64.add
+   local.set $5
+   local.get $4
+   local.get $5
+   f64.div
+   local.set $6
+   local.get $2
+   if (result i32)
+    i32.const 1
+   else
+    local.get $1
+    i32.const 1070596096
+    i32.lt_u
+   end
+   if
+    f64.const 1
+    local.get $0
+    local.get $0
+    local.get $6
+    f64.mul
+    f64.add
+    f64.sub
+    return
+   end
+   f64.const 0.5
+   local.get $0
+   f64.const 0.5
+   f64.sub
+   local.get $0
+   local.get $6
+   f64.mul
+   f64.add
+   f64.sub
+   return
+  end
+  local.get $1
+  i32.const 1077673984
+  i32.lt_u
+  if
+   local.get $2
+   if (result f64)
+    f64.const 2
+    block $~lib/math/erfc2|inlined.1 (result f64)
+     local.get $1
+     local.set $7
+     local.get $0
+     local.set $3
+     local.get $7
+     i32.const 1072955392
+     i32.lt_u
+     if
+      local.get $3
+      local.set $4
+      local.get $4
+      f64.abs
+      f64.const 1
+      f64.sub
+      local.set $6
+      f64.const -2.3621185607526594e-03
+      local.get $6
+      f64.const 0.41485611868374833
+      local.get $6
+      f64.const -0.3722078760357013
+      local.get $6
+      f64.const 0.31834661990116175
+      local.get $6
+      f64.const -0.11089469428239668
+      local.get $6
+      f64.const 0.035478304325618236
+      local.get $6
+      f64.const -0.002166375594868791
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $5
+      f64.const 1
+      local.get $6
+      f64.const 0.10642088040084423
+      local.get $6
+      f64.const 0.540397917702171
+      local.get $6
+      f64.const 0.07182865441419627
+      local.get $6
+      f64.const 0.12617121980876164
+      local.get $6
+      f64.const 0.01363708391202905
+      local.get $6
+      f64.const 0.011984499846799107
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $8
+      f64.const 1
+      f64.const 0.8450629115104675
+      f64.sub
+      local.get $5
+      local.get $8
+      f64.div
+      f64.sub
+      br $~lib/math/erfc2|inlined.1
+     end
+     local.get $3
+     f64.abs
+     local.set $3
+     f64.const 1
+     local.get $3
+     local.get $3
+     f64.mul
+     f64.div
+     local.set $8
+     local.get $7
+     i32.const 1074191213
+     i32.lt_u
+     if
+      f64.const -0.009864944034847148
+      local.get $8
+      f64.const -0.6938585727071818
+      local.get $8
+      f64.const -10.558626225323291
+      local.get $8
+      f64.const -62.375332450326006
+      local.get $8
+      f64.const -162.39666946257347
+      local.get $8
+      f64.const -184.60509290671104
+      local.get $8
+      f64.const -81.2874355063066
+      local.get $8
+      f64.const -9.814329344169145
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $5
+      f64.const 1
+      local.get $8
+      f64.const 19.651271667439257
+      local.get $8
+      f64.const 137.65775414351904
+      local.get $8
+      f64.const 434.56587747522923
+      local.get $8
+      f64.const 645.3872717332679
+      local.get $8
+      f64.const 429.00814002756783
+      local.get $8
+      f64.const 108.63500554177944
+      local.get $8
+      f64.const 6.570249770319282
+      local.get $8
+      f64.const -0.0604244152148581
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $6
+     else
+      f64.const -0.0098649429247001
+      local.get $8
+      f64.const -0.799283237680523
+      local.get $8
+      f64.const -17.757954917754752
+      local.get $8
+      f64.const -160.63638485582192
+      local.get $8
+      f64.const -637.5664433683896
+      local.get $8
+      f64.const -1025.0951316110772
+      local.get $8
+      f64.const -483.5191916086514
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $5
+      f64.const 1
+      local.get $8
+      f64.const 30.33806074348246
+      local.get $8
+      f64.const 325.7925129965739
+      local.get $8
+      f64.const 1536.729586084437
+      local.get $8
+      f64.const 3199.8582195085955
+      local.get $8
+      f64.const 2553.0504064331644
+      local.get $8
+      f64.const 474.52854120695537
+      local.get $8
+      f64.const -22.44095244658582
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $6
+     end
+     local.get $3
+     i64.reinterpret_f64
+     i64.const -4294967296
+     i64.and
+     f64.reinterpret_i64
+     local.set $4
+     local.get $4
+     f64.neg
+     local.get $4
+     f64.mul
+     f64.const 0.5625
+     f64.sub
+     call $~lib/math/NativeMath.exp
+     local.get $4
+     local.get $3
+     f64.sub
+     local.get $4
+     local.get $3
+     f64.add
+     f64.mul
+     local.get $5
+     local.get $6
+     f64.div
+     f64.add
+     call $~lib/math/NativeMath.exp
+     f64.mul
+     local.get $3
+     f64.div
+    end
+    f64.sub
+   else
+    block $~lib/math/erfc2|inlined.2 (result f64)
+     local.get $1
+     local.set $7
+     local.get $0
+     local.set $3
+     local.get $7
+     i32.const 1072955392
+     i32.lt_u
+     if
+      local.get $3
+      local.set $8
+      local.get $8
+      f64.abs
+      f64.const 1
+      f64.sub
+      local.set $4
+      f64.const -2.3621185607526594e-03
+      local.get $4
+      f64.const 0.41485611868374833
+      local.get $4
+      f64.const -0.3722078760357013
+      local.get $4
+      f64.const 0.31834661990116175
+      local.get $4
+      f64.const -0.11089469428239668
+      local.get $4
+      f64.const 0.035478304325618236
+      local.get $4
+      f64.const -0.002166375594868791
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $6
+      f64.const 1
+      local.get $4
+      f64.const 0.10642088040084423
+      local.get $4
+      f64.const 0.540397917702171
+      local.get $4
+      f64.const 0.07182865441419627
+      local.get $4
+      f64.const 0.12617121980876164
+      local.get $4
+      f64.const 0.01363708391202905
+      local.get $4
+      f64.const 0.011984499846799107
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $5
+      f64.const 1
+      f64.const 0.8450629115104675
+      f64.sub
+      local.get $6
+      local.get $5
+      f64.div
+      f64.sub
+      br $~lib/math/erfc2|inlined.2
+     end
+     local.get $3
+     f64.abs
+     local.set $3
+     f64.const 1
+     local.get $3
+     local.get $3
+     f64.mul
+     f64.div
+     local.set $5
+     local.get $7
+     i32.const 1074191213
+     i32.lt_u
+     if
+      f64.const -0.009864944034847148
+      local.get $5
+      f64.const -0.6938585727071818
+      local.get $5
+      f64.const -10.558626225323291
+      local.get $5
+      f64.const -62.375332450326006
+      local.get $5
+      f64.const -162.39666946257347
+      local.get $5
+      f64.const -184.60509290671104
+      local.get $5
+      f64.const -81.2874355063066
+      local.get $5
+      f64.const -9.814329344169145
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $6
+      f64.const 1
+      local.get $5
+      f64.const 19.651271667439257
+      local.get $5
+      f64.const 137.65775414351904
+      local.get $5
+      f64.const 434.56587747522923
+      local.get $5
+      f64.const 645.3872717332679
+      local.get $5
+      f64.const 429.00814002756783
+      local.get $5
+      f64.const 108.63500554177944
+      local.get $5
+      f64.const 6.570249770319282
+      local.get $5
+      f64.const -0.0604244152148581
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $4
+     else
+      f64.const -0.0098649429247001
+      local.get $5
+      f64.const -0.799283237680523
+      local.get $5
+      f64.const -17.757954917754752
+      local.get $5
+      f64.const -160.63638485582192
+      local.get $5
+      f64.const -637.5664433683896
+      local.get $5
+      f64.const -1025.0951316110772
+      local.get $5
+      f64.const -483.5191916086514
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $6
+      f64.const 1
+      local.get $5
+      f64.const 30.33806074348246
+      local.get $5
+      f64.const 325.7925129965739
+      local.get $5
+      f64.const 1536.729586084437
+      local.get $5
+      f64.const 3199.8582195085955
+      local.get $5
+      f64.const 2553.0504064331644
+      local.get $5
+      f64.const 474.52854120695537
+      local.get $5
+      f64.const -22.44095244658582
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      f64.mul
+      f64.add
+      local.set $4
+     end
+     local.get $3
+     i64.reinterpret_f64
+     i64.const -4294967296
+     i64.and
+     f64.reinterpret_i64
+     local.set $8
+     local.get $8
+     f64.neg
+     local.get $8
+     f64.mul
+     f64.const 0.5625
+     f64.sub
+     call $~lib/math/NativeMath.exp
+     local.get $8
+     local.get $3
+     f64.sub
+     local.get $8
+     local.get $3
+     f64.add
+     f64.mul
+     local.get $6
+     local.get $4
+     f64.div
+     f64.add
+     call $~lib/math/NativeMath.exp
+     f64.mul
+     local.get $3
+     f64.div
+    end
+   end
+   return
+  end
+  local.get $2
+  if (result f64)
+   f64.const 2
+   f64.const 2.2250738585072014e-308
+   f64.sub
+  else
+   f64.const 2.2250738585072014e-308
+   f64.const 2.2250738585072014e-308
+   f64.mul
+  end
+ )
+ (func $std/math/test_erfc (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i32) (result i32)
+  (local $4 f64)
+  (local $5 f64)
+  (local $6 f64)
+  local.get $0
+  f64.reinterpret_i64
+  local.set $4
+  local.get $1
+  f64.reinterpret_i64
+  local.set $5
+  local.get $2
+  f64.reinterpret_i64
+  local.set $6
+  local.get $4
+  call $~lib/math/NativeMath.erfc
+  local.get $5
+  local.get $6
+  local.get $3
+  call $std/math/check<f64>
+ )
+ (func $~lib/math/NativeMathf.erfc (param $0 f32) (result f32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 f32)
+  (local $4 f32)
+  (local $5 f32)
+  (local $6 f32)
+  (local $7 i32)
+  (local $8 f32)
+  local.get $0
+  i32.reinterpret_f32
+  local.set $1
+  local.get $1
+  i32.const 31
+  i32.shr_u
+  local.set $2
+  local.get $1
+  i32.const 2147483647
+  i32.and
+  local.set $1
+  local.get $1
+  i32.const 2139095040
+  i32.ge_u
+  if
+   local.get $2
+   i32.const 1
+   i32.shl
+   f32.convert_i32_u
+   f32.const 1
+   local.get $0
+   f32.div
+   f32.add
+   return
+  end
+  local.get $1
+  i32.const 1062731776
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 595591168
+   i32.lt_u
+   if
+    f32.const 1
+    local.get $0
+    f32.sub
+    return
+   end
+   local.get $0
+   local.get $0
+   f32.mul
+   local.set $3
+   f32.const 0.12837916612625122
+   local.get $3
+   f32.const -0.32504209876060486
+   local.get $3
+   f32.const -0.028481749817728996
+   local.get $3
+   f32.const -0.005770270247012377
+   local.get $3
+   f32.const -2.3763017452438362e-05
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   local.set $4
+   f32.const 1
+   local.get $3
+   f32.const 0.3979172110557556
+   local.get $3
+   f32.const 0.06502225250005722
+   local.get $3
+   f32.const 5.0813062116503716e-03
+   local.get $3
+   f32.const 1.324947370449081e-04
+   local.get $3
+   f32.const -3.9602282413397916e-06
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   f32.mul
+   f32.add
+   local.set $5
+   local.get $4
+   local.get $5
+   f32.div
+   local.set $6
+   local.get $2
+   if (result i32)
+    i32.const 1
+   else
+    local.get $1
+    i32.const 1048576000
+    i32.lt_u
+   end
+   if
+    f32.const 1
+    local.get $0
+    local.get $0
+    local.get $6
+    f32.mul
+    f32.add
+    f32.sub
+    return
+   end
+   f32.const 0.5
+   local.get $0
+   f32.const 0.5
+   f32.sub
+   local.get $0
+   local.get $6
+   f32.mul
+   f32.add
+   f32.sub
+   return
+  end
+  local.get $1
+  i32.const 1105199104
+  i32.lt_u
+  if
+   local.get $2
+   if (result f32)
+    f32.const 2
+    block $~lib/math/erfc2f|inlined.1 (result f32)
+     local.get $1
+     local.set $7
+     local.get $0
+     local.set $3
+     local.get $7
+     i32.const 1067450368
+     i32.lt_u
+     if
+      local.get $3
+      local.set $4
+      local.get $4
+      f32.abs
+      f32.const 1
+      f32.sub
+      local.set $6
+      f32.const -2.3621185682713985e-03
+      local.get $6
+      f32.const 0.41485610604286194
+      local.get $6
+      f32.const -0.3722078800201416
+      local.get $6
+      f32.const 0.31834661960601807
+      local.get $6
+      f32.const -0.11089469492435455
+      local.get $6
+      f32.const 0.03547830507159233
+      local.get $6
+      f32.const -0.002166375517845154
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $5
+      f32.const 1
+      local.get $6
+      f32.const 0.10642088204622269
+      local.get $6
+      f32.const 0.5403979420661926
+      local.get $6
+      f32.const 0.07182865589857101
+      local.get $6
+      f32.const 0.12617121636867523
+      local.get $6
+      f32.const 0.01363708358258009
+      local.get $6
+      f32.const 0.011984500102698803
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $8
+      f32.const 1
+      f32.const 0.8450629115104675
+      f32.sub
+      local.get $5
+      local.get $8
+      f32.div
+      f32.sub
+      br $~lib/math/erfc2f|inlined.1
+     end
+     local.get $3
+     f32.abs
+     local.set $3
+     f32.const 1
+     local.get $3
+     local.get $3
+     f32.mul
+     f32.div
+     local.set $8
+     local.get $7
+     i32.const 1077336941
+     i32.lt_u
+     if
+      f32.const -0.009864944033324718
+      local.get $8
+      f32.const -0.6938585638999939
+      local.get $8
+      f32.const -10.558626174926758
+      local.get $8
+      f32.const -62.37533187866211
+      local.get $8
+      f32.const -162.39666748046875
+      local.get $8
+      f32.const -184.60508728027344
+      local.get $8
+      f32.const -81.28743743896484
+      local.get $8
+      f32.const -9.814329147338867
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $5
+      f32.const 1
+      local.get $8
+      f32.const 19.65127182006836
+      local.get $8
+      f32.const 137.6577606201172
+      local.get $8
+      f32.const 434.5658874511719
+      local.get $8
+      f32.const 645.3872680664062
+      local.get $8
+      f32.const 429.0081481933594
+      local.get $8
+      f32.const 108.63500213623047
+      local.get $8
+      f32.const 6.570249557495117
+      local.get $8
+      f32.const -0.06042441353201866
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $6
+     else
+      f32.const -0.009864943102002144
+      local.get $8
+      f32.const -0.7992832660675049
+      local.get $8
+      f32.const -17.75795555114746
+      local.get $8
+      f32.const -160.63638305664062
+      local.get $8
+      f32.const -637.5664672851562
+      local.get $8
+      f32.const -1025.0950927734375
+      local.get $8
+      f32.const -483.5191955566406
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $5
+      f32.const 1
+      local.get $8
+      f32.const 30.33806037902832
+      local.get $8
+      f32.const 325.7925109863281
+      local.get $8
+      f32.const 1536.7296142578125
+      local.get $8
+      f32.const 3199.858154296875
+      local.get $8
+      f32.const 2553.05029296875
+      local.get $8
+      f32.const 474.5285339355469
+      local.get $8
+      f32.const -22.44095230102539
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $6
+     end
+     local.get $3
+     i32.reinterpret_f32
+     i32.const -8192
+     i32.and
+     f32.reinterpret_i32
+     local.set $4
+     local.get $4
+     f32.neg
+     local.get $4
+     f32.mul
+     f32.const 0.5625
+     f32.sub
+     call $~lib/math/NativeMathf.exp
+     local.get $4
+     local.get $3
+     f32.sub
+     local.get $4
+     local.get $3
+     f32.add
+     f32.mul
+     local.get $5
+     local.get $6
+     f32.div
+     f32.add
+     call $~lib/math/NativeMathf.exp
+     f32.mul
+     local.get $3
+     f32.div
+    end
+    f32.sub
+   else
+    block $~lib/math/erfc2f|inlined.2 (result f32)
+     local.get $1
+     local.set $7
+     local.get $0
+     local.set $3
+     local.get $7
+     i32.const 1067450368
+     i32.lt_u
+     if
+      local.get $3
+      local.set $8
+      local.get $8
+      f32.abs
+      f32.const 1
+      f32.sub
+      local.set $4
+      f32.const -2.3621185682713985e-03
+      local.get $4
+      f32.const 0.41485610604286194
+      local.get $4
+      f32.const -0.3722078800201416
+      local.get $4
+      f32.const 0.31834661960601807
+      local.get $4
+      f32.const -0.11089469492435455
+      local.get $4
+      f32.const 0.03547830507159233
+      local.get $4
+      f32.const -0.002166375517845154
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $6
+      f32.const 1
+      local.get $4
+      f32.const 0.10642088204622269
+      local.get $4
+      f32.const 0.5403979420661926
+      local.get $4
+      f32.const 0.07182865589857101
+      local.get $4
+      f32.const 0.12617121636867523
+      local.get $4
+      f32.const 0.01363708358258009
+      local.get $4
+      f32.const 0.011984500102698803
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $5
+      f32.const 1
+      f32.const 0.8450629115104675
+      f32.sub
+      local.get $6
+      local.get $5
+      f32.div
+      f32.sub
+      br $~lib/math/erfc2f|inlined.2
+     end
+     local.get $3
+     f32.abs
+     local.set $3
+     f32.const 1
+     local.get $3
+     local.get $3
+     f32.mul
+     f32.div
+     local.set $5
+     local.get $7
+     i32.const 1077336941
+     i32.lt_u
+     if
+      f32.const -0.009864944033324718
+      local.get $5
+      f32.const -0.6938585638999939
+      local.get $5
+      f32.const -10.558626174926758
+      local.get $5
+      f32.const -62.37533187866211
+      local.get $5
+      f32.const -162.39666748046875
+      local.get $5
+      f32.const -184.60508728027344
+      local.get $5
+      f32.const -81.28743743896484
+      local.get $5
+      f32.const -9.814329147338867
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $6
+      f32.const 1
+      local.get $5
+      f32.const 19.65127182006836
+      local.get $5
+      f32.const 137.6577606201172
+      local.get $5
+      f32.const 434.5658874511719
+      local.get $5
+      f32.const 645.3872680664062
+      local.get $5
+      f32.const 429.0081481933594
+      local.get $5
+      f32.const 108.63500213623047
+      local.get $5
+      f32.const 6.570249557495117
+      local.get $5
+      f32.const -0.06042441353201866
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $4
+     else
+      f32.const -0.009864943102002144
+      local.get $5
+      f32.const -0.7992832660675049
+      local.get $5
+      f32.const -17.75795555114746
+      local.get $5
+      f32.const -160.63638305664062
+      local.get $5
+      f32.const -637.5664672851562
+      local.get $5
+      f32.const -1025.0950927734375
+      local.get $5
+      f32.const -483.5191955566406
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $6
+      f32.const 1
+      local.get $5
+      f32.const 30.33806037902832
+      local.get $5
+      f32.const 325.7925109863281
+      local.get $5
+      f32.const 1536.7296142578125
+      local.get $5
+      f32.const 3199.858154296875
+      local.get $5
+      f32.const 2553.05029296875
+      local.get $5
+      f32.const 474.5285339355469
+      local.get $5
+      f32.const -22.44095230102539
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      f32.mul
+      f32.add
+      local.set $4
+     end
+     local.get $3
+     i32.reinterpret_f32
+     i32.const -8192
+     i32.and
+     f32.reinterpret_i32
+     local.set $8
+     local.get $8
+     f32.neg
+     local.get $8
+     f32.mul
+     f32.const 0.5625
+     f32.sub
+     call $~lib/math/NativeMathf.exp
+     local.get $8
+     local.get $3
+     f32.sub
+     local.get $8
+     local.get $3
+     f32.add
+     f32.mul
+     local.get $6
+     local.get $4
+     f32.div
+     f32.add
+     call $~lib/math/NativeMathf.exp
+     f32.mul
+     local.get $3
+     f32.div
+    end
+   end
+   return
+  end
+  local.get $2
+  if (result f32)
+   f32.const 2
+   f32.const 0
+   f32.sub
+  else
+   f32.const 0
+   f32.const 0
+   f32.mul
+  end
+ )
+ (func $std/math/test_erfcf (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 f32)
+  (local $5 f32)
+  (local $6 f32)
+  local.get $0
+  f32.reinterpret_i32
+  local.set $4
+  local.get $1
+  f32.reinterpret_i32
+  local.set $5
+  local.get $2
+  f32.reinterpret_i32
+  local.set $6
+  local.get $4
+  call $~lib/math/NativeMathf.erfc
+  local.get $5
+  local.get $6
+  local.get $3
+  call $std/math/check<f32>
  )
  (func $~lib/math/dtoi32 (param $0 f64) (result i32)
   (local $1 i32)
@@ -58040,6 +60118,374 @@
   global.get $std/math/INEXACT
   call $std/math/test_sincos
   drop
+  i64.const -4602641186874283791
+  i64.const -4616189618054758400
+  i64.const -4822430703297757184
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const 4616578323568966759
+  i64.const 4607182418792819341
+  i64.const 4595959478666395648
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const -4602464091242371353
+  i64.const -4616189618054758400
+  i64.const -4856313964973260800
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const -4604332007749985084
+  i64.const -4616189618054758400
+  i64.const -4675333723976105984
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const 4621406507342668262
+  i64.const 4607182418800017408
+  i64.const 4264908847119859712
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const 4604137858433287319
+  i64.const 4604037324040016550
+  i64.const 4600115794217533440
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const -4622375691843501615
+  i64.const -4621869099206057201
+  i64.const -4625754138708279296
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const 4603235101512779211
+  i64.const 4603336934479865465
+  i64.const 4587405971839516672
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const 4605148163534189634
+  i64.const 4604718076478330597
+  i64.const 4582222713501777920
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const -4619083057392940530
+  i64.const -4619225918560826409
+  i64.const -4626487030853926912
+  global.get $std/math/INEXACT
+  call $std/math/test_erf
+  drop
+  i64.const 0
+  i64.const 0
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erf
+  drop
+  i64.const 1152921504606846976
+  i64.const 1152921504606846976
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erf
+  drop
+  i64.const 9218868437227405312
+  i64.const 4607182418800017408
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erf
+  drop
+  i64.const -4503599627370496
+  i64.const -4616189618054758400
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erf
+  drop
+  i64.const 9221120237041090560
+  i64.const 9221120237041090560
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erf
+  drop
+  i32.const -1056894512
+  i32.const -1082130432
+  i32.const -1709554081
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const 1082854452
+  i32.const 1065353216
+  i32.const 1004251905
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const -1056564646
+  i32.const -1082130432
+  i32.const -1772666530
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const -1060043912
+  i32.const -1082130432
+  i32.const -1435564515
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const 1091847646
+  i32.const 1065353216
+  i32.const 184549376
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const 1059682280
+  i32.const 1059495020
+  i32.const -1101644848
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const -1093652892
+  i32.const -1092709290
+  i32.const 1050393313
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const 1058000765
+  i32.const 1058190444
+  i32.const 1053212850
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const 1061564120
+  i32.const 1060763021
+  i32.const 1055470256
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const -1087519883
+  i32.const -1087785983
+  i32.const 1053987903
+  global.get $std/math/INEXACT
+  call $std/math/test_erff
+  drop
+  i32.const 0
+  i32.const 0
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erff
+  drop
+  i32.const 268435456
+  i32.const 268435456
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erff
+  drop
+  i32.const 2139095040
+  i32.const 1065353216
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erff
+  drop
+  i32.const -8388608
+  i32.const -1082130432
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erff
+  drop
+  i32.const 2143289344
+  i32.const 2143289344
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erff
+  drop
+  i64.const -4602641186874283791
+  i64.const 4611686018427387904
+  i64.const 4396437733929648128
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const 4616578323568966759
+  i64.const 4470796096516416978
+  i64.const -4625010188632457216
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const -4602464091242371353
+  i64.const 4611686018427387904
+  i64.const 4362554471180402688
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const -4604332007749985084
+  i64.const 4611686018427387904
+  i64.const 4543534713251299328
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const 4621406507342668262
+  i64.const 4030905104282833751
+  i64.const -4621755121502519296
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const 4604137858433287319
+  i64.const 4599961809437907637
+  i64.const 4598797670365003776
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const -4622375691843501615
+  i64.const 4609140248232720580
+  i64.const 4599231454545707008
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const 4603235101512779211
+  i64.const 4601362588558209806
+  i64.const -4631462465387888640
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const 4605148163534189634
+  i64.const 4598600304561279542
+  i64.const -4636645723725627392
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const -4619083057392940530
+  i64.const 4610167868174353899
+  i64.const -4622622464378142720
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i64.const 0
+  i64.const 4607182418800017408
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erfc
+  drop
+  i64.const -9223372036854775808
+  i64.const 4607182418800017408
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erfc
+  drop
+  i64.const 9218868437227405312
+  i64.const 0
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erfc
+  drop
+  i64.const -4503599627370496
+  i64.const 4611686018427387904
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erfc
+  drop
+  i64.const 9221120237041090560
+  i64.const 9221120237041090560
+  i64.const 0
+  i32.const 0
+  call $std/math/test_erfc
+  drop
+  i64.const 4608830954484908218
+  i64.const 4587852795391849103
+  i64.const 4600709147707572224
+  global.get $std/math/INEXACT
+  call $std/math/test_erfc
+  drop
+  i32.const -1056894512
+  i32.const 1073741824
+  i32.const 429540959
+  global.get $std/math/INEXACT
+  call $std/math/test_erfcf
+  drop
+  i32.const 1082854452
+  i32.const 811313921
+  i32.const -1096552700
+  global.get $std/math/INEXACT
+  call $std/math/test_erfcf
+  drop
+  i32.const -1056564646
+  i32.const 1073741824
+  i32.const 366428508
+  global.get $std/math/INEXACT
+  call $std/math/test_erfcf
+  drop
+  i32.const -1060043912
+  i32.const 1073741824
+  i32.const 703530525
+  global.get $std/math/INEXACT
+  call $std/math/test_erfcf
+  drop
+  i32.const 1091847646
+  i32.const 2182553
+  i32.const -1090778605
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_erfcf
+  drop
+  i32.const 1059682280
+  i32.const 1051903784
+  i32.const 1054227408
+  global.get $std/math/INEXACT
+  call $std/math/test_erfcf
+  drop
+  i32.const -1093652892
+  i32.const 1068999958
+  i32.const 1054413128
+  global.get $std/math/INEXACT
+  call $std/math/test_erfcf
+  drop
+  i32.const 1058000765
+  i32.const 1054512937
+  i32.const 1046805814
+  global.get $std/math/INEXACT
+  call $std/math/test_erfcf
+  drop
+  i32.const 1061564120
+  i32.const 1049367783
+  i32.const 1035364990
+  global.get $std/math/INEXACT
+  call $std/math/test_erfcf
+  drop
+  i32.const -1087519883
+  i32.const 1070914049
+  i32.const 1050064352
+  global.get $std/math/INEXACT
+  call $std/math/test_erfcf
+  drop
+  i32.const 0
+  i32.const 1065353216
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erfcf
+  drop
+  i32.const -2147483648
+  i32.const 1065353216
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erfcf
+  drop
+  i32.const 2139095040
+  i32.const 0
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erfcf
+  drop
+  i32.const -8388608
+  i32.const 1073741824
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erfcf
+  drop
+  i32.const 2143289344
+  i32.const 2143289344
+  i32.const 0
+  i32.const 0
+  call $std/math/test_erfcf
+  drop
   f64.const 2
   f64.const 4
   call $~lib/math/NativeMath.imul
@@ -58049,7 +60495,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4010
+   i32.const 4168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58063,7 +60509,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4011
+   i32.const 4169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58077,7 +60523,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4012
+   i32.const 4170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58091,7 +60537,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4013
+   i32.const 4171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58105,7 +60551,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4014
+   i32.const 4172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58119,7 +60565,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4015
+   i32.const 4173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58133,7 +60579,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4016
+   i32.const 4174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58147,7 +60593,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4017
+   i32.const 4175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58161,7 +60607,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4018
+   i32.const 4176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58175,7 +60621,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4019
+   i32.const 4177
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58189,7 +60635,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4020
+   i32.const 4178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58203,7 +60649,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4021
+   i32.const 4179
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58216,7 +60662,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4025
+   i32.const 4183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58229,7 +60675,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4026
+   i32.const 4184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58242,7 +60688,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4027
+   i32.const 4185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58255,7 +60701,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4028
+   i32.const 4186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58268,7 +60714,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4029
+   i32.const 4187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58281,7 +60727,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4030
+   i32.const 4188
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58294,7 +60740,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4031
+   i32.const 4189
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58307,7 +60753,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4032
+   i32.const 4190
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58320,7 +60766,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4033
+   i32.const 4191
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58333,7 +60779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4034
+   i32.const 4192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58346,7 +60792,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4035
+   i32.const 4193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58360,7 +60806,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4036
+   i32.const 4194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58373,7 +60819,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4037
+   i32.const 4195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58386,7 +60832,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4038
+   i32.const 4196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58400,7 +60846,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4039
+   i32.const 4197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58413,7 +60859,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4040
+   i32.const 4198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58427,7 +60873,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4044
+   i32.const 4202
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58441,7 +60887,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4045
+   i32.const 4203
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58455,7 +60901,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4046
+   i32.const 4204
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58469,7 +60915,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4047
+   i32.const 4205
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58483,7 +60929,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4049
+   i32.const 4207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58497,7 +60943,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4050
+   i32.const 4208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58511,7 +60957,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4051
+   i32.const 4209
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58525,7 +60971,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4052
+   i32.const 4210
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58539,7 +60985,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4054
+   i32.const 4212
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58553,7 +60999,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4055
+   i32.const 4213
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58567,7 +61013,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4056
+   i32.const 4214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58581,7 +61027,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4057
+   i32.const 4215
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58595,7 +61041,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4059
+   i32.const 4217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58609,7 +61055,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4060
+   i32.const 4218
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58623,7 +61069,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4061
+   i32.const 4219
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58637,7 +61083,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4062
+   i32.const 4220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58651,7 +61097,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4064
+   i32.const 4222
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58665,7 +61111,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4065
+   i32.const 4223
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58679,7 +61125,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4066
+   i32.const 4224
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58693,7 +61139,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4067
+   i32.const 4225
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58707,7 +61153,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4069
+   i32.const 4227
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58721,7 +61167,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4070
+   i32.const 4228
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58735,7 +61181,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4071
+   i32.const 4229
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58749,7 +61195,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4072
+   i32.const 4230
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58763,7 +61209,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4073
+   i32.const 4231
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58777,7 +61223,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4075
+   i32.const 4233
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58791,7 +61237,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4076
+   i32.const 4234
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58805,7 +61251,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4077
+   i32.const 4235
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58819,7 +61265,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4078
+   i32.const 4236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58851,7 +61297,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4084
+   i32.const 4242
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58865,7 +61311,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4085
+   i32.const 4243
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58879,7 +61325,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4086
+   i32.const 4244
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58893,7 +61339,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4087
+   i32.const 4245
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58907,7 +61353,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4088
+   i32.const 4246
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58921,7 +61367,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4089
+   i32.const 4247
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58935,7 +61381,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4091
+   i32.const 4249
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58949,7 +61395,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4092
+   i32.const 4250
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58981,7 +61427,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4095
+   i32.const 4253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58995,7 +61441,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4097
+   i32.const 4255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59009,7 +61455,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4098
+   i32.const 4256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59041,7 +61487,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4101
+   i32.const 4259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59059,7 +61505,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4103
+   i32.const 4261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59077,7 +61523,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4104
+   i32.const 4262
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59093,7 +61539,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4105
+   i32.const 4263
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59109,7 +61555,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4106
+   i32.const 4264
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59125,7 +61571,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4107
+   i32.const 4265
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59139,7 +61585,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4109
+   i32.const 4267
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59153,7 +61599,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4110
+   i32.const 4268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59167,7 +61613,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4111
+   i32.const 4269
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59181,7 +61627,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4112
+   i32.const 4270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59195,7 +61641,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4113
+   i32.const 4271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59209,7 +61655,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4114
+   i32.const 4272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59223,7 +61669,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4115
+   i32.const 4273
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59237,7 +61683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4116
+   i32.const 4274
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59251,7 +61697,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4117
+   i32.const 4275
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59271,7 +61717,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4119
+   i32.const 4277
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59289,7 +61735,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4120
+   i32.const 4278
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59304,7 +61750,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4122
+   i32.const 4280
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59319,7 +61765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4123
+   i32.const 4281
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59334,7 +61780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4124
+   i32.const 4282
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59348,7 +61794,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4125
+   i32.const 4283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59362,7 +61808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4126
+   i32.const 4284
    i32.const 1
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/wasi/seed.optimized.wat
+++ b/tests/compiler/wasi/seed.optimized.wat
@@ -297,7 +297,7 @@
   (local $3 i32)
   i32.const 5
   local.set $2
-  i32.const 1399
+  i32.const 1499
   local.set $1
   i32.const 0
   i32.const 12
@@ -318,7 +318,7 @@
   local.tee $0
   i32.const 40
   i32.store8
-  i32.const 1399
+  i32.const 1499
   call $~lib/util/number/decimalCount32
   local.tee $3
   local.get $0

--- a/tests/compiler/wasi/seed.optimized.wat
+++ b/tests/compiler/wasi/seed.optimized.wat
@@ -297,7 +297,7 @@
   (local $3 i32)
   i32.const 5
   local.set $2
-  i32.const 1417
+  i32.const 1517
   local.set $1
   i32.const 0
   i32.const 12
@@ -318,7 +318,7 @@
   local.tee $0
   i32.const 40
   i32.store8
-  i32.const 1417
+  i32.const 1517
   call $~lib/util/number/decimalCount32
   local.tee $3
   local.get $0

--- a/tests/compiler/wasi/seed.untouched.wat
+++ b/tests/compiler/wasi/seed.untouched.wat
@@ -610,7 +610,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1399
+   i32.const 1499
    i32.const 5
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/wasi/seed.untouched.wat
+++ b/tests/compiler/wasi/seed.untouched.wat
@@ -610,7 +610,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1417
+   i32.const 1517
    i32.const 5
    call $~lib/wasi/index/abort
    unreachable


### PR DESCRIPTION
Error Function and Complementary Error Function is not including in JavaScript's Math but these special functions very important for statistics and other analysis and simulations due to erf / erfc is gaussian's integral.

- [x] I've read the contributing guidelines