### PR TITLE
Handle blocks larger than MAXSIZE in TLSF

### DIFF
--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -207,9 +207,8 @@ function insertBlock(root: Root, block: Block): void {
 
   // merge with right block if also free
   if (rightInfo & FREE) {
-    let newSize = (blockInfo & ~TAGS_MASK) + BLOCK_OVERHEAD + (rightInfo & ~TAGS_MASK);
     removeBlock(root, right);
-    block.mmInfo = blockInfo = (blockInfo & TAGS_MASK) | newSize;
+    block.mmInfo = blockInfo = blockInfo + BLOCK_OVERHEAD + (rightInfo & ~TAGS_MASK); // keep block tags
     right = GETRIGHT(block);
     rightInfo = right.mmInfo;
     // 'back' is set below
@@ -220,10 +219,9 @@ function insertBlock(root: Root, block: Block): void {
     let left = GETFREELEFT(block);
     let leftInfo = left.mmInfo;
     if (DEBUG) assert(leftInfo & FREE); // must be free according to right tags
-    let newSize = (leftInfo & ~TAGS_MASK) + BLOCK_OVERHEAD + (blockInfo & ~TAGS_MASK);
     removeBlock(root, left);
-    left.mmInfo = blockInfo = (leftInfo & TAGS_MASK) | newSize;
     block = left;
+    block.mmInfo = blockInfo = leftInfo + BLOCK_OVERHEAD + (blockInfo & ~TAGS_MASK); // keep left tags
     // 'back' is set below
   }
 

--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -208,13 +208,11 @@ function insertBlock(root: Root, block: Block): void {
   // merge with right block if also free
   if (rightInfo & FREE) {
     let newSize = (blockInfo & ~TAGS_MASK) + BLOCK_OVERHEAD + (rightInfo & ~TAGS_MASK);
-    if (newSize < BLOCK_MAXSIZE) {
-      removeBlock(root, right);
-      block.mmInfo = blockInfo = (blockInfo & TAGS_MASK) | newSize;
-      right = GETRIGHT(block);
-      rightInfo = right.mmInfo;
-      // 'back' is set below
-    }
+    removeBlock(root, right);
+    block.mmInfo = blockInfo = (blockInfo & TAGS_MASK) | newSize;
+    right = GETRIGHT(block);
+    rightInfo = right.mmInfo;
+    // 'back' is set below
   }
 
   // merge with left block if also free
@@ -223,12 +221,10 @@ function insertBlock(root: Root, block: Block): void {
     let leftInfo = left.mmInfo;
     if (DEBUG) assert(leftInfo & FREE); // must be free according to right tags
     let newSize = (leftInfo & ~TAGS_MASK) + BLOCK_OVERHEAD + (blockInfo & ~TAGS_MASK);
-    if (newSize < BLOCK_MAXSIZE) {
-      removeBlock(root, left);
-      left.mmInfo = blockInfo = (leftInfo & TAGS_MASK) | newSize;
-      block = left;
-      // 'back' is set below
-    }
+    removeBlock(root, left);
+    left.mmInfo = blockInfo = (leftInfo & TAGS_MASK) | newSize;
+    block = left;
+    // 'back' is set below
   }
 
   right.mmInfo = rightInfo | LEFTFREE;
@@ -236,7 +232,7 @@ function insertBlock(root: Root, block: Block): void {
 
   // we now know the size of the block
   var size = blockInfo & ~TAGS_MASK;
-  if (DEBUG) assert(size >= BLOCK_MINSIZE && size < BLOCK_MAXSIZE); // must be a valid size
+  if (DEBUG) assert(size >= BLOCK_MINSIZE); // must be a valid size
   if (DEBUG) assert(changetype<usize>(block) + BLOCK_OVERHEAD + size == changetype<usize>(right)); // must match
 
   // set 'back' to itself at the end of block
@@ -249,8 +245,9 @@ function insertBlock(root: Root, block: Block): void {
     sl = <u32>(size >> AL_BITS);
   } else {
     const inv: usize = sizeof<usize>() * 8 - 1;
-    fl = inv - clz<usize>(size);
-    sl = <u32>((size >> (fl - SL_BITS)) ^ (1 << SL_BITS));
+    let boundedSize = min(size, BLOCK_MAXSIZE);
+    fl = inv - clz<usize>(boundedSize);
+    sl = <u32>((boundedSize >> (fl - SL_BITS)) ^ (1 << SL_BITS));
     fl -= SB_BITS - 1;
   }
   if (DEBUG) assert(fl < FL_BITS && sl < SL_SIZE); // fl/sl out of range
@@ -272,7 +269,7 @@ function removeBlock(root: Root, block: Block): void {
   var blockInfo = block.mmInfo;
   if (DEBUG) assert(blockInfo & FREE); // must be free
   var size = blockInfo & ~TAGS_MASK;
-  if (DEBUG) assert(size >= BLOCK_MINSIZE && size < BLOCK_MAXSIZE); // must be valid
+  if (DEBUG) assert(size >= BLOCK_MINSIZE); // must be valid
 
   // mapping_insert
   var fl: usize, sl: u32;
@@ -281,8 +278,9 @@ function removeBlock(root: Root, block: Block): void {
     sl = <u32>(size >> AL_BITS);
   } else {
     const inv: usize = sizeof<usize>() * 8 - 1;
-    fl = inv - clz<usize>(size);
-    sl = <u32>((size >> (fl - SL_BITS)) ^ (1 << SL_BITS));
+    let boundedSize = min(size, BLOCK_MAXSIZE);
+    fl = inv - clz<usize>(boundedSize);
+    sl = <u32>((boundedSize >> (fl - SL_BITS)) ^ (1 << SL_BITS));
     fl -= SB_BITS - 1;
   }
   if (DEBUG) assert(fl < FL_BITS && sl < SL_SIZE); // fl/sl out of range
@@ -528,8 +526,6 @@ export function reallocateBlock(root: Root, block: Block, size: usize): Block {
     let mergeSize = blockSize + BLOCK_OVERHEAD + (rightInfo & ~TAGS_MASK);
     if (mergeSize >= payloadSize) {
       removeBlock(root, right);
-      // TODO: this can yield an intermediate block larger than BLOCK_MAXSIZE, which
-      // is immediately split though. does this trigger any assertions / issues?
       block.mmInfo = (blockInfo & TAGS_MASK) | mergeSize;
       prepareBlock(root, block, payloadSize);
       if (isDefined(ASC_RTRACE)) onresize(block, BLOCK_OVERHEAD + blockSize);

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -274,7 +274,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -283,18 +283,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -308,12 +302,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -337,7 +338,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -422,8 +423,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -436,7 +435,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -456,13 +455,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -471,35 +474,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -507,76 +500,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1440
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -586,12 +563,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -599,34 +576,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -634,14 +615,14 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -664,7 +645,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -677,12 +658,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -704,7 +685,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -732,7 +713,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -760,7 +741,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1108,7 +1089,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1196,7 +1177,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1248,7 +1229,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1279,7 +1260,7 @@
   if
    i32.const 1104
    i32.const 1440
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1370,7 +1351,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1385,7 +1366,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1404,7 +1385,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -274,7 +274,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -288,7 +288,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -338,7 +338,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -466,18 +466,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -509,7 +503,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -519,18 +513,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -548,7 +536,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -563,7 +551,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -615,7 +603,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -685,7 +673,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -713,7 +701,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -741,7 +729,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1089,7 +1077,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1177,7 +1165,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1229,7 +1217,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1260,7 +1248,7 @@
   if
    i32.const 1104
    i32.const 1440
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1351,7 +1339,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1366,7 +1354,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1385,7 +1373,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -398,7 +398,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -418,7 +418,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -481,7 +481,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -655,11 +655,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -668,24 +668,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -702,34 +692,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 416
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -738,20 +730,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -763,17 +743,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -783,7 +763,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -791,7 +771,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -801,33 +781,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -835,21 +815,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -859,22 +839,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -895,56 +875,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -964,7 +944,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1007,7 +987,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1040,7 +1020,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1283,7 +1263,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1614,7 +1594,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1698,7 +1678,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1763,7 +1743,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1914,7 +1894,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2023,7 +2003,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2043,7 +2023,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -398,7 +398,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -414,18 +414,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -441,12 +434,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -479,41 +481,41 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -526,55 +528,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -667,38 +669,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -723,7 +720,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -742,24 +739,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -777,18 +769,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -806,7 +791,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -827,12 +812,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -865,22 +859,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -902,21 +896,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -931,11 +925,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -944,13 +938,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -970,7 +964,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1013,7 +1007,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1046,7 +1040,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1289,7 +1283,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1620,7 +1614,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1704,7 +1698,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1769,7 +1763,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1920,7 +1914,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2029,7 +2023,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2049,7 +2043,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.optimized.wat
+++ b/tests/compiler/class-implements.optimized.wat
@@ -295,7 +295,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -309,7 +309,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -359,7 +359,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -487,18 +487,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -530,7 +524,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -540,18 +534,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -569,7 +557,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -584,7 +572,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -636,7 +624,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -706,7 +694,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -734,7 +722,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -762,7 +750,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1110,7 +1098,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1178,7 +1166,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1259,7 +1247,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1274,7 +1262,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.optimized.wat
+++ b/tests/compiler/class-implements.optimized.wat
@@ -295,7 +295,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -304,18 +304,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -329,12 +323,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -358,7 +359,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -443,8 +444,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -457,7 +456,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -477,13 +476,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -492,35 +495,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -528,76 +521,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -607,12 +584,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -620,34 +597,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -655,14 +636,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -685,7 +666,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -698,12 +679,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -725,7 +706,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -753,7 +734,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -781,7 +762,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1129,7 +1110,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1197,7 +1178,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1278,7 +1259,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1293,7 +1274,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.untouched.wat
+++ b/tests/compiler/class-implements.untouched.wat
@@ -408,7 +408,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,18 +424,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -451,12 +444,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -489,41 +491,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -536,55 +538,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -677,38 +679,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -733,7 +730,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -752,24 +749,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -787,18 +779,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -816,7 +801,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -837,12 +822,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -875,22 +869,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -912,21 +906,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -941,11 +935,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -954,13 +948,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -980,7 +974,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1023,7 +1017,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1056,7 +1050,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1299,7 +1293,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1630,7 +1624,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1714,7 +1708,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1779,7 +1773,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1930,7 +1924,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2039,7 +2033,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2059,7 +2053,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.untouched.wat
+++ b/tests/compiler/class-implements.untouched.wat
@@ -408,7 +408,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -428,7 +428,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -491,7 +491,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -665,11 +665,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -678,24 +678,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -712,34 +702,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -748,20 +740,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -773,17 +753,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -793,7 +773,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -801,7 +781,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -811,33 +791,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -845,21 +825,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -869,22 +849,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -905,56 +885,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -974,7 +954,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1017,7 +997,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1050,7 +1030,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1293,7 +1273,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1624,7 +1604,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1708,7 +1688,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1773,7 +1753,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1924,7 +1904,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2033,7 +2013,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2053,7 +2033,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.optimized.wat
+++ b/tests/compiler/class-overloading.optimized.wat
@@ -333,7 +333,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -347,7 +347,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -397,7 +397,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -525,18 +525,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -568,7 +562,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -578,18 +572,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -607,7 +595,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -622,7 +610,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -674,7 +662,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -744,7 +732,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -772,7 +760,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -800,7 +788,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1148,7 +1136,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1216,7 +1204,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1297,7 +1285,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1312,7 +1300,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.optimized.wat
+++ b/tests/compiler/class-overloading.optimized.wat
@@ -333,7 +333,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -342,18 +342,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -367,12 +361,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -396,7 +397,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -481,8 +482,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -495,7 +494,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -515,13 +514,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -530,35 +533,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -566,76 +559,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1424
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -645,12 +622,12 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -658,34 +635,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -693,14 +674,14 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -723,7 +704,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -736,12 +717,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -763,7 +744,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -791,7 +772,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -819,7 +800,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1167,7 +1148,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1235,7 +1216,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1316,7 +1297,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1331,7 +1312,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -414,7 +414,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -434,7 +434,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -497,7 +497,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -671,11 +671,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -684,24 +684,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -718,34 +708,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 400
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -754,20 +746,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -779,17 +759,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -799,7 +779,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -807,7 +787,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -817,33 +797,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -851,21 +831,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -875,22 +855,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -911,56 +891,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -980,7 +960,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1023,7 +1003,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1056,7 +1036,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1299,7 +1279,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1630,7 +1610,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1714,7 +1694,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1779,7 +1759,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1930,7 +1910,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2039,7 +2019,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2059,7 +2039,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -414,7 +414,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -430,18 +430,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -457,12 +450,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -495,41 +497,41 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -542,55 +544,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -683,38 +685,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -739,7 +736,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -758,24 +755,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -793,18 +785,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -822,7 +807,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -843,12 +828,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -881,22 +875,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -918,21 +912,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -947,11 +941,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -960,13 +954,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -986,7 +980,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1029,7 +1023,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1062,7 +1056,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1305,7 +1299,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1636,7 +1630,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1720,7 +1714,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1785,7 +1779,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1936,7 +1930,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2045,7 +2039,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2065,7 +2059,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -281,7 +281,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -295,7 +295,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -345,7 +345,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -473,18 +473,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -516,7 +510,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -526,18 +520,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -555,7 +543,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -570,7 +558,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -622,7 +610,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -692,7 +680,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -720,7 +708,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -748,7 +736,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1096,7 +1084,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1184,7 +1172,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1236,7 +1224,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1267,7 +1255,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1358,7 +1346,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1373,7 +1361,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1392,7 +1380,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -281,7 +281,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -290,18 +290,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -315,12 +309,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -344,7 +345,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -429,8 +430,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -443,7 +442,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -463,13 +462,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -478,35 +481,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -514,76 +507,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -593,12 +570,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -606,34 +583,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -641,14 +622,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -671,7 +652,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -684,12 +665,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -711,7 +692,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -739,7 +720,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -767,7 +748,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1115,7 +1096,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1203,7 +1184,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1255,7 +1236,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1286,7 +1267,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1377,7 +1358,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1392,7 +1373,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1411,7 +1392,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -510,7 +510,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -530,7 +530,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -593,7 +593,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -767,11 +767,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -780,24 +780,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -814,34 +804,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -850,20 +842,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -875,17 +855,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -895,7 +875,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -903,7 +883,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -913,33 +893,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -947,21 +927,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -971,22 +951,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1007,56 +987,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1076,7 +1056,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1119,7 +1099,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1152,7 +1132,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1395,7 +1375,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1726,7 +1706,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1810,7 +1790,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1875,7 +1855,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2026,7 +2006,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2135,7 +2115,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2155,7 +2135,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -510,7 +510,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -526,18 +526,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -553,12 +546,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -591,41 +593,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -638,55 +640,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -779,38 +781,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -835,7 +832,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -854,24 +851,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -889,18 +881,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -918,7 +903,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -939,12 +924,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -977,22 +971,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1014,21 +1008,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1043,11 +1037,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1056,13 +1050,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1082,7 +1076,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1125,7 +1119,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1158,7 +1152,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1401,7 +1395,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1732,7 +1726,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1816,7 +1810,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1881,7 +1875,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2032,7 +2026,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2141,7 +2135,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2161,7 +2155,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.optimized.wat
+++ b/tests/compiler/constructor.optimized.wat
@@ -342,7 +342,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -351,18 +351,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -376,12 +370,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -405,7 +406,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -490,8 +491,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -504,7 +503,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -524,13 +523,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -539,35 +542,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -575,76 +568,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -654,12 +631,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -667,34 +644,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -702,14 +683,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -732,7 +713,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -745,12 +726,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -772,7 +753,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -800,7 +781,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -828,7 +809,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1176,7 +1157,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1264,7 +1245,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1316,7 +1297,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1347,7 +1328,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1438,7 +1419,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1453,7 +1434,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1472,7 +1453,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.optimized.wat
+++ b/tests/compiler/constructor.optimized.wat
@@ -342,7 +342,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -356,7 +356,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -406,7 +406,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -534,18 +534,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -577,7 +571,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -587,18 +581,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -616,7 +604,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -631,7 +619,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -683,7 +671,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -753,7 +741,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -781,7 +769,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -809,7 +797,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1157,7 +1145,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1245,7 +1233,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1297,7 +1285,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1328,7 +1316,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1419,7 +1407,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1434,7 +1422,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1453,7 +1441,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -408,7 +408,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,18 +424,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -451,12 +444,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -489,41 +491,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -536,55 +538,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -677,38 +679,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -733,7 +730,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -752,24 +749,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -787,18 +779,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -816,7 +801,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -837,12 +822,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -875,22 +869,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -912,21 +906,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -941,11 +935,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -954,13 +948,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -980,7 +974,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1023,7 +1017,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1056,7 +1050,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1299,7 +1293,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1630,7 +1624,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1714,7 +1708,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1779,7 +1773,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1930,7 +1924,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2039,7 +2033,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2059,7 +2053,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -408,7 +408,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -428,7 +428,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -491,7 +491,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -665,11 +665,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -678,24 +678,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -712,34 +702,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -748,20 +740,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -773,17 +753,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -793,7 +773,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -801,7 +781,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -811,33 +791,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -845,21 +825,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -869,22 +849,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -905,56 +885,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -974,7 +954,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1017,7 +997,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1050,7 +1030,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1293,7 +1273,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1624,7 +1604,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1708,7 +1688,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1773,7 +1753,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1924,7 +1904,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2033,7 +2013,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2053,7 +2033,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -273,7 +273,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -287,7 +287,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -337,7 +337,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -465,18 +465,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -508,7 +502,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -518,18 +512,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -547,7 +535,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -562,7 +550,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -614,7 +602,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -684,7 +672,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -712,7 +700,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -740,7 +728,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1088,7 +1076,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1156,7 +1144,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1237,7 +1225,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1252,7 +1240,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -273,7 +273,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -282,18 +282,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -307,12 +301,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -336,7 +337,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -421,8 +422,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -435,7 +434,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -455,13 +454,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -470,35 +473,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -506,76 +499,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1424
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -585,12 +562,12 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -598,34 +575,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -633,14 +614,14 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -663,7 +644,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -676,12 +657,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -703,7 +684,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,7 +712,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -759,7 +740,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1088,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1175,7 +1156,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1256,7 +1237,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1271,7 +1252,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -811,7 +811,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -831,7 +831,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -894,7 +894,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1068,11 +1068,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -1081,24 +1081,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -1115,34 +1105,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 400
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1151,20 +1143,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1176,17 +1156,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1196,7 +1176,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1204,7 +1184,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1214,33 +1194,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1248,21 +1228,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1272,22 +1252,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1308,56 +1288,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1377,7 +1357,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1420,7 +1400,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1453,7 +1433,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1696,7 +1676,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2027,7 +2007,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2111,7 +2091,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2176,7 +2156,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2327,7 +2307,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2436,7 +2416,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2456,7 +2436,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -811,7 +811,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -827,18 +827,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -854,12 +847,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -892,41 +894,41 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -939,55 +941,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -1080,38 +1082,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1136,7 +1133,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1155,24 +1152,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1190,18 +1182,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1219,7 +1204,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1240,12 +1225,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1278,22 +1272,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1315,21 +1309,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1344,11 +1338,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1357,13 +1351,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1383,7 +1377,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1426,7 +1420,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1459,7 +1453,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1702,7 +1696,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2033,7 +2027,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2117,7 +2111,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2182,7 +2176,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2333,7 +2327,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2442,7 +2436,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2462,7 +2456,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.optimized.wat
+++ b/tests/compiler/empty-exportruntime.optimized.wat
@@ -292,7 +292,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -306,7 +306,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -356,7 +356,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -484,18 +484,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -527,7 +521,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -537,18 +531,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -566,7 +554,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -581,7 +569,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -633,7 +621,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -703,7 +691,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,7 +719,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -759,7 +747,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1095,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1195,7 +1183,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1247,7 +1235,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1278,7 +1266,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1369,7 +1357,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1384,7 +1372,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1403,7 +1391,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.optimized.wat
+++ b/tests/compiler/empty-exportruntime.optimized.wat
@@ -292,7 +292,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -301,18 +301,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -326,12 +320,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -355,7 +356,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -440,8 +441,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -454,7 +453,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -474,13 +473,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -489,35 +492,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -525,76 +518,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -604,12 +581,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -617,34 +594,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -652,14 +633,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -682,7 +663,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -695,12 +676,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -722,7 +703,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -750,7 +731,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -778,7 +759,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1107,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1214,7 +1195,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1266,7 +1247,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1297,7 +1278,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1388,7 +1369,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1403,7 +1384,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1422,7 +1403,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.untouched.wat
+++ b/tests/compiler/empty-exportruntime.untouched.wat
@@ -404,7 +404,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -420,18 +420,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -447,12 +440,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -485,41 +487,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -532,55 +534,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -673,38 +675,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -729,7 +726,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -748,24 +745,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -783,18 +775,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -812,7 +797,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -833,12 +818,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -871,22 +865,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -908,21 +902,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -937,11 +931,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -950,13 +944,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -976,7 +970,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1019,7 +1013,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1052,7 +1046,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1295,7 +1289,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1626,7 +1620,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1710,7 +1704,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1775,7 +1769,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1926,7 +1920,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2035,7 +2029,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2055,7 +2049,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-exportruntime.untouched.wat
+++ b/tests/compiler/empty-exportruntime.untouched.wat
@@ -404,7 +404,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,7 +424,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -487,7 +487,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -661,11 +661,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -674,24 +674,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -708,34 +698,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -744,20 +736,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -769,17 +749,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -789,7 +769,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -797,7 +777,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -807,33 +787,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -841,21 +821,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -865,22 +845,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -901,56 +881,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -970,7 +950,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1013,7 +993,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1046,7 +1026,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1289,7 +1269,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1620,7 +1600,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1704,7 +1684,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1769,7 +1749,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1920,7 +1900,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2029,7 +2009,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2049,7 +2029,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.optimized.wat
+++ b/tests/compiler/empty-new.optimized.wat
@@ -269,7 +269,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -283,7 +283,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -333,7 +333,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -461,18 +461,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -504,7 +498,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -514,18 +508,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -543,7 +531,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -558,7 +546,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -610,7 +598,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -680,7 +668,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -708,7 +696,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -736,7 +724,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1084,7 +1072,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1152,7 +1140,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1233,7 +1221,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1248,7 +1236,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.optimized.wat
+++ b/tests/compiler/empty-new.optimized.wat
@@ -269,7 +269,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -278,18 +278,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -303,12 +297,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -332,7 +333,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -417,8 +418,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -431,7 +430,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -451,13 +450,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -466,35 +469,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -502,76 +495,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -581,12 +558,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -594,34 +571,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -629,14 +610,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -659,7 +640,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -672,12 +653,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -699,7 +680,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -727,7 +708,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -755,7 +736,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1103,7 +1084,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1171,7 +1152,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1252,7 +1233,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1267,7 +1248,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.untouched.wat
+++ b/tests/compiler/empty-new.untouched.wat
@@ -397,7 +397,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -417,7 +417,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -480,7 +480,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -654,11 +654,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -667,24 +667,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -701,34 +691,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -737,20 +729,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -762,17 +742,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -782,7 +762,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -790,7 +770,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -800,33 +780,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -834,21 +814,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -858,22 +838,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -894,56 +874,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -963,7 +943,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1006,7 +986,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1039,7 +1019,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1282,7 +1262,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1613,7 +1593,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1697,7 +1677,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1762,7 +1742,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1913,7 +1893,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2022,7 +2002,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2042,7 +2022,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.untouched.wat
+++ b/tests/compiler/empty-new.untouched.wat
@@ -397,7 +397,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -413,18 +413,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -440,12 +433,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -478,41 +480,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -525,55 +527,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -666,38 +668,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -722,7 +719,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -741,24 +738,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -776,18 +768,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -805,7 +790,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -826,12 +811,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -864,22 +858,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -901,21 +895,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -930,11 +924,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -943,13 +937,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -969,7 +963,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1012,7 +1006,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1045,7 +1039,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1288,7 +1282,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1619,7 +1613,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1703,7 +1697,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1768,7 +1762,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1919,7 +1913,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2028,7 +2022,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2048,7 +2042,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -323,7 +323,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -337,7 +337,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -387,7 +387,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -515,18 +515,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -558,7 +552,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -568,18 +562,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -597,7 +585,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -612,7 +600,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -664,7 +652,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -734,7 +722,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -762,7 +750,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -790,7 +778,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1138,7 +1126,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1206,7 +1194,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1287,7 +1275,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1302,7 +1290,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -323,7 +323,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -332,18 +332,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -357,12 +351,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -386,7 +387,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -471,8 +472,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -485,7 +484,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -505,13 +504,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -520,35 +523,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -556,76 +549,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -635,12 +612,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -648,34 +625,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -683,14 +664,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -713,7 +694,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -726,12 +707,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -753,7 +734,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -781,7 +762,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -809,7 +790,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1157,7 +1138,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1225,7 +1206,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1306,7 +1287,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1321,7 +1302,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -461,7 +461,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -481,7 +481,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -544,7 +544,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -718,11 +718,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -731,24 +731,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -765,34 +755,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -801,20 +793,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -826,17 +806,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -846,7 +826,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -854,7 +834,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -864,33 +844,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -898,21 +878,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -922,22 +902,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -958,56 +938,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1027,7 +1007,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1070,7 +1050,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1103,7 +1083,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1346,7 +1326,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1677,7 +1657,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1761,7 +1741,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1826,7 +1806,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1977,7 +1957,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2086,7 +2066,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2106,7 +2086,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -461,7 +461,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -477,18 +477,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -504,12 +497,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -542,41 +544,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -589,55 +591,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -730,38 +732,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -786,7 +783,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -805,24 +802,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -840,18 +832,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -869,7 +854,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -890,12 +875,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -928,22 +922,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -965,21 +959,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -994,11 +988,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1007,13 +1001,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1033,7 +1027,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1076,7 +1070,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1109,7 +1103,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1352,7 +1346,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1683,7 +1677,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1767,7 +1761,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1832,7 +1826,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1983,7 +1977,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2092,7 +2086,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2112,7 +2106,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.optimized.wat
+++ b/tests/compiler/exportstar-rereexport.optimized.wat
@@ -324,7 +324,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -338,7 +338,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -388,7 +388,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -516,18 +516,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -559,7 +553,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -569,18 +563,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -598,7 +586,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -613,7 +601,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -665,7 +653,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -735,7 +723,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -763,7 +751,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -791,7 +779,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1139,7 +1127,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1207,7 +1195,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1288,7 +1276,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1303,7 +1291,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.optimized.wat
+++ b/tests/compiler/exportstar-rereexport.optimized.wat
@@ -324,7 +324,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -333,18 +333,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -358,12 +352,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -387,7 +388,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -472,8 +473,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -486,7 +485,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -506,13 +505,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -521,35 +524,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -557,76 +550,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1440
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -636,12 +613,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -649,34 +626,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -684,14 +665,14 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -714,7 +695,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -727,12 +708,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -754,7 +735,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -782,7 +763,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -810,7 +791,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1158,7 +1139,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1226,7 +1207,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1307,7 +1288,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1322,7 +1303,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.untouched.wat
+++ b/tests/compiler/exportstar-rereexport.untouched.wat
@@ -442,7 +442,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -462,7 +462,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -525,7 +525,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -699,11 +699,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -712,24 +712,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -746,34 +736,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 416
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -782,20 +774,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -807,17 +787,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -827,7 +807,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -835,7 +815,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -845,33 +825,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -879,21 +859,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -903,22 +883,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -939,56 +919,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1008,7 +988,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1051,7 +1031,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1084,7 +1064,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1327,7 +1307,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1658,7 +1638,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1742,7 +1722,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1807,7 +1787,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1958,7 +1938,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2067,7 +2047,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2087,7 +2067,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.untouched.wat
+++ b/tests/compiler/exportstar-rereexport.untouched.wat
@@ -442,7 +442,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -458,18 +458,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -485,12 +478,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -523,41 +525,41 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -570,55 +572,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -711,38 +713,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -767,7 +764,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -786,24 +783,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -821,18 +813,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -850,7 +835,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -871,12 +856,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -909,22 +903,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -946,21 +940,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -975,11 +969,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -988,13 +982,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1014,7 +1008,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1057,7 +1051,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1090,7 +1084,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1333,7 +1327,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1664,7 +1658,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1748,7 +1742,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1813,7 +1807,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1964,7 +1958,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2073,7 +2067,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2093,7 +2087,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -288,7 +288,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -302,7 +302,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -352,7 +352,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -480,18 +480,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -523,7 +517,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -533,18 +527,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -562,7 +550,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -577,7 +565,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -629,7 +617,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -699,7 +687,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -727,7 +715,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -755,7 +743,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1103,7 +1091,7 @@
        if
         i32.const 0
         i32.const 1552
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1191,7 +1179,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1243,7 +1231,7 @@
     if
      i32.const 0
      i32.const 1552
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1274,7 +1262,7 @@
   if
    i32.const 1216
    i32.const 1552
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1365,7 +1353,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1380,7 +1368,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1399,7 +1387,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -288,7 +288,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -297,18 +297,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1552
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -322,12 +316,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -351,7 +352,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -436,8 +437,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -450,7 +449,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -470,13 +469,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -485,35 +488,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -521,76 +514,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1552
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1552
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -600,12 +577,12 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -613,34 +590,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -648,14 +629,14 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -678,7 +659,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -691,12 +672,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -718,7 +699,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -746,7 +727,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -774,7 +755,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1122,7 +1103,7 @@
        if
         i32.const 0
         i32.const 1552
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1210,7 +1191,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1262,7 +1243,7 @@
     if
      i32.const 0
      i32.const 1552
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1293,7 +1274,7 @@
   if
    i32.const 1216
    i32.const 1552
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1384,7 +1365,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1399,7 +1380,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1418,7 +1399,7 @@
   if
    i32.const 0
    i32.const 1552
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -406,7 +406,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -422,18 +422,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 528
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -449,12 +442,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -487,41 +489,41 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -534,55 +536,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -675,38 +677,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -731,7 +728,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -750,24 +747,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -785,18 +777,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 528
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -814,7 +799,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -835,12 +820,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -873,22 +867,22 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -910,21 +904,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -939,11 +933,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -952,13 +946,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -978,7 +972,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1021,7 +1015,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1048,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1297,7 +1291,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1628,7 +1622,7 @@
   if
    i32.const 192
    i32.const 528
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1712,7 +1706,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1777,7 +1771,7 @@
     if
      i32.const 0
      i32.const 528
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1928,7 +1922,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2037,7 +2031,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2057,7 +2051,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -406,7 +406,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -489,7 +489,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -663,11 +663,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -676,24 +676,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -710,34 +700,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 528
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -746,20 +738,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -771,17 +751,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 528
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -791,7 +771,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -799,7 +779,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -809,33 +789,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -843,21 +823,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -867,22 +847,22 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -903,56 +883,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -972,7 +952,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1015,7 +995,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1048,7 +1028,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1291,7 +1271,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1622,7 +1602,7 @@
   if
    i32.const 192
    i32.const 528
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1686,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1751,7 @@
     if
      i32.const 0
      i32.const 528
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1922,7 +1902,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2031,7 +2011,7 @@
    if
     i32.const 0
     i32.const 528
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2051,7 +2031,7 @@
   if
    i32.const 0
    i32.const 528
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.optimized.wat
+++ b/tests/compiler/extends-recursive.optimized.wat
@@ -276,7 +276,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -285,18 +285,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -310,12 +304,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -339,7 +340,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,8 +425,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -438,7 +437,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -458,13 +457,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -473,35 +476,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -509,76 +502,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -588,12 +565,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -601,34 +578,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -636,14 +617,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -666,7 +647,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -679,12 +660,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -706,7 +687,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -734,7 +715,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -762,7 +743,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1110,7 +1091,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1178,7 +1159,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1259,7 +1240,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1274,7 +1255,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.optimized.wat
+++ b/tests/compiler/extends-recursive.optimized.wat
@@ -276,7 +276,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -290,7 +290,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -340,7 +340,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -468,18 +468,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -511,7 +505,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -521,18 +515,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -550,7 +538,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -565,7 +553,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -617,7 +605,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -687,7 +675,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -715,7 +703,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -743,7 +731,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1091,7 +1079,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1159,7 +1147,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1240,7 +1228,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1255,7 +1243,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -402,7 +402,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -418,18 +418,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -445,12 +438,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -483,41 +485,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -530,55 +532,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -671,38 +673,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -727,7 +724,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -746,24 +743,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -781,18 +773,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -810,7 +795,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -831,12 +816,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -869,22 +863,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -906,21 +900,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -935,11 +929,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -948,13 +942,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -974,7 +968,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1017,7 +1011,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1050,7 +1044,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1293,7 +1287,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1624,7 +1618,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1708,7 +1702,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1773,7 +1767,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1924,7 +1918,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2033,7 +2027,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2053,7 +2047,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -402,7 +402,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -422,7 +422,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -485,7 +485,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -659,11 +659,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -672,24 +672,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -706,34 +696,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -742,20 +734,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -767,17 +747,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -787,7 +767,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -795,7 +775,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -805,33 +785,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -839,21 +819,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -863,22 +843,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -899,56 +879,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -968,7 +948,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1011,7 +991,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1044,7 +1024,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1287,7 +1267,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1618,7 +1598,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1702,7 +1682,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1767,7 +1747,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1918,7 +1898,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2027,7 +2007,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2047,7 +2027,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/features/simd.optimized.wat
+++ b/tests/compiler/features/simd.optimized.wat
@@ -31,7 +31,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -45,7 +45,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -95,7 +95,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -223,18 +223,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -266,7 +260,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -276,18 +270,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -305,7 +293,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -320,7 +308,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -372,7 +360,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -442,7 +430,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -470,7 +458,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -498,7 +486,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -680,7 +668,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -732,7 +720,7 @@
     if
      i32.const 0
      i32.const 1056
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -763,7 +751,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -854,7 +842,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -869,7 +857,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -888,7 +876,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1003,7 +991,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/features/simd.optimized.wat
+++ b/tests/compiler/features/simd.optimized.wat
@@ -31,7 +31,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -40,18 +40,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1056
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -65,12 +59,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -94,7 +95,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -179,8 +180,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -193,7 +192,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -213,13 +212,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -228,35 +231,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -264,76 +257,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1056
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1056
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -343,12 +320,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -356,34 +333,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -391,14 +372,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -421,7 +402,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -434,12 +415,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -461,7 +442,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -489,7 +470,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -517,7 +498,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -699,7 +680,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -751,7 +732,7 @@
     if
      i32.const 0
      i32.const 1056
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -782,7 +763,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -873,7 +854,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -888,7 +869,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -907,7 +888,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1022,7 +1003,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/features/simd.untouched.wat
+++ b/tests/compiler/features/simd.untouched.wat
@@ -70,7 +70,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -90,7 +90,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -153,7 +153,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -327,11 +327,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -340,24 +340,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -374,34 +364,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 32
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -410,20 +402,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -435,17 +415,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -455,7 +435,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -463,7 +443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -473,33 +453,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -507,21 +487,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -531,22 +511,22 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -567,56 +547,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -636,7 +616,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -679,7 +659,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -712,7 +692,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -952,7 +932,7 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1036,7 +1016,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1101,7 +1081,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1252,7 +1232,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1361,7 +1341,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1381,7 +1361,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1439,7 +1419,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/features/simd.untouched.wat
+++ b/tests/compiler/features/simd.untouched.wat
@@ -70,7 +70,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -86,18 +86,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -113,12 +106,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -151,41 +153,41 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -198,55 +200,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -339,38 +341,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -395,7 +392,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -414,24 +411,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -449,18 +441,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -478,7 +463,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -499,12 +484,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -537,22 +531,22 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -574,21 +568,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -603,11 +597,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -616,13 +610,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -642,7 +636,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -685,7 +679,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -718,7 +712,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -958,7 +952,7 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1042,7 +1036,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1107,7 +1101,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1258,7 +1252,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1367,7 +1361,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1387,7 +1381,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1445,7 +1439,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.optimized.wat
+++ b/tests/compiler/field-initialization.optimized.wat
@@ -294,7 +294,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -303,18 +303,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -328,12 +322,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -357,7 +358,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -442,8 +443,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -456,7 +455,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -476,13 +475,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -491,35 +494,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -527,76 +520,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -606,12 +583,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -619,34 +596,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -654,14 +635,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -684,7 +665,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -697,12 +678,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -724,7 +705,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -752,7 +733,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -780,7 +761,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1128,7 +1109,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1216,7 +1197,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1268,7 +1249,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1299,7 +1280,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1390,7 +1371,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1405,7 +1386,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1424,7 +1405,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.optimized.wat
+++ b/tests/compiler/field-initialization.optimized.wat
@@ -294,7 +294,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -308,7 +308,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -358,7 +358,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -486,18 +486,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -529,7 +523,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -539,18 +533,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -568,7 +556,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -583,7 +571,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -635,7 +623,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -705,7 +693,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -733,7 +721,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -761,7 +749,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1109,7 +1097,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1197,7 +1185,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1249,7 +1237,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1280,7 +1268,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1371,7 +1359,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1386,7 +1374,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1405,7 +1393,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.untouched.wat
+++ b/tests/compiler/field-initialization.untouched.wat
@@ -406,7 +406,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -489,7 +489,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -663,11 +663,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -676,24 +676,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -710,34 +700,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -746,20 +738,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -771,17 +751,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -791,7 +771,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -799,7 +779,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -809,33 +789,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -843,21 +823,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -867,22 +847,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -903,56 +883,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -972,7 +952,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1015,7 +995,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1048,7 +1028,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1291,7 +1271,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1622,7 +1602,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1686,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1751,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1922,7 +1902,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2031,7 +2011,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2051,7 +2031,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/field-initialization.untouched.wat
+++ b/tests/compiler/field-initialization.untouched.wat
@@ -406,7 +406,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -422,18 +422,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -449,12 +442,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -487,41 +489,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -534,55 +536,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -675,38 +677,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -731,7 +728,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -750,24 +747,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -785,18 +777,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -814,7 +799,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -835,12 +820,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -873,22 +867,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -910,21 +904,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -939,11 +933,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -952,13 +946,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -978,7 +972,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1021,7 +1015,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1048,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1297,7 +1291,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1628,7 +1622,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1712,7 +1706,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1777,7 +1771,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1928,7 +1922,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2037,7 +2031,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2057,7 +2051,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -273,7 +273,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -287,7 +287,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -337,7 +337,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -465,18 +465,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -508,7 +502,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -518,18 +512,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -547,7 +535,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -562,7 +550,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -614,7 +602,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -684,7 +672,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -712,7 +700,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -740,7 +728,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1088,7 +1076,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1156,7 +1144,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1237,7 +1225,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1252,7 +1240,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -273,7 +273,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -282,18 +282,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -307,12 +301,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -336,7 +337,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -421,8 +422,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -435,7 +434,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -455,13 +454,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -470,35 +473,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -506,76 +499,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1424
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -585,12 +562,12 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -598,34 +575,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -633,14 +614,14 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -663,7 +644,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -676,12 +657,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -703,7 +684,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,7 +712,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -759,7 +740,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1088,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1175,7 +1156,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1256,7 +1237,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1271,7 +1252,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -824,7 +824,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -844,7 +844,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -907,7 +907,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1081,11 +1081,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -1094,24 +1094,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -1128,34 +1118,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 400
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1164,20 +1156,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1189,17 +1169,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1209,7 +1189,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1217,7 +1197,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1227,33 +1207,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1261,21 +1241,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1285,22 +1265,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1321,56 +1301,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1390,7 +1370,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1433,7 +1413,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1466,7 +1446,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1709,7 +1689,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2040,7 +2020,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2124,7 +2104,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2189,7 +2169,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2340,7 +2320,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2449,7 +2429,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2469,7 +2449,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -824,7 +824,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -840,18 +840,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -867,12 +860,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -905,41 +907,41 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -952,55 +954,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -1093,38 +1095,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1149,7 +1146,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1168,24 +1165,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1203,18 +1195,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1232,7 +1217,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1253,12 +1238,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1291,22 +1285,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1328,21 +1322,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1357,11 +1351,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1370,13 +1364,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1396,7 +1390,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1439,7 +1433,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1472,7 +1466,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1715,7 +1709,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2046,7 +2040,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2130,7 +2124,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2195,7 +2189,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2346,7 +2340,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2455,7 +2449,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2475,7 +2469,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.optimized.wat
+++ b/tests/compiler/function-call.optimized.wat
@@ -311,7 +311,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -320,18 +320,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -345,12 +339,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -374,7 +375,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -459,8 +460,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -473,7 +472,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -493,13 +492,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -508,35 +511,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -544,76 +537,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1616
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -623,12 +600,12 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -636,34 +613,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -671,14 +652,14 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -701,7 +682,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -714,12 +695,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -741,7 +722,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -769,7 +750,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -797,7 +778,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1145,7 +1126,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1213,7 +1194,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1294,7 +1275,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1309,7 +1290,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.optimized.wat
+++ b/tests/compiler/function-call.optimized.wat
@@ -311,7 +311,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -325,7 +325,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -375,7 +375,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -503,18 +503,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -546,7 +540,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -556,18 +550,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -585,7 +573,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -600,7 +588,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -652,7 +640,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -722,7 +710,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -750,7 +738,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -778,7 +766,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1114,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1194,7 +1182,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1275,7 +1263,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1290,7 +1278,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.untouched.wat
+++ b/tests/compiler/function-call.untouched.wat
@@ -433,7 +433,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -453,7 +453,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -516,7 +516,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -690,11 +690,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -703,24 +703,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -737,34 +727,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 592
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -773,20 +765,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -798,17 +778,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -818,7 +798,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -826,7 +806,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -836,33 +816,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -870,21 +850,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -894,22 +874,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -930,56 +910,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -999,7 +979,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1042,7 +1022,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1075,7 +1055,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1318,7 +1298,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1649,7 +1629,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1733,7 +1713,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1798,7 +1778,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1949,7 +1929,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2058,7 +2038,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2078,7 +2058,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.untouched.wat
+++ b/tests/compiler/function-call.untouched.wat
@@ -433,7 +433,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -449,18 +449,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -476,12 +469,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -514,41 +516,41 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -561,55 +563,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -702,38 +704,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -758,7 +755,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -777,24 +774,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -812,18 +804,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -841,7 +826,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -862,12 +847,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -900,22 +894,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -937,21 +931,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -966,11 +960,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -979,13 +973,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1005,7 +999,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1048,7 +1042,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1081,7 +1075,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1324,7 +1318,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1655,7 +1649,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1739,7 +1733,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1804,7 +1798,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1955,7 +1949,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2064,7 +2058,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2084,7 +2078,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -340,7 +340,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -349,18 +349,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1936
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -374,12 +368,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -403,7 +404,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -488,8 +489,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -502,7 +501,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -522,13 +521,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -537,35 +540,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -573,76 +566,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1936
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1936
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -652,12 +629,12 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -665,34 +642,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -700,14 +681,14 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -730,7 +711,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -743,12 +724,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -770,7 +751,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -798,7 +779,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -826,7 +807,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1174,7 +1155,7 @@
        if
         i32.const 0
         i32.const 1936
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1242,7 +1223,7 @@
     if
      i32.const 0
      i32.const 1936
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1323,7 +1304,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1338,7 +1319,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -340,7 +340,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -354,7 +354,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -404,7 +404,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -532,18 +532,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -575,7 +569,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -585,18 +579,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -614,7 +602,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -629,7 +617,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -681,7 +669,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -751,7 +739,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -779,7 +767,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -807,7 +795,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1155,7 +1143,7 @@
        if
         i32.const 0
         i32.const 1936
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1223,7 +1211,7 @@
     if
      i32.const 0
      i32.const 1936
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1304,7 +1292,7 @@
    if
     i32.const 0
     i32.const 1936
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1319,7 +1307,7 @@
   if
    i32.const 0
    i32.const 1936
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -589,7 +589,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -605,18 +605,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 912
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -632,12 +625,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -670,41 +672,41 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -717,55 +719,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -858,38 +860,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -914,7 +911,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -933,24 +930,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -968,18 +960,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 912
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -997,7 +982,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1018,12 +1003,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1056,22 +1050,22 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1093,21 +1087,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1122,11 +1116,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1135,13 +1129,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1161,7 +1155,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1204,7 +1198,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1237,7 +1231,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1480,7 +1474,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1811,7 +1805,7 @@
   if
    i32.const 576
    i32.const 912
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1895,7 +1889,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1960,7 +1954,7 @@
     if
      i32.const 0
      i32.const 912
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2111,7 +2105,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2220,7 +2214,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2240,7 +2234,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -589,7 +589,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -609,7 +609,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -672,7 +672,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -846,11 +846,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -859,24 +859,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -893,34 +883,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 912
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -929,20 +921,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -954,17 +934,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 912
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -974,7 +954,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -982,7 +962,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -992,33 +972,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1026,21 +1006,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1050,22 +1030,22 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1086,56 +1066,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1155,7 +1135,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1198,7 +1178,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1231,7 +1211,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1474,7 +1454,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1805,7 +1785,7 @@
   if
    i32.const 576
    i32.const 912
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1889,7 +1869,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1954,7 +1934,7 @@
     if
      i32.const 0
      i32.const 912
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2105,7 +2085,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2214,7 +2194,7 @@
    if
     i32.const 0
     i32.const 912
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2234,7 +2214,7 @@
   if
    i32.const 0
    i32.const 912
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.optimized.wat
+++ b/tests/compiler/getter-call.optimized.wat
@@ -276,7 +276,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -285,18 +285,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -310,12 +304,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -339,7 +340,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,8 +425,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -438,7 +437,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -458,13 +457,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -473,35 +476,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -509,76 +502,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -588,12 +565,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -601,34 +578,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -636,14 +617,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -666,7 +647,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -679,12 +660,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -706,7 +687,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -734,7 +715,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -762,7 +743,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1110,7 +1091,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1178,7 +1159,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1259,7 +1240,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1274,7 +1255,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.optimized.wat
+++ b/tests/compiler/getter-call.optimized.wat
@@ -276,7 +276,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -290,7 +290,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -340,7 +340,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -468,18 +468,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -511,7 +505,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -521,18 +515,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -550,7 +538,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -565,7 +553,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -617,7 +605,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -687,7 +675,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -715,7 +703,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -743,7 +731,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1091,7 +1079,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1159,7 +1147,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1240,7 +1228,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1255,7 +1243,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -401,7 +401,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -421,7 +421,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -484,7 +484,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -658,11 +658,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -671,24 +671,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -705,34 +695,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -741,20 +733,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -766,17 +746,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -786,7 +766,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -794,7 +774,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -804,33 +784,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -838,21 +818,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -862,22 +842,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -898,56 +878,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -967,7 +947,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1010,7 +990,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1043,7 +1023,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1286,7 +1266,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1617,7 +1597,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1701,7 +1681,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1766,7 +1746,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1917,7 +1897,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2026,7 +2006,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2046,7 +2026,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -401,7 +401,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -417,18 +417,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -444,12 +437,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -482,41 +484,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -529,55 +531,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -670,38 +672,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -726,7 +723,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -745,24 +742,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -780,18 +772,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -809,7 +794,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -830,12 +815,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -868,22 +862,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -905,21 +899,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -934,11 +928,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -947,13 +941,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -973,7 +967,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1016,7 +1010,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1043,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1292,7 +1286,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1623,7 +1617,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1707,7 +1701,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1772,7 +1766,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1923,7 +1917,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2032,7 +2026,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2052,7 +2046,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.optimized.wat
+++ b/tests/compiler/heap.optimized.wat
@@ -39,7 +39,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -53,7 +53,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -103,7 +103,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -231,18 +231,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -274,7 +268,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -284,18 +278,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -313,7 +301,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -328,7 +316,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -380,7 +368,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -450,7 +438,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -478,7 +466,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -506,7 +494,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -639,7 +627,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -713,7 +701,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -765,7 +753,7 @@
     if
      i32.const 0
      i32.const 1056
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -800,7 +788,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -942,7 +930,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -957,7 +945,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1009,7 +997,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.optimized.wat
+++ b/tests/compiler/heap.optimized.wat
@@ -39,7 +39,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -48,18 +48,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1056
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -73,12 +67,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -102,7 +103,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -187,8 +188,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -201,7 +200,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -221,13 +220,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -236,35 +239,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -272,76 +265,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1056
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1056
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -351,12 +328,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -364,34 +341,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -399,14 +380,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -429,7 +410,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -442,12 +423,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -469,7 +450,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -497,7 +478,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -525,7 +506,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -658,7 +639,7 @@
   if
    i32.const 1120
    i32.const 1056
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -732,7 +713,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -784,7 +765,7 @@
     if
      i32.const 0
      i32.const 1056
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -819,7 +800,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -961,7 +942,7 @@
    if
     i32.const 0
     i32.const 1056
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -976,7 +957,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1028,7 +1009,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.untouched.wat
+++ b/tests/compiler/heap.untouched.wat
@@ -70,7 +70,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -90,7 +90,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -153,7 +153,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -327,11 +327,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -340,24 +340,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -374,34 +364,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 32
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -410,20 +402,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -435,17 +415,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -455,7 +435,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -463,7 +443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -473,33 +453,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -507,21 +487,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -531,22 +511,22 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -567,56 +547,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -636,7 +616,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -679,7 +659,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -712,7 +692,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -952,7 +932,7 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1036,7 +1016,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1101,7 +1081,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1252,7 +1232,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1361,7 +1341,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1381,7 +1361,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1443,7 +1423,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/heap.untouched.wat
+++ b/tests/compiler/heap.untouched.wat
@@ -70,7 +70,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -86,18 +86,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -113,12 +106,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -151,41 +153,41 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -198,55 +200,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -339,38 +341,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -395,7 +392,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -414,24 +411,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -449,18 +441,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -478,7 +463,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -499,12 +484,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -537,22 +531,22 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -574,21 +568,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -603,11 +597,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -616,13 +610,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -642,7 +636,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -685,7 +679,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -718,7 +712,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -958,7 +952,7 @@
   if
    i32.const 96
    i32.const 32
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1042,7 +1036,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1107,7 +1101,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1258,7 +1252,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1367,7 +1361,7 @@
    if
     i32.const 0
     i32.const 32
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1387,7 +1381,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1449,7 +1443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/implicit-getter-setter.optimized.wat
+++ b/tests/compiler/implicit-getter-setter.optimized.wat
@@ -282,7 +282,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -291,18 +291,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -316,12 +310,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -345,7 +346,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -430,8 +431,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -444,7 +443,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -464,13 +463,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -479,35 +482,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -515,76 +508,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -594,12 +571,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -607,34 +584,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -642,14 +623,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -672,7 +653,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -685,12 +666,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -712,7 +693,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -740,7 +721,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -768,7 +749,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1116,7 +1097,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1184,7 +1165,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1265,7 +1246,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1280,7 +1261,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/implicit-getter-setter.optimized.wat
+++ b/tests/compiler/implicit-getter-setter.optimized.wat
@@ -282,7 +282,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -296,7 +296,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -346,7 +346,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -474,18 +474,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -517,7 +511,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -527,18 +521,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -556,7 +544,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -571,7 +559,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -623,7 +611,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -693,7 +681,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -721,7 +709,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -749,7 +737,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1097,7 +1085,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1165,7 +1153,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1246,7 +1234,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1261,7 +1249,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -407,7 +407,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -427,7 +427,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -490,7 +490,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -664,11 +664,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -677,24 +677,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -711,34 +701,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -747,20 +739,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -772,17 +752,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -792,7 +772,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -800,7 +780,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -810,33 +790,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -844,21 +824,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -868,22 +848,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -904,56 +884,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -973,7 +953,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1016,7 +996,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1029,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1292,7 +1272,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1623,7 +1603,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1707,7 +1687,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1772,7 +1752,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1923,7 +1903,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2032,7 +2012,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2052,7 +2032,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -407,7 +407,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -423,18 +423,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -450,12 +443,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -488,41 +490,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -535,55 +537,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -676,38 +678,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -732,7 +729,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -751,24 +748,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -786,18 +778,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -815,7 +800,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -836,12 +821,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -874,22 +868,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -911,21 +905,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -940,11 +934,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -953,13 +947,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -979,7 +973,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1022,7 +1016,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1055,7 +1049,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1298,7 +1292,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1629,7 +1623,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1713,7 +1707,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1778,7 +1772,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1929,7 +1923,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2038,7 +2032,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2058,7 +2052,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -309,7 +309,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -318,18 +318,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -343,12 +337,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -372,7 +373,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -457,8 +458,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -471,7 +470,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -491,13 +490,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -506,35 +509,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -542,76 +535,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1424
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -621,12 +598,12 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -634,34 +611,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -669,14 +650,14 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -699,7 +680,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -712,12 +693,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -739,7 +720,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -767,7 +748,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -795,7 +776,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1143,7 +1124,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1231,7 +1212,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1283,7 +1264,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1314,7 +1295,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1405,7 +1386,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1420,7 +1401,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1439,7 +1420,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -309,7 +309,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -323,7 +323,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -373,7 +373,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -501,18 +501,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -544,7 +538,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -554,18 +548,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -583,7 +571,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -598,7 +586,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -650,7 +638,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -720,7 +708,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -748,7 +736,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -776,7 +764,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1124,7 +1112,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1212,7 +1200,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1264,7 +1252,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1295,7 +1283,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1386,7 +1374,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1401,7 +1389,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1420,7 +1408,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -416,7 +416,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -432,18 +432,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -459,12 +452,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -497,41 +499,41 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -544,55 +546,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -685,38 +687,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -741,7 +738,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -760,24 +757,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -795,18 +787,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -824,7 +809,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -845,12 +830,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -883,22 +877,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -920,21 +914,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -949,11 +943,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -962,13 +956,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -988,7 +982,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1031,7 +1025,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1064,7 +1058,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1307,7 +1301,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1638,7 +1632,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1722,7 +1716,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1787,7 +1781,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1938,7 +1932,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2047,7 +2041,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2067,7 +2061,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -416,7 +416,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -436,7 +436,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -499,7 +499,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -673,11 +673,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -686,24 +686,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -720,34 +710,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 400
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -756,20 +748,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -781,17 +761,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -801,7 +781,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -809,7 +789,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -819,33 +799,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -853,21 +833,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -877,22 +857,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -913,56 +893,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -982,7 +962,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1025,7 +1005,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1058,7 +1038,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1301,7 +1281,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1632,7 +1612,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1716,7 +1696,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1781,7 +1761,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1932,7 +1912,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2041,7 +2021,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2061,7 +2041,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -294,18 +294,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1472
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -319,12 +313,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -348,7 +349,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -433,8 +434,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -447,7 +446,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -467,13 +466,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -482,35 +485,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -518,76 +511,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1472
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1472
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -597,12 +574,12 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -610,34 +587,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -645,14 +626,14 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -675,7 +656,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -688,12 +669,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -715,7 +696,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -743,7 +724,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -771,7 +752,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1100,7 @@
        if
         i32.const 0
         i32.const 1472
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1207,7 +1188,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1259,7 +1240,7 @@
     if
      i32.const 0
      i32.const 1472
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1290,7 +1271,7 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1381,7 +1362,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1396,7 +1377,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1415,7 +1396,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -299,7 +299,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -349,7 +349,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -477,18 +477,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -520,7 +514,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -530,18 +524,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -559,7 +547,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -574,7 +562,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -626,7 +614,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -696,7 +684,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +712,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -752,7 +740,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1100,7 +1088,7 @@
        if
         i32.const 0
         i32.const 1472
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1188,7 +1176,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1240,7 +1228,7 @@
     if
      i32.const 0
      i32.const 1472
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1271,7 +1259,7 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1362,7 +1350,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1377,7 +1365,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1396,7 +1384,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -607,7 +607,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -623,18 +623,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 448
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -650,12 +643,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -688,41 +690,41 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -735,55 +737,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -876,38 +878,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -932,7 +929,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -951,24 +948,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -986,18 +978,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 448
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1015,7 +1000,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1036,12 +1021,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1074,22 +1068,22 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1111,21 +1105,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1140,11 +1134,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1153,13 +1147,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1179,7 +1173,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1222,7 +1216,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1255,7 +1249,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1498,7 +1492,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1829,7 +1823,7 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1913,7 +1907,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1978,7 +1972,7 @@
     if
      i32.const 0
      i32.const 448
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2129,7 +2123,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2238,7 +2232,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2258,7 +2252,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -607,7 +607,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -627,7 +627,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -690,7 +690,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -864,11 +864,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -877,24 +877,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -911,34 +901,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 448
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -947,20 +939,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -972,17 +952,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 448
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -992,7 +972,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1000,7 +980,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1010,33 +990,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1044,21 +1024,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1068,22 +1048,22 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1104,56 +1084,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1173,7 +1153,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1216,7 +1196,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1249,7 +1229,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1492,7 +1472,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1823,7 +1803,7 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1907,7 +1887,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1972,7 +1952,7 @@
     if
      i32.const 0
      i32.const 448
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2123,7 +2103,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2232,7 +2212,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2252,7 +2232,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof-class.optimized.wat
+++ b/tests/compiler/instanceof-class.optimized.wat
@@ -288,7 +288,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -302,7 +302,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -352,7 +352,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -480,18 +480,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -523,7 +517,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -533,18 +527,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -562,7 +550,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -577,7 +565,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -629,7 +617,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -699,7 +687,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -727,7 +715,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -755,7 +743,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1103,7 +1091,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1171,7 +1159,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1252,7 +1240,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1267,7 +1255,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof-class.optimized.wat
+++ b/tests/compiler/instanceof-class.optimized.wat
@@ -288,7 +288,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -297,18 +297,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -322,12 +316,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -351,7 +352,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -436,8 +437,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -450,7 +449,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -470,13 +469,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -485,35 +488,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -521,76 +514,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -600,12 +577,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -613,34 +590,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -648,14 +629,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -678,7 +659,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -691,12 +672,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -718,7 +699,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -746,7 +727,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -774,7 +755,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1122,7 +1103,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1190,7 +1171,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1271,7 +1252,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1286,7 +1267,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -400,7 +400,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -416,18 +416,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -443,12 +436,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -481,41 +483,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -528,55 +530,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -669,38 +671,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -725,7 +722,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -744,24 +741,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -779,18 +771,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -808,7 +793,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -829,12 +814,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -867,22 +861,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -904,21 +898,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -933,11 +927,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -946,13 +940,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -972,7 +966,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1015,7 +1009,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1048,7 +1042,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1291,7 +1285,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1622,7 +1616,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1700,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1765,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1922,7 +1916,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2031,7 +2025,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2051,7 +2045,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -400,7 +400,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -420,7 +420,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -483,7 +483,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -657,11 +657,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -670,24 +670,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -704,34 +694,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -740,20 +732,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -765,17 +745,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -785,7 +765,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -793,7 +773,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -803,33 +783,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -837,21 +817,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -861,22 +841,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -897,56 +877,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -966,7 +946,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1009,7 +989,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1042,7 +1022,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1285,7 +1265,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1616,7 +1596,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1700,7 +1680,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1765,7 +1745,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1916,7 +1896,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2025,7 +2005,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2045,7 +2025,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -276,7 +276,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -285,18 +285,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -310,12 +304,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -339,7 +340,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,8 +425,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -438,7 +437,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -458,13 +457,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -473,35 +476,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -509,76 +502,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -588,12 +565,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -601,34 +578,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -636,14 +617,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -666,7 +647,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -679,12 +660,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -706,7 +687,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -734,7 +715,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -762,7 +743,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1110,7 +1091,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1178,7 +1159,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1259,7 +1240,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1274,7 +1255,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -276,7 +276,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -290,7 +290,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -340,7 +340,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -468,18 +468,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -511,7 +505,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -521,18 +515,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -550,7 +538,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -565,7 +553,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -617,7 +605,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -687,7 +675,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -715,7 +703,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -743,7 +731,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1091,7 +1079,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1159,7 +1147,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1240,7 +1228,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1255,7 +1243,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -400,7 +400,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -416,18 +416,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -443,12 +436,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -481,41 +483,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -528,55 +530,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -669,38 +671,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -725,7 +722,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -744,24 +741,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -779,18 +771,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -808,7 +793,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -829,12 +814,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -867,22 +861,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -904,21 +898,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -933,11 +927,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -946,13 +940,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -972,7 +966,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1015,7 +1009,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1048,7 +1042,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1291,7 +1285,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1622,7 +1616,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1700,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1765,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1922,7 +1916,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2031,7 +2025,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2051,7 +2045,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -400,7 +400,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -420,7 +420,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -483,7 +483,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -657,11 +657,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -670,24 +670,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -704,34 +694,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -740,20 +732,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -765,17 +745,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -785,7 +765,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -793,7 +773,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -803,33 +783,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -837,21 +817,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -861,22 +841,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -897,56 +877,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -966,7 +946,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1009,7 +989,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1042,7 +1022,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1285,7 +1265,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1616,7 +1596,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1700,7 +1680,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1765,7 +1745,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1916,7 +1896,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2025,7 +2005,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2045,7 +2025,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.optimized.wat
+++ b/tests/compiler/issues/1225.optimized.wat
@@ -282,7 +282,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -291,18 +291,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -316,12 +310,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -345,7 +346,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -430,8 +431,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -444,7 +443,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -464,13 +463,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -479,35 +482,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -515,76 +508,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -594,12 +571,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -607,34 +584,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -642,14 +623,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -672,7 +653,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -685,12 +666,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -712,7 +693,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -740,7 +721,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -768,7 +749,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1116,7 +1097,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1184,7 +1165,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1265,7 +1246,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1280,7 +1261,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.optimized.wat
+++ b/tests/compiler/issues/1225.optimized.wat
@@ -282,7 +282,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -296,7 +296,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -346,7 +346,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -474,18 +474,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -517,7 +511,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -527,18 +521,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -556,7 +544,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -571,7 +559,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -623,7 +611,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -693,7 +681,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -721,7 +709,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -749,7 +737,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1097,7 +1085,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1165,7 +1153,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1246,7 +1234,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1261,7 +1249,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.untouched.wat
+++ b/tests/compiler/issues/1225.untouched.wat
@@ -411,7 +411,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -427,18 +427,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -454,12 +447,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -492,41 +494,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -539,55 +541,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -680,38 +682,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -736,7 +733,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -755,24 +752,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -790,18 +782,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -819,7 +804,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -840,12 +825,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -878,22 +872,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -915,21 +909,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -944,11 +938,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -957,13 +951,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -983,7 +977,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1026,7 +1020,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1059,7 +1053,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1302,7 +1296,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1633,7 +1627,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1717,7 +1711,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1782,7 +1776,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1933,7 +1927,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2042,7 +2036,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2062,7 +2056,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.untouched.wat
+++ b/tests/compiler/issues/1225.untouched.wat
@@ -411,7 +411,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -431,7 +431,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -494,7 +494,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -668,11 +668,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -681,24 +681,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -715,34 +705,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -751,20 +743,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -776,17 +756,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -796,7 +776,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -804,7 +784,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -814,33 +794,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -848,21 +828,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -872,22 +852,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -908,56 +888,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -977,7 +957,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1020,7 +1000,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1053,7 +1033,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1296,7 +1276,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1627,7 +1607,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1711,7 +1691,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1776,7 +1756,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1927,7 +1907,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2036,7 +2016,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2056,7 +2036,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -284,7 +284,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -298,7 +298,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -348,7 +348,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -476,18 +476,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -519,7 +513,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -529,18 +523,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -558,7 +546,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -573,7 +561,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -625,7 +613,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -695,7 +683,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -723,7 +711,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -751,7 +739,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1099,7 +1087,7 @@
        if
         i32.const 0
         i32.const 1488
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1187,7 +1175,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1239,7 +1227,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1270,7 +1258,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1361,7 +1349,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1376,7 +1364,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1395,7 +1383,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -284,7 +284,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -293,18 +293,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1488
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -318,12 +312,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -347,7 +348,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -432,8 +433,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -446,7 +445,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -466,13 +465,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -481,35 +484,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -517,76 +510,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1488
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1488
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -596,12 +573,12 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -609,34 +586,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -644,14 +625,14 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -674,7 +655,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -687,12 +668,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -714,7 +695,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -742,7 +723,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -770,7 +751,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1118,7 +1099,7 @@
        if
         i32.const 0
         i32.const 1488
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1206,7 +1187,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1258,7 +1239,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1289,7 +1270,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1380,7 +1361,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1395,7 +1376,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1414,7 +1395,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -401,7 +401,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -417,18 +417,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 464
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -444,12 +437,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -482,41 +484,41 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -529,55 +531,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -670,38 +672,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -726,7 +723,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -745,24 +742,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -780,18 +772,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 464
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -809,7 +794,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -830,12 +815,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -868,22 +862,22 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -905,21 +899,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -934,11 +928,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -947,13 +941,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -973,7 +967,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1016,7 +1010,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1049,7 +1043,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1292,7 +1286,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1623,7 +1617,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1707,7 +1701,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1772,7 +1766,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1923,7 +1917,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2032,7 +2026,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2052,7 +2046,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -401,7 +401,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -421,7 +421,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -484,7 +484,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -658,11 +658,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -671,24 +671,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -705,34 +695,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 464
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -741,20 +733,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -766,17 +746,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 464
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -786,7 +766,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -794,7 +774,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -804,33 +784,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -838,21 +818,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -862,22 +842,22 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -898,56 +878,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -967,7 +947,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1010,7 +990,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1043,7 +1023,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1286,7 +1266,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1617,7 +1597,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1701,7 +1681,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1766,7 +1746,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1917,7 +1897,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2026,7 +2006,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2046,7 +2026,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -273,7 +273,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -287,7 +287,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -337,7 +337,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -465,18 +465,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -508,7 +502,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -518,18 +512,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -547,7 +535,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -562,7 +550,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -614,7 +602,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -684,7 +672,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -712,7 +700,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -740,7 +728,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1088,7 +1076,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1156,7 +1144,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1237,7 +1225,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1252,7 +1240,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -273,7 +273,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -282,18 +282,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -307,12 +301,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -336,7 +337,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -421,8 +422,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -435,7 +434,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -455,13 +454,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -470,35 +473,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -506,76 +499,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1440
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -585,12 +562,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -598,34 +575,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -633,14 +614,14 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -663,7 +644,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -676,12 +657,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -703,7 +684,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,7 +712,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -759,7 +740,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1088,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1175,7 +1156,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1256,7 +1237,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1271,7 +1252,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -423,7 +423,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -439,18 +439,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -466,12 +459,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -504,41 +506,41 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -551,55 +553,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -692,38 +694,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -748,7 +745,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -767,24 +764,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -802,18 +794,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -831,7 +816,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -852,12 +837,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -890,22 +884,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -927,21 +921,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -956,11 +950,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -969,13 +963,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -995,7 +989,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1038,7 +1032,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1071,7 +1065,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1314,7 +1308,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1645,7 +1639,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1729,7 +1723,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1794,7 +1788,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1945,7 +1939,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2054,7 +2048,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2074,7 +2068,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -423,7 +423,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -443,7 +443,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -506,7 +506,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -680,11 +680,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -693,24 +693,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -727,34 +717,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 416
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -763,20 +755,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -788,17 +768,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -808,7 +788,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -816,7 +796,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -826,33 +806,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -860,21 +840,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -884,22 +864,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -920,56 +900,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -989,7 +969,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1032,7 +1012,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1065,7 +1045,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1308,7 +1288,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1639,7 +1619,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1723,7 +1703,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1788,7 +1768,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1939,7 +1919,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2048,7 +2028,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2068,7 +2048,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -277,7 +277,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -291,7 +291,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -341,7 +341,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -469,18 +469,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -512,7 +506,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -522,18 +516,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -551,7 +539,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -566,7 +554,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -618,7 +606,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -688,7 +676,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -716,7 +704,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -744,7 +732,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1092,7 +1080,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1160,7 +1148,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1241,7 +1229,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1256,7 +1244,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -277,7 +277,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -286,18 +286,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -311,12 +305,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -340,7 +341,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -425,8 +426,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -439,7 +438,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -459,13 +458,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -474,35 +477,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -510,76 +503,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -589,12 +566,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -602,34 +579,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -637,14 +618,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -667,7 +648,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -680,12 +661,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -707,7 +688,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -735,7 +716,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -763,7 +744,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1111,7 +1092,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1179,7 +1160,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1260,7 +1241,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1275,7 +1256,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -400,7 +400,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -416,18 +416,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -443,12 +436,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -481,41 +483,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -528,55 +530,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -669,38 +671,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -725,7 +722,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -744,24 +741,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -779,18 +771,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -808,7 +793,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -829,12 +814,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -867,22 +861,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -904,21 +898,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -933,11 +927,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -946,13 +940,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -972,7 +966,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1015,7 +1009,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1048,7 +1042,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1291,7 +1285,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1622,7 +1616,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1700,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1765,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1922,7 +1916,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2031,7 +2025,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2051,7 +2045,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -400,7 +400,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -420,7 +420,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -483,7 +483,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -657,11 +657,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -670,24 +670,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -704,34 +694,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -740,20 +732,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -765,17 +745,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -785,7 +765,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -793,7 +773,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -803,33 +783,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -837,21 +817,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -861,22 +841,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -897,56 +877,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -966,7 +946,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1009,7 +989,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1042,7 +1022,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1285,7 +1265,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1616,7 +1596,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1700,7 +1680,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1765,7 +1745,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1916,7 +1896,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2025,7 +2005,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2045,7 +2025,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.optimized.wat
+++ b/tests/compiler/new.optimized.wat
@@ -313,7 +313,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -327,7 +327,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -377,7 +377,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -505,18 +505,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -548,7 +542,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -558,18 +552,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -587,7 +575,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -602,7 +590,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -654,7 +642,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +712,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -752,7 +740,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -780,7 +768,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1128,7 +1116,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1196,7 +1184,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1277,7 +1265,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1292,7 +1280,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.optimized.wat
+++ b/tests/compiler/new.optimized.wat
@@ -313,7 +313,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -322,18 +322,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -347,12 +341,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -376,7 +377,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -461,8 +462,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -475,7 +474,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -495,13 +494,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -510,35 +513,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -546,76 +539,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -625,12 +602,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -638,34 +615,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -673,14 +654,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -703,7 +684,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -716,12 +697,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -743,7 +724,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -771,7 +752,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -799,7 +780,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1147,7 +1128,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1215,7 +1196,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1296,7 +1277,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1311,7 +1292,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.untouched.wat
+++ b/tests/compiler/new.untouched.wat
@@ -403,7 +403,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -419,18 +419,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -446,12 +439,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -484,41 +486,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -531,55 +533,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -672,38 +674,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -728,7 +725,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -747,24 +744,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -782,18 +774,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -811,7 +796,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -832,12 +817,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -870,22 +864,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -907,21 +901,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -936,11 +930,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -949,13 +943,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -975,7 +969,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1018,7 +1012,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1051,7 +1045,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1294,7 +1288,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1625,7 +1619,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1709,7 +1703,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1774,7 +1768,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1925,7 +1919,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2034,7 +2028,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2054,7 +2048,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.untouched.wat
+++ b/tests/compiler/new.untouched.wat
@@ -403,7 +403,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -423,7 +423,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -486,7 +486,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -660,11 +660,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -673,24 +673,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -707,34 +697,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -743,20 +735,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -768,17 +748,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -788,7 +768,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -796,7 +776,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -806,33 +786,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -840,21 +820,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -864,22 +844,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -900,56 +880,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -969,7 +949,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1012,7 +992,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1045,7 +1025,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1288,7 +1268,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1619,7 +1599,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1703,7 +1683,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1768,7 +1748,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1919,7 +1899,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2028,7 +2008,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2048,7 +2028,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -359,7 +359,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -373,7 +373,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -423,7 +423,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -551,18 +551,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -594,7 +588,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -604,18 +598,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -633,7 +621,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -648,7 +636,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -700,7 +688,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -770,7 +758,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -798,7 +786,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -826,7 +814,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1174,7 +1162,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1262,7 +1250,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1314,7 +1302,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1345,7 +1333,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1436,7 +1424,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1451,7 +1439,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1470,7 +1458,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -359,7 +359,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -368,18 +368,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -393,12 +387,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -422,7 +423,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -507,8 +508,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -521,7 +520,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -541,13 +540,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -556,35 +559,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -592,76 +585,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1616
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -671,12 +648,12 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -684,34 +661,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -719,14 +700,14 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -749,7 +730,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -762,12 +743,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -789,7 +770,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -817,7 +798,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -845,7 +826,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1193,7 +1174,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1281,7 +1262,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1333,7 +1314,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1364,7 +1345,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1455,7 +1436,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1470,7 +1451,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1489,7 +1470,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -501,7 +501,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -517,18 +517,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -544,12 +537,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -582,41 +584,41 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -629,55 +631,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -770,38 +772,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -826,7 +823,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -845,24 +842,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -880,18 +872,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -909,7 +894,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -930,12 +915,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -968,22 +962,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1005,21 +999,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1034,11 +1028,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1047,13 +1041,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1073,7 +1067,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1116,7 +1110,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1149,7 +1143,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1392,7 +1386,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1723,7 +1717,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1807,7 +1801,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1872,7 +1866,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2023,7 +2017,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2132,7 +2126,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2152,7 +2146,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -501,7 +501,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -521,7 +521,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -584,7 +584,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -758,11 +758,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -771,24 +771,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -805,34 +795,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 592
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -841,20 +833,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -866,17 +846,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -886,7 +866,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -894,7 +874,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -904,33 +884,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -938,21 +918,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -962,22 +942,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -998,56 +978,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1067,7 +1047,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1110,7 +1090,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1143,7 +1123,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1386,7 +1366,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1717,7 +1697,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1801,7 +1781,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1866,7 +1846,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2017,7 +1997,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2126,7 +2106,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2146,7 +2126,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -352,7 +352,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -361,18 +361,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -386,12 +380,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -415,7 +416,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -500,8 +501,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -514,7 +513,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -534,13 +533,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -549,35 +552,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -585,76 +578,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1440
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -664,12 +641,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -677,34 +654,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -712,14 +693,14 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -742,7 +723,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -755,12 +736,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -782,7 +763,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -810,7 +791,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -838,7 +819,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1003,7 +984,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1279,7 +1260,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1331,7 +1312,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1362,7 +1343,7 @@
   if
    i32.const 1312
    i32.const 1440
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1453,7 +1434,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1468,7 +1449,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1487,7 +1468,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -352,7 +352,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -366,7 +366,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -416,7 +416,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -544,18 +544,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -587,7 +581,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -597,18 +591,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -626,7 +614,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -641,7 +629,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -693,7 +681,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -763,7 +751,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -791,7 +779,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -819,7 +807,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -984,7 +972,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1260,7 +1248,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1312,7 +1300,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1343,7 +1331,7 @@
   if
    i32.const 1312
    i32.const 1440
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1434,7 +1422,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1449,7 +1437,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1468,7 +1456,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -490,7 +490,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -506,18 +506,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -533,12 +526,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -571,41 +573,41 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -618,55 +620,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -759,38 +761,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -815,7 +812,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -834,24 +831,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -869,18 +861,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -898,7 +883,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -919,12 +904,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -957,22 +951,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -994,21 +988,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1023,11 +1017,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1036,13 +1030,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1062,7 +1056,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1105,7 +1099,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1138,7 +1132,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1381,7 +1375,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1712,7 +1706,7 @@
   if
    i32.const 288
    i32.const 416
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1796,7 +1790,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1861,7 +1855,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2012,7 +2006,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2121,7 +2115,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2141,7 +2135,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -490,7 +490,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -510,7 +510,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -573,7 +573,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -747,11 +747,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -760,24 +760,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -794,34 +784,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 416
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -830,20 +822,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -855,17 +835,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -875,7 +855,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -883,7 +863,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -893,33 +873,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -927,21 +907,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -951,22 +931,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -987,56 +967,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1056,7 +1036,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1099,7 +1079,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1132,7 +1112,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1375,7 +1355,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1686,7 @@
   if
    i32.const 288
    i32.const 416
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1790,7 +1770,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1855,7 +1835,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2006,7 +1986,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2115,7 +2095,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2135,7 +2115,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.optimized.wat
+++ b/tests/compiler/optional-typeparameters.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -299,7 +299,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -349,7 +349,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -477,18 +477,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -520,7 +514,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -530,18 +524,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -559,7 +547,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -574,7 +562,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -626,7 +614,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -696,7 +684,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +712,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -752,7 +740,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1100,7 +1088,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1168,7 +1156,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1249,7 +1237,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1264,7 +1252,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.optimized.wat
+++ b/tests/compiler/optional-typeparameters.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -294,18 +294,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -319,12 +313,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -348,7 +349,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -433,8 +434,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -447,7 +446,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -467,13 +466,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -482,35 +485,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -518,76 +511,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -597,12 +574,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -610,34 +587,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -645,14 +626,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -675,7 +656,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -688,12 +669,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -715,7 +696,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -743,7 +724,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -771,7 +752,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1100,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1187,7 +1168,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1268,7 +1249,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1283,7 +1264,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -406,7 +406,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -489,7 +489,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -663,11 +663,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -676,24 +676,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -710,34 +700,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -746,20 +738,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -771,17 +751,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -791,7 +771,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -799,7 +779,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -809,33 +789,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -843,21 +823,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -867,22 +847,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -903,56 +883,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -972,7 +952,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1015,7 +995,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1048,7 +1028,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1291,7 +1271,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1622,7 +1602,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1686,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1751,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1922,7 +1902,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2031,7 +2011,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2051,7 +2031,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -406,7 +406,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -422,18 +422,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -449,12 +442,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -487,41 +489,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -534,55 +536,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -675,38 +677,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -731,7 +728,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -750,24 +747,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -785,18 +777,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -814,7 +799,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -835,12 +820,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -873,22 +867,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -910,21 +904,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -939,11 +933,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -952,13 +946,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -978,7 +972,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1021,7 +1015,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1054,7 +1048,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1297,7 +1291,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1628,7 +1622,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1712,7 +1706,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1777,7 +1771,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1928,7 +1922,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2037,7 +2031,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2057,7 +2051,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -362,7 +362,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -371,18 +371,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -396,12 +390,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -425,7 +426,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -510,8 +511,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -524,7 +523,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -544,13 +543,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -559,35 +562,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -595,76 +588,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1440
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -674,12 +651,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -687,34 +664,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -722,14 +703,14 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -752,7 +733,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -765,12 +746,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -792,7 +773,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -820,7 +801,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -848,7 +829,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1196,7 +1177,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1264,7 +1245,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1345,7 +1326,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1360,7 +1341,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -362,7 +362,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -376,7 +376,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -554,18 +554,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -597,7 +591,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -607,18 +601,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -636,7 +624,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -651,7 +639,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -703,7 +691,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -773,7 +761,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -801,7 +789,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -829,7 +817,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1177,7 +1165,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1245,7 +1233,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1326,7 +1314,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1341,7 +1329,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -490,7 +490,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -510,7 +510,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -573,7 +573,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -747,11 +747,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -760,24 +760,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -794,34 +784,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 416
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -830,20 +822,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -855,17 +835,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -875,7 +855,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -883,7 +863,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -893,33 +873,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -927,21 +907,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -951,22 +931,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -987,56 +967,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1056,7 +1036,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1099,7 +1079,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1132,7 +1112,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1375,7 +1355,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1686,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1790,7 +1770,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1855,7 +1835,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2006,7 +1986,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2115,7 +2095,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2135,7 +2115,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -490,7 +490,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -506,18 +506,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -533,12 +526,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -571,41 +573,41 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -618,55 +620,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -759,38 +761,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -815,7 +812,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -834,24 +831,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -869,18 +861,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -898,7 +883,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -919,12 +904,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -957,22 +951,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -994,21 +988,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1023,11 +1017,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1036,13 +1030,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1062,7 +1056,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1105,7 +1099,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1138,7 +1132,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1381,7 +1375,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1712,7 +1706,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1796,7 +1790,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1861,7 +1855,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2012,7 +2006,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2121,7 +2115,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2141,7 +2135,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.optimized.wat
+++ b/tests/compiler/rereexport.optimized.wat
@@ -324,7 +324,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -338,7 +338,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -388,7 +388,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -516,18 +516,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -559,7 +553,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -569,18 +563,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -598,7 +586,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -613,7 +601,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -665,7 +653,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -735,7 +723,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -763,7 +751,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -791,7 +779,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1139,7 +1127,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1207,7 +1195,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1288,7 +1276,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1303,7 +1291,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.optimized.wat
+++ b/tests/compiler/rereexport.optimized.wat
@@ -324,7 +324,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -333,18 +333,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -358,12 +352,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -387,7 +388,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -472,8 +473,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -486,7 +485,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -506,13 +505,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -521,35 +524,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -557,76 +550,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1440
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -636,12 +613,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -649,34 +626,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -684,14 +665,14 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -714,7 +695,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -727,12 +708,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -754,7 +735,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -782,7 +763,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -810,7 +791,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1158,7 +1139,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1226,7 +1207,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1307,7 +1288,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1322,7 +1303,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -442,7 +442,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -462,7 +462,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -525,7 +525,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -699,11 +699,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -712,24 +712,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -746,34 +736,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 416
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -782,20 +774,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -807,17 +787,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -827,7 +807,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -835,7 +815,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -845,33 +825,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -879,21 +859,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -903,22 +883,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -939,56 +919,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1008,7 +988,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1051,7 +1031,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1084,7 +1064,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1327,7 +1307,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1658,7 +1638,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1742,7 +1722,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1807,7 +1787,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1958,7 +1938,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2067,7 +2047,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2087,7 +2067,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -442,7 +442,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -458,18 +458,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -485,12 +478,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -523,41 +525,41 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -570,55 +572,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -711,38 +713,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -767,7 +764,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -786,24 +783,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -821,18 +813,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -850,7 +835,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -871,12 +856,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -909,22 +903,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -946,21 +940,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -975,11 +969,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -988,13 +982,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1014,7 +1008,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1057,7 +1051,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1090,7 +1084,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1333,7 +1327,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1664,7 +1658,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1748,7 +1742,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1813,7 +1807,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1964,7 +1958,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2073,7 +2067,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2093,7 +2087,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -290,7 +290,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -304,7 +304,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -354,7 +354,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -482,18 +482,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -525,7 +519,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -535,18 +529,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -564,7 +552,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -579,7 +567,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -631,7 +619,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -701,7 +689,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -729,7 +717,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -757,7 +745,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1105,7 +1093,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1193,7 +1181,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1245,7 +1233,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1276,7 +1264,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1367,7 +1355,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1382,7 +1370,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1401,7 +1389,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -290,7 +290,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -299,18 +299,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -324,12 +318,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -353,7 +354,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -438,8 +439,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -452,7 +451,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -472,13 +471,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -487,35 +490,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -523,76 +516,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1424
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -602,12 +579,12 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -615,34 +592,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -650,14 +631,14 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -680,7 +661,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -693,12 +674,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -720,7 +701,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -748,7 +729,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -776,7 +757,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1124,7 +1105,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1212,7 +1193,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1264,7 +1245,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1295,7 +1276,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1386,7 +1367,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1401,7 +1382,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1420,7 +1401,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -416,7 +416,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -432,18 +432,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -459,12 +452,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -497,41 +499,41 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -544,55 +546,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -685,38 +687,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -741,7 +738,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -760,24 +757,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -795,18 +787,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -824,7 +809,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -845,12 +830,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -883,22 +877,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -920,21 +914,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -949,11 +943,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -962,13 +956,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -988,7 +982,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1031,7 +1025,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1064,7 +1058,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1307,7 +1301,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1638,7 +1632,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1722,7 +1716,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1787,7 +1781,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1938,7 +1932,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2047,7 +2041,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2067,7 +2061,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -416,7 +416,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -436,7 +436,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -499,7 +499,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -673,11 +673,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -686,24 +686,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -720,34 +710,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 400
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -756,20 +748,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -781,17 +761,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -801,7 +781,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -809,7 +789,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -819,33 +799,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -853,21 +833,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -877,22 +857,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -913,56 +893,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -982,7 +962,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1025,7 +1005,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1058,7 +1038,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1301,7 +1281,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1632,7 +1612,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1716,7 +1696,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1781,7 +1761,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1932,7 +1912,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2041,7 +2021,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2061,7 +2041,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -521,7 +521,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -535,7 +535,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -585,7 +585,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -713,18 +713,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -756,7 +750,7 @@
    if
     i32.const 0
     i32.const 1776
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -766,18 +760,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -795,7 +783,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -810,7 +798,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -862,7 +850,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -932,7 +920,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -960,7 +948,7 @@
    if
     i32.const 0
     i32.const 1776
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -988,7 +976,7 @@
    if
     i32.const 0
     i32.const 1776
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1336,7 +1324,7 @@
        if
         i32.const 0
         i32.const 1776
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1424,7 +1412,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1476,7 +1464,7 @@
     if
      i32.const 0
      i32.const 1776
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1507,7 +1495,7 @@
   if
    i32.const 1440
    i32.const 1776
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1598,7 +1586,7 @@
    if
     i32.const 0
     i32.const 1776
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1613,7 +1601,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1632,7 +1620,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -521,7 +521,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -530,18 +530,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1776
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -555,12 +549,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -584,7 +585,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -669,8 +670,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -683,7 +682,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -703,13 +702,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -718,35 +721,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -754,76 +747,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1776
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1776
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -833,12 +810,12 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -846,34 +823,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -881,14 +862,14 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -911,7 +892,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -924,12 +905,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -951,7 +932,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -979,7 +960,7 @@
    if
     i32.const 0
     i32.const 1776
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1007,7 +988,7 @@
    if
     i32.const 0
     i32.const 1776
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1355,7 +1336,7 @@
        if
         i32.const 0
         i32.const 1776
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1443,7 +1424,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1495,7 +1476,7 @@
     if
      i32.const 0
      i32.const 1776
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1526,7 +1507,7 @@
   if
    i32.const 1440
    i32.const 1776
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1617,7 +1598,7 @@
    if
     i32.const 0
     i32.const 1776
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1632,7 +1613,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1651,7 +1632,7 @@
   if
    i32.const 0
    i32.const 1776
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -676,7 +676,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -696,7 +696,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -759,7 +759,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -933,11 +933,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -946,24 +946,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -980,34 +970,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 752
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1016,20 +1008,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1041,17 +1021,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 752
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1061,7 +1041,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1069,7 +1049,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1079,33 +1059,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1113,21 +1093,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1137,22 +1117,22 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1173,56 +1153,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1242,7 +1222,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1285,7 +1265,7 @@
    if
     i32.const 0
     i32.const 752
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1318,7 +1298,7 @@
    if
     i32.const 0
     i32.const 752
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1561,7 +1541,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1892,7 +1872,7 @@
   if
    i32.const 416
    i32.const 752
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1976,7 +1956,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2041,7 +2021,7 @@
     if
      i32.const 0
      i32.const 752
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2192,7 +2172,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2301,7 +2281,7 @@
    if
     i32.const 0
     i32.const 752
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2321,7 +2301,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -676,7 +676,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -692,18 +692,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 752
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -719,12 +712,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -757,41 +759,41 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -804,55 +806,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -945,38 +947,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1001,7 +998,7 @@
    if
     i32.const 0
     i32.const 752
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1020,24 +1017,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1055,18 +1047,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 752
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1084,7 +1069,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1105,12 +1090,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1143,22 +1137,22 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1180,21 +1174,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1209,11 +1203,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1222,13 +1216,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1248,7 +1242,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1291,7 +1285,7 @@
    if
     i32.const 0
     i32.const 752
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1324,7 +1318,7 @@
    if
     i32.const 0
     i32.const 752
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1567,7 +1561,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1898,7 +1892,7 @@
   if
    i32.const 416
    i32.const 752
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1982,7 +1976,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2047,7 +2041,7 @@
     if
      i32.const 0
      i32.const 752
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2198,7 +2192,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2307,7 +2301,7 @@
    if
     i32.const 0
     i32.const 752
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2327,7 +2321,7 @@
   if
    i32.const 0
    i32.const 752
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -341,7 +341,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -355,7 +355,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -405,7 +405,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -533,18 +533,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -576,7 +570,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -586,18 +580,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -615,7 +603,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -630,7 +618,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -682,7 +670,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -752,7 +740,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -780,7 +768,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -808,7 +796,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1156,7 +1144,7 @@
        if
         i32.const 0
         i32.const 1504
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1244,7 +1232,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1296,7 +1284,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1327,7 +1315,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1418,7 +1406,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1433,7 +1421,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1452,7 +1440,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -341,7 +341,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -350,18 +350,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -375,12 +369,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -404,7 +405,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -489,8 +490,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -503,7 +502,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -523,13 +522,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -538,35 +541,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -574,76 +567,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1504
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -653,12 +630,12 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -666,34 +643,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -701,14 +682,14 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -731,7 +712,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -744,12 +725,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -771,7 +752,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -799,7 +780,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -827,7 +808,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1175,7 +1156,7 @@
        if
         i32.const 0
         i32.const 1504
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1263,7 +1244,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1315,7 +1296,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1346,7 +1327,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1437,7 +1418,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1452,7 +1433,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1471,7 +1452,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -439,7 +439,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -459,7 +459,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -522,7 +522,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -696,11 +696,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -709,24 +709,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -743,34 +733,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 480
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -779,20 +771,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -804,17 +784,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -824,7 +804,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -832,7 +812,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -842,33 +822,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -876,21 +856,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -900,22 +880,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -936,56 +916,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1005,7 +985,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1048,7 +1028,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1081,7 +1061,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1324,7 +1304,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1655,7 +1635,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1739,7 +1719,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1804,7 +1784,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1955,7 +1935,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2064,7 +2044,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2084,7 +2064,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -439,7 +439,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -455,18 +455,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -482,12 +475,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -520,41 +522,41 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -567,55 +569,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -708,38 +710,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -764,7 +761,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -783,24 +780,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -818,18 +810,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -847,7 +832,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -868,12 +853,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -906,22 +900,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -943,21 +937,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -972,11 +966,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -985,13 +979,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1011,7 +1005,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1054,7 +1048,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1087,7 +1081,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1330,7 +1324,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1661,7 +1655,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1745,7 +1739,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1810,7 +1804,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1961,7 +1955,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2070,7 +2064,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2090,7 +2084,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -308,7 +308,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -317,18 +317,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1792
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -342,12 +336,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -371,7 +372,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -456,8 +457,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -470,7 +469,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -490,13 +489,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -505,35 +508,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -541,76 +534,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1792
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1792
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -620,12 +597,12 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -633,34 +610,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -668,14 +649,14 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -698,7 +679,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -711,12 +692,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -738,7 +719,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -766,7 +747,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -794,7 +775,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1142,7 +1123,7 @@
        if
         i32.const 0
         i32.const 1792
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1230,7 +1211,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1282,7 +1263,7 @@
     if
      i32.const 0
      i32.const 1792
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1313,7 +1294,7 @@
   if
    i32.const 1456
    i32.const 1792
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1404,7 +1385,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1419,7 +1400,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1438,7 +1419,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -308,7 +308,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -322,7 +322,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -372,7 +372,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -500,18 +500,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -543,7 +537,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -553,18 +547,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -582,7 +570,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -597,7 +585,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -649,7 +637,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -719,7 +707,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -747,7 +735,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -775,7 +763,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1123,7 +1111,7 @@
        if
         i32.const 0
         i32.const 1792
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1211,7 +1199,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1263,7 +1251,7 @@
     if
      i32.const 0
      i32.const 1792
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1294,7 +1282,7 @@
   if
    i32.const 1456
    i32.const 1792
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1385,7 +1373,7 @@
    if
     i32.const 0
     i32.const 1792
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1400,7 +1388,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1419,7 +1407,7 @@
   if
    i32.const 0
    i32.const 1792
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -484,7 +484,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -504,7 +504,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -567,7 +567,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -741,11 +741,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -754,24 +754,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -788,34 +778,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 768
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -824,20 +816,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -849,17 +829,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 768
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -869,7 +849,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -877,7 +857,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -887,33 +867,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -921,21 +901,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -945,22 +925,22 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -981,56 +961,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1050,7 +1030,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1093,7 +1073,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1106,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1369,7 +1349,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1700,7 +1680,7 @@
   if
    i32.const 432
    i32.const 768
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1784,7 +1764,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1849,7 +1829,7 @@
     if
      i32.const 0
      i32.const 768
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2000,7 +1980,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2109,7 +2089,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2129,7 +2109,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -484,7 +484,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -500,18 +500,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 768
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -527,12 +520,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -565,41 +567,41 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -612,55 +614,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -753,38 +755,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -809,7 +806,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -828,24 +825,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -863,18 +855,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 768
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -892,7 +877,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -913,12 +898,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -951,22 +945,22 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -988,21 +982,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1017,11 +1011,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1030,13 +1024,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1056,7 +1050,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1099,7 +1093,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1132,7 +1126,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1375,7 +1369,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1700,7 @@
   if
    i32.const 432
    i32.const 768
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1790,7 +1784,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1855,7 +1849,7 @@
     if
      i32.const 0
      i32.const 768
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2006,7 +2000,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2115,7 +2109,7 @@
    if
     i32.const 0
     i32.const 768
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2135,7 +2129,7 @@
   if
    i32.const 0
    i32.const 768
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-nested.optimized.wat
+++ b/tests/compiler/resolve-nested.optimized.wat
@@ -282,7 +282,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -291,18 +291,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -316,12 +310,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -345,7 +346,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -430,8 +431,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -444,7 +443,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -464,13 +463,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -479,35 +482,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -515,76 +508,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -594,12 +571,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -607,34 +584,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -642,14 +623,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -672,7 +653,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -685,12 +666,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -712,7 +693,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -740,7 +721,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -768,7 +749,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1116,7 +1097,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1184,7 +1165,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1265,7 +1246,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1280,7 +1261,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-nested.optimized.wat
+++ b/tests/compiler/resolve-nested.optimized.wat
@@ -282,7 +282,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -296,7 +296,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -346,7 +346,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -474,18 +474,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -517,7 +511,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -527,18 +521,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -556,7 +544,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -571,7 +559,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -623,7 +611,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -693,7 +681,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -721,7 +709,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -749,7 +737,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1097,7 +1085,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1165,7 +1153,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1246,7 +1234,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1261,7 +1249,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-nested.untouched.wat
+++ b/tests/compiler/resolve-nested.untouched.wat
@@ -422,7 +422,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -442,7 +442,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -505,7 +505,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -679,11 +679,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -692,24 +692,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -726,34 +716,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -762,20 +754,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -787,17 +767,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -807,7 +787,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -815,7 +795,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -825,33 +805,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -859,21 +839,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -883,22 +863,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -919,56 +899,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -988,7 +968,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1031,7 +1011,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1064,7 +1044,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1307,7 +1287,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1638,7 +1618,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1722,7 +1702,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1787,7 +1767,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1938,7 +1918,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2047,7 +2027,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2067,7 +2047,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-nested.untouched.wat
+++ b/tests/compiler/resolve-nested.untouched.wat
@@ -422,7 +422,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -438,18 +438,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -465,12 +458,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -503,41 +505,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -550,55 +552,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -691,38 +693,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -747,7 +744,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -766,24 +763,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -801,18 +793,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -830,7 +815,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -851,12 +836,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -889,22 +883,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -926,21 +920,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -955,11 +949,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -968,13 +962,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -994,7 +988,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1037,7 +1031,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1070,7 +1064,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1313,7 +1307,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1644,7 +1638,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1728,7 +1722,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1793,7 +1787,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1944,7 +1938,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2053,7 +2047,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2073,7 +2067,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.optimized.wat
+++ b/tests/compiler/resolve-new.optimized.wat
@@ -278,7 +278,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -292,7 +292,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -342,7 +342,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -470,18 +470,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -513,7 +507,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -523,18 +517,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -552,7 +540,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -567,7 +555,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -619,7 +607,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -689,7 +677,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -717,7 +705,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -745,7 +733,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1093,7 +1081,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1161,7 +1149,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1242,7 +1230,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1257,7 +1245,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.optimized.wat
+++ b/tests/compiler/resolve-new.optimized.wat
@@ -278,7 +278,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -287,18 +287,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -312,12 +306,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -341,7 +342,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -426,8 +427,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -440,7 +439,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -460,13 +459,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -475,35 +478,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -511,76 +504,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -590,12 +567,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -603,34 +580,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -638,14 +619,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -668,7 +649,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -681,12 +662,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -708,7 +689,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -736,7 +717,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -764,7 +745,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1112,7 +1093,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1180,7 +1161,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1261,7 +1242,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1276,7 +1257,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.untouched.wat
+++ b/tests/compiler/resolve-new.untouched.wat
@@ -398,7 +398,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -418,7 +418,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -481,7 +481,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -655,11 +655,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -668,24 +668,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -702,34 +692,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -738,20 +730,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -763,17 +743,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -783,7 +763,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -791,7 +771,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -801,33 +781,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -835,21 +815,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -859,22 +839,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -895,56 +875,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -964,7 +944,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1007,7 +987,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1040,7 +1020,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1283,7 +1263,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1614,7 +1594,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1698,7 +1678,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1763,7 +1743,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1914,7 +1894,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2023,7 +2003,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2043,7 +2023,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.untouched.wat
+++ b/tests/compiler/resolve-new.untouched.wat
@@ -398,7 +398,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -414,18 +414,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -441,12 +434,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -479,41 +481,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -526,55 +528,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -667,38 +669,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -723,7 +720,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -742,24 +739,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -777,18 +769,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -806,7 +791,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -827,12 +812,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -865,22 +859,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -902,21 +896,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -931,11 +925,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -944,13 +938,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -970,7 +964,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1013,7 +1007,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1046,7 +1040,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1289,7 +1283,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1620,7 +1614,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1704,7 +1698,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1769,7 +1763,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1920,7 +1914,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2029,7 +2023,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2049,7 +2043,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -308,7 +308,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -317,18 +317,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -342,12 +336,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -371,7 +372,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -456,8 +457,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -470,7 +469,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -490,13 +489,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -505,35 +508,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -541,76 +534,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1616
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -620,12 +597,12 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -633,34 +610,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -668,14 +649,14 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -698,7 +679,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -711,12 +692,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -738,7 +719,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -766,7 +747,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -794,7 +775,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1142,7 +1123,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1230,7 +1211,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1282,7 +1263,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1313,7 +1294,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1404,7 +1385,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1419,7 +1400,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1438,7 +1419,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -308,7 +308,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -322,7 +322,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -372,7 +372,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -500,18 +500,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -543,7 +537,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -553,18 +547,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -582,7 +570,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -597,7 +585,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -649,7 +637,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -719,7 +707,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -747,7 +735,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -775,7 +763,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1123,7 +1111,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1211,7 +1199,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1263,7 +1251,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1294,7 +1282,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1385,7 +1373,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1400,7 +1388,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1419,7 +1407,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -484,7 +484,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -500,18 +500,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -527,12 +520,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -565,41 +567,41 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -612,55 +614,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -753,38 +755,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -809,7 +806,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -828,24 +825,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -863,18 +855,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -892,7 +877,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -913,12 +898,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -951,22 +945,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -988,21 +982,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1017,11 +1011,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1030,13 +1024,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1056,7 +1050,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1099,7 +1093,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1132,7 +1126,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1375,7 +1369,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1706,7 +1700,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1790,7 +1784,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1855,7 +1849,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2006,7 +2000,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2115,7 +2109,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2135,7 +2129,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -484,7 +484,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -504,7 +504,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -567,7 +567,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -741,11 +741,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -754,24 +754,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -788,34 +778,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 592
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -824,20 +816,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -849,17 +829,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -869,7 +849,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -877,7 +857,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -887,33 +867,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -921,21 +901,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -945,22 +925,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -981,56 +961,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1050,7 +1030,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1093,7 +1073,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1106,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1369,7 +1349,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1700,7 +1680,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1784,7 +1764,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1849,7 +1829,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2000,7 +1980,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2109,7 +2089,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2129,7 +2109,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -354,7 +354,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -368,7 +368,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -418,7 +418,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -546,18 +546,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -589,7 +583,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -599,18 +593,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -628,7 +616,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -643,7 +631,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -695,7 +683,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -765,7 +753,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -793,7 +781,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -821,7 +809,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1169,7 +1157,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1257,7 +1245,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1309,7 +1297,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1340,7 +1328,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1431,7 +1419,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1446,7 +1434,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1465,7 +1453,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -354,7 +354,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -363,18 +363,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -388,12 +382,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -417,7 +418,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -502,8 +503,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -516,7 +515,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -536,13 +535,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -551,35 +554,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -587,76 +580,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1616
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -666,12 +643,12 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -679,34 +656,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -714,14 +695,14 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -744,7 +725,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -757,12 +738,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -784,7 +765,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -812,7 +793,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -840,7 +821,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1188,7 +1169,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1276,7 +1257,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1328,7 +1309,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1359,7 +1340,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1450,7 +1431,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1465,7 +1446,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1484,7 +1465,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -492,7 +492,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -512,7 +512,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -575,7 +575,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -749,11 +749,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -762,24 +762,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -796,34 +786,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 592
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -832,20 +824,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -857,17 +837,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -877,7 +857,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -885,7 +865,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -895,33 +875,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -929,21 +909,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -953,22 +933,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -989,56 +969,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1058,7 +1038,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1101,7 +1081,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1134,7 +1114,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1377,7 +1357,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1708,7 +1688,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1792,7 +1772,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1857,7 +1837,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2008,7 +1988,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2117,7 +2097,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2137,7 +2117,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -492,7 +492,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -508,18 +508,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -535,12 +528,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -573,41 +575,41 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -620,55 +622,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -761,38 +763,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -817,7 +814,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -836,24 +833,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -871,18 +863,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -900,7 +885,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -921,12 +906,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -959,22 +953,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -996,21 +990,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1025,11 +1019,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1038,13 +1032,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1064,7 +1058,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1107,7 +1101,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1140,7 +1134,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1383,7 +1377,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1714,7 +1708,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1798,7 +1792,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1863,7 +1857,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2014,7 +2008,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2123,7 +2117,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2143,7 +2137,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -328,7 +328,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -337,18 +337,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -362,12 +356,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -391,7 +392,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -476,8 +477,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -490,7 +489,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -510,13 +509,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -525,35 +528,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -561,76 +554,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1616
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -640,12 +617,12 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -653,34 +630,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -688,14 +669,14 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -718,7 +699,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -731,12 +712,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -758,7 +739,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -786,7 +767,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -814,7 +795,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1162,7 +1143,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1250,7 +1231,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1302,7 +1283,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1333,7 +1314,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1424,7 +1405,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1439,7 +1420,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1458,7 +1439,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -328,7 +328,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -342,7 +342,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -392,7 +392,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -520,18 +520,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -563,7 +557,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -573,18 +567,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -602,7 +590,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -617,7 +605,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -669,7 +657,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -739,7 +727,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -767,7 +755,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -795,7 +783,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1143,7 +1131,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1231,7 +1219,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1283,7 +1271,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1314,7 +1302,7 @@
   if
    i32.const 1280
    i32.const 1616
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1405,7 +1393,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1420,7 +1408,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1439,7 +1427,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -481,7 +481,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -497,18 +497,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -524,12 +517,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -562,41 +564,41 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -609,55 +611,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -750,38 +752,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -806,7 +803,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -825,24 +822,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -860,18 +852,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -889,7 +874,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -910,12 +895,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -948,22 +942,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -985,21 +979,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1014,11 +1008,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1027,13 +1021,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1053,7 +1047,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1096,7 +1090,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1129,7 +1123,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1372,7 +1366,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1703,7 +1697,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1787,7 +1781,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1852,7 +1846,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2003,7 +1997,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2112,7 +2106,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2132,7 +2126,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -481,7 +481,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -501,7 +501,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -564,7 +564,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -738,11 +738,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -751,24 +751,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -785,34 +775,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 592
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -821,20 +813,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -846,17 +826,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -866,7 +846,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -874,7 +854,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -884,33 +864,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -918,21 +898,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -942,22 +922,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -978,56 +958,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1047,7 +1027,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1090,7 +1070,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1123,7 +1103,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1366,7 +1346,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1697,7 +1677,7 @@
   if
    i32.const 256
    i32.const 592
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1781,7 +1761,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1846,7 +1826,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1997,7 +1977,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2106,7 +2086,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2126,7 +2106,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -276,7 +276,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -285,18 +285,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -310,12 +304,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -339,7 +340,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,8 +425,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -438,7 +437,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -458,13 +457,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -473,35 +476,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -509,76 +502,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1440
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -588,12 +565,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -601,34 +578,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -636,14 +617,14 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -666,7 +647,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -679,12 +660,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -706,7 +687,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -734,7 +715,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -762,7 +743,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -963,7 +944,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 565
+     i32.const 561
      i32.const 3
      call $~lib/builtins/abort
      unreachable
@@ -1198,7 +1179,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1279,7 +1260,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1294,7 +1275,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -276,7 +276,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -290,7 +290,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -340,7 +340,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -468,18 +468,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -511,7 +505,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -521,18 +515,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -550,7 +538,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -565,7 +553,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -617,7 +605,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -687,7 +675,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -715,7 +703,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -743,7 +731,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -944,7 +932,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 561
+     i32.const 559
      i32.const 3
      call $~lib/builtins/abort
      unreachable
@@ -1179,7 +1167,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1260,7 +1248,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1275,7 +1263,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -417,7 +417,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -437,7 +437,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -500,7 +500,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -674,11 +674,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -687,24 +687,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -721,34 +711,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 416
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -757,20 +749,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -782,17 +762,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -802,7 +782,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -810,7 +790,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -820,33 +800,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -854,21 +834,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -878,22 +858,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -914,56 +894,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -983,7 +963,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1026,7 +1006,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1059,7 +1039,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1302,7 +1282,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1637,7 +1617,7 @@
   if
    i32.const 32
    i32.const 416
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1721,7 +1701,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1786,7 +1766,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1937,7 +1917,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2046,7 +2026,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2066,7 +2046,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -417,7 +417,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -433,18 +433,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -460,12 +453,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -498,41 +500,41 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -545,55 +547,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -686,38 +688,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -742,7 +739,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -761,24 +758,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -796,18 +788,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -825,7 +810,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -846,12 +831,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -884,22 +878,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -921,21 +915,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -950,11 +944,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -963,13 +957,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -989,7 +983,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1032,7 +1026,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1065,7 +1059,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1308,7 +1302,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1643,7 +1637,7 @@
   if
    i32.const 32
    i32.const 416
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1727,7 +1721,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1792,7 +1786,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1943,7 +1937,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2052,7 +2046,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2072,7 +2066,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/instanceof.optimized.wat
+++ b/tests/compiler/rt/instanceof.optimized.wat
@@ -317,7 +317,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -331,7 +331,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -381,7 +381,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -509,18 +509,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -552,7 +546,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -562,18 +556,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -591,7 +579,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -606,7 +594,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -658,7 +646,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -728,7 +716,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -756,7 +744,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -784,7 +772,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1132,7 +1120,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1200,7 +1188,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1281,7 +1269,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1296,7 +1284,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/instanceof.optimized.wat
+++ b/tests/compiler/rt/instanceof.optimized.wat
@@ -317,7 +317,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -326,18 +326,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -351,12 +345,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -380,7 +381,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -465,8 +466,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -479,7 +478,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -499,13 +498,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -514,35 +517,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -550,76 +543,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -629,12 +606,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -642,34 +619,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -677,14 +658,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -707,7 +688,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -720,12 +701,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -747,7 +728,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -775,7 +756,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -803,7 +784,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1151,7 +1132,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1219,7 +1200,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1300,7 +1281,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1315,7 +1296,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -408,7 +408,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,18 +424,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -451,12 +444,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -489,41 +491,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -536,55 +538,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -677,38 +679,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -733,7 +730,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -752,24 +749,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -787,18 +779,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -816,7 +801,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -837,12 +822,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -875,22 +869,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -912,21 +906,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -941,11 +935,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -954,13 +948,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -980,7 +974,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1023,7 +1017,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1056,7 +1050,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1299,7 +1293,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1630,7 +1624,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1714,7 +1708,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1779,7 +1773,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1930,7 +1924,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2039,7 +2033,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2059,7 +2053,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -408,7 +408,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -428,7 +428,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -491,7 +491,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -665,11 +665,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -678,24 +678,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -712,34 +702,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -748,20 +740,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -773,17 +753,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -793,7 +773,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -801,7 +781,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -811,33 +791,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -845,21 +825,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -869,22 +849,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -905,56 +885,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -974,7 +954,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1017,7 +997,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1050,7 +1030,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1293,7 +1273,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1624,7 +1604,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1708,7 +1688,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1773,7 +1753,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1924,7 +1904,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2033,7 +2013,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2053,7 +2033,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.optimized.wat
+++ b/tests/compiler/rt/runtime-incremental-export.optimized.wat
@@ -292,7 +292,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -306,7 +306,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -356,7 +356,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -484,18 +484,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -527,7 +521,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -537,18 +531,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -566,7 +554,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -581,7 +569,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -633,7 +621,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -703,7 +691,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,7 +719,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -759,7 +747,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1095,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1195,7 +1183,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1247,7 +1235,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1278,7 +1266,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1369,7 +1357,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1384,7 +1372,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1403,7 +1391,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.optimized.wat
+++ b/tests/compiler/rt/runtime-incremental-export.optimized.wat
@@ -292,7 +292,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -301,18 +301,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -326,12 +320,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -355,7 +356,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -440,8 +441,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -454,7 +453,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -474,13 +473,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -489,35 +492,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -525,76 +518,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -604,12 +581,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -617,34 +594,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -652,14 +633,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -682,7 +663,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -695,12 +676,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -722,7 +703,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -750,7 +731,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -778,7 +759,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1107,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1214,7 +1195,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1266,7 +1247,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1297,7 +1278,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1388,7 +1369,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1403,7 +1384,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1422,7 +1403,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.untouched.wat
+++ b/tests/compiler/rt/runtime-incremental-export.untouched.wat
@@ -404,7 +404,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -420,18 +420,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -447,12 +440,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -485,41 +487,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -532,55 +534,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -673,38 +675,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -729,7 +726,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -748,24 +745,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -783,18 +775,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -812,7 +797,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -833,12 +818,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -871,22 +865,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -908,21 +902,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -937,11 +931,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -950,13 +944,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -976,7 +970,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1019,7 +1013,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1052,7 +1046,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1295,7 +1289,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1626,7 +1620,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1710,7 +1704,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1775,7 +1769,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1926,7 +1920,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2035,7 +2029,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2055,7 +2049,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-incremental-export.untouched.wat
+++ b/tests/compiler/rt/runtime-incremental-export.untouched.wat
@@ -404,7 +404,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,7 +424,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -487,7 +487,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -661,11 +661,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -674,24 +674,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -708,34 +698,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -744,20 +736,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -769,17 +749,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -789,7 +769,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -797,7 +777,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -807,33 +787,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -841,21 +821,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -865,22 +845,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -901,56 +881,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -970,7 +950,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1013,7 +993,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1046,7 +1026,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1289,7 +1269,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1620,7 +1600,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1704,7 +1684,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1769,7 +1749,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1920,7 +1900,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2029,7 +2009,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2049,7 +2029,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-minimal-export.optimized.wat
+++ b/tests/compiler/rt/runtime-minimal-export.optimized.wat
@@ -47,7 +47,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -61,7 +61,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -111,7 +111,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -239,18 +239,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -282,7 +276,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -292,18 +286,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -321,7 +309,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -336,7 +324,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -388,7 +376,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -458,7 +446,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -486,7 +474,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -514,7 +502,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -696,7 +684,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -748,7 +736,7 @@
     if
      i32.const 0
      i32.const 1184
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -779,7 +767,7 @@
   if
    i32.const 1056
    i32.const 1184
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -870,7 +858,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -885,7 +873,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -904,7 +892,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1338,7 +1326,7 @@
       if
        i32.const 0
        i32.const 1184
-       i32.const 561
+       i32.const 559
        i32.const 3
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/rt/runtime-minimal-export.optimized.wat
+++ b/tests/compiler/rt/runtime-minimal-export.optimized.wat
@@ -47,7 +47,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -56,18 +56,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1184
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -81,12 +75,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -110,7 +111,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -195,8 +196,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -209,7 +208,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -229,13 +228,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -244,35 +247,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -280,76 +273,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1184
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1184
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -359,12 +336,12 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -372,34 +349,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -407,14 +388,14 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -437,7 +418,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -450,12 +431,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -477,7 +458,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -505,7 +486,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -533,7 +514,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -715,7 +696,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -767,7 +748,7 @@
     if
      i32.const 0
      i32.const 1184
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -798,7 +779,7 @@
   if
    i32.const 1056
    i32.const 1184
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -889,7 +870,7 @@
    if
     i32.const 0
     i32.const 1184
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -904,7 +885,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -923,7 +904,7 @@
   if
    i32.const 0
    i32.const 1184
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1357,7 +1338,7 @@
       if
        i32.const 0
        i32.const 1184
-       i32.const 565
+       i32.const 561
        i32.const 3
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/rt/runtime-minimal-export.untouched.wat
+++ b/tests/compiler/rt/runtime-minimal-export.untouched.wat
@@ -78,7 +78,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -98,7 +98,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -161,7 +161,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -335,11 +335,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -348,24 +348,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -382,34 +372,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 160
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -418,20 +410,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -443,17 +423,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 160
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -463,7 +443,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -471,7 +451,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -481,33 +461,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -515,21 +495,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -539,22 +519,22 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -575,56 +555,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -644,7 +624,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -687,7 +667,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -720,7 +700,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -960,7 +940,7 @@
   if
    i32.const 32
    i32.const 160
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1044,7 +1024,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1109,7 +1089,7 @@
     if
      i32.const 0
      i32.const 160
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1260,7 +1240,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1369,7 +1349,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1389,7 +1369,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1684,7 +1664,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/runtime-minimal-export.untouched.wat
+++ b/tests/compiler/rt/runtime-minimal-export.untouched.wat
@@ -78,7 +78,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -94,18 +94,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 160
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -121,12 +114,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -159,41 +161,41 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -206,55 +208,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -347,38 +349,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -403,7 +400,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -422,24 +419,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -457,18 +449,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 160
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -486,7 +471,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -507,12 +492,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -545,22 +539,22 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -582,21 +576,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -611,11 +605,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -624,13 +618,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -650,7 +644,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -693,7 +687,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -726,7 +720,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -966,7 +960,7 @@
   if
    i32.const 32
    i32.const 160
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1050,7 +1044,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1115,7 +1109,7 @@
     if
      i32.const 0
      i32.const 160
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1266,7 +1260,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1375,7 +1369,7 @@
    if
     i32.const 0
     i32.const 160
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1395,7 +1389,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1690,7 +1684,7 @@
   if
    i32.const 0
    i32.const 160
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std-wasi/console.optimized.wat
+++ b/tests/compiler/std-wasi/console.optimized.wat
@@ -942,7 +942,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -951,18 +951,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 4224
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -976,12 +970,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1005,7 +1006,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1090,8 +1091,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -1104,7 +1103,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -1124,13 +1123,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -1139,35 +1142,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -1175,76 +1168,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 4224
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 4224
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -1254,12 +1231,12 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -1267,34 +1244,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -1302,14 +1283,14 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1332,7 +1313,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1345,12 +1326,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -1372,7 +1353,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1400,7 +1381,7 @@
    if
     i32.const 0
     i32.const 4224
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1428,7 +1409,7 @@
    if
     i32.const 0
     i32.const 4224
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1610,7 +1591,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1662,7 +1643,7 @@
     if
      i32.const 0
      i32.const 4224
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1693,7 +1674,7 @@
   if
    i32.const 4288
    i32.const 4224
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1784,7 +1765,7 @@
    if
     i32.const 0
     i32.const 4224
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1799,7 +1780,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1818,7 +1799,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1933,7 +1914,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/console.optimized.wat
+++ b/tests/compiler/std-wasi/console.optimized.wat
@@ -942,7 +942,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -956,7 +956,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1006,7 +1006,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1134,18 +1134,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -1177,7 +1171,7 @@
    if
     i32.const 0
     i32.const 4224
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1187,18 +1181,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -1216,7 +1204,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1231,7 +1219,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1283,7 +1271,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1353,7 +1341,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1381,7 +1369,7 @@
    if
     i32.const 0
     i32.const 4224
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1409,7 +1397,7 @@
    if
     i32.const 0
     i32.const 4224
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1591,7 +1579,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1643,7 +1631,7 @@
     if
      i32.const 0
      i32.const 4224
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1674,7 +1662,7 @@
   if
    i32.const 4288
    i32.const 4224
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1765,7 +1753,7 @@
    if
     i32.const 0
     i32.const 4224
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1780,7 +1768,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1799,7 +1787,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1914,7 +1902,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/console.untouched.wat
+++ b/tests/compiler/std-wasi/console.untouched.wat
@@ -1393,7 +1393,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1413,7 +1413,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1476,7 +1476,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1650,11 +1650,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -1663,24 +1663,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -1697,34 +1687,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 3200
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1733,20 +1725,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1758,17 +1738,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 3200
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1778,7 +1758,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1786,7 +1766,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1796,33 +1776,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1830,21 +1810,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1854,22 +1834,22 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1890,56 +1870,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1959,7 +1939,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2002,7 +1982,7 @@
    if
     i32.const 0
     i32.const 3200
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2035,7 +2015,7 @@
    if
     i32.const 0
     i32.const 3200
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -2275,7 +2255,7 @@
   if
    i32.const 3264
    i32.const 3200
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -2359,7 +2339,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2424,7 +2404,7 @@
     if
      i32.const 0
      i32.const 3200
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -2575,7 +2555,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2684,7 +2664,7 @@
    if
     i32.const 0
     i32.const 3200
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2704,7 +2684,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2762,7 +2742,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/console.untouched.wat
+++ b/tests/compiler/std-wasi/console.untouched.wat
@@ -1393,7 +1393,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1409,18 +1409,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 3200
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1436,12 +1429,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -1474,41 +1476,41 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -1521,55 +1523,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -1662,38 +1664,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1718,7 +1715,7 @@
    if
     i32.const 0
     i32.const 3200
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1737,24 +1734,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1772,18 +1764,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 3200
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1801,7 +1786,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1822,12 +1807,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1860,22 +1854,22 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1897,21 +1891,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1926,11 +1920,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1939,13 +1933,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1965,7 +1959,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2008,7 +2002,7 @@
    if
     i32.const 0
     i32.const 3200
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2041,7 +2035,7 @@
    if
     i32.const 0
     i32.const 3200
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -2281,7 +2275,7 @@
   if
    i32.const 3264
    i32.const 3200
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -2365,7 +2359,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2430,7 +2424,7 @@
     if
      i32.const 0
      i32.const 3200
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -2581,7 +2575,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2690,7 +2684,7 @@
    if
     i32.const 0
     i32.const 3200
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2710,7 +2704,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2768,7 +2762,7 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/crypto.optimized.wat
+++ b/tests/compiler/std-wasi/crypto.optimized.wat
@@ -832,7 +832,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -846,7 +846,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -896,7 +896,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1024,18 +1024,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -1067,7 +1061,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1077,18 +1071,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -1106,7 +1094,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1121,7 +1109,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1173,7 +1161,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1243,7 +1231,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1271,7 +1259,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1299,7 +1287,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1464,7 +1452,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
@@ -1740,7 +1728,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1792,7 +1780,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1823,7 +1811,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1914,7 +1902,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1929,7 +1917,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1948,7 +1936,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/crypto.optimized.wat
+++ b/tests/compiler/std-wasi/crypto.optimized.wat
@@ -832,7 +832,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -841,18 +841,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -866,12 +860,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -895,7 +896,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -980,8 +981,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -994,7 +993,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -1014,13 +1013,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -1029,35 +1032,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -1065,76 +1058,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1504
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -1144,12 +1121,12 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -1157,34 +1134,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -1192,14 +1173,14 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1222,7 +1203,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1235,12 +1216,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -1262,7 +1243,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1290,7 +1271,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1318,7 +1299,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1483,7 +1464,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
@@ -1759,7 +1740,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1811,7 +1792,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1842,7 +1823,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1933,7 +1914,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1948,7 +1929,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1967,7 +1948,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/crypto.untouched.wat
+++ b/tests/compiler/std-wasi/crypto.untouched.wat
@@ -952,7 +952,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -972,7 +972,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1035,7 +1035,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1209,11 +1209,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -1222,24 +1222,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -1256,34 +1246,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 480
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1292,20 +1284,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1317,17 +1297,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1337,7 +1317,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1345,7 +1325,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1355,33 +1335,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1389,21 +1369,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1413,22 +1393,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1449,56 +1429,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1518,7 +1498,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1561,7 +1541,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1594,7 +1574,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1837,7 +1817,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
@@ -2168,7 +2148,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -2252,7 +2232,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2317,7 +2297,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -2468,7 +2448,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2577,7 +2557,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2597,7 +2577,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/crypto.untouched.wat
+++ b/tests/compiler/std-wasi/crypto.untouched.wat
@@ -952,7 +952,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -968,18 +968,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -995,12 +988,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -1033,41 +1035,41 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -1080,55 +1082,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -1221,38 +1223,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1277,7 +1274,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1296,24 +1293,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1331,18 +1323,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1360,7 +1345,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1381,12 +1366,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1419,22 +1413,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1456,21 +1450,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1485,11 +1479,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1498,13 +1492,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1524,7 +1518,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1567,7 +1561,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1600,7 +1594,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1843,7 +1837,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
@@ -2174,7 +2168,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -2258,7 +2252,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2323,7 +2317,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -2474,7 +2468,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2583,7 +2577,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2603,7 +2597,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -930,7 +930,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -944,7 +944,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -994,7 +994,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1122,18 +1122,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -1165,7 +1159,7 @@
    if
     i32.const 0
     i32.const 4176
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1175,18 +1169,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -1204,7 +1192,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1219,7 +1207,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1271,7 +1259,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1341,7 +1329,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1369,7 +1357,7 @@
    if
     i32.const 0
     i32.const 4176
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1397,7 +1385,7 @@
    if
     i32.const 0
     i32.const 4176
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1579,7 +1567,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1631,7 +1619,7 @@
     if
      i32.const 0
      i32.const 4176
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1662,7 +1650,7 @@
   if
    i32.const 4240
    i32.const 4176
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1753,7 +1741,7 @@
    if
     i32.const 0
     i32.const 4176
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1768,7 +1756,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1787,7 +1775,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1902,7 +1890,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -930,7 +930,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -939,18 +939,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 4176
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -964,12 +958,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -993,7 +994,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1078,8 +1079,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -1092,7 +1091,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -1112,13 +1111,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -1127,35 +1130,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -1163,76 +1156,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 4176
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 4176
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -1242,12 +1219,12 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -1255,34 +1232,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -1290,14 +1271,14 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1320,7 +1301,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1333,12 +1314,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -1360,7 +1341,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1388,7 +1369,7 @@
    if
     i32.const 0
     i32.const 4176
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1416,7 +1397,7 @@
    if
     i32.const 0
     i32.const 4176
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1598,7 +1579,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1650,7 +1631,7 @@
     if
      i32.const 0
      i32.const 4176
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1681,7 +1662,7 @@
   if
    i32.const 4240
    i32.const 4176
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1772,7 +1753,7 @@
    if
     i32.const 0
     i32.const 4176
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1787,7 +1768,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1806,7 +1787,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1921,7 +1902,7 @@
   if
    i32.const 0
    i32.const 4176
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -1392,7 +1392,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1408,18 +1408,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 3152
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1435,12 +1428,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -1473,41 +1475,41 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -1520,55 +1522,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -1661,38 +1663,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1717,7 +1714,7 @@
    if
     i32.const 0
     i32.const 3152
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1736,24 +1733,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1771,18 +1763,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 3152
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1800,7 +1785,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1821,12 +1806,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1859,22 +1853,22 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1896,21 +1890,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1925,11 +1919,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1938,13 +1932,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1964,7 +1958,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2007,7 +2001,7 @@
    if
     i32.const 0
     i32.const 3152
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2040,7 +2034,7 @@
    if
     i32.const 0
     i32.const 3152
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -2280,7 +2274,7 @@
   if
    i32.const 3216
    i32.const 3152
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -2364,7 +2358,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2429,7 +2423,7 @@
     if
      i32.const 0
      i32.const 3152
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -2580,7 +2574,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2689,7 +2683,7 @@
    if
     i32.const 0
     i32.const 3152
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2709,7 +2703,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2767,7 +2761,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -1392,7 +1392,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1412,7 +1412,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1475,7 +1475,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1649,11 +1649,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -1662,24 +1662,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -1696,34 +1686,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 3152
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1732,20 +1724,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1757,17 +1737,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 3152
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1777,7 +1757,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1785,7 +1765,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1795,33 +1775,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1829,21 +1809,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1853,22 +1833,22 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1889,56 +1869,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1958,7 +1938,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2001,7 +1981,7 @@
    if
     i32.const 0
     i32.const 3152
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2034,7 +2014,7 @@
    if
     i32.const 0
     i32.const 3152
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -2274,7 +2254,7 @@
   if
    i32.const 3216
    i32.const 3152
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -2358,7 +2338,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2423,7 +2403,7 @@
     if
      i32.const 0
      i32.const 3152
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -2574,7 +2554,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2683,7 +2663,7 @@
    if
     i32.const 0
     i32.const 3152
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -2703,7 +2683,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2761,7 +2741,7 @@
   if
    i32.const 0
    i32.const 3152
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -368,7 +368,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -382,7 +382,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -432,7 +432,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -560,18 +560,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -603,7 +597,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -613,18 +607,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -642,7 +630,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -657,7 +645,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -709,7 +697,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -779,7 +767,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -807,7 +795,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -835,7 +823,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1183,7 +1171,7 @@
        if
         i32.const 0
         i32.const 1744
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1271,7 +1259,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1323,7 +1311,7 @@
     if
      i32.const 0
      i32.const 1744
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1354,7 +1342,7 @@
   if
    i32.const 1472
    i32.const 1744
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1445,7 +1433,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1460,7 +1448,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1479,7 +1467,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -368,7 +368,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -377,18 +377,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1744
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -402,12 +396,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -431,7 +432,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -516,8 +517,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -530,7 +529,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -550,13 +549,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -565,35 +568,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -601,76 +594,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1744
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1744
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -680,12 +657,12 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -693,34 +670,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -728,14 +709,14 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -758,7 +739,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -771,12 +752,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -798,7 +779,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -826,7 +807,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -854,7 +835,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1202,7 +1183,7 @@
        if
         i32.const 0
         i32.const 1744
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1290,7 +1271,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1342,7 +1323,7 @@
     if
      i32.const 0
      i32.const 1744
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1373,7 +1354,7 @@
   if
    i32.const 1472
    i32.const 1744
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1464,7 +1445,7 @@
    if
     i32.const 0
     i32.const 1744
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1479,7 +1460,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1498,7 +1479,7 @@
   if
    i32.const 0
    i32.const 1744
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -474,7 +474,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -494,7 +494,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -557,7 +557,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,11 +731,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -744,24 +744,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -778,34 +768,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 720
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -814,20 +806,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -839,17 +819,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 720
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -859,7 +839,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -867,7 +847,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -877,33 +857,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -911,21 +891,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -935,22 +915,22 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -971,56 +951,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1040,7 +1020,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1083,7 +1063,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1116,7 +1096,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1359,7 +1339,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1690,7 +1670,7 @@
   if
    i32.const 448
    i32.const 720
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1774,7 +1754,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1839,7 +1819,7 @@
     if
      i32.const 0
      i32.const 720
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1990,7 +1970,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2099,7 +2079,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2119,7 +2099,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -474,7 +474,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -490,18 +490,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 720
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -517,12 +510,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -555,41 +557,41 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -602,55 +604,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -743,38 +745,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -799,7 +796,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -818,24 +815,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -853,18 +845,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 720
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -882,7 +867,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -903,12 +888,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -941,22 +935,22 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -978,21 +972,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1007,11 +1001,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1020,13 +1014,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1046,7 +1040,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1089,7 +1083,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1122,7 +1116,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1365,7 +1359,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1696,7 +1690,7 @@
   if
    i32.const 448
    i32.const 720
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1780,7 +1774,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1845,7 +1839,7 @@
     if
      i32.const 0
      i32.const 720
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1996,7 +1990,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2105,7 +2099,7 @@
    if
     i32.const 0
     i32.const 720
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2125,7 +2119,7 @@
   if
    i32.const 0
    i32.const 720
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -924,7 +924,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -933,18 +933,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1488
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -958,12 +952,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -987,7 +988,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1072,8 +1073,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -1086,7 +1085,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -1106,13 +1105,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -1121,35 +1124,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -1157,76 +1150,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1488
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1488
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -1236,12 +1213,12 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -1249,34 +1226,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -1284,14 +1265,14 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1314,7 +1295,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1327,12 +1308,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -1354,7 +1335,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1382,7 +1363,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1410,7 +1391,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1575,7 +1556,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1851,7 +1832,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1903,7 +1884,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1934,7 +1915,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2025,7 +2006,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2040,7 +2021,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2059,7 +2040,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -924,7 +924,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -938,7 +938,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -988,7 +988,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1116,18 +1116,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -1159,7 +1153,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1169,18 +1163,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -1198,7 +1186,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1213,7 +1201,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1265,7 +1253,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1335,7 +1323,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1363,7 +1351,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1391,7 +1379,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1556,7 +1544,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1832,7 +1820,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1884,7 +1872,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1915,7 +1903,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2006,7 +1994,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2021,7 +2009,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2040,7 +2028,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -788,7 +788,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -804,18 +804,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 464
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -831,12 +824,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -869,41 +871,41 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -916,55 +918,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -1057,38 +1059,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1113,7 +1110,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1132,24 +1129,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1167,18 +1159,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 464
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1196,7 +1181,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1217,12 +1202,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1255,22 +1249,22 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1292,21 +1286,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1321,11 +1315,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1334,13 +1328,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1360,7 +1354,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1403,7 +1397,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1436,7 +1430,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1679,7 +1673,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2010,7 +2004,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2094,7 +2088,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2159,7 +2153,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2310,7 +2304,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2419,7 +2413,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2439,7 +2433,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -788,7 +788,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -808,7 +808,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -871,7 +871,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1045,11 +1045,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -1058,24 +1058,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -1092,34 +1082,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 464
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1128,20 +1120,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1153,17 +1133,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 464
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1173,7 +1153,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1181,7 +1161,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1191,33 +1171,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1225,21 +1205,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1249,22 +1229,22 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1285,56 +1265,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1354,7 +1334,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1397,7 +1377,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1430,7 +1410,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1673,7 +1653,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2004,7 +1984,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2088,7 +2068,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2153,7 +2133,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2304,7 +2284,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2413,7 +2393,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2433,7 +2413,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -294,18 +294,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -319,12 +313,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -348,7 +349,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -433,8 +434,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -447,7 +446,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -467,13 +466,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -482,35 +485,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -518,76 +511,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1504
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -597,12 +574,12 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -610,34 +587,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -645,14 +626,14 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -675,7 +656,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -688,12 +669,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -715,7 +696,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -743,7 +724,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -771,7 +752,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1100,7 @@
        if
         i32.const 0
         i32.const 1504
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1207,7 +1188,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1259,7 +1240,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1290,7 +1271,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1381,7 +1362,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1396,7 +1377,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1415,7 +1396,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -299,7 +299,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -349,7 +349,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -477,18 +477,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -520,7 +514,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -530,18 +524,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -559,7 +547,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -574,7 +562,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -626,7 +614,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -696,7 +684,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +712,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -752,7 +740,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1100,7 +1088,7 @@
        if
         i32.const 0
         i32.const 1504
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1188,7 +1176,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1240,7 +1228,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1271,7 +1259,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1362,7 +1350,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1377,7 +1365,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1396,7 +1384,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -404,7 +404,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -420,18 +420,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -447,12 +440,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -485,41 +487,41 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -532,55 +534,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -673,38 +675,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -729,7 +726,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -748,24 +745,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -783,18 +775,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -812,7 +797,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -833,12 +818,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -871,22 +865,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -908,21 +902,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -937,11 +931,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -950,13 +944,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -976,7 +970,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1019,7 +1013,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1052,7 +1046,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1295,7 +1289,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1626,7 +1620,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1710,7 +1704,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1775,7 +1769,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1926,7 +1920,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2035,7 +2029,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2055,7 +2049,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -404,7 +404,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,7 +424,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -487,7 +487,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -661,11 +661,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -674,24 +674,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -708,34 +698,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 480
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -744,20 +736,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -769,17 +749,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -789,7 +769,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -797,7 +777,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -807,33 +787,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -841,21 +821,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -865,22 +845,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -901,56 +881,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -970,7 +950,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1013,7 +993,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1046,7 +1026,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1289,7 +1269,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1620,7 +1600,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1704,7 +1684,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1769,7 +1749,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1920,7 +1900,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2029,7 +2009,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2049,7 +2029,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -292,7 +292,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -306,7 +306,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -356,7 +356,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -484,18 +484,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -527,7 +521,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -537,18 +531,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -566,7 +554,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -581,7 +569,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -633,7 +621,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -703,7 +691,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,7 +719,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -759,7 +747,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1095,7 @@
        if
         i32.const 0
         i32.const 1504
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1195,7 +1183,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1247,7 +1235,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1278,7 +1266,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1369,7 +1357,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1384,7 +1372,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1403,7 +1391,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -292,7 +292,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -301,18 +301,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -326,12 +320,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -355,7 +356,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -440,8 +441,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -454,7 +453,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -474,13 +473,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -489,35 +492,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -525,76 +518,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1504
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -604,12 +581,12 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -617,34 +594,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -652,14 +633,14 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -682,7 +663,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -695,12 +676,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -722,7 +703,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -750,7 +731,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -778,7 +759,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1126,7 +1107,7 @@
        if
         i32.const 0
         i32.const 1504
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1214,7 +1195,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1266,7 +1247,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1297,7 +1278,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1388,7 +1369,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1403,7 +1384,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1422,7 +1403,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -411,7 +411,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -427,18 +427,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -454,12 +447,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -492,41 +494,41 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -539,55 +541,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -680,38 +682,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -736,7 +733,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -755,24 +752,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -790,18 +782,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -819,7 +804,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -840,12 +825,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -878,22 +872,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -915,21 +909,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -944,11 +938,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -957,13 +951,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -983,7 +977,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1026,7 +1020,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1059,7 +1053,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1302,7 +1296,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1633,7 +1627,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1717,7 +1711,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1782,7 +1776,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1933,7 +1927,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2042,7 +2036,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2062,7 +2056,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -411,7 +411,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -431,7 +431,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -494,7 +494,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -668,11 +668,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -681,24 +681,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -715,34 +705,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 480
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -751,20 +743,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -776,17 +756,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -796,7 +776,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -804,7 +784,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -814,33 +794,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -848,21 +828,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -872,22 +852,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -908,56 +888,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -977,7 +957,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1020,7 +1000,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1053,7 +1033,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1296,7 +1276,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1627,7 +1607,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1711,7 +1691,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1776,7 +1756,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1927,7 +1907,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2036,7 +2016,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2056,7 +2036,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -294,18 +294,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -319,12 +313,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -348,7 +349,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -433,8 +434,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -447,7 +446,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -467,13 +466,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -482,35 +485,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -518,76 +511,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1440
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -597,12 +574,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -610,34 +587,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -645,14 +626,14 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -675,7 +656,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -688,12 +669,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -715,7 +696,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -743,7 +724,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -771,7 +752,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1100,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1187,7 +1168,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1268,7 +1249,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1283,7 +1264,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -299,7 +299,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -349,7 +349,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -477,18 +477,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -520,7 +514,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -530,18 +524,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -559,7 +547,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -574,7 +562,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -626,7 +614,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -696,7 +684,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +712,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -752,7 +740,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1100,7 +1088,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1168,7 +1156,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1249,7 +1237,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1264,7 +1252,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -413,7 +413,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -433,7 +433,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -496,7 +496,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -670,11 +670,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -683,24 +683,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -717,34 +707,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 416
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -753,20 +745,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -778,17 +758,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -798,7 +778,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -806,7 +786,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -816,33 +796,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -850,21 +830,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -874,22 +854,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -910,56 +890,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -979,7 +959,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1022,7 +1002,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1055,7 +1035,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1298,7 +1278,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1629,7 +1609,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1713,7 +1693,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1778,7 +1758,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1929,7 +1909,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2038,7 +2018,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2058,7 +2038,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -413,7 +413,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -429,18 +429,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -456,12 +449,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -494,41 +496,41 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -541,55 +543,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -682,38 +684,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -738,7 +735,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -757,24 +754,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -792,18 +784,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -821,7 +806,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -842,12 +827,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -880,22 +874,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -917,21 +911,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -946,11 +940,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -959,13 +953,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -985,7 +979,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1028,7 +1022,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1061,7 +1055,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1304,7 +1298,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1635,7 +1629,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1719,7 +1713,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1784,7 +1778,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1935,7 +1929,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2044,7 +2038,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2064,7 +2058,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -308,7 +308,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -317,18 +317,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -342,12 +336,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -371,7 +372,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -456,8 +457,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -470,7 +469,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -490,13 +489,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -505,35 +508,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -541,76 +534,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -620,12 +597,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -633,34 +610,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -668,14 +649,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -698,7 +679,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -711,12 +692,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -738,7 +719,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -766,7 +747,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -794,7 +775,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1142,7 +1123,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1230,7 +1211,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1282,7 +1263,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1313,7 +1294,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1404,7 +1385,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1419,7 +1400,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1438,7 +1419,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -308,7 +308,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -322,7 +322,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -372,7 +372,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -500,18 +500,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -543,7 +537,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -553,18 +547,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -582,7 +570,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -597,7 +585,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -649,7 +637,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -719,7 +707,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -747,7 +735,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -775,7 +763,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1123,7 +1111,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1211,7 +1199,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1263,7 +1251,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1294,7 +1282,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1385,7 +1373,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1400,7 +1388,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1419,7 +1407,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -424,7 +424,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -444,7 +444,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -507,7 +507,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -681,11 +681,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -694,24 +694,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -728,34 +718,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -764,20 +756,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -789,17 +769,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -809,7 +789,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -817,7 +797,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -827,33 +807,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -861,21 +841,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -885,22 +865,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -921,56 +901,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -990,7 +970,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1033,7 +1013,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1066,7 +1046,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1309,7 +1289,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1640,7 +1620,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1724,7 +1704,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1789,7 +1769,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1940,7 +1920,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2049,7 +2029,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2069,7 +2049,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -424,7 +424,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -440,18 +440,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -467,12 +460,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -505,41 +507,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -552,55 +554,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -693,38 +695,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -749,7 +746,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -768,24 +765,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -803,18 +795,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -832,7 +817,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -853,12 +838,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -891,22 +885,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -928,21 +922,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -957,11 +951,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -970,13 +964,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -996,7 +990,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1039,7 +1033,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1072,7 +1066,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1315,7 +1309,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1646,7 +1640,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1730,7 +1724,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1795,7 +1789,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1946,7 +1940,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2055,7 +2049,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2075,7 +2069,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -278,7 +278,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -292,7 +292,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -342,7 +342,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -470,18 +470,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -513,7 +507,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -523,18 +517,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -552,7 +540,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -567,7 +555,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -619,7 +607,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -689,7 +677,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -717,7 +705,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -745,7 +733,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1093,7 +1081,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1161,7 +1149,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1242,7 +1230,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1257,7 +1245,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -278,7 +278,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -287,18 +287,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -312,12 +306,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -341,7 +342,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -426,8 +427,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -440,7 +439,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -460,13 +459,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -475,35 +478,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -511,76 +504,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -590,12 +567,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -603,34 +580,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -638,14 +619,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -668,7 +649,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -681,12 +662,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -708,7 +689,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -736,7 +717,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -764,7 +745,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1112,7 +1093,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1180,7 +1161,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1261,7 +1242,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1276,7 +1257,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -411,7 +411,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -427,18 +427,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -454,12 +447,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -492,41 +494,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -539,55 +541,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -680,38 +682,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -736,7 +733,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -755,24 +752,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -790,18 +782,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -819,7 +804,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -840,12 +825,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -878,22 +872,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -915,21 +909,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -944,11 +938,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -957,13 +951,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -983,7 +977,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1026,7 +1020,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1059,7 +1053,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1302,7 +1296,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1633,7 +1627,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1717,7 +1711,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1782,7 +1776,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1933,7 +1927,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2042,7 +2036,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2062,7 +2056,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -411,7 +411,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -431,7 +431,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -494,7 +494,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -668,11 +668,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -681,24 +681,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -715,34 +705,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -751,20 +743,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -776,17 +756,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -796,7 +776,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -804,7 +784,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -814,33 +794,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -848,21 +828,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -872,22 +852,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -908,56 +888,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -977,7 +957,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1020,7 +1000,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1053,7 +1033,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1296,7 +1276,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1627,7 +1607,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1711,7 +1691,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1776,7 +1756,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1927,7 +1907,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2036,7 +2016,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2056,7 +2036,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -337,7 +337,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -346,18 +346,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -371,12 +365,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -400,7 +401,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -485,8 +486,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -499,7 +498,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -519,13 +518,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -534,35 +537,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -570,76 +563,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -649,12 +626,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -662,34 +639,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -697,14 +678,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -727,7 +708,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -740,12 +721,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -767,7 +748,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -795,7 +776,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -823,7 +804,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1171,7 +1152,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1239,7 +1220,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1320,7 +1301,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1335,7 +1316,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -337,7 +337,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -351,7 +351,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -401,7 +401,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -529,18 +529,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -572,7 +566,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -582,18 +576,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -611,7 +599,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -626,7 +614,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -678,7 +666,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -748,7 +736,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -776,7 +764,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -804,7 +792,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1152,7 +1140,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1220,7 +1208,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1301,7 +1289,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1316,7 +1304,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -465,7 +465,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -481,18 +481,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -508,12 +501,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -546,41 +548,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -593,55 +595,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -734,38 +736,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -790,7 +787,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -809,24 +806,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -844,18 +836,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -873,7 +858,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -894,12 +879,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -932,22 +926,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -969,21 +963,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -998,11 +992,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1011,13 +1005,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1037,7 +1031,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1080,7 +1074,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1113,7 +1107,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1356,7 +1350,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1687,7 +1681,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1765,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1836,7 +1830,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1987,7 +1981,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2096,7 +2090,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2116,7 +2110,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -465,7 +465,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -485,7 +485,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -548,7 +548,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -722,11 +722,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -735,24 +735,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -769,34 +759,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -805,20 +797,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -830,17 +810,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -850,7 +830,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -858,7 +838,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -868,33 +848,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -902,21 +882,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -926,22 +906,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -962,56 +942,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1031,7 +1011,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1074,7 +1054,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1107,7 +1087,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1350,7 +1330,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1681,7 +1661,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1765,7 +1745,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1830,7 +1810,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1981,7 +1961,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2090,7 +2070,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2110,7 +2090,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -299,7 +299,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -313,7 +313,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -363,7 +363,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -491,18 +491,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -534,7 +528,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -544,18 +538,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -573,7 +561,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -588,7 +576,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -640,7 +628,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -710,7 +698,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -738,7 +726,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -766,7 +754,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1114,7 +1102,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1202,7 +1190,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1254,7 +1242,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1285,7 +1273,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1376,7 +1364,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1391,7 +1379,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1410,7 +1398,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -299,7 +299,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -308,18 +308,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -333,12 +327,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -362,7 +363,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -447,8 +448,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -461,7 +460,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -481,13 +480,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -496,35 +499,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -532,76 +525,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -611,12 +588,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -624,34 +601,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -659,14 +640,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -689,7 +670,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -702,12 +683,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -729,7 +710,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -757,7 +738,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -785,7 +766,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1133,7 +1114,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1221,7 +1202,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1273,7 +1254,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1304,7 +1285,7 @@
   if
    i32.const 1056
    i32.const 1392
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1395,7 +1376,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1410,7 +1391,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1429,7 +1410,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -419,7 +419,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -439,7 +439,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -502,7 +502,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -676,11 +676,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -689,24 +689,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -723,34 +713,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -759,20 +751,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -784,17 +764,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -804,7 +784,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -812,7 +792,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -822,33 +802,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -856,21 +836,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -880,22 +860,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -916,56 +896,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -985,7 +965,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1028,7 +1008,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1061,7 +1041,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1304,7 +1284,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1635,7 +1615,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1719,7 +1699,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1784,7 +1764,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1935,7 +1915,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2044,7 +2024,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2064,7 +2044,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -419,7 +419,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -435,18 +435,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -462,12 +455,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -500,41 +502,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -547,55 +549,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -688,38 +690,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -744,7 +741,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -763,24 +760,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -798,18 +790,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -827,7 +812,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -848,12 +833,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -886,22 +880,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -923,21 +917,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -952,11 +946,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -965,13 +959,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -991,7 +985,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1034,7 +1028,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1067,7 +1061,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1310,7 +1304,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1641,7 +1635,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1725,7 +1719,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1790,7 +1784,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1941,7 +1935,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2050,7 +2044,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2070,7 +2064,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -329,7 +329,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -343,7 +343,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -393,7 +393,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -521,18 +521,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -564,7 +558,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -574,18 +568,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -603,7 +591,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -618,7 +606,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -670,7 +658,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -740,7 +728,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -768,7 +756,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -796,7 +784,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1144,7 +1132,7 @@
        if
         i32.const 0
         i32.const 1904
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1232,7 +1220,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1284,7 +1272,7 @@
     if
      i32.const 0
      i32.const 1904
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1315,7 +1303,7 @@
   if
    i32.const 1632
    i32.const 1904
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1406,7 +1394,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1421,7 +1409,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1440,7 +1428,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -329,7 +329,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -338,18 +338,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1904
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -363,12 +357,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -392,7 +393,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -477,8 +478,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -491,7 +490,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -511,13 +510,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -526,35 +529,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -562,76 +555,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1904
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1904
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -641,12 +618,12 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -654,34 +631,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -689,14 +670,14 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -719,7 +700,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -732,12 +713,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -759,7 +740,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -787,7 +768,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -815,7 +796,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1163,7 +1144,7 @@
        if
         i32.const 0
         i32.const 1904
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1251,7 +1232,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1303,7 +1284,7 @@
     if
      i32.const 0
      i32.const 1904
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1334,7 +1315,7 @@
   if
    i32.const 1632
    i32.const 1904
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1425,7 +1406,7 @@
    if
     i32.const 0
     i32.const 1904
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1440,7 +1421,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1459,7 +1440,7 @@
   if
    i32.const 0
    i32.const 1904
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -453,7 +453,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -469,18 +469,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 880
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -496,12 +489,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -534,41 +536,41 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -581,55 +583,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -722,38 +724,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -778,7 +775,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -797,24 +794,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -832,18 +824,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 880
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -861,7 +846,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -882,12 +867,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -920,22 +914,22 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -957,21 +951,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -986,11 +980,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -999,13 +993,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1025,7 +1019,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1068,7 +1062,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1101,7 +1095,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1344,7 +1338,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1675,7 +1669,7 @@
   if
    i32.const 608
    i32.const 880
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1759,7 +1753,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1824,7 +1818,7 @@
     if
      i32.const 0
      i32.const 880
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1975,7 +1969,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2084,7 +2078,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2104,7 +2098,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -453,7 +453,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -473,7 +473,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -536,7 +536,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -710,11 +710,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -723,24 +723,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -757,34 +747,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 880
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -793,20 +785,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -818,17 +798,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 880
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -838,7 +818,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -846,7 +826,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -856,33 +836,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -890,21 +870,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -914,22 +894,22 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -950,56 +930,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1019,7 +999,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1062,7 +1042,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1095,7 +1075,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1338,7 +1318,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1669,7 +1649,7 @@
   if
    i32.const 608
    i32.const 880
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1753,7 +1733,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1818,7 +1798,7 @@
     if
      i32.const 0
      i32.const 880
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1969,7 +1949,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2078,7 +2058,7 @@
    if
     i32.const 0
     i32.const 880
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2098,7 +2078,7 @@
   if
    i32.const 0
    i32.const 880
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -420,7 +420,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -429,18 +429,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -454,12 +448,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -483,7 +484,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -568,8 +569,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -582,7 +581,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -602,13 +601,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -617,35 +620,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -653,76 +646,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1616
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1616
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -732,12 +709,12 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -745,34 +722,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -780,14 +761,14 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -810,7 +791,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -823,12 +804,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -850,7 +831,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -878,7 +859,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -906,7 +887,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1254,7 +1235,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1342,7 +1323,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1394,7 +1375,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1425,7 +1406,7 @@
   if
    i32.const 1344
    i32.const 1616
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1516,7 +1497,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1531,7 +1512,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1550,7 +1531,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -420,7 +420,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -434,7 +434,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -484,7 +484,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -612,18 +612,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -655,7 +649,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -665,18 +659,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -694,7 +682,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -709,7 +697,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -761,7 +749,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -831,7 +819,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -859,7 +847,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -887,7 +875,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1235,7 +1223,7 @@
        if
         i32.const 0
         i32.const 1616
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1323,7 +1311,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1375,7 +1363,7 @@
     if
      i32.const 0
      i32.const 1616
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1406,7 +1394,7 @@
   if
    i32.const 1344
    i32.const 1616
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1497,7 +1485,7 @@
    if
     i32.const 0
     i32.const 1616
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1512,7 +1500,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1531,7 +1519,7 @@
   if
    i32.const 0
    i32.const 1616
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -509,7 +509,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -525,18 +525,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -552,12 +545,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -590,41 +592,41 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -637,55 +639,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -778,38 +780,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -834,7 +831,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -853,24 +850,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -888,18 +880,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -917,7 +902,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -938,12 +923,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -976,22 +970,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1013,21 +1007,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1042,11 +1036,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1055,13 +1049,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1081,7 +1075,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1124,7 +1118,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1157,7 +1151,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1400,7 +1394,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1731,7 +1725,7 @@
   if
    i32.const 320
    i32.const 592
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1815,7 +1809,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1880,7 +1874,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2031,7 +2025,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2140,7 +2134,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2160,7 +2154,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -509,7 +509,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -529,7 +529,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -592,7 +592,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -766,11 +766,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -779,24 +779,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -813,34 +803,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 592
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -849,20 +841,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -874,17 +854,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 592
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -894,7 +874,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -902,7 +882,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -912,33 +892,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -946,21 +926,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -970,22 +950,22 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1006,56 +986,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1075,7 +1055,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1118,7 +1098,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1151,7 +1131,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1394,7 +1374,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1725,7 +1705,7 @@
   if
    i32.const 320
    i32.const 592
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1809,7 +1789,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1874,7 +1854,7 @@
     if
      i32.const 0
      i32.const 592
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2025,7 +2005,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2134,7 +2114,7 @@
    if
     i32.const 0
     i32.const 592
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2154,7 +2134,7 @@
   if
    i32.const 0
    i32.const 592
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -719,7 +719,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -733,7 +733,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -783,7 +783,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -911,18 +911,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -954,7 +948,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -964,18 +958,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -993,7 +981,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1008,7 +996,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1060,7 +1048,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1130,7 +1118,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1158,7 +1146,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1186,7 +1174,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1534,7 +1522,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1622,7 +1610,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1674,7 +1662,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1705,7 +1693,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1796,7 +1784,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1811,7 +1799,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1830,7 +1818,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -719,7 +719,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -728,18 +728,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -753,12 +747,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -782,7 +783,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -867,8 +868,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -881,7 +880,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -901,13 +900,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -916,35 +919,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -952,76 +945,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1424
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1424
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -1031,12 +1008,12 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -1044,34 +1021,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -1079,14 +1060,14 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1109,7 +1090,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1122,12 +1103,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -1149,7 +1130,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1177,7 +1158,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1205,7 +1186,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1553,7 +1534,7 @@
        if
         i32.const 0
         i32.const 1424
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1641,7 +1622,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1693,7 +1674,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1724,7 +1705,7 @@
   if
    i32.const 1088
    i32.const 1424
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1815,7 +1796,7 @@
    if
     i32.const 0
     i32.const 1424
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1830,7 +1811,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1849,7 +1830,7 @@
   if
    i32.const 0
    i32.const 1424
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -586,7 +586,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -606,7 +606,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -669,7 +669,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -843,11 +843,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -856,24 +856,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -890,34 +880,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 400
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -926,20 +918,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -951,17 +931,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -971,7 +951,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -979,7 +959,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -989,33 +969,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1023,21 +1003,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1047,22 +1027,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1083,56 +1063,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1152,7 +1132,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1195,7 +1175,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1228,7 +1208,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1471,7 +1451,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1802,7 +1782,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1886,7 +1866,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1951,7 +1931,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2102,7 +2082,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2211,7 +2191,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2231,7 +2211,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -586,7 +586,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -602,18 +602,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -629,12 +622,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -667,41 +669,41 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -714,55 +716,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -855,38 +857,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -911,7 +908,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -930,24 +927,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -965,18 +957,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 400
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -994,7 +979,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1015,12 +1000,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1053,22 +1047,22 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1090,21 +1084,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1119,11 +1113,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1132,13 +1126,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1158,7 +1152,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1201,7 +1195,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1234,7 +1228,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1477,7 +1471,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1808,7 +1802,7 @@
   if
    i32.const 64
    i32.const 400
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1892,7 +1886,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1957,7 +1951,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2108,7 +2102,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2217,7 +2211,7 @@
    if
     i32.const 0
     i32.const 400
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2237,7 +2231,7 @@
   if
    i32.const 0
    i32.const 400
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -300,7 +300,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -314,7 +314,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -364,7 +364,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -492,18 +492,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -535,7 +529,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -545,18 +539,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -574,7 +562,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -589,7 +577,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -641,7 +629,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -711,7 +699,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -739,7 +727,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -767,7 +755,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1115,7 +1103,7 @@
        if
         i32.const 0
         i32.const 1488
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1203,7 +1191,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1255,7 +1243,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1286,7 +1274,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1377,7 +1365,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1392,7 +1380,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1411,7 +1399,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -300,7 +300,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -309,18 +309,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1488
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -334,12 +328,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -363,7 +364,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -448,8 +449,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -462,7 +461,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -482,13 +481,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -497,35 +500,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -533,76 +526,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1488
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1488
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -612,12 +589,12 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -625,34 +602,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -660,14 +641,14 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -690,7 +671,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -703,12 +684,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -730,7 +711,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -758,7 +739,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -786,7 +767,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1134,7 +1115,7 @@
        if
         i32.const 0
         i32.const 1488
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1222,7 +1203,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1274,7 +1255,7 @@
     if
      i32.const 0
      i32.const 1488
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1305,7 +1286,7 @@
   if
    i32.const 1152
    i32.const 1488
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1396,7 +1377,7 @@
    if
     i32.const 0
     i32.const 1488
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1411,7 +1392,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1430,7 +1411,7 @@
   if
    i32.const 0
    i32.const 1488
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -419,7 +419,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -439,7 +439,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -502,7 +502,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -676,11 +676,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -689,24 +689,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -723,34 +713,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 464
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -759,20 +751,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -784,17 +764,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 464
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -804,7 +784,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -812,7 +792,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -822,33 +802,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -856,21 +836,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -880,22 +860,22 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -916,56 +896,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -985,7 +965,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1028,7 +1008,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1061,7 +1041,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1304,7 +1284,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1635,7 +1615,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1719,7 +1699,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1784,7 +1764,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1935,7 +1915,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2044,7 +2024,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2064,7 +2044,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -419,7 +419,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -435,18 +435,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 464
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -462,12 +455,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -500,41 +502,41 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -547,55 +549,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -688,38 +690,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -744,7 +741,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -763,24 +760,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -798,18 +790,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 464
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -827,7 +812,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -848,12 +833,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -886,22 +880,22 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -923,21 +917,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -952,11 +946,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -965,13 +959,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -991,7 +985,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1034,7 +1028,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1067,7 +1061,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1310,7 +1304,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1641,7 +1635,7 @@
   if
    i32.const 128
    i32.const 464
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1725,7 +1719,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1790,7 +1784,7 @@
     if
      i32.const 0
      i32.const 464
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1941,7 +1935,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2050,7 +2044,7 @@
    if
     i32.const 0
     i32.const 464
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2070,7 +2064,7 @@
   if
    i32.const 0
    i32.const 464
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -1313,7 +1313,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1327,7 +1327,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1377,7 +1377,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1505,18 +1505,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -1548,7 +1542,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1558,18 +1552,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -1587,7 +1575,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1602,7 +1590,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1654,7 +1642,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1724,7 +1712,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1752,7 +1740,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1780,7 +1768,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2128,7 +2116,7 @@
        if
         i32.const 0
         i32.const 1648
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -2216,7 +2204,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2268,7 +2256,7 @@
     if
      i32.const 0
      i32.const 1648
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2299,7 +2287,7 @@
   if
    i32.const 1376
    i32.const 1648
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2390,7 +2378,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2405,7 +2393,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2424,7 +2412,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -1313,7 +1313,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1322,18 +1322,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1648
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1347,12 +1341,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1376,7 +1377,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1461,8 +1462,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -1475,7 +1474,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -1495,13 +1494,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -1510,35 +1513,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -1546,76 +1539,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1648
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1648
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -1625,12 +1602,12 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -1638,34 +1615,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -1673,14 +1654,14 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1703,7 +1684,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1716,12 +1697,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -1743,7 +1724,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1771,7 +1752,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1799,7 +1780,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2147,7 +2128,7 @@
        if
         i32.const 0
         i32.const 1648
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -2235,7 +2216,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2287,7 +2268,7 @@
     if
      i32.const 0
      i32.const 1648
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2318,7 +2299,7 @@
   if
    i32.const 1376
    i32.const 1648
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2409,7 +2390,7 @@
    if
     i32.const 0
     i32.const 1648
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2424,7 +2405,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2443,7 +2424,7 @@
   if
    i32.const 0
    i32.const 1648
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -1122,7 +1122,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1138,18 +1138,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 624
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1165,12 +1158,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -1203,41 +1205,41 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -1250,55 +1252,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -1391,38 +1393,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1447,7 +1444,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1466,24 +1463,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1501,18 +1493,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 624
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1530,7 +1515,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1551,12 +1536,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1589,22 +1583,22 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1626,21 +1620,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1655,11 +1649,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1668,13 +1662,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1694,7 +1688,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1737,7 +1731,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1770,7 +1764,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2013,7 +2007,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2344,7 +2338,7 @@
   if
    i32.const 352
    i32.const 624
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2428,7 +2422,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2493,7 +2487,7 @@
     if
      i32.const 0
      i32.const 624
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2644,7 +2638,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2753,7 +2747,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2773,7 +2767,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -1122,7 +1122,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1142,7 +1142,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1205,7 +1205,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1379,11 +1379,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -1392,24 +1392,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -1426,34 +1416,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 624
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1462,20 +1454,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1487,17 +1467,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 624
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1507,7 +1487,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1515,7 +1495,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1525,33 +1505,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1559,21 +1539,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1583,22 +1563,22 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1619,56 +1599,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1688,7 +1668,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1731,7 +1711,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1764,7 +1744,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -2007,7 +1987,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2338,7 +2318,7 @@
   if
    i32.const 352
    i32.const 624
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2422,7 +2402,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2487,7 +2467,7 @@
     if
      i32.const 0
      i32.const 624
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2638,7 +2618,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2747,7 +2727,7 @@
    if
     i32.const 0
     i32.const 624
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2767,7 +2747,7 @@
   if
    i32.const 0
    i32.const 624
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -390,7 +390,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -404,7 +404,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -454,7 +454,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -582,18 +582,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -625,7 +619,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -635,18 +629,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -664,7 +652,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -679,7 +667,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -731,7 +719,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -801,7 +789,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -829,7 +817,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -857,7 +845,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1205,7 +1193,7 @@
        if
         i32.const 0
         i32.const 1472
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1293,7 +1281,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1345,7 +1333,7 @@
     if
      i32.const 0
      i32.const 1472
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1376,7 +1364,7 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1467,7 +1455,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1482,7 +1470,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1501,7 +1489,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -390,7 +390,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -399,18 +399,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1472
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -424,12 +418,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -453,7 +454,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -538,8 +539,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -552,7 +551,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -572,13 +571,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -587,35 +590,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -623,76 +616,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1472
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1472
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -702,12 +679,12 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -715,34 +692,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -750,14 +731,14 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -780,7 +761,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -793,12 +774,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -820,7 +801,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -848,7 +829,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -876,7 +857,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1224,7 +1205,7 @@
        if
         i32.const 0
         i32.const 1472
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1312,7 +1293,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1364,7 +1345,7 @@
     if
      i32.const 0
      i32.const 1472
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1395,7 +1376,7 @@
   if
    i32.const 1136
    i32.const 1472
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1486,7 +1467,7 @@
    if
     i32.const 0
     i32.const 1472
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1501,7 +1482,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1520,7 +1501,7 @@
   if
    i32.const 0
    i32.const 1472
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -456,7 +456,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -476,7 +476,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -539,7 +539,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -713,11 +713,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -726,24 +726,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -760,34 +750,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 448
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -796,20 +788,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -821,17 +801,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 448
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -841,7 +821,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -849,7 +829,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -859,33 +839,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -893,21 +873,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -917,22 +897,22 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -953,56 +933,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1022,7 +1002,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1065,7 +1045,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1098,7 +1078,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1341,7 +1321,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1672,7 +1652,7 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1756,7 +1736,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1821,7 +1801,7 @@
     if
      i32.const 0
      i32.const 448
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1972,7 +1952,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2081,7 +2061,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2101,7 +2081,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -456,7 +456,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -472,18 +472,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 448
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -499,12 +492,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -537,41 +539,41 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -584,55 +586,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -725,38 +727,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -781,7 +778,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -800,24 +797,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -835,18 +827,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 448
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -864,7 +849,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -885,12 +870,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -923,22 +917,22 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -960,21 +954,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -989,11 +983,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1002,13 +996,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1028,7 +1022,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1071,7 +1065,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1104,7 +1098,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1347,7 +1341,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1678,7 +1672,7 @@
   if
    i32.const 112
    i32.const 448
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1762,7 +1756,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1827,7 +1821,7 @@
     if
      i32.const 0
      i32.const 448
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1978,7 +1972,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2087,7 +2081,7 @@
    if
     i32.const 0
     i32.const 448
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2107,7 +2101,7 @@
   if
    i32.const 0
    i32.const 448
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -891,7 +891,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -905,7 +905,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -955,7 +955,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1083,18 +1083,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -1126,7 +1120,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1136,18 +1130,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -1165,7 +1153,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1180,7 +1168,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1232,7 +1220,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1302,7 +1290,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1330,7 +1318,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1358,7 +1346,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1523,7 +1511,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1799,7 +1787,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1851,7 +1839,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1882,7 +1870,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1973,7 +1961,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1988,7 +1976,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2007,7 +1995,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -891,7 +891,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -900,18 +900,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -925,12 +919,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -954,7 +955,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1039,8 +1040,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -1053,7 +1052,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -1073,13 +1072,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -1088,35 +1091,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -1124,76 +1117,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1504
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1504
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -1203,12 +1180,12 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -1216,34 +1193,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -1251,14 +1232,14 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1281,7 +1262,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -1294,12 +1275,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -1321,7 +1302,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1349,7 +1330,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1377,7 +1358,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1542,7 +1523,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1818,7 +1799,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1870,7 +1851,7 @@
     if
      i32.const 0
      i32.const 1504
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1901,7 +1882,7 @@
   if
    i32.const 1168
    i32.const 1504
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1992,7 +1973,7 @@
    if
     i32.const 0
     i32.const 1504
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2007,7 +1988,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2026,7 +2007,7 @@
   if
    i32.const 0
    i32.const 1504
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -743,7 +743,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -763,7 +763,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -826,7 +826,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1000,11 +1000,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -1013,24 +1013,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -1047,34 +1037,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 480
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1083,20 +1075,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1108,17 +1088,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1128,7 +1108,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1136,7 +1116,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1146,33 +1126,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1180,21 +1160,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1204,22 +1184,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1240,56 +1220,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1309,7 +1289,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1352,7 +1332,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1385,7 +1365,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1628,7 +1608,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1959,7 +1939,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2043,7 +2023,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2108,7 +2088,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2259,7 +2239,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2368,7 +2348,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2388,7 +2368,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -743,7 +743,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -759,18 +759,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -786,12 +779,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -824,41 +826,41 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -871,55 +873,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -1012,38 +1014,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1068,7 +1065,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1087,24 +1084,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1122,18 +1114,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 480
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1151,7 +1136,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1172,12 +1157,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1210,22 +1204,22 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1247,21 +1241,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1276,11 +1270,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1289,13 +1283,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1315,7 +1309,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1358,7 +1352,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1391,7 +1385,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1634,7 +1628,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1965,7 +1959,7 @@
   if
    i32.const 144
    i32.const 480
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2049,7 +2043,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2114,7 +2108,7 @@
     if
      i32.const 0
      i32.const 480
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2265,7 +2259,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2374,7 +2368,7 @@
    if
     i32.const 0
     i32.const 480
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2394,7 +2388,7 @@
   if
    i32.const 0
    i32.const 480
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.optimized.wat
+++ b/tests/compiler/super-inline.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -299,7 +299,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -349,7 +349,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -477,18 +477,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -520,7 +514,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -530,18 +524,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -559,7 +547,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -574,7 +562,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -626,7 +614,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -696,7 +684,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +712,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -752,7 +740,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1100,7 +1088,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1168,7 +1156,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1249,7 +1237,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1264,7 +1252,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.optimized.wat
+++ b/tests/compiler/super-inline.optimized.wat
@@ -285,7 +285,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -294,18 +294,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -319,12 +313,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -348,7 +349,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -433,8 +434,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -447,7 +446,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -467,13 +466,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -482,35 +485,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -518,76 +511,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1392
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1392
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -597,12 +574,12 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -610,34 +587,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -645,14 +626,14 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -675,7 +656,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -688,12 +669,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -715,7 +696,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -743,7 +724,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -771,7 +752,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1119,7 +1100,7 @@
        if
         i32.const 0
         i32.const 1392
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1187,7 +1168,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1268,7 +1249,7 @@
    if
     i32.const 0
     i32.const 1392
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1283,7 +1264,7 @@
   if
    i32.const 0
    i32.const 1392
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.untouched.wat
+++ b/tests/compiler/super-inline.untouched.wat
@@ -399,7 +399,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -415,18 +415,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -442,12 +435,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -480,41 +482,41 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -527,55 +529,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -668,38 +670,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -724,7 +721,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -743,24 +740,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -778,18 +770,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -807,7 +792,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -828,12 +813,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -866,22 +860,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -903,21 +897,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -932,11 +926,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -945,13 +939,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -971,7 +965,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1014,7 +1008,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1047,7 +1041,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1290,7 +1284,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1621,7 +1615,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1705,7 +1699,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1770,7 +1764,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1921,7 +1915,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2030,7 +2024,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2050,7 +2044,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.untouched.wat
+++ b/tests/compiler/super-inline.untouched.wat
@@ -399,7 +399,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -419,7 +419,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -482,7 +482,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -656,11 +656,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -669,24 +669,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -703,34 +693,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 368
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -739,20 +731,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -764,17 +744,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 368
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -784,7 +764,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -792,7 +772,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -802,33 +782,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -836,21 +816,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -860,22 +840,22 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -896,56 +876,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -965,7 +945,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1008,7 +988,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1041,7 +1021,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1284,7 +1264,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1615,7 +1595,7 @@
   if
    i32.const 32
    i32.const 368
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1699,7 +1679,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1764,7 +1744,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1915,7 +1895,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2024,7 +2004,7 @@
    if
     i32.const 0
     i32.const 368
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2044,7 +2024,7 @@
   if
    i32.const 0
    i32.const 368
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/templateliteral.optimized.wat
+++ b/tests/compiler/templateliteral.optimized.wat
@@ -429,7 +429,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -443,7 +443,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -493,7 +493,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -621,18 +621,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -664,7 +658,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -674,18 +668,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -703,7 +691,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -718,7 +706,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -770,7 +758,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -840,7 +828,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -868,7 +856,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -896,7 +884,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1244,7 +1232,7 @@
        if
         i32.const 0
         i32.const 1520
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1332,7 +1320,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1384,7 +1372,7 @@
     if
      i32.const 0
      i32.const 1520
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1415,7 +1403,7 @@
   if
    i32.const 1392
    i32.const 1520
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1506,7 +1494,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1521,7 +1509,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1540,7 +1528,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/templateliteral.optimized.wat
+++ b/tests/compiler/templateliteral.optimized.wat
@@ -429,7 +429,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -438,18 +438,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1520
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -463,12 +457,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -492,7 +493,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -577,8 +578,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -591,7 +590,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -611,13 +610,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -626,35 +629,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -662,76 +655,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1520
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1520
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -741,12 +718,12 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -754,34 +731,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -789,14 +770,14 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -819,7 +800,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -832,12 +813,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -859,7 +840,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -887,7 +868,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -915,7 +896,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1263,7 +1244,7 @@
        if
         i32.const 0
         i32.const 1520
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1351,7 +1332,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1403,7 +1384,7 @@
     if
      i32.const 0
      i32.const 1520
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1434,7 +1415,7 @@
   if
    i32.const 1392
    i32.const 1520
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1525,7 +1506,7 @@
    if
     i32.const 0
     i32.const 1520
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1540,7 +1521,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1559,7 +1540,7 @@
   if
    i32.const 0
    i32.const 1520
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/templateliteral.untouched.wat
+++ b/tests/compiler/templateliteral.untouched.wat
@@ -556,7 +556,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -572,18 +572,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 496
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -599,12 +592,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -637,41 +639,41 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -684,55 +686,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -825,38 +827,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -881,7 +878,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -900,24 +897,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -935,18 +927,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 496
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -964,7 +949,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -985,12 +970,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1023,22 +1017,22 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1060,21 +1054,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1089,11 +1083,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1102,13 +1096,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1128,7 +1122,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1171,7 +1165,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1204,7 +1198,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1447,7 +1441,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1778,7 +1772,7 @@
   if
    i32.const 368
    i32.const 496
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1862,7 +1856,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1927,7 +1921,7 @@
     if
      i32.const 0
      i32.const 496
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2078,7 +2072,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2187,7 +2181,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2207,7 +2201,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/templateliteral.untouched.wat
+++ b/tests/compiler/templateliteral.untouched.wat
@@ -556,7 +556,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -576,7 +576,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -639,7 +639,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -813,11 +813,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -826,24 +826,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -860,34 +850,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 496
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -896,20 +888,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -921,17 +901,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 496
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -941,7 +921,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -949,7 +929,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -959,33 +939,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -993,21 +973,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1017,22 +997,22 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1053,56 +1033,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1122,7 +1102,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1165,7 +1145,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1198,7 +1178,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1441,7 +1421,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1772,7 +1752,7 @@
   if
    i32.const 368
    i32.const 496
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1856,7 +1836,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1921,7 +1901,7 @@
     if
      i32.const 0
      i32.const 496
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2072,7 +2052,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2181,7 +2161,7 @@
    if
     i32.const 0
     i32.const 496
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2201,7 +2181,7 @@
   if
    i32.const 0
    i32.const 496
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/throw.optimized.wat
+++ b/tests/compiler/throw.optimized.wat
@@ -280,7 +280,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -289,18 +289,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1632
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -314,12 +308,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -343,7 +344,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -428,8 +429,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -442,7 +441,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -462,13 +461,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -477,35 +480,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -513,76 +506,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1632
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1632
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -592,12 +569,12 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -605,34 +582,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -640,14 +621,14 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -670,7 +651,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -683,12 +664,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -710,7 +691,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -730,7 +711,7 @@
    if
     i32.const 0
     i32.const 1632
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -901,7 +882,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/throw.optimized.wat
+++ b/tests/compiler/throw.optimized.wat
@@ -280,7 +280,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -294,7 +294,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -344,7 +344,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -472,18 +472,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -515,7 +509,7 @@
    if
     i32.const 0
     i32.const 1632
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -525,18 +519,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -554,7 +542,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -569,7 +557,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -621,7 +609,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -691,7 +679,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -711,7 +699,7 @@
    if
     i32.const 0
     i32.const 1632
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -882,7 +870,7 @@
   if
    i32.const 0
    i32.const 1632
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/throw.untouched.wat
+++ b/tests/compiler/throw.untouched.wat
@@ -514,7 +514,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -534,7 +534,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -597,7 +597,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -771,11 +771,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -784,24 +784,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -818,34 +808,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 608
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -854,20 +846,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -879,17 +859,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 608
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -899,7 +879,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -907,7 +887,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -917,33 +897,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -951,21 +931,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -975,22 +955,22 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1011,56 +991,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1080,7 +1060,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1123,7 +1103,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1156,7 +1136,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1399,7 +1379,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/throw.untouched.wat
+++ b/tests/compiler/throw.untouched.wat
@@ -514,7 +514,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -530,18 +530,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 608
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -557,12 +550,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -595,41 +597,41 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -642,55 +644,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -783,38 +785,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -839,7 +836,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -858,24 +855,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -893,18 +885,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 608
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -922,7 +907,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -943,12 +928,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -981,22 +975,22 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1018,21 +1012,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1047,11 +1041,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1060,13 +1054,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1086,7 +1080,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1129,7 +1123,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1162,7 +1156,7 @@
    if
     i32.const 0
     i32.const 608
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1405,7 +1399,7 @@
   if
    i32.const 0
    i32.const 608
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -416,7 +416,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -425,18 +425,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1696
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -450,12 +444,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -479,7 +480,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -564,8 +565,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -578,7 +577,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -598,13 +597,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -613,35 +616,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -649,76 +642,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1696
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1696
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -728,12 +705,12 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -741,34 +718,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -776,14 +757,14 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -806,7 +787,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -819,12 +800,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -846,7 +827,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -874,7 +855,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -902,7 +883,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1250,7 +1231,7 @@
        if
         i32.const 0
         i32.const 1696
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1318,7 +1299,7 @@
     if
      i32.const 0
      i32.const 1696
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1399,7 +1380,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1414,7 +1395,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -416,7 +416,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -430,7 +430,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -480,7 +480,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -608,18 +608,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -651,7 +645,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -661,18 +655,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -690,7 +678,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -705,7 +693,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -757,7 +745,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -827,7 +815,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -855,7 +843,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -883,7 +871,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1231,7 +1219,7 @@
        if
         i32.const 0
         i32.const 1696
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1299,7 +1287,7 @@
     if
      i32.const 0
      i32.const 1696
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1380,7 +1368,7 @@
    if
     i32.const 0
     i32.const 1696
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1395,7 +1383,7 @@
   if
    i32.const 0
    i32.const 1696
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -578,7 +578,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -598,7 +598,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -661,7 +661,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -835,11 +835,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -848,24 +848,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -882,34 +872,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 672
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -918,20 +910,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -943,17 +923,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 672
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -963,7 +943,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -971,7 +951,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -981,33 +961,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1015,21 +995,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1039,22 +1019,22 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1075,56 +1055,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1144,7 +1124,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1187,7 +1167,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1220,7 +1200,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1463,7 +1443,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1794,7 +1774,7 @@
   if
    i32.const 336
    i32.const 672
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1878,7 +1858,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1943,7 +1923,7 @@
     if
      i32.const 0
      i32.const 672
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2094,7 +2074,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2203,7 +2183,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2223,7 +2203,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -578,7 +578,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -594,18 +594,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 672
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -621,12 +614,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -659,41 +661,41 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -706,55 +708,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -847,38 +849,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -903,7 +900,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -922,24 +919,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -957,18 +949,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 672
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -986,7 +971,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1007,12 +992,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1045,22 +1039,22 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1082,21 +1076,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1111,11 +1105,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1124,13 +1118,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1150,7 +1144,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1193,7 +1187,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1226,7 +1220,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1469,7 +1463,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -1800,7 +1794,7 @@
   if
    i32.const 336
    i32.const 672
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -1884,7 +1878,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1949,7 +1943,7 @@
     if
      i32.const 0
      i32.const 672
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2100,7 +2094,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2209,7 +2203,7 @@
    if
     i32.const 0
     i32.const 672
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2229,7 +2223,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/wasi/trace.optimized.wat
+++ b/tests/compiler/wasi/trace.optimized.wat
@@ -387,7 +387,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -401,7 +401,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -451,7 +451,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -579,18 +579,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -622,7 +616,7 @@
    if
     i32.const 0
     i32.const 1104
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -632,18 +626,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -661,7 +649,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -676,7 +664,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -728,7 +716,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -798,7 +786,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -826,7 +814,7 @@
    if
     i32.const 0
     i32.const 1104
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -854,7 +842,7 @@
    if
     i32.const 0
     i32.const 1104
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1036,7 +1024,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1088,7 +1076,7 @@
     if
      i32.const 0
      i32.const 1104
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1119,7 +1107,7 @@
   if
    i32.const 1168
    i32.const 1104
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1210,7 +1198,7 @@
    if
     i32.const 0
     i32.const 1104
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1225,7 +1213,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1244,7 +1232,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2776,7 +2764,7 @@
    if
     i32.const 0
     i32.const 1104
-    i32.const 561
+    i32.const 559
     i32.const 3
     call $~lib/wasi/index/abort
     unreachable

--- a/tests/compiler/wasi/trace.optimized.wat
+++ b/tests/compiler/wasi/trace.optimized.wat
@@ -387,7 +387,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -396,18 +396,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1104
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -421,12 +415,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -450,7 +451,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -535,8 +536,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -549,7 +548,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -569,13 +568,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -584,35 +587,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -620,76 +613,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1104
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1104
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -699,12 +676,12 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -712,34 +689,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -747,14 +728,14 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -777,7 +758,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -790,12 +771,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -817,7 +798,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -845,7 +826,7 @@
    if
     i32.const 0
     i32.const 1104
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -873,7 +854,7 @@
    if
     i32.const 0
     i32.const 1104
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1055,7 +1036,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1107,7 +1088,7 @@
     if
      i32.const 0
      i32.const 1104
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1138,7 +1119,7 @@
   if
    i32.const 1168
    i32.const 1104
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1229,7 +1210,7 @@
    if
     i32.const 0
     i32.const 1104
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1244,7 +1225,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1263,7 +1244,7 @@
   if
    i32.const 0
    i32.const 1104
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2795,7 +2776,7 @@
    if
     i32.const 0
     i32.const 1104
-    i32.const 565
+    i32.const 561
     i32.const 3
     call $~lib/wasi/index/abort
     unreachable

--- a/tests/compiler/wasi/trace.untouched.wat
+++ b/tests/compiler/wasi/trace.untouched.wat
@@ -629,7 +629,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -645,18 +645,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 80
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -672,12 +665,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -710,41 +712,41 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -757,55 +759,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -898,38 +900,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -954,7 +951,7 @@
    if
     i32.const 0
     i32.const 80
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -973,24 +970,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1008,18 +1000,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 80
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1037,7 +1022,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1058,12 +1043,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1096,22 +1090,22 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1133,21 +1127,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1162,11 +1156,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1175,13 +1169,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1201,7 +1195,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1244,7 +1238,7 @@
    if
     i32.const 0
     i32.const 80
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1277,7 +1271,7 @@
    if
     i32.const 0
     i32.const 80
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1517,7 +1511,7 @@
   if
    i32.const 144
    i32.const 80
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1601,7 +1595,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1666,7 +1660,7 @@
     if
      i32.const 0
      i32.const 80
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1817,7 +1811,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1926,7 +1920,7 @@
    if
     i32.const 0
     i32.const 80
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1946,7 +1940,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -4720,7 +4714,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/wasi/trace.untouched.wat
+++ b/tests/compiler/wasi/trace.untouched.wat
@@ -629,7 +629,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -649,7 +649,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -712,7 +712,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -886,11 +886,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -899,24 +899,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -933,34 +923,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 80
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -969,20 +961,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -994,17 +974,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 80
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1014,7 +994,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1022,7 +1002,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1032,33 +1012,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1066,21 +1046,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1090,22 +1070,22 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1126,56 +1106,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1195,7 +1175,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1238,7 +1218,7 @@
    if
     i32.const 0
     i32.const 80
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1271,7 +1251,7 @@
    if
     i32.const 0
     i32.const 80
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/wasi/index/abort
     unreachable
@@ -1511,7 +1491,7 @@
   if
    i32.const 144
    i32.const 80
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/wasi/index/abort
    unreachable
@@ -1595,7 +1575,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1660,7 +1640,7 @@
     if
      i32.const 0
      i32.const 80
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/wasi/index/abort
      unreachable
@@ -1811,7 +1791,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -1920,7 +1900,7 @@
    if
     i32.const 0
     i32.const 80
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/wasi/index/abort
     unreachable
@@ -1940,7 +1920,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -4714,7 +4694,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -362,7 +362,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -371,18 +371,12 @@
   i32.const -4
   i32.and
   local.tee $2
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $2
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -396,12 +390,19 @@
    i32.shr_u
    local.set $2
   else
-   local.get $2
    i32.const 31
    local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
    i32.clz
    i32.sub
-   local.tee $3
+   local.set $3
+   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
    i32.shr_u
@@ -425,7 +426,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -510,8 +511,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
   local.get $1
   i32.eqz
   if
@@ -524,7 +523,7 @@
   end
   local.get $1
   i32.load
-  local.tee $4
+  local.tee $3
   i32.const 1
   i32.and
   i32.eqz
@@ -544,13 +543,17 @@
   i32.const -4
   i32.and
   i32.add
-  local.tee $5
+  local.tee $4
   i32.load
   local.tee $2
   i32.const 1
   i32.and
   if
+   local.get $0
    local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
    i32.const -4
    i32.and
    i32.const 4
@@ -559,35 +562,25 @@
    i32.const -4
    i32.and
    i32.add
+   local.get $3
+   i32.const 3
+   i32.and
+   i32.or
    local.tee $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $5
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $1
-    i32.const 4
-    i32.add
-    local.get $1
-    i32.load
-    i32.const -4
-    i32.and
-    i32.add
-    local.tee $5
-    i32.load
-    local.set $2
-   end
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
   end
-  local.get $4
+  local.get $3
   i32.const 2
   i32.and
   if
@@ -595,76 +588,60 @@
    i32.const 4
    i32.sub
    i32.load
-   local.tee $3
+   local.tee $1
    i32.load
-   local.tee $7
+   local.tee $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 1440
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $7
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
    i32.const -4
    i32.and
    i32.const 4
    i32.add
-   local.get $4
+   local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.tee $8
-   i32.const 1073741820
-   i32.lt_u
-   if (result i32)
-    local.get $0
-    local.get $3
-    call $~lib/rt/tlsf/removeBlock
-    local.get $3
-    local.get $8
-    local.get $7
-    i32.const 3
-    i32.and
-    i32.or
-    local.tee $4
-    i32.store
-    local.get $3
-   else
-    local.get $1
-   end
-   local.set $1
+   local.get $6
+   i32.const 3
+   i32.and
+   i32.or
+   local.tee $3
+   i32.store
   end
-  local.get $5
+  local.get $4
   local.get $2
   i32.const 2
   i32.or
   i32.store
-  local.get $4
+  local.get $3
   i32.const -4
   i32.and
   local.tee $3
-  i32.const 1073741820
-  i32.lt_u
-  i32.const 0
-  local.get $3
   i32.const 12
-  i32.ge_u
-  select
-  i32.eqz
+  i32.lt_u
   if
    i32.const 0
    i32.const 1440
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   local.get $3
   local.get $1
   i32.const 4
@@ -674,12 +651,12 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $4
   i32.const 4
   i32.sub
   local.get $1
@@ -687,34 +664,38 @@
   local.get $3
   i32.const 256
   i32.lt_u
-  if
+  if (result i32)
    local.get $3
    i32.const 4
    i32.shr_u
-   local.set $3
   else
-   local.get $3
    i32.const 31
    local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    i32.clz
    i32.sub
    local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.shr_u
    i32.const 16
    i32.xor
-   local.set $3
-   local.get $4
-   i32.const 7
-   i32.sub
-   local.set $6
   end
-  local.get $3
+  local.tee $3
   i32.const 16
   i32.lt_u
   i32.const 0
-  local.get $6
+  local.get $5
   i32.const 23
   i32.lt_u
   select
@@ -722,14 +703,14 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -752,7 +733,7 @@
   end
   local.get $0
   local.get $3
-  local.get $6
+  local.get $5
   i32.const 4
   i32.shl
   i32.add
@@ -765,12 +746,12 @@
   local.get $0
   i32.load
   i32.const 1
-  local.get $6
+  local.get $5
   i32.shl
   i32.or
   i32.store
   local.get $0
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -792,7 +773,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -820,7 +801,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -848,7 +829,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1196,7 +1177,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 565
+        i32.const 561
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1264,7 +1245,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1345,7 +1326,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1360,7 +1341,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -362,7 +362,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -376,7 +376,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -554,18 +554,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $3
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $2
    i32.const -4
    i32.and
    i32.add
-   local.get $3
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
    local.get $1
@@ -597,7 +591,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -607,18 +601,12 @@
    call $~lib/rt/tlsf/removeBlock
    local.get $1
    local.get $6
-   i32.const -4
-   i32.and
    i32.const 4
    i32.add
    local.get $3
    i32.const -4
    i32.and
    i32.add
-   local.get $6
-   i32.const 3
-   i32.and
-   i32.or
    local.tee $3
    i32.store
   end
@@ -636,7 +624,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -651,7 +639,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -703,7 +691,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -773,7 +761,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -801,7 +789,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -829,7 +817,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1177,7 +1165,7 @@
        if
         i32.const 0
         i32.const 1440
-        i32.const 561
+        i32.const 559
         i32.const 3
         call $~lib/builtins/abort
         unreachable
@@ -1245,7 +1233,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -1326,7 +1314,7 @@
    if
     i32.const 0
     i32.const 1440
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1341,7 +1329,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -853,7 +853,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 273
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -869,18 +869,11 @@
   local.get $3
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $3
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 275
+   i32.const 272
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -896,12 +889,21 @@
    i32.shr_u
    local.set $5
   else
-   i32.const 31
    local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $4
-   local.get $3
+   local.get $6
    local.get $4
    i32.const 4
    i32.sub
@@ -934,41 +936,41 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 288
+   i32.const 286
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
   i32.load offset=4
-  local.set $6
+  local.set $8
   local.get $1
   i32.load offset=8
-  local.set $7
-  local.get $6
+  local.set $9
+  local.get $8
   if
-   local.get $6
-   local.get $7
+   local.get $8
+   local.get $9
    call $~lib/rt/tlsf/Block#set:next
   end
-  local.get $7
+  local.get $9
   if
-   local.get $7
-   local.get $6
+   local.get $9
+   local.get $8
    call $~lib/rt/tlsf/Block#set:prev
   end
   local.get $1
   local.get $0
   local.set $10
   local.get $4
-  local.set $9
+  local.set $6
   local.get $5
-  local.set $8
+  local.set $7
   local.get $10
-  local.get $9
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $8
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
@@ -981,55 +983,55 @@
    local.get $4
    local.set $10
    local.get $5
-   local.set $9
-   local.get $7
-   local.set $8
+   local.set $6
+   local.get $9
+   local.set $7
    local.get $11
    local.get $10
    i32.const 4
    i32.shl
-   local.get $9
+   local.get $6
    i32.add
    i32.const 2
    i32.shl
    i32.add
-   local.get $8
-   i32.store offset=96
    local.get $7
+   i32.store offset=96
+   local.get $9
    i32.eqz
    if
     local.get $0
-    local.set $9
+    local.set $6
     local.get $4
-    local.set $8
-    local.get $9
-    local.get $8
+    local.set $7
+    local.get $6
+    local.get $7
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.set $9
+    local.set $6
     local.get $0
-    local.set $8
+    local.set $7
     local.get $4
     local.set $11
-    local.get $9
+    local.get $6
     i32.const 1
     local.get $5
     i32.shl
     i32.const -1
     i32.xor
     i32.and
-    local.tee $9
+    local.tee $6
     local.set $10
-    local.get $8
+    local.get $7
     local.get $11
     i32.const 2
     i32.shl
     i32.add
     local.get $10
     i32.store offset=4
-    local.get $9
+    local.get $6
     i32.eqz
     if
      local.get $0
@@ -1122,38 +1124,33 @@
    i32.and
    i32.add
    local.set $3
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 3
+   i32.and
    local.get $3
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $4
-    call $~lib/rt/tlsf/removeBlock
-    local.get $1
-    local.get $2
-    i32.const 3
-    i32.and
-    local.get $3
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $1
-    local.set $6
-    local.get $6
-    i32.const 4
-    i32.add
-    local.get $6
-    i32.load
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    local.set $4
-    local.get $4
-    i32.load
-    local.set $5
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $6
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
   end
   local.get $2
   i32.const 2
@@ -1178,7 +1175,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 224
+    i32.const 222
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1197,24 +1194,19 @@
    i32.and
    i32.add
    local.set $7
+   local.get $0
+   local.get $6
+   call $~lib/rt/tlsf/removeBlock
+   local.get $6
+   local.get $3
+   i32.const 3
+   i32.and
    local.get $7
-   i32.const 1073741820
-   i32.lt_u
-   if
-    local.get $0
-    local.get $6
-    call $~lib/rt/tlsf/removeBlock
-    local.get $6
-    local.get $3
-    i32.const 3
-    i32.and
-    local.get $7
-    i32.or
-    local.tee $2
-    call $~lib/rt/common/BLOCK#set:mmInfo
-    local.get $6
-    local.set $1
-   end
+   i32.or
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $6
+   local.set $1
   end
   local.get $4
   local.get $5
@@ -1232,18 +1224,11 @@
   local.get $8
   i32.const 12
   i32.ge_u
-  if (result i32)
-   local.get $8
-   i32.const 1073741820
-   i32.lt_u
-  else
-   i32.const 0
-  end
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 239
+   i32.const 235
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1261,7 +1246,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 240
+   i32.const 236
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1282,12 +1267,21 @@
    i32.shr_u
    local.set $10
   else
-   i32.const 31
    local.get $8
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
    i32.clz
    i32.sub
    local.set $9
-   local.get $8
+   local.get $6
    local.get $9
    i32.const 4
    i32.sub
@@ -1320,22 +1314,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 256
+   i32.const 253
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $7
-  local.get $9
-  local.set $3
-  local.get $10
   local.set $6
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $6
   local.get $7
-  local.get $3
   i32.const 4
   i32.shl
-  local.get $6
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
@@ -1357,21 +1351,21 @@
   local.get $0
   local.set $12
   local.get $9
-  local.set $7
-  local.get $10
-  local.set $3
-  local.get $1
   local.set $6
+  local.get $10
+  local.set $7
+  local.get $1
+  local.set $3
   local.get $12
-  local.get $7
+  local.get $6
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $7
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $3
   i32.store offset=96
   local.get $0
   local.get $0
@@ -1386,11 +1380,11 @@
   local.get $9
   local.set $12
   local.get $0
-  local.set $3
+  local.set $7
   local.get $9
-  local.set $6
+  local.set $3
+  local.get $7
   local.get $3
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -1399,13 +1393,13 @@
   local.get $10
   i32.shl
   i32.or
-  local.set $7
+  local.set $6
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1425,7 +1419,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 381
+   i32.const 379
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1468,7 +1462,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 388
+    i32.const 386
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1501,7 +1495,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 401
+    i32.const 399
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1744,7 +1738,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 565
+   i32.const 561
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2075,7 +2069,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 462
+   i32.const 460
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2159,7 +2153,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 334
+   i32.const 332
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2224,7 +2218,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 347
+     i32.const 345
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2375,7 +2369,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 361
+   i32.const 359
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2484,7 +2478,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 500
+    i32.const 498
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2504,7 +2498,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 502
+   i32.const 500
    i32.const 14
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -853,7 +853,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 270
+   i32.const 268
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -873,7 +873,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 272
+   i32.const 270
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -936,7 +936,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 286
+   i32.const 284
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1110,11 +1110,11 @@
   i32.const 1
   i32.and
   if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
    local.get $2
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
    i32.const 4
    i32.add
    local.get $5
@@ -1123,24 +1123,14 @@
    i32.xor
    i32.and
    i32.add
-   local.set $3
-   local.get $0
-   local.get $4
-   call $~lib/rt/tlsf/removeBlock
-   local.get $1
-   local.get $2
-   i32.const 3
-   i32.and
-   local.get $3
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.add
-   local.get $6
+   local.get $3
    i32.load
    i32.const 3
    i32.const -1
@@ -1157,34 +1147,36 @@
   i32.and
   if
    local.get $1
-   local.set $6
-   local.get $6
+   local.set $3
+   local.get $3
    i32.const 4
    i32.sub
    i32.load
-   local.set $6
-   local.get $6
-   i32.load
    local.set $3
+   local.get $3
+   i32.load
+   local.set $6
    i32.const 1
    drop
-   local.get $3
+   local.get $6
    i32.const 1
    i32.and
    i32.eqz
    if
     i32.const 0
     i32.const 416
-    i32.const 222
+    i32.const 221
     i32.const 16
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $3
-   i32.const 3
-   i32.const -1
-   i32.xor
-   i32.and
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
    i32.const 4
    i32.add
    local.get $2
@@ -1193,20 +1185,8 @@
    i32.xor
    i32.and
    i32.add
-   local.set $7
-   local.get $0
-   local.get $6
-   call $~lib/rt/tlsf/removeBlock
-   local.get $6
-   local.get $3
-   i32.const 3
-   i32.and
-   local.get $7
-   i32.or
    local.tee $2
    call $~lib/rt/common/BLOCK#set:mmInfo
-   local.get $6
-   local.set $1
   end
   local.get $4
   local.get $5
@@ -1218,17 +1198,17 @@
   i32.const -1
   i32.xor
   i32.and
-  local.set $8
+  local.set $7
   i32.const 1
   drop
-  local.get $8
+  local.get $7
   i32.const 12
   i32.ge_u
   i32.eqz
   if
    i32.const 0
    i32.const 416
-   i32.const 235
+   i32.const 233
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1238,7 +1218,7 @@
   local.get $1
   i32.const 4
   i32.add
-  local.get $8
+  local.get $7
   i32.add
   local.get $4
   i32.eq
@@ -1246,7 +1226,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 236
+   i32.const 234
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1256,33 +1236,33 @@
   i32.sub
   local.get $1
   i32.store
-  local.get $8
+  local.get $7
   i32.const 256
   i32.lt_u
   if
    i32.const 0
-   local.set $9
-   local.get $8
+   local.set $8
+   local.get $7
    i32.const 4
    i32.shr_u
-   local.set $10
+   local.set $9
   else
-   local.get $8
-   local.tee $6
-   i32.const 1073741820
-   local.tee $7
-   local.get $6
    local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
    i32.lt_u
    select
-   local.set $6
+   local.set $3
    i32.const 31
-   local.get $6
+   local.get $3
    i32.clz
    i32.sub
-   local.set $9
-   local.get $6
-   local.get $9
+   local.set $8
+   local.get $3
+   local.get $8
    i32.const 4
    i32.sub
    i32.shr_u
@@ -1290,21 +1270,21 @@
    i32.const 4
    i32.shl
    i32.xor
-   local.set $10
-   local.get $9
+   local.set $9
+   local.get $8
    i32.const 8
    i32.const 1
    i32.sub
    i32.sub
-   local.set $9
+   local.set $8
   end
   i32.const 1
   drop
-  local.get $9
+  local.get $8
   i32.const 23
   i32.lt_u
   if (result i32)
-   local.get $10
+   local.get $9
    i32.const 16
    i32.lt_u
   else
@@ -1314,22 +1294,22 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 253
+   i32.const 251
    i32.const 14
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.set $6
-  local.get $9
-  local.set $7
-  local.get $10
+  local.set $10
+  local.get $8
   local.set $3
-  local.get $6
-  local.get $7
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
   i32.const 4
   i32.shl
-  local.get $3
+  local.get $6
   i32.add
   i32.const 2
   i32.shl
@@ -1350,56 +1330,56 @@
   end
   local.get $0
   local.set $12
+  local.get $8
+  local.set $10
   local.get $9
-  local.set $6
-  local.get $10
-  local.set $7
-  local.get $1
   local.set $3
+  local.get $1
+  local.set $6
   local.get $12
-  local.get $6
+  local.get $10
   i32.const 4
   i32.shl
-  local.get $7
+  local.get $3
   i32.add
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $6
   i32.store offset=96
   local.get $0
   local.get $0
   i32.load
   i32.const 1
-  local.get $9
+  local.get $8
   i32.shl
   i32.or
   call $~lib/rt/tlsf/Root#set:flMap
   local.get $0
   local.set $13
-  local.get $9
+  local.get $8
   local.set $12
   local.get $0
-  local.set $7
-  local.get $9
   local.set $3
-  local.get $7
+  local.get $8
+  local.set $6
   local.get $3
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=4
   i32.const 1
-  local.get $10
+  local.get $9
   i32.shl
   i32.or
-  local.set $6
+  local.set $10
   local.get $13
   local.get $12
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $10
   i32.store offset=4
  )
  (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -1419,7 +1399,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 379
+   i32.const 377
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1462,7 +1442,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 386
+    i32.const 384
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -1495,7 +1475,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 399
+    i32.const 397
     i32.const 5
     call $~lib/builtins/abort
     unreachable
@@ -1738,7 +1718,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 561
+   i32.const 559
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -2069,7 +2049,7 @@
   if
    i32.const 80
    i32.const 416
-   i32.const 460
+   i32.const 458
    i32.const 30
    call $~lib/builtins/abort
    unreachable
@@ -2153,7 +2133,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 332
+   i32.const 330
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2218,7 +2198,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 345
+     i32.const 343
      i32.const 18
      call $~lib/builtins/abort
      unreachable
@@ -2369,7 +2349,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 359
+   i32.const 357
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2478,7 +2458,7 @@
    if
     i32.const 0
     i32.const 416
-    i32.const 498
+    i32.const 496
     i32.const 16
     call $~lib/builtins/abort
     unreachable
@@ -2498,7 +2478,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 500
+   i32.const 498
    i32.const 14
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
The memory manager didn't account for blocks larger than MAXSIZE in all cases, which can happen for example when adding >1GB of initial memory to a module or, theoretically, when merging blocks where memory grew to >1GB . Instead of splitting defensively, which would require extra logic, this change always uses the last list for oversized blocks (these are split anyway before use) while also getting rid of two branches previously guarding for this case when attempting to merge.

fixes #1746

- [x] I've read the contributing guidelines