### PR TITLE
Fix assertion when compiling a property errored earlier

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -9019,7 +9019,8 @@ export class Compiler extends DiagnosticEmitter {
       }
       case ElementKind.PROPERTY: {
         let propertyInstance = <Property>target;
-        let getterInstance = assert(propertyInstance.getterInstance);
+        let getterInstance = propertyInstance.getterInstance;
+        if (!getterInstance) return module.unreachable(); // failed earlier
         let thisArg: ExpressionRef = 0;
         if (getterInstance.is(CommonFlags.INSTANCE)) {
           thisArg = this.compileExpression(


### PR DESCRIPTION
When compilation of a property failed earlier, for example due to an unknown type, we were hitting an assertion upon access to the property.

fixes #1711

- [x] I've read the contributing guidelines