### PR TITLE
feat: implemented getters / setters and various string fns on Date 

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -37,6 +37,7 @@ under the licensing terms detailed in LICENSE:
 * ookangzheng <git-ed@runbox.no>
 * yjhmelody <yjh465402634@gmail.com>
 * bnbarak <bn.barak@gmail.com>
+* Colin Eberhardt <colin.eberhardt@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly/bindings/Date.ts
+++ b/std/assembly/bindings/Date.ts
@@ -1,12 +1,1 @@
-export declare function UTC(
-  // NOTE: Using i32 below saves us a f64.convert_s instruction and moves the responsibility for
-  // converting the value to the WASM/JS boundary.
-  year: i32,
-  month: i32,
-  day: i32,
-  hour: i32,
-  minute: i32,
-  second: i32,
-  millisecond: f64
-): f64;
 export declare function now(): f64;

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -1,5 +1,5 @@
 import { E_VALUEOUTOFRANGE } from "util/error";
-import { UTC as Date_UTC, now as Date_now } from "./bindings/Date";
+import { now as Date_now } from "./bindings/Date";
 
 export class Date {
   @inline static UTC(
@@ -9,11 +9,9 @@ export class Date {
     hour: i32 = 0,
     minute: i32 = 0,
     second: i32 = 0,
-    millisecond: i64 = 0
+    millisecond: i32 = 0
   ): i64 {
-    return <i64>(
-      Date_UTC(year, month, day, hour, minute, second, <f64>millisecond)
-    );
+    return epochMillis(year, month + 1, day, hour, minute, second, millisecond);
   }
 
   @inline static now(): i64 {

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -125,7 +125,7 @@ export class Date {
 
   setUTCDate(value: i32): void {
     ymdFromEpochDays(i32(this.epochMillis / MILLIS_PER_DAY));
-    throwIfNotInRange(value, 1, lastDayOfMonth(year, month));
+    throwIfNotInRange(value, 1, daysInMonth(year, month));
     const mills = this.epochMillis % MILLIS_PER_DAY;
     this.epochMillis =
       i64(daysSinceEpoch(year, month, value)) * MILLIS_PER_DAY + mills;
@@ -205,15 +205,10 @@ function isLeap(y: i32): bool {
   return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
 }
 
-// http://howardhinnant.github.io/date_algorithms.html#last_day_of_month_common_year
-function lastDayOfMonthNonLeapYear(m: i32): i32 {
-  const days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-  return days[m - 1];
-}
-
-// http://howardhinnant.github.io/date_algorithms.html#last_day_of_month
-function lastDayOfMonth(y: i32, m: i32): i32 {
-  return m != 2 || !isLeap(y) ? lastDayOfMonthNonLeapYear(m) : 29;
+function daysInMonth(year: i32, month: i32): i32 {
+  return month == 2
+    ? 28 + i32(isLeap(year))
+    : 30 + ((month + i32(month >= 8)) & 1);
 }
 
 // ymdFromEpochDays returns values via globals to avoid allocations

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -20,6 +20,46 @@ export class Date {
     return <i64>Date_now();
   }
 
+  static fromString(dateTimeString: string): Date {
+    let hour: i32 = 0,
+      minute: i32 = 0,
+      second: i32 = 0,
+      millisecond: i32 = 0;
+    let dateString: string;
+
+    if (dateTimeString.includes("T")) {
+      // includes a time component
+      const parts = dateTimeString.split("T");
+      const timeString = parts[1];
+      // parse the HH-MM-SS component
+      const timeParts = timeString.split(":");
+      hour = I32.parseInt(timeParts[0]);
+      minute = I32.parseInt(timeParts[1]);
+      if (timeParts[2].includes(".")) {
+        // includes milliseconds
+        const secondParts = timeParts[2].split(".");
+        second = I32.parseInt(secondParts[0]);
+        millisecond = I32.parseInt(secondParts[1]);
+      } else {
+        second = I32.parseInt(timeParts[2]);
+      }
+      dateString = parts[0];
+    } else {
+      dateString = dateTimeString;
+    }
+    // parse the YYYY-MM-DD component
+    const parts = dateString.split("-");
+    const year = I32.parseInt(
+      parts[0].length == 2 ? "19" + parts[0] : parts[0]
+    );
+    const month = I32.parseInt(parts[1]);
+    const day = I32.parseInt(parts[2]);
+
+    return new Date(
+      epochMillis(year, month, day, hour, minute, second, millisecond)
+    );
+  }
+
   private epochMillis: i64;
 
   constructor(epochMillis: i64) {
@@ -105,6 +145,50 @@ export class Date {
     this.epochMillis =
       i64(daysSinceEpoch(value, ymd.month, ymd.day)) * MILLIS_PER_DAY + mills;
   }
+
+  toISOString(): string {
+    const ymd = ymdFromEpochDays(i32(this.epochMillis / MILLIS_PER_DAY));
+
+    let yearStr = ymd.year.toString();
+    if (yearStr.length > 4) {
+      yearStr = "+" + yearStr.padStart(6, "0");
+    }
+
+    return (
+      yearStr +
+      "-" +
+      ymd.month.toString().padStart(2, "0") +
+      "-" +
+      ymd.day.toString().padStart(2, "0") +
+      "T" +
+      this.getUTCHours().toString().padStart(2, "0") +
+      ":" +
+      this.getUTCMinutes().toString().padStart(2, "0") +
+      ":" +
+      this.getUTCSeconds().toString().padStart(2, "0") +
+      "." +
+      this.getUTCMilliseconds().toString().padStart(3, "0") +
+      "Z"
+    );
+  }
+}
+
+function epochMillis(
+  year: i32,
+  month: i32,
+  day: i32,
+  hour: i32,
+  minute: i32,
+  second: i32,
+  milliseconds: i32
+): i64 {
+  return (
+    i64(daysSinceEpoch(year, month, day)) * MILLIS_PER_DAY +
+    hour * MILLIS_PER_HOUR +
+    minute * MILLIS_PER_MINUTE +
+    second * MILLIS_PER_SECOND +
+    milliseconds
+  );
 }
 
 function throwIfNotInRange(value: i32, lower: i32, upper: i32): void {

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -1,10 +1,7 @@
-import {
-  UTC as Date_UTC,
-  now as Date_now
-} from "./bindings/Date";
+import { E_VALUEOUTOFRANGE } from "util/error";
+import { UTC as Date_UTC, now as Date_now } from "./bindings/Date";
 
 export class Date {
-
   @inline static UTC(
     year: i32,
     month: i32 = 0,
@@ -14,25 +11,157 @@ export class Date {
     second: i32 = 0,
     millisecond: i64 = 0
   ): i64 {
-    return <i64>Date_UTC(year, month, day, hour, minute, second, <f64>millisecond);
+    return <i64>(
+      Date_UTC(year, month, day, hour, minute, second, <f64>millisecond)
+    );
   }
 
   @inline static now(): i64 {
     return <i64>Date_now();
   }
 
-  private value: i64;
+  private epochMillis: i64;
 
-  constructor(value: i64) {
-    this.value = value;
+  constructor(epochMillis: i64) {
+    this.epochMillis = epochMillis;
   }
 
   getTime(): i64 {
-    return this.value;
+    return this.epochMillis;
   }
 
   setTime(value: i64): i64 {
-    this.value = value;
+    this.epochMillis = value;
     return value;
   }
+
+  getUTCFullYear(): i32 {
+    return ymdFromEpochDays(i32(this.epochMillis / MILLIS_PER_DAY)).year;
+  }
+
+  getUTCMonth(): i32 {
+    return ymdFromEpochDays(i32(this.epochMillis / MILLIS_PER_DAY)).month - 1;
+  }
+
+  getUTCDate(): i32 {
+    return ymdFromEpochDays(i32(this.epochMillis / MILLIS_PER_DAY)).day;
+  }
+
+  getUTCHours(): i32 {
+    return i32(this.epochMillis % MILLIS_PER_DAY) / MILLIS_PER_HOUR;
+  }
+
+  getUTCMinutes(): i32 {
+    return i32(this.epochMillis % MILLIS_PER_HOUR) / MILLIS_PER_MINUTE;
+  }
+
+  getUTCSeconds(): i32 {
+    return i32(this.epochMillis % MILLIS_PER_MINUTE) / MILLIS_PER_SECOND;
+  }
+
+  getUTCMilliseconds(): i32 {
+    return i32(this.epochMillis % MILLIS_PER_SECOND);
+  }
+
+  setUTCMilliseconds(value: i32): void {
+    this.epochMillis += value - this.getUTCMilliseconds();
+  }
+
+  setUTCSeconds(value: i32): void {
+    throwIfNotInRange(value, 0, 59);
+    this.epochMillis += (value - this.getUTCSeconds()) * MILLIS_PER_SECOND;
+  }
+
+  setUTCMinutes(value: i32): void {
+    throwIfNotInRange(value, 0, 59);
+    this.epochMillis += (value - this.getUTCMinutes()) * MILLIS_PER_MINUTE;
+  }
+
+  setUTCHours(value: i32): void {
+    throwIfNotInRange(value, 0, 23);
+    this.epochMillis += (value - this.getUTCHours()) * MILLIS_PER_HOUR;
+  }
+
+  setUTCDate(value: i32): void {
+    const ymd = ymdFromEpochDays(i32(this.epochMillis / MILLIS_PER_DAY));
+    throwIfNotInRange(value, 1, lastDayOfMonth(ymd.year, ymd.month));
+    const mills = this.epochMillis % MILLIS_PER_DAY;
+    this.epochMillis =
+      i64(daysSinceEpoch(ymd.year, ymd.month, value)) * MILLIS_PER_DAY + mills;
+  }
+
+  setUTCMonth(value: i32): void {
+    throwIfNotInRange(value, 1, 12);
+    const ymd = ymdFromEpochDays(i32(this.epochMillis / MILLIS_PER_DAY));
+    const mills = this.epochMillis % MILLIS_PER_DAY;
+    this.epochMillis =
+      i64(daysSinceEpoch(ymd.year, value + 1, ymd.day)) * MILLIS_PER_DAY +
+      mills;
+  }
+
+  setUTCFullYear(value: i32): void {
+    const ymd = ymdFromEpochDays(i32(this.epochMillis / MILLIS_PER_DAY));
+    const mills = this.epochMillis % MILLIS_PER_DAY;
+    this.epochMillis =
+      i64(daysSinceEpoch(value, ymd.month, ymd.day)) * MILLIS_PER_DAY + mills;
+  }
+}
+
+function throwIfNotInRange(value: i32, lower: i32, upper: i32): void {
+  if (value < lower || value > upper) throw new RangeError(E_VALUEOUTOFRANGE);
+}
+
+const MILLIS_PER_DAY = 1_000 * 60 * 60 * 24;
+const MILLIS_PER_HOUR = 1_000 * 60 * 60;
+const MILLIS_PER_MINUTE = 1_000 * 60;
+const MILLIS_PER_SECOND = 1_000;
+
+class YMD {
+  year: i32;
+  month: i32;
+  day: i32;
+}
+
+// http://howardhinnant.github.io/date_algorithms.html#is_leap
+function isLeap(y: i32): bool {
+  return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+}
+
+// http://howardhinnant.github.io/date_algorithms.html#last_day_of_month_common_year
+function lastDayOfMonthNonLeapYear(m: i32): i32 {
+  const days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return days[m - 1];
+}
+
+// http://howardhinnant.github.io/date_algorithms.html#last_day_of_month
+function lastDayOfMonth(y: i32, m: i32): i32 {
+  return m != 2 || !isLeap(y) ? lastDayOfMonthNonLeapYear(m) : 29;
+}
+
+// see: http://howardhinnant.github.io/date_algorithms.html#civil_from_days
+function ymdFromEpochDays(z: i32): YMD {
+  z += 719468;
+  const era = (z >= 0 ? z : z - 146096) / 146097;
+  const doe = z - era * 146097; // [0, 146096]
+  const yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // [0, 399]
+  const y = yoe + era * 400;
+  const doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+  const mp = (5 * doy + 2) / 153; // [0, 11]
+  const d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+  const m = mp + (mp < 10 ? 3 : -9); // [1, 12]
+  return {
+    year: y + (m <= 2 ? 1 : 0),
+    month: m,
+    day: d,
+  };
+}
+
+// http://howardhinnant.github.io/date_algorithms.html#days_from_civil
+function daysSinceEpoch(y: i32, m: i32, d: i32): i32 {
+  y -= m <= 2 ? 1 : 0;
+  const era = (y >= 0 ? y : y - 399) / 400;
+  const yoe = y - era * 400; // [0, 399]
+  const doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1; // [0, 365]
+  const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+  return era * 146097 + doe - 719468;
 }

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -20,9 +20,9 @@ export class Date {
 
   static fromString(dateTimeString: string): Date {
     let hour: i32 = 0,
-      minute: i32 = 0,
-      second: i32 = 0,
-      millisecond: i32 = 0;
+        minute: i32 = 0,
+        second: i32 = 0,
+        millisecond: i32 = 0;
     let dateString: string;
 
     if (dateTimeString.includes("T")) {

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1722,6 +1722,22 @@ declare class Date {
   getTime(): i64;
   /** Sets the UTC timestamp of this date in milliseconds. */
   setTime(value: i64): i64;
+
+  getUTCFullYear(): i32;
+  getUTCMonth(): i32;
+  getUTCDate(): i32;
+  getUTCHours(): i32;
+  getUTCMinutes(): i32;
+  getUTCSeconds(): i32;
+  getUTCMilliseconds(): i32;
+
+  setUTCFullYear(value: i32): void;
+  setUTCMonth(value: i32): void;
+  setUTCDate(value: i32): void;
+  setUTCHours(value: i32): void;
+  setUTCMinutes(value: i32): void;
+  setUTCSeconds(value: i32): void;
+  setUTCMilliseconds(value: i32): void;
 }
 
 /** Class for representing a runtime error. Base class of all errors. */

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1716,6 +1716,7 @@ declare class Date {
   ): i64;
   /** Returns the current UTC timestamp in milliseconds. */
   static now(): i64;
+  static fromString(dateStr: string): Date;
   /** Constructs a new date object from an UTC timestamp in milliseconds. */
   constructor(value: i64);
   /** Returns the UTC timestamp of this date in milliseconds. */
@@ -1738,6 +1739,8 @@ declare class Date {
   setUTCMinutes(value: i32): void;
   setUTCSeconds(value: i32): void;
   setUTCMilliseconds(value: i32): void;
+
+  toISOString(): string;
 }
 
 /** Class for representing a runtime error. Base class of all errors. */

--- a/std/assembly/util/error.ts
+++ b/std/assembly/util/error.ts
@@ -1,9 +1,13 @@
-// Common error messages for use accross the standard library. Keeping error messages compact
+// Common error messages for use across the standard library. Keeping error messages compact
 // and reusing them where possible ensures minimal static data in binaries.
 
 // @ts-ignore: decorator
 @lazy @inline
 export const E_INDEXOUTOFRANGE: string = "Index out of range";
+
+// @ts-ignore: decorator
+@lazy @inline
+export const E_VALUEOUTOFRANGE: string = "Value out of range";
 
 // @ts-ignore: decorator
 @lazy @inline

--- a/tests/compiler/std/date.json
+++ b/tests/compiler/std/date.json
@@ -1,4 +1,5 @@
 {
   "asc_flags": [
+    "--explicitStart"
   ]
 }

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -1,16 +1,17 @@
 (module
- (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
- (type $none_=>_i32 (func (result i32)))
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
- (type $none_=>_f64 (func (result f64)))
- (type $i32_i32_i32_i32_i32_i32_f64_=>_f64 (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
- (import "Date" "UTC" (func $~lib/bindings/Date/UTC (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i64_=>_i32 (func (param i64) (result i32)))
+ (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_i32_i32_i32_=>_i64 (func (param i32 i32 i32 i32 i32 i32 i32) (result i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "Date" "now" (func $~lib/bindings/Date/now (result f64)))
  (memory $0 1)
  (data (i32.const 1036) ",")
  (data (i32.const 1048) "\01\00\00\00\16\00\00\00s\00t\00d\00/\00d\00a\00t\00e\00.\00t\00s")
@@ -24,9 +25,67 @@
  (data (i32.const 1352) "\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
  (data (i32.const 1420) "<")
  (data (i32.const 1432) "\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data (i32.const 1488) "\04\00\00\00 \00\00\00\00\00\00\00 ")
- (data (i32.const 1516) " ")
- (global $std/date/creationTime (mut i64) (i64.const 0))
+ (data (i32.const 1484) "<")
+ (data (i32.const 1496) "\01\00\00\00$\00\00\00V\00a\00l\00u\00e\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
+ (data (i32.const 1548) ",")
+ (data (i32.const 1560) "\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00d\00a\00t\00e\00.\00t\00s")
+ (data (i32.const 1596) "|")
+ (data (i32.const 1608) "\01\00\00\00d\00\00\00t\00o\00S\00t\00r\00i\00n\00g\00(\00)\00 \00r\00a\00d\00i\00x\00 \00a\00r\00g\00u\00m\00e\00n\00t\00 \00m\00u\00s\00t\00 \00b\00e\00 \00b\00e\00t\00w\00e\00e\00n\00 \002\00 \00a\00n\00d\00 \003\006")
+ (data (i32.const 1724) "<")
+ (data (i32.const 1736) "\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00u\00t\00i\00l\00/\00n\00u\00m\00b\00e\00r\00.\00t\00s")
+ (data (i32.const 1788) "\1c")
+ (data (i32.const 1800) "\01\00\00\00\02\00\00\000")
+ (data (i32.const 1820) "\\")
+ (data (i32.const 1832) "\01\00\00\00H\00\00\000\001\002\003\004\005\006\007\008\009\00a\00b\00c\00d\00e\00f\00g\00h\00i\00j\00k\00l\00m\00n\00o\00p\00q\00r\00s\00t\00u\00v\00w\00x\00y\00z")
+ (data (i32.const 1916) "\1c")
+ (data (i32.const 1928) "\01\00\00\00\02\00\00\00+")
+ (data (i32.const 1948) "\1c")
+ (data (i32.const 1960) "\01")
+ (data (i32.const 1980) "\1c")
+ (data (i32.const 1992) "\01\00\00\00\02\00\00\00-")
+ (data (i32.const 2012) "\1c")
+ (data (i32.const 2024) "\01\00\00\00\02\00\00\00T")
+ (data (i32.const 2044) "\1c")
+ (data (i32.const 2056) "\01\00\00\00\02\00\00\00:")
+ (data (i32.const 2076) "\1c")
+ (data (i32.const 2088) "\01\00\00\00\02\00\00\00.")
+ (data (i32.const 2108) "\1c")
+ (data (i32.const 2120) "\01\00\00\00\02\00\00\00Z")
+ (data (i32.const 2140) "L")
+ (data (i32.const 2152) "\01\00\00\000\00\00\002\000\000\009\00-\000\001\00-\000\006\00T\000\008\00:\004\000\00:\003\001\00.\000\002\000\00Z")
+ (data (i32.const 2220) "L")
+ (data (i32.const 2232) "\01\00\00\000\00\00\002\000\000\009\00-\000\001\00-\000\006\00T\000\008\00:\004\000\00:\003\001\00.\004\005\006\00Z")
+ (data (i32.const 2300) "L")
+ (data (i32.const 2312) "\01\00\00\006\00\00\00+\000\001\002\001\008\004\00-\000\004\00-\000\008\00T\001\003\00:\000\007\00:\001\001\00.\000\002\000\00Z")
+ (data (i32.const 2380) ",")
+ (data (i32.const 2392) "\01\00\00\00\14\00\00\001\009\007\006\00-\000\002\00-\000\002")
+ (data (i32.const 2428) ",")
+ (data (i32.const 2440) "\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 2476) ",")
+ (data (i32.const 2488) "\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
+ (data (i32.const 2524) "|")
+ (data (i32.const 2536) "\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
+ (data (i32.const 2652) "\1c")
+ (data (i32.const 2664) "\01\00\00\00\04\00\00\001\009")
+ (data (i32.const 2684) ",")
+ (data (i32.const 2696) "\01\00\00\00\10\00\00\001\009\007\006\00-\002\00-\002")
+ (data (i32.const 2732) ",")
+ (data (i32.const 2744) "\01\00\00\00\14\00\00\002\003\004\005\00-\001\001\00-\000\004")
+ (data (i32.const 2780) ",")
+ (data (i32.const 2792) "\01\00\00\00\14\00\00\001\009\007\006\00-\000\004\00-\000\002")
+ (data (i32.const 2828) ",")
+ (data (i32.const 2840) "\01\00\00\00\10\00\00\007\006\00-\000\004\00-\000\002")
+ (data (i32.const 2876) "<")
+ (data (i32.const 2888) "\01\00\00\00&\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006")
+ (data (i32.const 2940) "L")
+ (data (i32.const 2952) "\01\00\00\00.\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006")
+ (data (i32.const 3020) "L")
+ (data (i32.const 3032) "\01\00\00\000\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00Z")
+ (data (i32.const 3104) "\06\00\00\00 \00\00\00\00\00\00\00 ")
+ (data (i32.const 3132) " \00\00\00\00\00\00\00\02A\00\00\00\00\00\00\02\t")
+ (global $~lib/date/year (mut i32) (i32.const 0))
+ (global $~lib/date/month (mut i32) (i32.const 0))
+ (global $~lib/date/day (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
@@ -37,10 +96,94 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $std/date/date (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 17908))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 19540))
+ (global $~started (mut i32) (i32.const 0))
  (export "memory" (memory $0))
- (start $~start)
+ (export "_start" (func $~start))
+ (func $~lib/date/daysSinceEpoch (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  local.get $1
+  i32.const 2
+  i32.le_s
+  i32.sub
+  local.tee $0
+  local.get $0
+  i32.const 399
+  i32.sub
+  local.get $0
+  i32.const 0
+  i32.ge_s
+  select
+  i32.const 400
+  i32.div_s
+  local.tee $3
+  i32.const 146097
+  i32.mul
+  local.get $2
+  local.get $1
+  i32.const -3
+  i32.const 9
+  local.get $1
+  i32.const 2
+  i32.gt_s
+  select
+  i32.add
+  i32.const 153
+  i32.mul
+  i32.const 2
+  i32.add
+  i32.const 5
+  i32.div_s
+  i32.add
+  local.get $0
+  local.get $3
+  i32.const 400
+  i32.mul
+  i32.sub
+  local.tee $0
+  i32.const 365
+  i32.mul
+  local.get $0
+  i32.const 4
+  i32.div_s
+  i32.add
+  local.get $0
+  i32.const 100
+  i32.div_s
+  i32.sub
+  i32.add
+  i32.add
+  i32.const 719469
+  i32.sub
+ )
+ (func $~lib/date/epochMillis (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32) (param $6 i32) (result i64)
+  local.get $6
+  i64.extend_i32_s
+  local.get $5
+  i32.const 1000
+  i32.mul
+  i64.extend_i32_s
+  local.get $4
+  i32.const 60000
+  i32.mul
+  i64.extend_i32_s
+  local.get $3
+  i32.const 3600000
+  i32.mul
+  i64.extend_i32_s
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  i64.const 86400000
+  i64.mul
+  i64.add
+  i64.add
+  i64.add
+  i64.add
+ )
  (func $~lib/rt/itcms/initLazy (param $0 i32) (result i32)
   local.get $0
   local.get $0
@@ -53,15 +196,17 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
-  global.get $std/date/date
-  local.tee $0
-  if
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
   i32.const 1296
   call $~lib/rt/itcms/__visit
+  i32.const 1504
+  call $~lib/rt/itcms/__visit
+  i32.const 2448
+  call $~lib/rt/itcms/__visit
+  i32.const 2544
+  call $~lib/rt/itcms/__visit
   i32.const 1104
+  call $~lib/rt/itcms/__visit
+  i32.const 1840
   call $~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
@@ -173,7 +318,7 @@
    if
     i32.const 0
     local.get $0
-    i32.const 17908
+    i32.const 19540
     i32.lt_u
     local.get $0
     i32.load offset=8
@@ -219,7 +364,7 @@
    i32.const 1
   else
    local.get $1
-   i32.const 1488
+   i32.const 3104
    i32.load
    i32.gt_u
    if
@@ -233,7 +378,7 @@
    local.get $1
    i32.const 3
    i32.shl
-   i32.const 1492
+   i32.const 3108
    i32.add
    i32.load
    i32.const 32
@@ -807,10 +952,10 @@
   if
    unreachable
   end
-  i32.const 17920
+  i32.const 19552
   i32.const 0
   i32.store
-  i32.const 19488
+  i32.const 21120
   i32.const 0
   i32.store
   loop $for-loop|0
@@ -821,7 +966,7 @@
     local.get $1
     i32.const 2
     i32.shl
-    i32.const 17920
+    i32.const 19552
     i32.add
     i32.const 0
     i32.store offset=4
@@ -839,7 +984,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 17920
+      i32.const 19552
       i32.add
       i32.const 0
       i32.store offset=96
@@ -857,13 +1002,13 @@
     br $for-loop|0
    end
   end
-  i32.const 17920
-  i32.const 19492
+  i32.const 19552
+  i32.const 21124
   memory.size
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 17920
+  i32.const 19552
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (result i32)
@@ -942,7 +1087,7 @@
       local.set $0
       loop $while-continue|0
        local.get $0
-       i32.const 17908
+       i32.const 19540
        i32.lt_u
        if
         local.get $0
@@ -1032,7 +1177,7 @@
       unreachable
      end
      local.get $0
-     i32.const 17908
+     i32.const 19540
      i32.lt_u
      if
       local.get $0
@@ -1055,7 +1200,7 @@
       i32.const 4
       i32.add
       local.tee $1
-      i32.const 17908
+      i32.const 19540
       i32.ge_u
       if
        global.get $~lib/rt/tlsf/ROOT
@@ -1120,18 +1265,86 @@
   end
   global.get $~lib/rt/itcms/visitCount
  )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  local.get $1
+  i32.const 256
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 4
+   i32.shr_u
+   local.set $1
+  else
+   i32.const 31
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
+   i32.const 536870910
+   i32.lt_u
+   select
+   local.tee $1
+   i32.clz
+   i32.sub
+   local.set $2
+   local.get $1
+   local.get $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $1
+   local.get $2
+   i32.const 7
+   i32.sub
+   local.set $2
+  end
+  local.get $1
+  i32.const 16
+  i32.lt_u
+  i32.const 0
+  local.get $2
+  i32.const 23
+  i32.lt_u
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1440
+   i32.const 330
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
   local.get $0
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
   i32.load offset=4
-  i32.const -2
+  i32.const -1
+  local.get $1
+  i32.shl
   i32.and
-  local.tee $2
+  local.tee $1
   if (result i32)
    local.get $0
-   local.get $2
+   local.get $1
    i32.ctz
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.add
    i32.const 2
    i32.shl
    i32.add
@@ -1139,7 +1352,11 @@
   else
    local.get $0
    i32.load
-   i32.const -2
+   i32.const -1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.shl
    i32.and
    local.tee $1
    if (result i32)
@@ -1177,18 +1394,42 @@
    end
   end
  )
- (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.const 1073741820
+  i32.ge_u
+  if
+   i32.const 1104
+   i32.const 1440
+   i32.const 458
+   i32.const 30
+   call $~lib/builtins/abort
+   unreachable
+  end
   local.get $0
+  i32.const 12
+  local.get $1
+  i32.const 19
+  i32.add
+  i32.const -16
+  i32.and
+  i32.const 4
+  i32.sub
+  local.get $1
+  i32.const 12
+  i32.le_u
+  select
+  local.tee $2
   call $~lib/rt/tlsf/searchBlock
   local.tee $1
   i32.eqz
   if
    i32.const 4
    memory.size
-   local.tee $2
+   local.tee $1
    i32.const 16
    i32.shl
    i32.const 4
@@ -1197,24 +1438,40 @@
    i32.load offset=1568
    i32.ne
    i32.shl
-   i32.const 65563
+   local.get $2
+   i32.const 1
+   i32.const 27
+   local.get $2
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.get $2
+   local.get $2
+   i32.const 536870910
+   i32.lt_u
+   select
+   i32.add
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
-   local.set $1
-   local.get $2
+   local.set $3
    local.get $1
+   local.get $3
    local.get $1
-   local.get $2
-   i32.lt_s
+   local.get $3
+   i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $1
+    local.get $3
     memory.grow
     i32.const 0
     i32.lt_s
@@ -1223,7 +1480,7 @@
     end
    end
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 16
    i32.shl
    memory.size
@@ -1231,6 +1488,7 @@
    i32.shl
    call $~lib/rt/tlsf/addMemory
    local.get $0
+   local.get $2
    call $~lib/rt/tlsf/searchBlock
    local.tee $1
    i32.eqz
@@ -1243,12 +1501,12 @@
     unreachable
    end
   end
+  local.get $2
   local.get $1
   i32.load
   i32.const -4
   i32.and
-  i32.const 28
-  i32.lt_u
+  i32.gt_u
   if
    i32.const 0
    i32.const 1440
@@ -1262,27 +1520,43 @@
   call $~lib/rt/tlsf/removeBlock
   local.get $1
   i32.load
-  local.tee $2
+  local.set $3
+  local.get $2
+  i32.const 4
+  i32.add
+  i32.const 15
+  i32.and
+  if
+   i32.const 0
+   i32.const 1440
+   i32.const 357
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
   i32.const -4
   i32.and
-  i32.const 28
+  local.get $2
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 16
   i32.ge_u
   if
    local.get $1
    local.get $2
+   local.get $3
    i32.const 2
    i32.and
-   i32.const 28
    i32.or
    i32.store
+   local.get $2
    local.get $1
-   i32.const 32
+   i32.const 4
+   i32.add
    i32.add
    local.tee $2
-   local.get $3
+   local.get $4
    i32.const 4
    i32.sub
    i32.const 1
@@ -1293,7 +1567,7 @@
    call $~lib/rt/tlsf/insertBlock
   else
    local.get $1
-   local.get $2
+   local.get $3
    i32.const -2
    i32.and
    i32.store
@@ -1319,21 +1593,207 @@
   end
   local.get $1
  )
- (func $~lib/rt/itcms/__new (result i32)
-  (local $0 i32)
-  (local $1 i32)
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  block $~lib/util/memory/memset|inlined.0
+   local.get $1
+   i32.eqz
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 0
+   i32.store8
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 1
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $1
+   i32.const 2
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 0
+   i32.store8 offset=1
+   local.get $0
+   i32.const 0
+   i32.store8 offset=2
+   local.get $2
+   i32.const 2
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $2
+   i32.const 3
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $1
+   i32.const 6
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 0
+   i32.store8 offset=3
+   local.get $2
+   i32.const 4
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $1
+   i32.const 8
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 0
+   local.get $0
+   i32.sub
+   i32.const 3
+   i32.and
+   local.tee $2
+   i32.add
+   local.tee $0
+   i32.const 0
+   i32.store
+   local.get $0
+   local.get $1
+   local.get $2
+   i32.sub
+   i32.const -4
+   i32.and
+   local.tee $2
+   i32.add
+   local.tee $1
+   i32.const 4
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $2
+   i32.const 8
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 0
+   i32.store offset=4
+   local.get $0
+   i32.const 0
+   i32.store offset=8
+   local.get $1
+   i32.const 12
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $2
+   i32.const 24
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 0
+   i32.store offset=12
+   local.get $0
+   i32.const 0
+   i32.store offset=16
+   local.get $0
+   i32.const 0
+   i32.store offset=20
+   local.get $0
+   i32.const 0
+   i32.store offset=24
+   local.get $1
+   i32.const 28
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
+   i32.const 24
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
+   i32.const 20
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
+   i32.const 16
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $0
+   local.get $0
+   i32.const 4
+   i32.and
+   i32.const 24
+   i32.add
+   local.tee $1
+   i32.add
+   local.set $0
+   local.get $2
+   local.get $1
+   i32.sub
+   local.set $1
+   loop $while-continue|0
+    local.get $1
+    i32.const 32
+    i32.ge_u
+    if
+     local.get $0
+     i64.const 0
+     i64.store
+     local.get $0
+     i64.const 0
+     i64.store offset=8
+     local.get $0
+     i64.const 0
+     i64.store offset=16
+     local.get $0
+     i64.const 0
+     i64.store offset=24
+     local.get $1
+     i32.const 32
+     i32.sub
+     local.set $1
+     local.get $0
+     i32.const 32
+     i32.add
+     local.set $0
+     br $while-continue|0
+    end
+   end
+  end
+ )
+ (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 1073741804
+  i32.ge_u
+  if
+   i32.const 1104
+   i32.const 1168
+   i32.const 260
+   i32.const 31
+   call $~lib/builtins/abort
+   unreachable
+  end
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
-    local.set $0
+    local.set $2
     loop $do-continue|0
-     local.get $0
+     local.get $2
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $0
+     local.set $2
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1349,7 +1809,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt
      end
-     local.get $0
+     local.get $2
      i32.const 0
      i32.gt_s
      br_if $do-continue|0
@@ -1366,25 +1826,30 @@
     global.set $~lib/rt/itcms/threshold
    end
   end
+  local.get $0
+  i32.const 16
+  i32.add
+  local.set $2
   global.get $~lib/rt/tlsf/ROOT
   i32.eqz
   if
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
+  local.get $2
   call $~lib/rt/tlsf/allocateBlock
-  local.tee $0
-  i32.const 3
+  local.tee $2
+  local.get $1
   i32.store offset=12
+  local.get $2
   local.get $0
-  i32.const 8
   i32.store offset=16
-  local.get $0
+  local.get $2
   global.get $~lib/rt/itcms/fromSpace
   global.get $~lib/rt/itcms/white
   call $~lib/rt/itcms/Object#linkTo
   global.get $~lib/rt/itcms/total
-  local.get $0
+  local.get $2
   i32.load
   i32.const -4
   i32.and
@@ -1392,94 +1857,360 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $0
+  local.get $2
   i32.const 20
   i32.add
-  local.tee $0
-  i32.const 0
-  i32.store8
-  local.get $0
-  i32.const 8
-  i32.add
   local.tee $1
-  i32.const 1
-  i32.sub
-  i32.const 0
-  i32.store8
   local.get $0
-  i32.const 0
-  i32.store8 offset=1
-  local.get $0
-  i32.const 0
-  i32.store8 offset=2
+  call $~lib/memory/memory.fill
   local.get $1
-  i32.const 2
+ )
+ (func $~lib/date/ymdFromEpochDays (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 719468
+  i32.add
+  local.tee $0
+  local.get $0
+  i32.const 146096
   i32.sub
-  i32.const 0
-  i32.store8
-  local.get $1
-  i32.const 3
-  i32.sub
-  i32.const 0
-  i32.store8
   local.get $0
   i32.const 0
-  i32.store8 offset=3
+  i32.ge_s
+  select
+  i32.const 146097
+  i32.div_s
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.const 146097
+  i32.mul
+  i32.sub
+  local.tee $0
+  local.get $0
+  i32.const 1460
+  i32.div_s
+  i32.sub
+  local.get $0
+  i32.const 36524
+  i32.div_s
+  i32.add
+  local.get $0
+  i32.const 146096
+  i32.div_s
+  i32.sub
+  i32.const 365
+  i32.div_s
+  local.tee $1
+  local.get $2
+  i32.const 400
+  i32.mul
+  i32.add
+  global.set $~lib/date/year
+  local.get $0
+  local.get $1
+  i32.const 365
+  i32.mul
   local.get $1
   i32.const 4
+  i32.div_s
+  i32.add
+  local.get $1
+  i32.const 100
+  i32.div_s
   i32.sub
-  i32.const 0
-  i32.store8
+  i32.sub
+  local.tee $1
+  i32.const 5
+  i32.mul
+  i32.const 2
+  i32.add
+  i32.const 153
+  i32.div_s
+  local.set $0
+  local.get $1
   local.get $0
- )
- (func $~lib/rt/__visit_members (param $0 i32)
-  block $invalid
-   block $~lib/date/Date
-    block $~lib/arraybuffer/ArrayBufferView
-     block $~lib/string/String
-      block $~lib/arraybuffer/ArrayBuffer
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load
-       br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $invalid
-      end
-      return
-     end
-     return
-    end
-    local.get $0
-    i32.load
-    local.tee $0
-    if
-     local.get $0
-     call $~lib/rt/itcms/__visit
-    end
-    return
-   end
-   return
-  end
-  unreachable
- )
- (func $~start
-  call $start:std/date
- )
- (func $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1524
+  i32.const 153
+  i32.mul
+  i32.const 2
+  i32.add
+  i32.const 5
+  i32.div_s
+  i32.sub
+  i32.const 1
+  i32.add
+  global.set $~lib/date/day
+  local.get $0
+  i32.const 3
+  i32.const -9
+  local.get $0
+  i32.const 10
   i32.lt_s
+  select
+  i32.add
+  global.set $~lib/date/month
+  global.get $~lib/date/year
+  global.get $~lib/date/month
+  i32.const 2
+  i32.le_s
+  i32.add
+  global.set $~lib/date/year
+ )
+ (func $~lib/date/Date#getUTCFullYear (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  global.get $~lib/date/year
+ )
+ (func $~lib/date/Date#getUTCMonth (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  global.get $~lib/date/month
+  i32.const 1
+  i32.sub
+ )
+ (func $~lib/date/Date#getUTCDate (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  global.get $~lib/date/day
+ )
+ (func $~lib/date/Date#getUTCHours (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.rem_s
+  i32.wrap_i64
+  i32.const 3600000
+  i32.div_s
+ )
+ (func $~lib/date/Date#getUTCMinutes (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  i64.const 3600000
+  i64.rem_s
+  i32.wrap_i64
+  i32.const 60000
+  i32.div_s
+ )
+ (func $~lib/date/Date#getUTCSeconds (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  i64.const 60000
+  i64.rem_s
+  i32.wrap_i64
+  i32.const 1000
+  i32.div_s
+ )
+ (func $~lib/date/Date#setUTCMilliseconds (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $0
+  i64.load
+  local.get $1
+  local.get $0
+  i64.load
+  i64.const 1000
+  i64.rem_s
+  i32.wrap_i64
+  i32.sub
+  i64.extend_i32_s
+  i64.add
+  i64.store
+ )
+ (func $~lib/date/throwIfNotInRange (param $0 i32) (param $1 i32) (param $2 i32)
+  i32.const 1
+  local.get $0
+  local.get $2
+  i32.gt_s
+  local.get $0
+  local.get $1
+  i32.lt_s
+  select
   if
-   i32.const 17936
-   i32.const 17984
-   i32.const 1
-   i32.const 1
+   i32.const 1504
+   i32.const 1568
+   i32.const 195
+   i32.const 39
    call $~lib/builtins/abort
    unreachable
   end
  )
- (func $start:std/date
-  (local $0 i32)
-  (local $1 i64)
+ (func $~lib/date/Date#setUTCSeconds (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.const 0
+  i32.const 59
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  local.get $0
+  i64.load
+  local.get $1
+  local.get $0
+  call $~lib/date/Date#getUTCSeconds
+  i32.sub
+  i32.const 1000
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  i64.store
+ )
+ (func $~lib/date/Date#setUTCMinutes (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.const 0
+  i32.const 59
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  local.get $0
+  i64.load
+  local.get $1
+  local.get $0
+  call $~lib/date/Date#getUTCMinutes
+  i32.sub
+  i32.const 60000
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  i64.store
+ )
+ (func $~lib/date/Date#setUTCHours (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.const 0
+  i32.const 23
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  local.get $0
+  i64.load
+  local.get $1
+  local.get $0
+  call $~lib/date/Date#getUTCHours
+  i32.sub
+  i32.const 3600000
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  i64.store
+ )
+ (func $~lib/date/Date#setUTCDate (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.get $1
+  i32.const 1
+  i32.const 0
+  i32.const 1
+  global.get $~lib/date/year
+  local.tee $2
+  i32.const 400
+  i32.rem_s
+  i32.eqz
+  local.get $2
+  i32.const 100
+  i32.rem_s
+  select
+  local.get $2
+  i32.const 3
+  i32.and
+  select
+  i32.const 28
+  i32.add
+  global.get $~lib/date/month
+  local.tee $2
+  local.get $2
+  i32.const 8
+  i32.ge_s
+  i32.add
+  i32.const 1
+  i32.and
+  i32.const 30
+  i32.add
+  local.get $2
+  i32.const 2
+  i32.eq
+  select
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.rem_s
+  global.get $~lib/date/year
+  global.get $~lib/date/month
+  local.get $1
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  i64.const 86400000
+  i64.mul
+  i64.add
+  i64.store
+ )
+ (func $~lib/date/Date#setUTCMonth (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.const 1
+  i32.const 12
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.get $0
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.rem_s
+  global.get $~lib/date/year
+  local.get $1
+  i32.const 1
+  i32.add
+  global.get $~lib/date/day
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  i64.const 86400000
+  i64.mul
+  i64.add
+  i64.store
+ )
+ (func $~lib/date/Date#setUTCFullYear (param $0 i32) (param $1 i32)
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.get $0
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.rem_s
+  local.get $1
+  global.get $~lib/date/month
+  global.get $~lib/date/day
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  i64.const 86400000
+  i64.mul
+  i64.add
+  i64.store
+ )
+ (func $~lib/number/I32#toString (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -1488,81 +2219,1972 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  i32.const 1970
+  block $__inlined_func$~lib/util/number/itoa32
+   local.get $0
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    i32.const 1808
+    local.set $0
+    br $__inlined_func$~lib/util/number/itoa32
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   local.get $0
+   i32.sub
+   local.get $0
+   local.get $0
+   i32.const 31
+   i32.shr_u
+   local.tee $2
+   select
+   local.tee $1
+   i32.const 10
+   i32.ge_u
+   i32.const 1
+   i32.add
+   local.get $1
+   i32.const 10000
+   i32.ge_u
+   i32.const 3
+   i32.add
+   local.get $1
+   i32.const 1000
+   i32.ge_u
+   i32.add
+   local.get $1
+   i32.const 100
+   i32.lt_u
+   select
+   local.get $1
+   i32.const 1000000
+   i32.ge_u
+   i32.const 6
+   i32.add
+   local.get $1
+   i32.const 1000000000
+   i32.ge_u
+   i32.const 8
+   i32.add
+   local.get $1
+   i32.const 100000000
+   i32.ge_u
+   i32.add
+   local.get $1
+   i32.const 10000000
+   i32.lt_u
+   select
+   local.get $1
+   i32.const 100000
+   i32.lt_u
+   select
+   local.get $2
+   i32.add
+   local.tee $3
+   i32.const 1
+   i32.shl
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   loop $do-continue|0
+    local.get $0
+    local.get $3
+    i32.const 1
+    i32.sub
+    local.tee $3
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $1
+    i32.const 10
+    i32.rem_u
+    i32.const 48
+    i32.add
+    i32.store16
+    local.get $1
+    i32.const 10
+    i32.div_u
+    local.tee $1
+    br_if $do-continue|0
+   end
+   local.get $2
+   if
+    local.get $0
+    i32.const 45
+    i32.store16
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+  end
+  local.get $0
+ )
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  block $~lib/util/memory/memmove|inlined.0
+   local.get $2
+   local.set $4
+   local.get $0
+   local.get $1
+   i32.eq
+   br_if $~lib/util/memory/memmove|inlined.0
+   local.get $0
+   local.get $1
+   i32.lt_u
+   if
+    local.get $1
+    i32.const 7
+    i32.and
+    local.get $0
+    i32.const 7
+    i32.and
+    i32.eq
+    if
+     loop $while-continue|0
+      local.get $0
+      i32.const 7
+      i32.and
+      if
+       local.get $4
+       i32.eqz
+       br_if $~lib/util/memory/memmove|inlined.0
+       local.get $4
+       i32.const 1
+       i32.sub
+       local.set $4
+       local.get $0
+       local.tee $2
+       i32.const 1
+       i32.add
+       local.set $0
+       local.get $1
+       local.tee $3
+       i32.const 1
+       i32.add
+       local.set $1
+       local.get $2
+       local.get $3
+       i32.load8_u
+       i32.store8
+       br $while-continue|0
+      end
+     end
+     loop $while-continue|1
+      local.get $4
+      i32.const 8
+      i32.ge_u
+      if
+       local.get $0
+       local.get $1
+       i64.load
+       i64.store
+       local.get $4
+       i32.const 8
+       i32.sub
+       local.set $4
+       local.get $0
+       i32.const 8
+       i32.add
+       local.set $0
+       local.get $1
+       i32.const 8
+       i32.add
+       local.set $1
+       br $while-continue|1
+      end
+     end
+    end
+    loop $while-continue|2
+     local.get $4
+     if
+      local.get $0
+      local.tee $2
+      i32.const 1
+      i32.add
+      local.set $0
+      local.get $1
+      local.tee $3
+      i32.const 1
+      i32.add
+      local.set $1
+      local.get $2
+      local.get $3
+      i32.load8_u
+      i32.store8
+      local.get $4
+      i32.const 1
+      i32.sub
+      local.set $4
+      br $while-continue|2
+     end
+    end
+   else
+    local.get $1
+    i32.const 7
+    i32.and
+    local.get $0
+    i32.const 7
+    i32.and
+    i32.eq
+    if
+     loop $while-continue|3
+      local.get $0
+      local.get $4
+      i32.add
+      i32.const 7
+      i32.and
+      if
+       local.get $4
+       i32.eqz
+       br_if $~lib/util/memory/memmove|inlined.0
+       local.get $4
+       i32.const 1
+       i32.sub
+       local.tee $4
+       local.get $0
+       i32.add
+       local.get $1
+       local.get $4
+       i32.add
+       i32.load8_u
+       i32.store8
+       br $while-continue|3
+      end
+     end
+     loop $while-continue|4
+      local.get $4
+      i32.const 8
+      i32.ge_u
+      if
+       local.get $4
+       i32.const 8
+       i32.sub
+       local.tee $4
+       local.get $0
+       i32.add
+       local.get $1
+       local.get $4
+       i32.add
+       i64.load
+       i64.store
+       br $while-continue|4
+      end
+     end
+    end
+    loop $while-continue|5
+     local.get $4
+     if
+      local.get $4
+      i32.const 1
+      i32.sub
+      local.tee $4
+      local.get $0
+      i32.add
+      local.get $1
+      local.get $4
+      i32.add
+      i32.load8_u
+      i32.store8
+      br $while-continue|5
+     end
+    end
+   end
+  end
+ )
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
+  i32.store
+  block $__inlined_func$~lib/string/String#concat
+   local.get $1
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 1
+   i32.shr_u
+   i32.const 1
+   i32.shl
+   local.tee $4
+   local.get $0
+   local.tee $2
+   i32.const 20
+   i32.sub
+   i32.load offset=16
+   i32.const 1
+   i32.shr_u
+   i32.const 1
+   i32.shl
+   local.tee $3
+   i32.add
+   local.tee $0
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    i32.const 1968
+    local.set $0
+    br $__inlined_func$~lib/string/String#concat
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   local.get $0
+   local.get $2
+   local.get $3
+   call $~lib/memory/memory.copy
+   local.get $0
+   local.get $3
+   i32.add
+   local.get $1
+   local.get $4
+   call $~lib/memory/memory.copy
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+  end
+  local.get $0
+ )
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 i32)
+  local.get $0
+  local.get $1
   i32.const 1
+  i32.shl
+  i32.add
+  local.tee $1
+  i32.const 7
+  i32.and
+  local.get $2
+  i32.const 7
+  i32.and
+  i32.or
+  i32.eqz
   i32.const 0
+  local.get $3
+  i32.const 4
+  i32.ge_u
+  select
+  if
+   loop $do-continue|0
+    local.get $1
+    i64.load
+    local.get $2
+    i64.load
+    i64.eq
+    if
+     local.get $1
+     i32.const 8
+     i32.add
+     local.set $1
+     local.get $2
+     i32.const 8
+     i32.add
+     local.set $2
+     local.get $3
+     i32.const 4
+     i32.sub
+     local.tee $3
+     i32.const 4
+     i32.ge_u
+     br_if $do-continue|0
+    end
+   end
+  end
+  loop $while-continue|1
+   local.get $3
+   local.tee $0
+   i32.const 1
+   i32.sub
+   local.set $3
+   local.get $0
+   if
+    local.get $1
+    i32.load16_u
+    local.tee $0
+    local.get $2
+    i32.load16_u
+    local.tee $4
+    i32.ne
+    if
+     local.get $0
+     local.get $4
+     i32.sub
+     return
+    end
+    local.get $1
+    i32.const 2
+    i32.add
+    local.set $1
+    local.get $2
+    i32.const 2
+    i32.add
+    local.set $2
+    br $while-continue|1
+   end
+  end
   i32.const 0
+ )
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  local.get $1
+  i32.eq
+  if
+   i32.const 1
+   return
+  end
+  local.get $1
+  i32.eqz
+  i32.const 1
+  local.get $0
+  select
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  local.tee $2
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  i32.ne
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
   i32.const 0
-  f64.const 0
-  call $~lib/bindings/Date/UTC
-  i64.trunc_f64_s
-  i64.eqz
+  local.get $1
+  local.get $2
+  call $~lib/util/string/compareImpl
+  i32.eqz
+ )
+ (func $~lib/string/String#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  local.tee $4
   i32.eqz
   if
    i32.const 0
-   i32.const 1056
+   return
+  end
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  local.tee $3
+  i32.eqz
+  if
+   i32.const -1
+   return
+  end
+  local.get $2
+  i32.const 0
+  local.get $2
+  i32.const 0
+  i32.gt_s
+  select
+  local.tee $2
+  local.get $3
+  local.get $2
+  local.get $3
+  i32.lt_s
+  select
+  local.set $2
+  local.get $3
+  local.get $4
+  i32.sub
+  local.set $3
+  loop $for-loop|0
+   local.get $2
+   local.get $3
+   i32.le_s
+   if
+    local.get $0
+    local.get $2
+    local.get $1
+    local.get $4
+    call $~lib/util/string/compareImpl
+    i32.eqz
+    if
+     local.get $2
+     return
+    end
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
+    br $for-loop|0
+   end
+  end
+  i32.const -1
+ )
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.eqz
+  if
+   return
+  end
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1168
+   i32.const 294
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/white
+  local.get $1
+  i32.const 20
+  i32.sub
+  local.tee $1
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.eq
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   local.tee $0
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   local.tee $3
+   local.set $4
+   local.get $3
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $2
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   else
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    i32.const 0
+    local.get $4
+    i32.const 3
+    i32.eq
+    select
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
+ (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  local.get $0
+  i32.load offset=12
+  local.tee $10
+  i32.const 1
+  i32.add
+  local.tee $6
+  local.set $3
+  local.get $6
+  local.get $0
+  i32.load offset=8
+  local.tee $7
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $3
+   i32.const 268435455
+   i32.gt_u
+   if
+    i32.const 2448
+    i32.const 2496
+    i32.const 14
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   i32.load
+   local.tee $8
+   local.set $2
+   block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $3
+    i32.const 2
+    i32.shl
+    local.tee $9
+    local.tee $4
+    local.get $8
+    i32.const 20
+    i32.sub
+    local.tee $5
+    i32.load
+    i32.const -4
+    i32.and
+    i32.const 16
+    i32.sub
+    i32.le_u
+    if
+     local.get $5
+     local.get $4
+     i32.store offset=16
+     br $__inlined_func$~lib/rt/itcms/__renew
+    end
+    local.get $4
+    local.get $5
+    i32.load offset=12
+    call $~lib/rt/itcms/__new
+    local.tee $3
+    local.get $2
+    local.get $4
+    local.get $5
+    i32.load offset=16
+    local.tee $2
+    local.get $2
+    local.get $4
+    i32.gt_u
+    select
+    call $~lib/memory/memory.copy
+    local.get $3
+    local.set $2
+   end
+   local.get $2
+   local.get $7
+   i32.add
+   local.get $9
+   local.get $7
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $2
+   local.get $8
+   i32.ne
+   if
+    local.get $0
+    local.get $2
+    i32.store
+    local.get $0
+    local.get $2
+    i32.store offset=4
+    local.get $0
+    local.get $2
+    i32.const 0
+    call $~lib/rt/itcms/__link
+   end
+   local.get $0
+   local.get $9
+   i32.store offset=8
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $10
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $1
+  i32.const 1
+  call $~lib/rt/itcms/__link
+  local.get $0
+  local.get $6
+  i32.store offset=12
+ )
+ (func $~lib/util/string/strtol<i32> (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  local.tee $2
+  i32.eqz
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  i32.load16_u
+  local.set $1
+  loop $while-continue|0
+   block $__inlined_func$~lib/util/string/isSpace (result i32)
+    local.get $1
+    i32.const 128
+    i32.or
+    i32.const 160
+    i32.eq
+    local.get $1
+    i32.const 9
+    i32.sub
+    i32.const 4
+    i32.le_u
+    i32.or
+    local.get $1
+    i32.const 5760
+    i32.lt_u
+    br_if $__inlined_func$~lib/util/string/isSpace
+    drop
+    i32.const 1
+    local.get $1
+    i32.const -8192
+    i32.add
+    i32.const 10
+    i32.le_u
+    br_if $__inlined_func$~lib/util/string/isSpace
+    drop
+    i32.const 1
+    local.get $1
+    i32.const 5760
+    i32.eq
+    local.get $1
+    i32.const 8232
+    i32.eq
+    i32.or
+    local.get $1
+    i32.const 8233
+    i32.eq
+    local.get $1
+    i32.const 8239
+    i32.eq
+    i32.or
+    i32.or
+    local.get $1
+    i32.const 8287
+    i32.eq
+    local.get $1
+    i32.const 12288
+    i32.eq
+    i32.or
+    local.get $1
+    i32.const 65279
+    i32.eq
+    i32.or
+    i32.or
+    br_if $__inlined_func$~lib/util/string/isSpace
+    drop
+    i32.const 0
+   end
+   if
+    local.get $0
+    i32.const 2
+    i32.add
+    local.tee $0
+    i32.load16_u
+    local.set $1
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  i32.const 1
+  local.set $3
+  i32.const 1
+  local.get $1
+  i32.const 43
+  i32.eq
+  local.get $1
+  i32.const 45
+  i32.eq
+  select
+  if
+   local.get $2
+   i32.const 1
+   i32.sub
+   local.tee $2
+   i32.eqz
+   if
+    i32.const 0
+    return
+   end
+   i32.const -1
+   i32.const 1
+   local.get $1
+   i32.const 45
+   i32.eq
+   select
+   local.set $3
+   local.get $0
+   i32.const 2
+   i32.add
+   local.tee $0
+   i32.load16_u
+   local.set $1
+  end
+  local.get $2
+  i32.const 2
+  i32.gt_s
+  i32.const 0
+  local.get $1
+  i32.const 48
+  i32.eq
+  select
+  if
+   block $break|1
+    block $case2|1
+     block $case1|1
+      local.get $0
+      i32.load16_u offset=2
+      i32.const 32
+      i32.or
+      local.tee $1
+      i32.const 98
+      i32.ne
+      if
+       local.get $1
+       i32.const 111
+       i32.eq
+       br_if $case1|1
+       local.get $1
+       i32.const 120
+       i32.eq
+       br_if $case2|1
+       br $break|1
+      end
+      local.get $0
+      i32.const 4
+      i32.add
+      local.set $0
+      local.get $2
+      i32.const 2
+      i32.sub
+      local.set $2
+      i32.const 2
+      local.set $5
+      br $break|1
+     end
+     local.get $0
+     i32.const 4
+     i32.add
+     local.set $0
+     local.get $2
+     i32.const 2
+     i32.sub
+     local.set $2
+     i32.const 8
+     local.set $5
+     br $break|1
+    end
+    local.get $0
+    i32.const 4
+    i32.add
+    local.set $0
+    local.get $2
+    i32.const 2
+    i32.sub
+    local.set $2
+    i32.const 16
+    local.set $5
+   end
+  end
+  local.get $5
+  i32.const 10
+  local.get $5
+  select
+  local.set $5
+  loop $while-continue|2
+   block $while-break|2
+    local.get $2
+    local.tee $1
+    i32.const 1
+    i32.sub
+    local.set $2
+    local.get $1
+    if
+     local.get $5
+     local.get $0
+     i32.load16_u
+     local.tee $1
+     i32.const 48
+     i32.sub
+     i32.const 10
+     i32.lt_u
+     if (result i32)
+      local.get $1
+      i32.const 48
+      i32.sub
+     else
+      local.get $1
+      i32.const 55
+      i32.sub
+      local.get $1
+      i32.const 87
+      i32.sub
+      local.get $1
+      local.get $1
+      i32.const 97
+      i32.sub
+      i32.const 25
+      i32.le_u
+      select
+      local.get $1
+      i32.const 65
+      i32.sub
+      i32.const 25
+      i32.le_u
+      select
+     end
+     local.tee $1
+     i32.le_u
+     if
+      local.get $4
+      i32.eqz
+      if
+       i32.const 0
+       return
+      end
+      br $while-break|2
+     end
+     local.get $1
+     local.get $4
+     local.get $5
+     i32.mul
+     i32.add
+     local.set $4
+     local.get $0
+     i32.const 2
+     i32.add
+     local.set $0
+     br $while-continue|2
+    end
+   end
+  end
+  local.get $3
+  local.get $4
+  i32.mul
+ )
+ (func $~lib/rt/__visit_members (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  block $invalid
+   block $~lib/array/Array<i32>
+    block $~lib/array/Array<~lib/string/String>
+     block $~lib/date/Date
+      block $~lib/arraybuffer/ArrayBufferView
+       block $~lib/string/String
+        block $~lib/arraybuffer/ArrayBuffer
+         local.get $0
+         i32.const 8
+         i32.sub
+         i32.load
+         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $~lib/array/Array<~lib/string/String> $~lib/array/Array<i32> $invalid
+        end
+        return
+       end
+       return
+      end
+      local.get $0
+      i32.load
+      local.tee $0
+      if
+       local.get $0
+       call $~lib/rt/itcms/__visit
+      end
+      return
+     end
+     return
+    end
+    local.get $0
+    i32.load offset=4
+    local.tee $1
+    local.get $0
+    i32.load offset=12
+    i32.const 2
+    i32.shl
+    i32.add
+    local.set $2
+    loop $while-continue|0
+     local.get $1
+     local.get $2
+     i32.lt_u
+     if
+      local.get $1
+      i32.load
+      local.tee $3
+      if
+       local.get $3
+       call $~lib/rt/itcms/__visit
+      end
+      local.get $1
+      i32.const 4
+      i32.add
+      local.set $1
+      br $while-continue|0
+     end
+    end
+    local.get $0
+    i32.load
+    call $~lib/rt/itcms/__visit
+    return
+   end
+   local.get $0
+   i32.load
+   call $~lib/rt/itcms/__visit
+   return
+  end
+  unreachable
+ )
+ (func $~start
+  global.get $~started
+  if
+   return
+  end
+  i32.const 1
+  global.set $~started
+  call $start:std/date
+ )
+ (func $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3156
+  i32.lt_s
+  if
+   i32.const 19568
+   i32.const 19616
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1970
+ )
+ (func $~lib/date/Date#toISOString (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 112
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=16
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=24
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=32
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=40
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=48
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=56
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=64
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=72
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=80
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=88
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=96
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=104
+  local.get $0
+  i64.load
+  i64.const 86400000
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  global.get $~lib/memory/__stack_pointer
+  global.get $~lib/date/year
+  call $~lib/number/I32#toString
+  local.tee $1
+  i32.store
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  i32.const 4
+  i32.gt_u
+  if
+   global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1936
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1808
+   i32.store offset=12
+   local.get $1
+   i32.const 6
+   call $~lib/string/String#padStart
+   local.set $1
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store offset=8
+   i32.const 1936
+   local.get $1
+   call $~lib/string/String.__concat
+   local.tee $1
+   i32.store
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2000
+  i32.store offset=100
+  local.get $1
+  i32.const 2000
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=92
+  global.get $~lib/date/month
+  call $~lib/number/I32#toString
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=104
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1808
+  i32.store offset=108
+  local.get $2
+  i32.const 2
+  call $~lib/string/String#padStart
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=96
+  local.get $1
+  local.get $2
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=84
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2000
+  i32.store offset=88
+  local.get $1
+  i32.const 2000
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=76
+  global.get $~lib/date/day
+  call $~lib/number/I32#toString
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=84
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1808
+  i32.store offset=92
+  local.get $2
+  i32.const 2
+  call $~lib/string/String#padStart
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=80
+  local.get $1
+  local.get $2
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=68
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2032
+  i32.store offset=72
+  local.get $1
+  i32.const 2032
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=60
+  local.get $0
+  call $~lib/date/Date#getUTCHours
+  call $~lib/number/I32#toString
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=68
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1808
+  i32.store offset=76
+  local.get $2
+  i32.const 2
+  call $~lib/string/String#padStart
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=64
+  local.get $1
+  local.get $2
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=52
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2064
+  i32.store offset=56
+  local.get $1
+  i32.const 2064
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=44
+  local.get $0
+  call $~lib/date/Date#getUTCMinutes
+  call $~lib/number/I32#toString
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=52
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1808
+  i32.store offset=60
+  local.get $2
+  i32.const 2
+  call $~lib/string/String#padStart
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=48
+  local.get $1
+  local.get $2
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=36
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2064
+  i32.store offset=40
+  local.get $1
+  i32.const 2064
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=28
+  local.get $0
+  call $~lib/date/Date#getUTCSeconds
+  call $~lib/number/I32#toString
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=36
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1808
+  i32.store offset=44
+  local.get $2
+  i32.const 2
+  call $~lib/string/String#padStart
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=32
+  local.get $1
+  local.get $2
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=12
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2096
+  i32.store offset=24
+  local.get $1
+  i32.const 2096
+  call $~lib/string/String.__concat
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=16
+  local.get $0
+  i64.load
+  i64.const 1000
+  i64.rem_s
+  i32.wrap_i64
+  call $~lib/number/I32#toString
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=12
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1808
+  i32.store offset=28
+  local.get $0
+  i32.const 3
+  call $~lib/string/String#padStart
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=20
+  local.get $1
+  local.get $0
+  call $~lib/string/String.__concat
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2128
+  i32.store offset=8
+  local.get $0
+  i32.const 2128
+  call $~lib/string/String.__concat
+  global.get $~lib/memory/__stack_pointer
+  i32.const 112
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/string/String#split (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 24
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=16
+  block $folding-inner2
+   block $folding-inner1
+    local.get $1
+    i32.eqz
+    if
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1
+     call $~lib/rt/__newArray
+     local.tee $1
+     i32.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.load offset=4
+     i32.store offset=4
+     local.get $1
+     i32.load offset=4
+     local.get $0
+     i32.store
+     local.get $1
+     local.get $0
+     i32.const 1
+     call $~lib/rt/itcms/__link
+     local.get $1
+     local.set $0
+     br $folding-inner1
+    end
+    local.get $0
+    i32.const 20
+    i32.sub
+    i32.load offset=16
+    i32.const 1
+    i32.shr_u
+    local.set $4
+    local.get $1
+    i32.const 20
+    i32.sub
+    i32.load offset=16
+    i32.const 1
+    i32.shr_u
+    local.tee $5
+    local.set $7
+    block $folding-inner0
+     local.get $5
+     if
+      local.get $4
+      i32.eqz
+      if
+       global.get $~lib/memory/__stack_pointer
+       i32.const 1
+       call $~lib/rt/__newArray
+       local.tee $0
+       i32.store offset=4
+       local.get $0
+       i32.load offset=4
+       i32.const 1968
+       i32.store
+       br $folding-inner1
+      end
+     else
+      local.get $4
+      i32.eqz
+      br_if $folding-inner0
+      global.get $~lib/memory/__stack_pointer
+      local.get $4
+      i32.const 2147483647
+      local.get $4
+      i32.const 2147483647
+      i32.ne
+      select
+      local.tee $4
+      call $~lib/rt/__newArray
+      local.tee $1
+      i32.store
+      local.get $1
+      i32.load offset=4
+      local.set $5
+      loop $for-loop|0
+       local.get $2
+       local.get $4
+       i32.lt_s
+       if
+        global.get $~lib/memory/__stack_pointer
+        i32.const 2
+        i32.const 1
+        call $~lib/rt/itcms/__new
+        local.tee $3
+        i32.store offset=8
+        local.get $3
+        local.get $0
+        local.get $2
+        i32.const 1
+        i32.shl
+        i32.add
+        i32.load16_u
+        i32.store16
+        local.get $5
+        local.get $2
+        i32.const 2
+        i32.shl
+        i32.add
+        local.get $3
+        i32.store
+        local.get $1
+        local.get $3
+        i32.const 1
+        call $~lib/rt/itcms/__link
+        local.get $2
+        i32.const 1
+        i32.add
+        local.set $2
+        br $for-loop|0
+       end
+      end
+      global.get $~lib/memory/__stack_pointer
+      i32.const 24
+      i32.add
+      global.set $~lib/memory/__stack_pointer
+      local.get $1
+      return
+     end
+     global.get $~lib/memory/__stack_pointer
+     i32.const 0
+     call $~lib/rt/__newArray
+     local.tee $2
+     i32.store offset=12
+     loop $while-continue|1
+      local.get $0
+      local.get $1
+      local.get $3
+      call $~lib/string/String#indexOf
+      local.tee $5
+      i32.const -1
+      i32.xor
+      if
+       local.get $5
+       local.get $3
+       i32.sub
+       local.tee $6
+       i32.const 0
+       i32.gt_s
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $6
+        i32.const 1
+        i32.shl
+        local.tee $8
+        i32.const 1
+        call $~lib/rt/itcms/__new
+        local.tee $6
+        i32.store offset=16
+        local.get $6
+        local.get $0
+        local.get $3
+        i32.const 1
+        i32.shl
+        i32.add
+        local.get $8
+        call $~lib/memory/memory.copy
+        local.get $2
+        local.get $6
+        call $~lib/array/Array<~lib/string/String>#push
+       else
+        global.get $~lib/memory/__stack_pointer
+        i32.const 1968
+        i32.store offset=20
+        local.get $2
+        i32.const 1968
+        call $~lib/array/Array<~lib/string/String>#push
+       end
+       local.get $9
+       i32.const 1
+       i32.add
+       local.tee $9
+       i32.const 2147483647
+       i32.eq
+       br_if $folding-inner2
+       local.get $5
+       local.get $7
+       i32.add
+       local.set $3
+       br $while-continue|1
+      end
+     end
+     local.get $3
+     i32.eqz
+     if
+      local.get $2
+      local.get $0
+      call $~lib/array/Array<~lib/string/String>#push
+      br $folding-inner2
+     end
+     local.get $4
+     local.get $3
+     i32.sub
+     local.tee $1
+     i32.const 0
+     i32.gt_s
+     if
+      global.get $~lib/memory/__stack_pointer
+      local.get $1
+      i32.const 1
+      i32.shl
+      local.tee $4
+      i32.const 1
+      call $~lib/rt/itcms/__new
+      local.tee $1
+      i32.store offset=4
+      local.get $1
+      local.get $0
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      local.get $4
+      call $~lib/memory/memory.copy
+      local.get $2
+      local.get $1
+      call $~lib/array/Array<~lib/string/String>#push
+     else
+      global.get $~lib/memory/__stack_pointer
+      i32.const 1968
+      i32.store offset=20
+      local.get $2
+      i32.const 1968
+      call $~lib/array/Array<~lib/string/String>#push
+     end
+     global.get $~lib/memory/__stack_pointer
+     i32.const 24
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $2
+     return
+    end
+    i32.const 0
+    call $~lib/rt/__newArray
+    local.set $0
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 24
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   return
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 24
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
+ (func $~lib/date/Date.fromString (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 32
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=16
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=24
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2032
+  i32.store
+  local.get $0
+  i32.const 2032
   i32.const 0
+  call $~lib/string/String#indexOf
+  i32.const -1
+  i32.ne
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2032
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.const 2032
+   call $~lib/string/String#split
+   local.tee $1
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.const 1
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.tee $0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2064
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.const 2064
+   call $~lib/string/String#split
+   local.tee $0
+   i32.store offset=12
+   local.get $0
+   i32.const 0
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=16
+   local.get $2
+   call $~lib/util/string/strtol<i32>
+   local.set $3
+   local.get $0
+   i32.const 1
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=16
+   local.get $2
+   call $~lib/util/string/strtol<i32>
+   local.set $4
+   local.get $0
+   i32.const 2
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=16
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2096
+   i32.store
+   local.get $2
+   i32.const 2096
+   i32.const 0
+   call $~lib/string/String#indexOf
+   i32.const -1
+   i32.ne
+   if
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.const 2
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store offset=16
+    global.get $~lib/memory/__stack_pointer
+    i32.const 2096
+    i32.store
+    local.get $0
+    i32.const 2096
+    call $~lib/string/String#split
+    local.tee $0
+    i32.store offset=20
+    local.get $0
+    i32.const 0
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $2
+    global.get $~lib/memory/__stack_pointer
+    local.get $2
+    i32.store offset=16
+    local.get $2
+    call $~lib/util/string/strtol<i32>
+    local.set $2
+    local.get $0
+    i32.const 1
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store offset=16
+    local.get $0
+    call $~lib/util/string/strtol<i32>
+    local.set $5
+   else
+    local.get $0
+    i32.const 2
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store offset=16
+    local.get $0
+    call $~lib/util/string/strtol<i32>
+    local.set $2
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.const 0
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.tee $0
+   i32.store offset=24
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2000
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.const 2000
+  call $~lib/string/String#split
+  local.tee $0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#__get
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  i32.const 2
+  i32.eq
+  if (result i32)
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2672
+   i32.store
+   local.get $0
+   i32.const 0
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.set $1
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store offset=28
+   i32.const 2672
+   local.get $1
+   call $~lib/string/String.__concat
+  else
+   local.get $0
+   i32.const 0
+   call $~lib/array/Array<~lib/string/String>#__get
+  end
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=16
+  local.get $1
+  call $~lib/util/string/strtol<i32>
+  local.get $0
+  i32.const 1
+  call $~lib/array/Array<~lib/string/String>#__get
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=16
+  local.get $1
+  call $~lib/util/string/strtol<i32>
+  local.get $0
+  i32.const 2
+  call $~lib/array/Array<~lib/string/String>#__get
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=16
+  local.get $0
+  call $~lib/util/string/strtol<i32>
+  local.get $3
+  local.get $4
+  local.get $2
+  local.get $5
+  call $~lib/date/epochMillis
+  call $~lib/date/Date#constructor
+  global.get $~lib/memory/__stack_pointer
+  i32.const 32
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $start:std/date
+  (local $0 i32)
+  (local $1 i64)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=8
+  i32.const 1970
+  i32.const 1
   i32.const 1
   i32.const 0
   i32.const 0
   i32.const 0
-  f64.const 0
-  call $~lib/bindings/Date/UTC
-  i64.trunc_f64_s
+  i32.const 0
+  call $~lib/date/epochMillis
   i64.eqz
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2
-   i32.const 1
+   i32.const 3
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1970
+  i32.const 1
+  i32.const 1
+  i32.const 0
+  i32.const 0
+  i32.const 0
+  i32.const 0
+  call $~lib/date/epochMillis
+  i64.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 2018
-  i32.const 10
+  i32.const 11
   i32.const 10
   i32.const 11
   i32.const 0
   i32.const 0
-  f64.const 1
-  call $~lib/bindings/Date/UTC
-  i64.trunc_f64_s
-  global.set $std/date/creationTime
-  global.get $std/date/creationTime
+  i32.const 1
+  call $~lib/date/epochMillis
   i64.const 1541847600001
   i64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 5
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  call $~lib/bindings/Date/now
-  i64.trunc_f64_s
-  global.get $std/date/creationTime
-  i64.le_s
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 7
-   i32.const 1
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   memory.size
   i32.const 16
   i32.shl
-  i32.const 17908
+  i32.const 19540
   i32.sub
   i32.const 1
   i32.shr_u
@@ -1576,8 +4198,865 @@
   i32.const 1392
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/fromSpace
-  global.get $std/date/creationTime
-  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i64.const 1541847600001
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  i64.load
+  i64.const 1541847600001
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 15
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i64.const 1541847600002
+  i64.store
+  local.get $0
+  i64.load
+  i64.const 1541847600002
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 17
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 5918283958183706
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 189512
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 25
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCMonth
+  i32.const 11
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 26
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCDate
+  i32.const 14
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 27
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCHours
+  i32.const 22
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 28
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 29
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 43
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 30
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i64.load
+  i64.const 1000
+  i64.rem_s
+  i32.wrap_i64
+  i32.const 706
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 31
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 123814991274
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 1973
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 37
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCMonth
+  i32.const 11
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 38
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCDate
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 39
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCHours
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 40
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 41
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 11
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 42
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i64.load
+  i64.const 1000
+  i64.rem_s
+  i32.wrap_i64
+  i32.const 274
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 43
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 399464523963984
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  i64.load
+  i64.const 1000
+  i64.rem_s
+  i32.wrap_i64
+  i32.const 984
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 49
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 12
+  call $~lib/date/Date#setUTCMilliseconds
+  local.get $0
+  i64.load
+  i64.const 1000
+  i64.rem_s
+  i32.wrap_i64
+  i32.const 12
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 51
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 568
+  call $~lib/date/Date#setUTCMilliseconds
+  local.get $0
+  i64.load
+  i64.const 1000
+  i64.rem_s
+  i32.wrap_i64
+  i32.const 568
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 53
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/date/Date#setUTCMilliseconds
+  local.get $0
+  i32.const 999
+  call $~lib/date/Date#setUTCMilliseconds
+  global.get $~lib/memory/__stack_pointer
+  i64.const 372027318331986
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 31
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 62
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 12
+  call $~lib/date/Date#setUTCSeconds
+  local.get $0
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 12
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 64
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 50
+  call $~lib/date/Date#setUTCSeconds
+  local.get $0
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 66
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/date/Date#setUTCSeconds
+  local.get $0
+  i32.const 59
+  call $~lib/date/Date#setUTCSeconds
+  global.get $~lib/memory/__stack_pointer
+  i64.const 372027318331986
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 45
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 75
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 12
+  call $~lib/date/Date#setUTCMinutes
+  local.get $0
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 12
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 77
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 50
+  call $~lib/date/Date#setUTCMinutes
+  local.get $0
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 79
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/date/Date#setUTCMinutes
+  local.get $0
+  i32.const 59
+  call $~lib/date/Date#setUTCMinutes
+  global.get $~lib/memory/__stack_pointer
+  i64.const 372027318331986
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#getUTCHours
+  i32.const 17
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 88
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 12
+  call $~lib/date/Date#setUTCHours
+  local.get $0
+  call $~lib/date/Date#getUTCHours
+  i32.const 12
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 90
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 2
+  call $~lib/date/Date#setUTCHours
+  local.get $0
+  call $~lib/date/Date#getUTCHours
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 92
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/date/Date#setUTCHours
+  local.get $0
+  i32.const 23
+  call $~lib/date/Date#setUTCHours
+  global.get $~lib/memory/__stack_pointer
+  i64.const 123814991274
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 1973
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 101
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/date/Date#getUTCMonth
+  i32.const 11
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 102
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 12
+  call $~lib/date/Date#setUTCDate
+  local.get $0
+  call $~lib/date/Date#getUTCDate
+  i32.const 12
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 106
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 2
+  call $~lib/date/Date#setUTCDate
+  local.get $0
+  call $~lib/date/Date#getUTCDate
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 108
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 1
+  call $~lib/date/Date#setUTCDate
+  local.get $0
+  i32.const 30
+  call $~lib/date/Date#setUTCDate
+  local.get $0
+  i32.const 1
+  call $~lib/date/Date#setUTCMonth
+  local.get $0
+  i32.const 1
+  call $~lib/date/Date#setUTCDate
+  local.get $0
+  i32.const 31
+  call $~lib/date/Date#setUTCDate
+  local.get $0
+  i32.const 2024
+  call $~lib/date/Date#setUTCFullYear
+  local.get $0
+  i32.const 2
+  call $~lib/date/Date#setUTCMonth
+  local.get $0
+  i32.const 1
+  call $~lib/date/Date#setUTCDate
+  local.get $0
+  i32.const 29
+  call $~lib/date/Date#setUTCDate
+  global.get $~lib/memory/__stack_pointer
+  i64.const 7899943856218720
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#getUTCMonth
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 130
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 10
+  call $~lib/date/Date#setUTCMonth
+  local.get $0
+  call $~lib/date/Date#getUTCMonth
+  i32.const 10
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 132
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 2
+  call $~lib/date/Date#setUTCMonth
+  local.get $0
+  call $~lib/date/Date#getUTCMonth
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 134
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 1
+  call $~lib/date/Date#setUTCMonth
+  local.get $0
+  i32.const 12
+  call $~lib/date/Date#setUTCMonth
+  global.get $~lib/memory/__stack_pointer
+  i64.const 7941202527925698
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 253616
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 143
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 1976
+  call $~lib/date/Date#setUTCFullYear
+  local.get $0
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 1976
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 145
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 20212
+  call $~lib/date/Date#setUTCFullYear
+  local.get $0
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 20212
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 147
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 1231231231020
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#toISOString
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2160
+  i32.store offset=8
+  local.get $0
+  i32.const 2160
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 153
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 1231231231456
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#toISOString
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2240
+  i32.store offset=8
+  local.get $0
+  i32.const 2240
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 155
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i64.const 322331231231020
+  call $~lib/date/Date#constructor
+  local.tee $0
+  i32.store
+  local.get $0
+  call $~lib/date/Date#toISOString
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2320
+  i32.store offset=8
+  local.get $0
+  i32.const 2320
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 157
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2400
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2400
+  call $~lib/date/Date.fromString
+  local.tee $0
+  i32.store
+  local.get $0
+  i64.load
+  i64.const 192067200000
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 164
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2704
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2704
+  call $~lib/date/Date.fromString
+  local.tee $0
+  i32.store
+  local.get $0
+  i64.load
+  i64.const 192067200000
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 166
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2752
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2752
+  call $~lib/date/Date.fromString
+  local.tee $0
+  i32.store
+  local.get $0
+  i64.load
+  i64.const 11860387200000
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 168
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2800
+  i32.store offset=8
+  i32.const 2800
+  call $~lib/date/Date.fromString
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  local.get $0
+  i64.load
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2848
+  i32.store offset=8
+  i32.const 2848
+  call $~lib/date/Date.fromString
+  local.set $0
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  local.get $0
+  i64.load
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 171
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2896
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2896
+  call $~lib/date/Date.fromString
+  local.tee $0
+  i32.store
+  local.get $0
+  i64.load
+  i64.const 192112496000
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 178
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2960
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2960
+  call $~lib/date/Date.fromString
+  local.tee $0
+  i32.store
+  local.get $0
+  i64.load
+  i64.const 192112496456
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 182
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3040
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3040
+  call $~lib/date/Date.fromString
+  local.tee $0
+  i32.store
+  local.get $0
+  i64.load
+  i64.const 192112496456
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 186
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/date/Date#constructor (param $0 i64) (result i32)
+  (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -1587,61 +5066,220 @@
   i32.const 0
   i32.store
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.const 3
   call $~lib/rt/itcms/__new
-  local.tee $0
+  local.tee $1
   i32.store
-  local.get $0
+  local.get $1
   i64.const 0
   i64.store
-  local.get $0
   local.get $1
+  local.get $0
   i64.store
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $0
-  global.set $std/date/date
+  local.get $1
+ )
+ (func $~lib/string/String#padStart (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   global.get $~lib/memory/__stack_pointer
-  global.get $std/date/date
-  local.tee $0
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
   i32.store
-  global.get $std/date/creationTime
+  i32.const 1
+  i32.const 1804
+  i32.load
+  i32.const 1
+  i32.shr_u
+  i32.const 1
+  i32.shl
+  local.tee $3
+  i32.eqz
   local.get $0
-  i64.load
-  i64.ne
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+  i32.const 1
+  i32.shl
+  local.tee $5
+  local.get $1
+  i32.const 1
+  i32.shl
+  local.tee $2
+  i32.gt_u
+  select
   if
-   i32.const 0
-   i32.const 1056
-   i32.const 10
-   i32.const 1
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   return
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.const 1
+  call $~lib/rt/itcms/__new
+  local.tee $1
+  i32.store
+  local.get $3
+  local.get $2
+  local.get $5
+  i32.sub
+  local.tee $2
+  i32.lt_u
+  if
+   local.get $3
+   local.get $2
+   i32.const 2
+   i32.sub
+   local.get $3
+   i32.div_u
+   i32.mul
+   local.tee $6
+   local.set $7
+   loop $while-continue|0
+    local.get $4
+    local.get $7
+    i32.lt_u
+    if
+     local.get $1
+     local.get $4
+     i32.add
+     i32.const 1808
+     local.get $3
+     call $~lib/memory/memory.copy
+     local.get $3
+     local.get $4
+     i32.add
+     local.set $4
+     br $while-continue|0
+    end
+   end
+   local.get $1
+   local.get $6
+   i32.add
+   i32.const 1808
+   local.get $2
+   local.get $6
+   i32.sub
+   call $~lib/memory/memory.copy
+  else
+   local.get $1
+   i32.const 1808
+   local.get $2
+   call $~lib/memory/memory.copy
+  end
+  local.get $1
+  local.get $2
+  i32.add
+  local.get $0
+  local.get $5
+  call $~lib/memory/memory.copy
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $~lib/rt/__newArray (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.const 2
+  i32.shl
+  local.tee $3
+  i32.const 0
+  call $~lib/rt/itcms/__new
+  local.tee $2
+  i32.store
+  i32.const 16
+  i32.const 4
+  call $~lib/rt/itcms/__new
+  local.tee $1
+  local.get $2
+  i32.store
+  local.get $1
+  local.get $2
+  i32.const 0
+  call $~lib/rt/itcms/__link
+  local.get $1
+  local.get $2
+  i32.store offset=4
+  local.get $1
+  local.get $3
+  i32.store offset=8
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 1296
+   i32.const 2496
+   i32.const 92
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  global.get $std/date/date
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
   local.tee $0
   i32.store
   local.get $0
-  global.get $std/date/creationTime
-  i64.const 1
-  i64.add
-  i64.store
-  global.get $~lib/memory/__stack_pointer
-  global.get $std/date/date
-  local.tee $0
-  i32.store
-  local.get $0
-  i64.load
-  global.get $std/date/creationTime
-  i64.const 1
-  i64.add
-  i64.ne
+  i32.eqz
   if
-   i32.const 0
-   i32.const 1056
-   i32.const 12
-   i32.const 1
+   i32.const 2544
+   i32.const 2496
+   i32.const 96
+   i32.const 40
    call $~lib/builtins/abort
    unreachable
   end
@@ -1649,5 +5287,6 @@
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
+  local.get $0
  )
 )

--- a/tests/compiler/std/date.ts
+++ b/tests/compiler/std/date.ts
@@ -1,185 +1,187 @@
 // Date UTC /////////////////////////////////////////////////////////////////////////////////
 {
-    assert(Date.UTC(1970, 0, 1) == 0);
-    assert(Date.UTC(1970, 0, 1, 0, 0, 0, 0) == 0);
+  assert(Date.UTC(1970, 0, 1) == 0);
+  assert(Date.UTC(1970, 0, 1, 0, 0, 0, 0) == 0);
 
-    let creationTime = Date.UTC(2018, 10, 10, 11, 0, 0, 1);
-    assert(creationTime == 1541847600001);
+  let creationTime = Date.UTC(2018, 10, 10, 11, 0, 0, 1);
+  assert(creationTime == 1541847600001);
 }
 
 // Date get / set Time /////////////////////////////////////////////////////////////////////////////////
 
 {
-    let creationTime = 1541847600001;
-    let date = new Date(creationTime);
-    assert(date.getTime() == creationTime);
-    date.setTime(creationTime + 1);
-    assert(date.getTime() == creationTime + 1);
+  let creationTime = 1541847600001;
+  let date = new Date(creationTime);
+  assert(date.getTime() == creationTime);
+  date.setTime(creationTime + 1);
+  assert(date.getTime() == creationTime + 1);
 }
 
-  
 // Date getters /////////////////////////////////////////////////////////////////////////////////
 
 {
-    // from +189512-12-14T22:09:43.706Z"
-    let date = new Date(5918283958183706);
-    assert(date.getUTCFullYear() == 189512);
-    assert(date.getUTCMonth() == 11);
-    assert(date.getUTCDate() == 14);
-    assert(date.getUTCHours() == 22);
-    assert(date.getUTCMinutes() == 9);
-    assert(date.getUTCSeconds() == 43);
-    assert(date.getUTCMilliseconds() == 706);
+  // from +189512-12-14T22:09:43.706Z"
+  let date = new Date(5918283958183706);
+  assert(date.getUTCFullYear() == 189512);
+  assert(date.getUTCMonth() == 11);
+  assert(date.getUTCDate() == 14);
+  assert(date.getUTCHours() == 22);
+  assert(date.getUTCMinutes() == 9);
+  assert(date.getUTCSeconds() == 43);
+  assert(date.getUTCMilliseconds() == 706);
 }
 
 {
-    // from 1973-12-04T01:03:11.274Z"
-    let date = new Date(123814991274);
-    assert(date.getUTCFullYear() == 1973);
-    assert(date.getUTCMonth() == 11);
-    assert(date.getUTCDate() == 4);
-    assert(date.getUTCHours() == 1);
-    assert(date.getUTCMinutes() == 3);
-    assert(date.getUTCSeconds() == 11);
-    assert(date.getUTCMilliseconds() == 274);
+  // from 1973-12-04T01:03:11.274Z"
+  let date = new Date(123814991274);
+  assert(date.getUTCFullYear() == 1973);
+  assert(date.getUTCMonth() == 11);
+  assert(date.getUTCDate() == 4);
+  assert(date.getUTCHours() == 1);
+  assert(date.getUTCMinutes() == 3);
+  assert(date.getUTCSeconds() == 11);
+  assert(date.getUTCMilliseconds() == 274);
 }
 
 // Date#setUTCMilliseconds /////////////////////////////////////////////////////////////////////////////////
 {
-    let date = new Date(399464523963984);
-    assert(date.getUTCMilliseconds() == 984);
-    date.setUTCMilliseconds(12);
-    assert(date.getUTCMilliseconds() == 12);
-    date.setUTCMilliseconds(568);
-    assert(date.getUTCMilliseconds() == 568);
-    // test boundaries
-    date.setUTCMilliseconds(0);
-    date.setUTCMilliseconds(999);
+  let date = new Date(399464523963984);
+  assert(date.getUTCMilliseconds() == 984);
+  date.setUTCMilliseconds(12);
+  assert(date.getUTCMilliseconds() == 12);
+  date.setUTCMilliseconds(568);
+  assert(date.getUTCMilliseconds() == 568);
+  // test boundaries
+  date.setUTCMilliseconds(0);
+  date.setUTCMilliseconds(999);
 }
 
 // Date#setUTCSeconds /////////////////////////////////////////////////////////////////////////////////
 {
-    let date = new Date(372027318331986);
-    assert(date.getUTCSeconds() == 31);
-    date.setUTCSeconds(12);
-    assert(date.getUTCSeconds() == 12);
-    date.setUTCSeconds(50);
-    assert(date.getUTCSeconds() == 50);
-    // test boundaries
-    date.setUTCSeconds(0);
-    date.setUTCSeconds(59);
+  let date = new Date(372027318331986);
+  assert(date.getUTCSeconds() == 31);
+  date.setUTCSeconds(12);
+  assert(date.getUTCSeconds() == 12);
+  date.setUTCSeconds(50);
+  assert(date.getUTCSeconds() == 50);
+  // test boundaries
+  date.setUTCSeconds(0);
+  date.setUTCSeconds(59);
 }
 
 // Date#setUTCMinutes /////////////////////////////////////////////////////////////////////////////////
 {
-    let date = new Date(372027318331986);
-    assert(date.getUTCMinutes() == 45);
-    date.setUTCMinutes(12);
-    assert(date.getUTCMinutes() == 12);
-    date.setUTCMinutes(50);
-    assert(date.getUTCMinutes() == 50);
-    // test boundaries
-    date.setUTCMinutes(0);
-    date.setUTCMinutes(59);
+  let date = new Date(372027318331986);
+  assert(date.getUTCMinutes() == 45);
+  date.setUTCMinutes(12);
+  assert(date.getUTCMinutes() == 12);
+  date.setUTCMinutes(50);
+  assert(date.getUTCMinutes() == 50);
+  // test boundaries
+  date.setUTCMinutes(0);
+  date.setUTCMinutes(59);
 }
 
 // Date#setUTCHours /////////////////////////////////////////////////////////////////////////////////
 {
-    let date = new Date(372027318331986);
-    assert(date.getUTCHours() == 17);
-    date.setUTCHours(12);
-    assert(date.getUTCHours() == 12);
-    date.setUTCHours(2);
-    assert(date.getUTCHours() == 2);
-    // test boundaries
-    date.setUTCHours(0);
-    date.setUTCHours(23);
+  let date = new Date(372027318331986);
+  assert(date.getUTCHours() == 17);
+  date.setUTCHours(12);
+  assert(date.getUTCHours() == 12);
+  date.setUTCHours(2);
+  assert(date.getUTCHours() == 2);
+  // test boundaries
+  date.setUTCHours(0);
+  date.setUTCHours(23);
 }
 
 // Date#setUTCDate /////////////////////////////////////////////////////////////////////////////////
 {
-    let date = new Date(123814991274);
-    assert(date.getUTCFullYear() == 1973);
-    assert(date.getUTCMonth() == 11);
+  let date = new Date(123814991274);
+  assert(date.getUTCFullYear() == 1973);
+  assert(date.getUTCMonth() == 11);
 
-    // test a few values
-    date.setUTCDate(12);
-    assert(date.getUTCDate() == 12);
-    date.setUTCDate(2);
-    assert(date.getUTCDate() == 2);
+  // test a few values
+  date.setUTCDate(12);
+  assert(date.getUTCDate() == 12);
+  date.setUTCDate(2);
+  assert(date.getUTCDate() == 2);
 
-    // test boundaries
-    // nov has 30 days
-    date.setUTCDate(1);
-    date.setUTCDate(30);
+  // test boundaries
+  // nov has 30 days
+  date.setUTCDate(1);
+  date.setUTCDate(30);
 
-    // jan has 31 days
-    date.setUTCMonth(1);
-    date.setUTCDate(1);
-    date.setUTCDate(31);
+  // jan has 31 days
+  date.setUTCMonth(1);
+  date.setUTCDate(1);
+  date.setUTCDate(31);
 
-    // feb on leap year
-    date.setUTCFullYear(2024);
-    date.setUTCMonth(2);
-    date.setUTCDate(1);
-    date.setUTCDate(29);
+  // feb on leap year
+  date.setUTCFullYear(2024);
+  date.setUTCMonth(2);
+  date.setUTCDate(1);
+  date.setUTCDate(29);
 }
 
 // Date#setUTCMonth /////////////////////////////////////////////////////////////////////////////////
 {
-    let date = new Date(7899943856218720);
-    assert(date.getUTCMonth() == 3);
-    date.setUTCMonth(10);
-    assert(date.getUTCMonth() == 10);
-    date.setUTCMonth(2);
-    assert(date.getUTCMonth() == 2);
-    // test boundaries
-    date.setUTCMonth(1);
-    date.setUTCMonth(12);
+  let date = new Date(7899943856218720);
+  assert(date.getUTCMonth() == 3);
+  date.setUTCMonth(10);
+  assert(date.getUTCMonth() == 10);
+  date.setUTCMonth(2);
+  assert(date.getUTCMonth() == 2);
+  // test boundaries
+  date.setUTCMonth(1);
+  date.setUTCMonth(12);
 }
 
 // Date#setUTCFullYear /////////////////////////////////////////////////////////////////////////////////
 {
-    let date = new Date(7941202527925698);
-    assert(date.getUTCFullYear() == 253616);
-    date.setUTCFullYear(1976);
-    assert(date.getUTCFullYear() == 1976);
-    date.setUTCFullYear(20212);
-    assert(date.getUTCFullYear() == 20212);
+  let date = new Date(7941202527925698);
+  assert(date.getUTCFullYear() == 253616);
+  date.setUTCFullYear(1976);
+  assert(date.getUTCFullYear() == 1976);
+  date.setUTCFullYear(20212);
+  assert(date.getUTCFullYear() == 20212);
 }
 
 // Date#toString /////////////////////////////////////////////////////////////////////////////////
 {
-    let date = new Date(1231231231020);
-    assert(date.toISOString() == "2009-01-06T08:40:31.020Z");
-    date = new Date(1231231231456);
-    assert(date.toISOString() == "2009-01-06T08:40:31.456Z");
-    date = new Date(322331231231020)
-    assert(date.toISOString() == "+012184-04-08T13:07:11.020Z");
+  let date = new Date(1231231231020);
+  assert(date.toISOString() == "2009-01-06T08:40:31.020Z");
+  date = new Date(1231231231456);
+  assert(date.toISOString() == "2009-01-06T08:40:31.456Z");
+  date = new Date(322331231231020);
+  assert(date.toISOString() == "+012184-04-08T13:07:11.020Z");
 }
 
 // Date#fromString /////////////////////////////////////////////////////////////////////////////////
 {
-    // supports year / month / day
-    let date = Date.fromString("1976-02-02");
-    assert(date.getTime() == 192067200000);
-    date = Date.fromString("1976-2-2");
-    assert(date.getTime() == 192067200000);
-    date = Date.fromString("2345-11-04");
-    assert(date.getTime() == 11860387200000);
+  // supports year / month / day
+  let date = Date.fromString("1976-02-02");
+  assert(date.getTime() == 192067200000);
+  date = Date.fromString("1976-2-2");
+  assert(date.getTime() == 192067200000);
+  date = Date.fromString("2345-11-04");
+  assert(date.getTime() == 11860387200000);
 
-    // supports two digit years
-    assert(Date.fromString("1976-04-02").getTime() == Date.fromString("76-04-02").getTime());
+  // supports two digit years
+  assert(
+    Date.fromString("1976-04-02").getTime() ==
+      Date.fromString("76-04-02").getTime()
+  );
 
-    // supports year / month / day / hour / minute / second
-    date = Date.fromString("1976-02-02T12:34:56");
-    assert(date.getTime() == 192112496000);
+  // supports year / month / day / hour / minute / second
+  date = Date.fromString("1976-02-02T12:34:56");
+  assert(date.getTime() == 192112496000);
 
-    // supports milliseconds
-    date = Date.fromString("1976-02-02T12:34:56.456");
-    assert(date.getTime() == 192112496456);
+  // supports milliseconds
+  date = Date.fromString("1976-02-02T12:34:56.456");
+  assert(date.getTime() == 192112496456);
 
-    // supports 'Z' suffix
-    date = Date.fromString("1976-02-02T12:34:56.456Z");
-    assert(date.getTime() == 192112496456);
+  // supports 'Z' suffix
+  date = Date.fromString("1976-02-02T12:34:56.456Z");
+  assert(date.getTime() == 192112496456);
 }

--- a/tests/compiler/std/date.ts
+++ b/tests/compiler/std/date.ts
@@ -148,3 +148,38 @@
     assert(date.getUTCFullYear() == 20212);
 }
 
+// Date#toString /////////////////////////////////////////////////////////////////////////////////
+{
+    let date = new Date(1231231231020);
+    assert(date.toISOString() == "2009-01-06T08:40:31.020Z");
+    date = new Date(1231231231456);
+    assert(date.toISOString() == "2009-01-06T08:40:31.456Z");
+    date = new Date(322331231231020)
+    assert(date.toISOString() == "+012184-04-08T13:07:11.020Z");
+}
+
+// Date#fromString /////////////////////////////////////////////////////////////////////////////////
+{
+    // supports year / month / day
+    let date = Date.fromString("1976-02-02");
+    assert(date.getTime() == 192067200000);
+    date = Date.fromString("1976-2-2");
+    assert(date.getTime() == 192067200000);
+    date = Date.fromString("2345-11-04");
+    assert(date.getTime() == 11860387200000);
+
+    // supports two digit years
+    assert(Date.fromString("1976-04-02").getTime() == Date.fromString("76-04-02").getTime());
+
+    // supports year / month / day / hour / minute / second
+    date = Date.fromString("1976-02-02T12:34:56");
+    assert(date.getTime() == 192112496000);
+
+    // supports milliseconds
+    date = Date.fromString("1976-02-02T12:34:56.456");
+    assert(date.getTime() == 192112496456);
+
+    // supports 'Z' suffix
+    date = Date.fromString("1976-02-02T12:34:56.456Z");
+    assert(date.getTime() == 192112496456);
+}

--- a/tests/compiler/std/date.ts
+++ b/tests/compiler/std/date.ts
@@ -1,12 +1,150 @@
-assert(Date.UTC(1970, 0, 1) == 0);
-assert(Date.UTC(1970, 0, 1, 0, 0, 0, 0) == 0);
+// Date UTC /////////////////////////////////////////////////////////////////////////////////
+{
+    assert(Date.UTC(1970, 0, 1) == 0);
+    assert(Date.UTC(1970, 0, 1, 0, 0, 0, 0) == 0);
 
-var creationTime = Date.UTC(2018, 10, 10, 11, 0, 0, 1);
-assert(creationTime == 1541847600001);
+    let creationTime = Date.UTC(2018, 10, 10, 11, 0, 0, 1);
+    assert(creationTime == 1541847600001);
+}
 
-assert(Date.now() > creationTime);
+// Date get / set Time /////////////////////////////////////////////////////////////////////////////////
 
-var date = new Date(creationTime);
-assert(date.getTime() == creationTime);
-date.setTime(creationTime + 1);
-assert(date.getTime() == creationTime + 1);
+{
+    let creationTime = 1541847600001;
+    let date = new Date(creationTime);
+    assert(date.getTime() == creationTime);
+    date.setTime(creationTime + 1);
+    assert(date.getTime() == creationTime + 1);
+}
+
+  
+// Date getters /////////////////////////////////////////////////////////////////////////////////
+
+{
+    // from +189512-12-14T22:09:43.706Z"
+    let date = new Date(5918283958183706);
+    assert(date.getUTCFullYear() == 189512);
+    assert(date.getUTCMonth() == 11);
+    assert(date.getUTCDate() == 14);
+    assert(date.getUTCHours() == 22);
+    assert(date.getUTCMinutes() == 9);
+    assert(date.getUTCSeconds() == 43);
+    assert(date.getUTCMilliseconds() == 706);
+}
+
+{
+    // from 1973-12-04T01:03:11.274Z"
+    let date = new Date(123814991274);
+    assert(date.getUTCFullYear() == 1973);
+    assert(date.getUTCMonth() == 11);
+    assert(date.getUTCDate() == 4);
+    assert(date.getUTCHours() == 1);
+    assert(date.getUTCMinutes() == 3);
+    assert(date.getUTCSeconds() == 11);
+    assert(date.getUTCMilliseconds() == 274);
+}
+
+// Date#setUTCMilliseconds /////////////////////////////////////////////////////////////////////////////////
+{
+    let date = new Date(399464523963984);
+    assert(date.getUTCMilliseconds() == 984);
+    date.setUTCMilliseconds(12);
+    assert(date.getUTCMilliseconds() == 12);
+    date.setUTCMilliseconds(568);
+    assert(date.getUTCMilliseconds() == 568);
+    // test boundaries
+    date.setUTCMilliseconds(0);
+    date.setUTCMilliseconds(999);
+}
+
+// Date#setUTCSeconds /////////////////////////////////////////////////////////////////////////////////
+{
+    let date = new Date(372027318331986);
+    assert(date.getUTCSeconds() == 31);
+    date.setUTCSeconds(12);
+    assert(date.getUTCSeconds() == 12);
+    date.setUTCSeconds(50);
+    assert(date.getUTCSeconds() == 50);
+    // test boundaries
+    date.setUTCSeconds(0);
+    date.setUTCSeconds(59);
+}
+
+// Date#setUTCMinutes /////////////////////////////////////////////////////////////////////////////////
+{
+    let date = new Date(372027318331986);
+    assert(date.getUTCMinutes() == 45);
+    date.setUTCMinutes(12);
+    assert(date.getUTCMinutes() == 12);
+    date.setUTCMinutes(50);
+    assert(date.getUTCMinutes() == 50);
+    // test boundaries
+    date.setUTCMinutes(0);
+    date.setUTCMinutes(59);
+}
+
+// Date#setUTCHours /////////////////////////////////////////////////////////////////////////////////
+{
+    let date = new Date(372027318331986);
+    assert(date.getUTCHours() == 17);
+    date.setUTCHours(12);
+    assert(date.getUTCHours() == 12);
+    date.setUTCHours(2);
+    assert(date.getUTCHours() == 2);
+    // test boundaries
+    date.setUTCHours(0);
+    date.setUTCHours(23);
+}
+
+// Date#setUTCDate /////////////////////////////////////////////////////////////////////////////////
+{
+    let date = new Date(123814991274);
+    assert(date.getUTCFullYear() == 1973);
+    assert(date.getUTCMonth() == 11);
+
+    // test a few values
+    date.setUTCDate(12);
+    assert(date.getUTCDate() == 12);
+    date.setUTCDate(2);
+    assert(date.getUTCDate() == 2);
+
+    // test boundaries
+    // nov has 30 days
+    date.setUTCDate(1);
+    date.setUTCDate(30);
+
+    // jan has 31 days
+    date.setUTCMonth(1);
+    date.setUTCDate(1);
+    date.setUTCDate(31);
+
+    // feb on leap year
+    date.setUTCFullYear(2024);
+    date.setUTCMonth(2);
+    date.setUTCDate(1);
+    date.setUTCDate(29);
+}
+
+// Date#setUTCMonth /////////////////////////////////////////////////////////////////////////////////
+{
+    let date = new Date(7899943856218720);
+    assert(date.getUTCMonth() == 3);
+    date.setUTCMonth(10);
+    assert(date.getUTCMonth() == 10);
+    date.setUTCMonth(2);
+    assert(date.getUTCMonth() == 2);
+    // test boundaries
+    date.setUTCMonth(1);
+    date.setUTCMonth(12);
+}
+
+// Date#setUTCFullYear /////////////////////////////////////////////////////////////////////////////////
+{
+    let date = new Date(7941202527925698);
+    assert(date.getUTCFullYear() == 253616);
+    date.setUTCFullYear(1976);
+    assert(date.getUTCFullYear() == 1976);
+    date.setUTCFullYear(20212);
+    assert(date.getUTCFullYear() == 20212);
+}
+

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -2,21 +2,20 @@
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
- (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_=>_i64 (func (param i32) (result i64)))
  (type $i32_i64_=>_i64 (func (param i32 i64) (result i64)))
- (type $none_=>_f64 (func (result f64)))
  (type $i32_i32_i32_i32_i32_i32_f64_=>_f64 (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
  (import "Date" "UTC" (func $~lib/bindings/Date/UTC (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "Date" "now" (func $~lib/bindings/Date/now (result f64)))
  (memory $0 1)
  (data (i32.const 12) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\16\00\00\00s\00t\00d\00/\00d\00a\00t\00e\00.\00t\00s\00\00\00\00\00\00\00")
  (data (i32.const 60) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
@@ -27,9 +26,16 @@
  (data (i32.const 316) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
  (data (i32.const 368) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 396) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 464) "\04\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00")
+ (data (i32.const 460) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00V\00a\00l\00u\00e\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 524) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00d\00a\00t\00e\00.\00t\00s\00\00\00\00\00")
+ (data (i32.const 572) "L\00\00\00\00\00\00\00\00\00\00\00\00\00\00\000\00\00\00\1f\00\00\00\1c\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 652) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
+ (data (i32.const 704) "\06\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\02\t\00\00\00\00\00\00")
  (table $0 1 funcref)
- (global $std/date/creationTime (mut i64) (i64.const 0))
+ (global $~lib/date/MILLIS_PER_DAY i32 (i32.const 86400000))
+ (global $~lib/date/MILLIS_PER_HOUR i32 (i32.const 3600000))
+ (global $~lib/date/MILLIS_PER_MINUTE i32 (i32.const 60000))
+ (global $~lib/date/MILLIS_PER_SECOND i32 (i32.const 1000))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
@@ -42,14 +48,14 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
- (global $std/date/date (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 464))
- (global $~lib/memory/__data_end i32 (i32.const 500))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 16884))
- (global $~lib/memory/__heap_base i32 (i32.const 16884))
+ (global $~lib/rt/__rtti_base i32 (i32.const 704))
+ (global $~lib/memory/__data_end i32 (i32.const 756))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 17140))
+ (global $~lib/memory/__heap_base i32 (i32.const 17140))
+ (global $~started (mut i32) (i32.const 0))
  (export "memory" (memory $0))
- (start $~start)
- (func $~lib/date/Date#set:value (param $0 i32) (param $1 i64)
+ (export "_start" (func $~start))
+ (func $~lib/date/Date#set:epochMillis (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
   i64.store
@@ -2366,76 +2372,1814 @@
  (func $~lib/date/Date#setTime (param $0 i32) (param $1 i64) (result i64)
   local.get $0
   local.get $1
-  call $~lib/date/Date#set:value
+  call $~lib/date/Date#set:epochMillis
   local.get $1
  )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  global.get $std/date/date
-  local.tee $1
-  if
-   local.get $1
-   local.get $0
-   call $~lib/rt/itcms/__visit
-  end
-  i32.const 272
+ (func $~lib/date/YMD#set:year (param $0 i32) (param $1 i32)
   local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 80
-  local.get $0
-  call $~lib/rt/itcms/__visit
+  local.get $1
+  i32.store
  )
- (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
-  (local $2 i32)
+ (func $~lib/date/YMD#set:month (param $0 i32) (param $1 i32)
   local.get $0
+  local.get $1
+  i32.store offset=4
+ )
+ (func $~lib/date/YMD#set:day (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=8
+ )
+ (func $~lib/date/Date#getUTCFullYear (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
   i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
  )
- (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
-  block $invalid
-   block $~lib/date/Date
-    block $~lib/arraybuffer/ArrayBufferView
-     block $~lib/string/String
-      block $~lib/arraybuffer/ArrayBuffer
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load
-       br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $invalid
-      end
-      return
-     end
-     return
-    end
-    local.get $0
-    local.get $1
-    call $~lib/arraybuffer/ArrayBufferView~visit
-    return
-   end
-   return
-  end
-  unreachable
+ (func $~lib/date/Date#getUTCMonth (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  i32.load offset=4
+  i32.const 1
+  i32.sub
  )
- (func $~start
-  call $start:std/date
+ (func $~lib/date/Date#getUTCDate (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  i32.load offset=8
  )
- (func $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__data_end
+ (func $~lib/date/Date#getUTCHours (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.rem_s
+  i32.wrap_i64
+  global.get $~lib/date/MILLIS_PER_HOUR
+  i32.div_s
+ )
+ (func $~lib/date/Date#getUTCMinutes (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_HOUR
+  i64.extend_i32_s
+  i64.rem_s
+  i32.wrap_i64
+  global.get $~lib/date/MILLIS_PER_MINUTE
+  i32.div_s
+ )
+ (func $~lib/date/Date#getUTCSeconds (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_MINUTE
+  i64.extend_i32_s
+  i64.rem_s
+  i32.wrap_i64
+  global.get $~lib/date/MILLIS_PER_SECOND
+  i32.div_s
+ )
+ (func $~lib/date/Date#getUTCMilliseconds (param $0 i32) (result i32)
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_SECOND
+  i64.extend_i32_s
+  i64.rem_s
+  i32.wrap_i64
+ )
+ (func $~lib/date/Date#setUTCMilliseconds (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $0
+  i64.load
+  local.get $1
+  local.get $0
+  call $~lib/date/Date#getUTCMilliseconds
+  i32.sub
+  i64.extend_i32_s
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+ )
+ (func $~lib/date/throwIfNotInRange (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  local.get $1
   i32.lt_s
+  if (result i32)
+   i32.const 1
+  else
+   local.get $0
+   local.get $2
+   i32.gt_s
+  end
   if
-   i32.const 16912
-   i32.const 16960
-   i32.const 1
-   i32.const 1
+   i32.const 480
+   i32.const 544
+   i32.const 111
+   i32.const 39
    call $~lib/builtins/abort
    unreachable
   end
+ )
+ (func $~lib/date/Date#setUTCSeconds (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.const 0
+  i32.const 59
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  local.get $0
+  i64.load
+  local.get $1
+  local.get $0
+  call $~lib/date/Date#getUTCSeconds
+  i32.sub
+  global.get $~lib/date/MILLIS_PER_SECOND
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+ )
+ (func $~lib/date/Date#setUTCMinutes (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.const 0
+  i32.const 59
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  local.get $0
+  i64.load
+  local.get $1
+  local.get $0
+  call $~lib/date/Date#getUTCMinutes
+  i32.sub
+  global.get $~lib/date/MILLIS_PER_MINUTE
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+ )
+ (func $~lib/date/Date#setUTCHours (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.const 0
+  i32.const 23
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  local.get $0
+  i64.load
+  local.get $1
+  local.get $0
+  call $~lib/date/Date#getUTCHours
+  i32.sub
+  global.get $~lib/date/MILLIS_PER_HOUR
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+ )
+ (func $~lib/date/isLeap (param $0 i32) (result i32)
+  local.get $0
+  i32.const 4
+  i32.rem_s
+  i32.const 0
+  i32.eq
+  if (result i32)
+   local.get $0
+   i32.const 100
+   i32.rem_s
+   i32.const 0
+   i32.ne
+   if (result i32)
+    i32.const 1
+   else
+    local.get $0
+    i32.const 400
+    i32.rem_s
+    i32.const 0
+    i32.eq
+   end
+  else
+   i32.const 0
+  end
+ )
+ (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  loop $while-continue|0
+   local.get $2
+   if (result i32)
+    local.get $1
+    i32.const 3
+    i32.and
+   else
+    i32.const 0
+   end
+   local.set $5
+   local.get $5
+   if
+    local.get $0
+    local.tee $6
+    i32.const 1
+    i32.add
+    local.set $0
+    local.get $6
+    local.get $1
+    local.tee $6
+    i32.const 1
+    i32.add
+    local.set $1
+    local.get $6
+    i32.load8_u
+    i32.store8
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  local.get $0
+  i32.const 3
+  i32.and
+  i32.const 0
+  i32.eq
+  if
+   loop $while-continue|1
+    local.get $2
+    i32.const 16
+    i32.ge_u
+    local.set $5
+    local.get $5
+    if
+     local.get $0
+     local.get $1
+     i32.load
+     i32.store
+     local.get $0
+     i32.const 4
+     i32.add
+     local.get $1
+     i32.const 4
+     i32.add
+     i32.load
+     i32.store
+     local.get $0
+     i32.const 8
+     i32.add
+     local.get $1
+     i32.const 8
+     i32.add
+     i32.load
+     i32.store
+     local.get $0
+     i32.const 12
+     i32.add
+     local.get $1
+     i32.const 12
+     i32.add
+     i32.load
+     i32.store
+     local.get $1
+     i32.const 16
+     i32.add
+     local.set $1
+     local.get $0
+     i32.const 16
+     i32.add
+     local.set $0
+     local.get $2
+     i32.const 16
+     i32.sub
+     local.set $2
+     br $while-continue|1
+    end
+   end
+   local.get $2
+   i32.const 8
+   i32.and
+   if
+    local.get $0
+    local.get $1
+    i32.load
+    i32.store
+    local.get $0
+    i32.const 4
+    i32.add
+    local.get $1
+    i32.const 4
+    i32.add
+    i32.load
+    i32.store
+    local.get $0
+    i32.const 8
+    i32.add
+    local.set $0
+    local.get $1
+    i32.const 8
+    i32.add
+    local.set $1
+   end
+   local.get $2
+   i32.const 4
+   i32.and
+   if
+    local.get $0
+    local.get $1
+    i32.load
+    i32.store
+    local.get $0
+    i32.const 4
+    i32.add
+    local.set $0
+    local.get $1
+    i32.const 4
+    i32.add
+    local.set $1
+   end
+   local.get $2
+   i32.const 2
+   i32.and
+   if
+    local.get $0
+    local.get $1
+    i32.load16_u
+    i32.store16
+    local.get $0
+    i32.const 2
+    i32.add
+    local.set $0
+    local.get $1
+    i32.const 2
+    i32.add
+    local.set $1
+   end
+   local.get $2
+   i32.const 1
+   i32.and
+   if
+    local.get $0
+    local.tee $5
+    i32.const 1
+    i32.add
+    local.set $0
+    local.get $5
+    local.get $1
+    local.tee $5
+    i32.const 1
+    i32.add
+    local.set $1
+    local.get $5
+    i32.load8_u
+    i32.store8
+   end
+   return
+  end
+  local.get $2
+  i32.const 32
+  i32.ge_u
+  if
+   block $break|2
+    block $case2|2
+     block $case1|2
+      block $case0|2
+       local.get $0
+       i32.const 3
+       i32.and
+       local.set $5
+       local.get $5
+       i32.const 1
+       i32.eq
+       br_if $case0|2
+       local.get $5
+       i32.const 2
+       i32.eq
+       br_if $case1|2
+       local.get $5
+       i32.const 3
+       i32.eq
+       br_if $case2|2
+       br $break|2
+      end
+      local.get $1
+      i32.load
+      local.set $3
+      local.get $0
+      local.tee $5
+      i32.const 1
+      i32.add
+      local.set $0
+      local.get $5
+      local.get $1
+      local.tee $5
+      i32.const 1
+      i32.add
+      local.set $1
+      local.get $5
+      i32.load8_u
+      i32.store8
+      local.get $0
+      local.tee $5
+      i32.const 1
+      i32.add
+      local.set $0
+      local.get $5
+      local.get $1
+      local.tee $5
+      i32.const 1
+      i32.add
+      local.set $1
+      local.get $5
+      i32.load8_u
+      i32.store8
+      local.get $0
+      local.tee $5
+      i32.const 1
+      i32.add
+      local.set $0
+      local.get $5
+      local.get $1
+      local.tee $5
+      i32.const 1
+      i32.add
+      local.set $1
+      local.get $5
+      i32.load8_u
+      i32.store8
+      local.get $2
+      i32.const 3
+      i32.sub
+      local.set $2
+      loop $while-continue|3
+       local.get $2
+       i32.const 17
+       i32.ge_u
+       local.set $5
+       local.get $5
+       if
+        local.get $1
+        i32.const 1
+        i32.add
+        i32.load
+        local.set $4
+        local.get $0
+        local.get $3
+        i32.const 24
+        i32.shr_u
+        local.get $4
+        i32.const 8
+        i32.shl
+        i32.or
+        i32.store
+        local.get $1
+        i32.const 5
+        i32.add
+        i32.load
+        local.set $3
+        local.get $0
+        i32.const 4
+        i32.add
+        local.get $4
+        i32.const 24
+        i32.shr_u
+        local.get $3
+        i32.const 8
+        i32.shl
+        i32.or
+        i32.store
+        local.get $1
+        i32.const 9
+        i32.add
+        i32.load
+        local.set $4
+        local.get $0
+        i32.const 8
+        i32.add
+        local.get $3
+        i32.const 24
+        i32.shr_u
+        local.get $4
+        i32.const 8
+        i32.shl
+        i32.or
+        i32.store
+        local.get $1
+        i32.const 13
+        i32.add
+        i32.load
+        local.set $3
+        local.get $0
+        i32.const 12
+        i32.add
+        local.get $4
+        i32.const 24
+        i32.shr_u
+        local.get $3
+        i32.const 8
+        i32.shl
+        i32.or
+        i32.store
+        local.get $1
+        i32.const 16
+        i32.add
+        local.set $1
+        local.get $0
+        i32.const 16
+        i32.add
+        local.set $0
+        local.get $2
+        i32.const 16
+        i32.sub
+        local.set $2
+        br $while-continue|3
+       end
+      end
+      br $break|2
+     end
+     local.get $1
+     i32.load
+     local.set $3
+     local.get $0
+     local.tee $5
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $5
+     local.get $1
+     local.tee $5
+     i32.const 1
+     i32.add
+     local.set $1
+     local.get $5
+     i32.load8_u
+     i32.store8
+     local.get $0
+     local.tee $5
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $5
+     local.get $1
+     local.tee $5
+     i32.const 1
+     i32.add
+     local.set $1
+     local.get $5
+     i32.load8_u
+     i32.store8
+     local.get $2
+     i32.const 2
+     i32.sub
+     local.set $2
+     loop $while-continue|4
+      local.get $2
+      i32.const 18
+      i32.ge_u
+      local.set $5
+      local.get $5
+      if
+       local.get $1
+       i32.const 2
+       i32.add
+       i32.load
+       local.set $4
+       local.get $0
+       local.get $3
+       i32.const 16
+       i32.shr_u
+       local.get $4
+       i32.const 16
+       i32.shl
+       i32.or
+       i32.store
+       local.get $1
+       i32.const 6
+       i32.add
+       i32.load
+       local.set $3
+       local.get $0
+       i32.const 4
+       i32.add
+       local.get $4
+       i32.const 16
+       i32.shr_u
+       local.get $3
+       i32.const 16
+       i32.shl
+       i32.or
+       i32.store
+       local.get $1
+       i32.const 10
+       i32.add
+       i32.load
+       local.set $4
+       local.get $0
+       i32.const 8
+       i32.add
+       local.get $3
+       i32.const 16
+       i32.shr_u
+       local.get $4
+       i32.const 16
+       i32.shl
+       i32.or
+       i32.store
+       local.get $1
+       i32.const 14
+       i32.add
+       i32.load
+       local.set $3
+       local.get $0
+       i32.const 12
+       i32.add
+       local.get $4
+       i32.const 16
+       i32.shr_u
+       local.get $3
+       i32.const 16
+       i32.shl
+       i32.or
+       i32.store
+       local.get $1
+       i32.const 16
+       i32.add
+       local.set $1
+       local.get $0
+       i32.const 16
+       i32.add
+       local.set $0
+       local.get $2
+       i32.const 16
+       i32.sub
+       local.set $2
+       br $while-continue|4
+      end
+     end
+     br $break|2
+    end
+    local.get $1
+    i32.load
+    local.set $3
+    local.get $0
+    local.tee $5
+    i32.const 1
+    i32.add
+    local.set $0
+    local.get $5
+    local.get $1
+    local.tee $5
+    i32.const 1
+    i32.add
+    local.set $1
+    local.get $5
+    i32.load8_u
+    i32.store8
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    loop $while-continue|5
+     local.get $2
+     i32.const 19
+     i32.ge_u
+     local.set $5
+     local.get $5
+     if
+      local.get $1
+      i32.const 3
+      i32.add
+      i32.load
+      local.set $4
+      local.get $0
+      local.get $3
+      i32.const 8
+      i32.shr_u
+      local.get $4
+      i32.const 24
+      i32.shl
+      i32.or
+      i32.store
+      local.get $1
+      i32.const 7
+      i32.add
+      i32.load
+      local.set $3
+      local.get $0
+      i32.const 4
+      i32.add
+      local.get $4
+      i32.const 8
+      i32.shr_u
+      local.get $3
+      i32.const 24
+      i32.shl
+      i32.or
+      i32.store
+      local.get $1
+      i32.const 11
+      i32.add
+      i32.load
+      local.set $4
+      local.get $0
+      i32.const 8
+      i32.add
+      local.get $3
+      i32.const 8
+      i32.shr_u
+      local.get $4
+      i32.const 24
+      i32.shl
+      i32.or
+      i32.store
+      local.get $1
+      i32.const 15
+      i32.add
+      i32.load
+      local.set $3
+      local.get $0
+      i32.const 12
+      i32.add
+      local.get $4
+      i32.const 8
+      i32.shr_u
+      local.get $3
+      i32.const 24
+      i32.shl
+      i32.or
+      i32.store
+      local.get $1
+      i32.const 16
+      i32.add
+      local.set $1
+      local.get $0
+      i32.const 16
+      i32.add
+      local.set $0
+      local.get $2
+      i32.const 16
+      i32.sub
+      local.set $2
+      br $while-continue|5
+     end
+    end
+    br $break|2
+   end
+  end
+  local.get $2
+  i32.const 16
+  i32.and
+  if
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+  end
+  local.get $2
+  i32.const 8
+  i32.and
+  if
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+  end
+  local.get $2
+  i32.const 4
+  i32.and
+  if
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+  end
+  local.get $2
+  i32.const 2
+  i32.and
+  if
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+  end
+  local.get $2
+  i32.const 1
+  i32.and
+  if
+   local.get $0
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $0
+   local.get $5
+   local.get $1
+   local.tee $5
+   i32.const 1
+   i32.add
+   local.set $1
+   local.get $5
+   i32.load8_u
+   i32.store8
+  end
+ )
+ (func $~lib/memory/memory.copy (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  block $~lib/util/memory/memmove|inlined.0
+   local.get $0
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $3
+   local.get $5
+   local.get $4
+   i32.eq
+   if
+    br $~lib/util/memory/memmove|inlined.0
+   end
+   i32.const 0
+   i32.const 1
+   i32.lt_s
+   drop
+   local.get $4
+   local.get $5
+   i32.sub
+   local.get $3
+   i32.sub
+   i32.const 0
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.sub
+   i32.le_u
+   if
+    local.get $5
+    local.get $4
+    local.get $3
+    call $~lib/util/memory/memcpy
+    br $~lib/util/memory/memmove|inlined.0
+   end
+   local.get $5
+   local.get $4
+   i32.lt_u
+   if
+    i32.const 0
+    i32.const 2
+    i32.lt_s
+    drop
+    local.get $4
+    i32.const 7
+    i32.and
+    local.get $5
+    i32.const 7
+    i32.and
+    i32.eq
+    if
+     loop $while-continue|0
+      local.get $5
+      i32.const 7
+      i32.and
+      local.set $6
+      local.get $6
+      if
+       local.get $3
+       i32.eqz
+       if
+        br $~lib/util/memory/memmove|inlined.0
+       end
+       local.get $3
+       i32.const 1
+       i32.sub
+       local.set $3
+       local.get $5
+       local.tee $7
+       i32.const 1
+       i32.add
+       local.set $5
+       local.get $7
+       local.get $4
+       local.tee $7
+       i32.const 1
+       i32.add
+       local.set $4
+       local.get $7
+       i32.load8_u
+       i32.store8
+       br $while-continue|0
+      end
+     end
+     loop $while-continue|1
+      local.get $3
+      i32.const 8
+      i32.ge_u
+      local.set $6
+      local.get $6
+      if
+       local.get $5
+       local.get $4
+       i64.load
+       i64.store
+       local.get $3
+       i32.const 8
+       i32.sub
+       local.set $3
+       local.get $5
+       i32.const 8
+       i32.add
+       local.set $5
+       local.get $4
+       i32.const 8
+       i32.add
+       local.set $4
+       br $while-continue|1
+      end
+     end
+    end
+    loop $while-continue|2
+     local.get $3
+     local.set $6
+     local.get $6
+     if
+      local.get $5
+      local.tee $7
+      i32.const 1
+      i32.add
+      local.set $5
+      local.get $7
+      local.get $4
+      local.tee $7
+      i32.const 1
+      i32.add
+      local.set $4
+      local.get $7
+      i32.load8_u
+      i32.store8
+      local.get $3
+      i32.const 1
+      i32.sub
+      local.set $3
+      br $while-continue|2
+     end
+    end
+   else
+    i32.const 0
+    i32.const 2
+    i32.lt_s
+    drop
+    local.get $4
+    i32.const 7
+    i32.and
+    local.get $5
+    i32.const 7
+    i32.and
+    i32.eq
+    if
+     loop $while-continue|3
+      local.get $5
+      local.get $3
+      i32.add
+      i32.const 7
+      i32.and
+      local.set $6
+      local.get $6
+      if
+       local.get $3
+       i32.eqz
+       if
+        br $~lib/util/memory/memmove|inlined.0
+       end
+       local.get $5
+       local.get $3
+       i32.const 1
+       i32.sub
+       local.tee $3
+       i32.add
+       local.get $4
+       local.get $3
+       i32.add
+       i32.load8_u
+       i32.store8
+       br $while-continue|3
+      end
+     end
+     loop $while-continue|4
+      local.get $3
+      i32.const 8
+      i32.ge_u
+      local.set $6
+      local.get $6
+      if
+       local.get $3
+       i32.const 8
+       i32.sub
+       local.set $3
+       local.get $5
+       local.get $3
+       i32.add
+       local.get $4
+       local.get $3
+       i32.add
+       i64.load
+       i64.store
+       br $while-continue|4
+      end
+     end
+    end
+    loop $while-continue|5
+     local.get $3
+     local.set $6
+     local.get $6
+     if
+      local.get $5
+      local.get $3
+      i32.const 1
+      i32.sub
+      local.tee $3
+      i32.add
+      local.get $4
+      local.get $3
+      i32.add
+      i32.load8_u
+      i32.store8
+      br $while-continue|5
+     end
+    end
+   end
+  end
+ )
+ (func $~lib/rt/__newBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  local.get $1
+  call $~lib/rt/itcms/__new
+  local.set $3
+  local.get $2
+  if
+   local.get $3
+   local.get $2
+   local.get $0
+   call $~lib/memory/memory.copy
+  end
+  local.get $3
+ )
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.eqz
+  if
+   return
+  end
+  i32.const 1
+  drop
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 294
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 20
+  i32.sub
+  local.set $3
+  local.get $3
+  call $~lib/rt/itcms/Object#get:color
+  global.get $~lib/rt/itcms/white
+  i32.eq
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   local.set $4
+   local.get $4
+   call $~lib/rt/itcms/Object#get:color
+   local.set $5
+   local.get $5
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $2
+    if
+     local.get $4
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $3
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   else
+    local.get $5
+    i32.const 3
+    i32.eq
+    if (result i32)
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
+ (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 272
+   i32.const 672
+   i32.const 92
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.set $2
+  i32.const 0
+  drop
+  local.get $2
+ )
+ (func $~lib/date/lastDayOfMonth (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  i32.const 2
+  i32.ne
+  if (result i32)
+   i32.const 1
+  else
+   local.get $0
+   call $~lib/date/isLeap
+   i32.eqz
+  end
+  if (result i32)
+   local.get $1
+   call $~lib/date/lastDayOfMonthNonLeapYear
+  else
+   i32.const 29
+  end
+ )
+ (func $~lib/date/daysSinceEpoch (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  local.get $1
+  i32.const 2
+  i32.le_s
+  if (result i32)
+   i32.const 1
+  else
+   i32.const 0
+  end
+  i32.sub
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.ge_s
+  if (result i32)
+   local.get $0
+  else
+   local.get $0
+   i32.const 399
+   i32.sub
+  end
+  i32.const 400
+  i32.div_s
+  local.set $3
+  local.get $0
+  local.get $3
+  i32.const 400
+  i32.mul
+  i32.sub
+  local.set $4
+  i32.const 153
+  local.get $1
+  local.get $1
+  i32.const 2
+  i32.gt_s
+  if (result i32)
+   i32.const -3
+  else
+   i32.const 9
+  end
+  i32.add
+  i32.mul
+  i32.const 2
+  i32.add
+  i32.const 5
+  i32.div_s
+  local.get $2
+  i32.add
+  i32.const 1
+  i32.sub
+  local.set $5
+  local.get $4
+  i32.const 365
+  i32.mul
+  local.get $4
+  i32.const 4
+  i32.div_s
+  i32.add
+  local.get $4
+  i32.const 100
+  i32.div_s
+  i32.sub
+  local.get $5
+  i32.add
+  local.set $6
+  local.get $3
+  i32.const 146097
+  i32.mul
+  local.get $6
+  i32.add
+  i32.const 719468
+  i32.sub
+ )
+ (func $~lib/date/Date#setUTCDate (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i64)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.tee $2
+  i32.store
+  local.get $1
+  i32.const 1
+  local.get $2
+  i32.load
+  local.get $2
+  i32.load offset=4
+  call $~lib/date/lastDayOfMonth
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.rem_s
+  local.set $3
+  local.get $0
+  local.get $2
+  i32.load
+  local.get $2
+  i32.load offset=4
+  local.get $1
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.mul
+  local.get $3
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/date/Date#setUTCMonth (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i64)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  i32.const 1
+  i32.const 12
+  call $~lib/date/throwIfNotInRange
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.tee $2
+  i32.store
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.rem_s
+  local.set $3
+  local.get $0
+  local.get $2
+  i32.load
+  local.get $1
+  i32.const 1
+  i32.add
+  local.get $2
+  i32.load offset=8
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.mul
+  local.get $3
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/date/Date#setUTCFullYear (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i64)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.tee $2
+  i32.store
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.rem_s
+  local.set $3
+  local.get $0
+  local.get $1
+  local.get $2
+  i32.load offset=4
+  local.get $2
+  i32.load offset=8
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.mul
+  local.get $3
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $start:std/date
   (local $0 i32)
@@ -2445,7 +4189,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i64)
-  (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -2484,8 +4227,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1
-   i32.const 1
+   i32.const 3
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -2519,8 +4262,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2
-   i32.const 1
+   i32.const 4
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -2548,29 +4291,16 @@
   f64.convert_i64_s
   call $~lib/bindings/Date/UTC
   i64.trunc_f64_s
-  global.set $std/date/creationTime
-  global.get $std/date/creationTime
+  local.set $6
+  local.get $6
   i64.const 1541847600001
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 5
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  call $~lib/bindings/Date/now
-  i64.trunc_f64_s
-  global.get $std/date/creationTime
-  i64.gt_s
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 7
-   i32.const 1
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -2591,47 +4321,36 @@
   i32.const 368
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/fromSpace
-  i32.const 0
-  global.get $std/date/creationTime
-  call $~lib/date/Date#constructor
-  global.set $std/date/date
-  global.get $std/date/date
-  local.set $7
+  i64.const 1541847600001
+  local.set $6
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  i32.const 0
+  local.get $6
+  call $~lib/date/Date#constructor
+  local.tee $5
   i32.store
-  local.get $7
+  local.get $5
   call $~lib/date/Date#getTime
-  global.get $std/date/creationTime
+  local.get $6
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 10
-   i32.const 1
+   i32.const 15
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/date/date
-  local.set $7
-  global.get $~lib/memory/__stack_pointer
-  local.get $7
-  i32.store
-  local.get $7
-  global.get $std/date/creationTime
+  local.get $5
+  local.get $6
   i64.const 1
   i64.add
   call $~lib/date/Date#setTime
   drop
-  global.get $std/date/date
-  local.set $7
-  global.get $~lib/memory/__stack_pointer
-  local.get $7
-  i32.store
-  local.get $7
+  local.get $5
   call $~lib/date/Date#getTime
-  global.get $std/date/creationTime
+  local.get $6
   i64.const 1
   i64.add
   i64.eq
@@ -2639,8 +4358,629 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 12
-   i32.const 1
+   i32.const 17
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 5918283958183706
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 189512
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 26
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCMonth
+  i32.const 11
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 27
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCDate
+  i32.const 14
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 28
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCHours
+  i32.const 22
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 29
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 30
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 43
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 31
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCMilliseconds
+  i32.const 706
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 32
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 123814991274
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 1973
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 38
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCMonth
+  i32.const 11
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 39
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCDate
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 40
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCHours
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 41
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 42
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 11
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 43
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCMilliseconds
+  i32.const 274
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 44
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 399464523963984
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getUTCMilliseconds
+  i32.const 984
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 50
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 12
+  call $~lib/date/Date#setUTCMilliseconds
+  local.get $5
+  call $~lib/date/Date#getUTCMilliseconds
+  i32.const 12
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 52
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 568
+  call $~lib/date/Date#setUTCMilliseconds
+  local.get $5
+  call $~lib/date/Date#getUTCMilliseconds
+  i32.const 568
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 54
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 0
+  call $~lib/date/Date#setUTCMilliseconds
+  local.get $5
+  i32.const 999
+  call $~lib/date/Date#setUTCMilliseconds
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 372027318331986
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 31
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 63
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 12
+  call $~lib/date/Date#setUTCSeconds
+  local.get $5
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 12
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 65
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 50
+  call $~lib/date/Date#setUTCSeconds
+  local.get $5
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 67
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 0
+  call $~lib/date/Date#setUTCSeconds
+  local.get $5
+  i32.const 59
+  call $~lib/date/Date#setUTCSeconds
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 372027318331986
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 45
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 76
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 12
+  call $~lib/date/Date#setUTCMinutes
+  local.get $5
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 12
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 78
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 50
+  call $~lib/date/Date#setUTCMinutes
+  local.get $5
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 80
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 0
+  call $~lib/date/Date#setUTCMinutes
+  local.get $5
+  i32.const 59
+  call $~lib/date/Date#setUTCMinutes
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 372027318331986
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getUTCHours
+  i32.const 17
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 89
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 12
+  call $~lib/date/Date#setUTCHours
+  local.get $5
+  call $~lib/date/Date#getUTCHours
+  i32.const 12
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 91
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 2
+  call $~lib/date/Date#setUTCHours
+  local.get $5
+  call $~lib/date/Date#getUTCHours
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 93
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 0
+  call $~lib/date/Date#setUTCHours
+  local.get $5
+  i32.const 23
+  call $~lib/date/Date#setUTCHours
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 123814991274
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 1973
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 102
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/date/Date#getUTCMonth
+  i32.const 11
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 103
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 12
+  call $~lib/date/Date#setUTCDate
+  local.get $5
+  call $~lib/date/Date#getUTCDate
+  i32.const 12
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 107
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 2
+  call $~lib/date/Date#setUTCDate
+  local.get $5
+  call $~lib/date/Date#getUTCDate
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 109
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 1
+  call $~lib/date/Date#setUTCDate
+  local.get $5
+  i32.const 30
+  call $~lib/date/Date#setUTCDate
+  local.get $5
+  i32.const 1
+  call $~lib/date/Date#setUTCMonth
+  local.get $5
+  i32.const 1
+  call $~lib/date/Date#setUTCDate
+  local.get $5
+  i32.const 31
+  call $~lib/date/Date#setUTCDate
+  local.get $5
+  i32.const 2024
+  call $~lib/date/Date#setUTCFullYear
+  local.get $5
+  i32.const 2
+  call $~lib/date/Date#setUTCMonth
+  local.get $5
+  i32.const 1
+  call $~lib/date/Date#setUTCDate
+  local.get $5
+  i32.const 29
+  call $~lib/date/Date#setUTCDate
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 7899943856218720
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getUTCMonth
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 131
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 10
+  call $~lib/date/Date#setUTCMonth
+  local.get $5
+  call $~lib/date/Date#getUTCMonth
+  i32.const 10
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 133
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 2
+  call $~lib/date/Date#setUTCMonth
+  local.get $5
+  call $~lib/date/Date#getUTCMonth
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 135
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 1
+  call $~lib/date/Date#setUTCMonth
+  local.get $5
+  i32.const 12
+  call $~lib/date/Date#setUTCMonth
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 7941202527925698
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 253616
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 144
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 1976
+  call $~lib/date/Date#setUTCFullYear
+  local.get $5
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 1976
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 146
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 20212
+  call $~lib/date/Date#setUTCFullYear
+  local.get $5
+  call $~lib/date/Date#getUTCFullYear
+  i32.const 20212
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 148
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
@@ -2648,6 +4988,98 @@
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  i32.const 272
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 480
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 80
+  local.get $0
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/itcms/__visit
+  end
+ )
+ (func $~lib/array/Array<i32>#__visit (param $0 i32) (param $1 i32)
+  i32.const 0
+  drop
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/array/Array<i32>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i32>#__visit
+ )
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
+  block $invalid
+   block $~lib/array/Array<i32>
+    block $~lib/date/YMD
+     block $~lib/date/Date
+      block $~lib/arraybuffer/ArrayBufferView
+       block $~lib/string/String
+        block $~lib/arraybuffer/ArrayBuffer
+         local.get $0
+         i32.const 8
+         i32.sub
+         i32.load
+         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $~lib/date/YMD $~lib/array/Array<i32> $invalid
+        end
+        return
+       end
+       return
+      end
+      local.get $0
+      local.get $1
+      call $~lib/arraybuffer/ArrayBufferView~visit
+      return
+     end
+     return
+    end
+    return
+   end
+   local.get $0
+   local.get $1
+   call $~lib/array/Array<i32>~visit
+   return
+  end
+  unreachable
+ )
+ (func $~start
+  global.get $~started
+  if
+   return
+  end
+  i32.const 1
+  global.set $~started
+  call $start:std/date
+ )
+ (func $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__data_end
+  i32.lt_s
+  if
+   i32.const 17168
+   i32.const 17216
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
  )
  (func $~lib/date/Date#constructor (param $0 i32) (param $1 i64) (result i32)
   (local $2 i32)
@@ -2671,10 +5103,10 @@
   end
   local.get $0
   i64.const 0
-  call $~lib/date/Date#set:value
+  call $~lib/date/Date#set:epochMillis
   local.get $0
   local.get $1
-  call $~lib/date/Date#set:value
+  call $~lib/date/Date#set:epochMillis
   local.get $0
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -2682,5 +5114,266 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $2
+ )
+ (func $~lib/date/YMD#constructor (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.const 4
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/date/YMD#set:year
+  local.get $0
+  i32.const 0
+  call $~lib/date/YMD#set:month
+  local.get $0
+  i32.const 0
+  call $~lib/date/YMD#set:day
+  local.get $0
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $~lib/date/ymdFromEpochDays (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 719468
+  i32.add
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.ge_s
+  if (result i32)
+   local.get $0
+  else
+   local.get $0
+   i32.const 146096
+   i32.sub
+  end
+  i32.const 146097
+  i32.div_s
+  local.set $1
+  local.get $0
+  local.get $1
+  i32.const 146097
+  i32.mul
+  i32.sub
+  local.set $2
+  local.get $2
+  local.get $2
+  i32.const 1460
+  i32.div_s
+  i32.sub
+  local.get $2
+  i32.const 36524
+  i32.div_s
+  i32.add
+  local.get $2
+  i32.const 146096
+  i32.div_s
+  i32.sub
+  i32.const 365
+  i32.div_s
+  local.set $3
+  local.get $3
+  local.get $1
+  i32.const 400
+  i32.mul
+  i32.add
+  local.set $4
+  local.get $2
+  i32.const 365
+  local.get $3
+  i32.mul
+  local.get $3
+  i32.const 4
+  i32.div_s
+  i32.add
+  local.get $3
+  i32.const 100
+  i32.div_s
+  i32.sub
+  i32.sub
+  local.set $5
+  i32.const 5
+  local.get $5
+  i32.mul
+  i32.const 2
+  i32.add
+  i32.const 153
+  i32.div_s
+  local.set $6
+  local.get $5
+  i32.const 153
+  local.get $6
+  i32.mul
+  i32.const 2
+  i32.add
+  i32.const 5
+  i32.div_s
+  i32.sub
+  i32.const 1
+  i32.add
+  local.set $7
+  local.get $6
+  local.get $6
+  i32.const 10
+  i32.lt_s
+  if (result i32)
+   i32.const 3
+  else
+   i32.const -9
+  end
+  i32.add
+  local.set $8
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  call $~lib/date/YMD#constructor
+  local.tee $9
+  i32.store
+  local.get $9
+  local.get $4
+  local.get $8
+  i32.const 2
+  i32.le_s
+  if (result i32)
+   i32.const 1
+  else
+   i32.const 0
+  end
+  i32.add
+  call $~lib/date/YMD#set:year
+  local.get $9
+  local.get $8
+  call $~lib/date/YMD#set:month
+  local.get $9
+  local.get $7
+  call $~lib/date/YMD#set:day
+  local.get $9
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $10
+ )
+ (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  local.get $1
+  i32.shl
+  local.set $4
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.const 0
+  local.get $3
+  call $~lib/rt/__newBuffer
+  local.tee $5
+  i32.store
+  i32.const 16
+  local.get $2
+  call $~lib/rt/itcms/__new
+  local.set $6
+  local.get $6
+  local.get $5
+  i32.store
+  local.get $6
+  local.get $5
+  i32.const 0
+  call $~lib/rt/itcms/__link
+  local.get $6
+  local.get $5
+  i32.store offset=4
+  local.get $6
+  local.get $4
+  i32.store offset=8
+  local.get $6
+  local.get $0
+  i32.store offset=12
+  local.get $6
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $7
+ )
+ (func $~lib/date/lastDayOfMonthNonLeapYear (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.const 2
+  i32.const 5
+  i32.const 592
+  call $~lib/rt/__newArray
+  local.tee $2
+  i32.store
+  local.get $2
+  local.get $0
+  i32.const 1
+  i32.sub
+  call $~lib/array/Array<i32>#__get
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
  )
 )

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -60,12 +60,15 @@
  (data (i32.const 3388) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00&\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00\00\00\00\00\00\00")
  (data (i32.const 3452) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00.\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 3532) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 3616) "\07\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\02\t\00\00\00\00\00\00\02A\00\00\00\00\00\00")
+ (data (i32.const 3616) "\06\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00\02\t\00\00\00\00\00\00\02A\00\00\00\00\00\00")
  (table $0 1 funcref)
  (global $~lib/date/MILLIS_PER_DAY i32 (i32.const 86400000))
  (global $~lib/date/MILLIS_PER_HOUR i32 (i32.const 3600000))
  (global $~lib/date/MILLIS_PER_MINUTE i32 (i32.const 60000))
  (global $~lib/date/MILLIS_PER_SECOND i32 (i32.const 1000))
+ (global $~lib/date/year (mut i32) (i32.const 0))
+ (global $~lib/date/month (mut i32) (i32.const 0))
+ (global $~lib/date/day (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
@@ -80,9 +83,9 @@
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $~lib/builtins/i32.MAX_VALUE i32 (i32.const 2147483647))
  (global $~lib/rt/__rtti_base i32 (i32.const 3616))
- (global $~lib/memory/__data_end i32 (i32.const 3676))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 20060))
- (global $~lib/memory/__heap_base i32 (i32.const 20060))
+ (global $~lib/memory/__data_end i32 (i32.const 3668))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 20052))
+ (global $~lib/memory/__heap_base i32 (i32.const 20052))
  (global $~started (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
@@ -2512,20 +2515,113 @@
   call $~lib/date/Date#set:epochMillis
   local.get $1
  )
- (func $~lib/date/YMD#set:year (param $0 i32) (param $1 i32)
+ (func $~lib/date/ymdFromEpochDays (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.const 719468
+  i32.add
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.ge_s
+  if (result i32)
+   local.get $0
+  else
+   local.get $0
+   i32.const 146096
+   i32.sub
+  end
+  i32.const 146097
+  i32.div_s
+  local.set $1
   local.get $0
   local.get $1
-  i32.store
- )
- (func $~lib/date/YMD#set:month (param $0 i32) (param $1 i32)
-  local.get $0
+  i32.const 146097
+  i32.mul
+  i32.sub
+  local.set $2
+  local.get $2
+  local.get $2
+  i32.const 1460
+  i32.div_s
+  i32.sub
+  local.get $2
+  i32.const 36524
+  i32.div_s
+  i32.add
+  local.get $2
+  i32.const 146096
+  i32.div_s
+  i32.sub
+  i32.const 365
+  i32.div_s
+  local.set $3
+  local.get $3
   local.get $1
-  i32.store offset=4
- )
- (func $~lib/date/YMD#set:day (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store offset=8
+  i32.const 400
+  i32.mul
+  i32.add
+  global.set $~lib/date/year
+  local.get $2
+  i32.const 365
+  local.get $3
+  i32.mul
+  local.get $3
+  i32.const 4
+  i32.div_s
+  i32.add
+  local.get $3
+  i32.const 100
+  i32.div_s
+  i32.sub
+  i32.sub
+  local.set $4
+  i32.const 5
+  local.get $4
+  i32.mul
+  i32.const 2
+  i32.add
+  i32.const 153
+  i32.div_s
+  local.set $5
+  local.get $4
+  i32.const 153
+  local.get $5
+  i32.mul
+  i32.const 2
+  i32.add
+  i32.const 5
+  i32.div_s
+  i32.sub
+  i32.const 1
+  i32.add
+  global.set $~lib/date/day
+  local.get $5
+  local.get $5
+  i32.const 10
+  i32.lt_s
+  if (result i32)
+   i32.const 3
+  else
+   i32.const -9
+  end
+  i32.add
+  global.set $~lib/date/month
+  global.get $~lib/date/year
+  global.get $~lib/date/month
+  i32.const 2
+  i32.le_s
+  if (result i32)
+   i32.const 1
+  else
+   i32.const 0
+  end
+  i32.add
+  global.set $~lib/date/year
  )
  (func $~lib/date/Date#getUTCFullYear (param $0 i32) (result i32)
   local.get $0
@@ -2535,7 +2631,7 @@
   i64.div_s
   i32.wrap_i64
   call $~lib/date/ymdFromEpochDays
-  i32.load
+  global.get $~lib/date/year
  )
  (func $~lib/date/Date#getUTCMonth (param $0 i32) (result i32)
   local.get $0
@@ -2545,7 +2641,7 @@
   i64.div_s
   i32.wrap_i64
   call $~lib/date/ymdFromEpochDays
-  i32.load offset=4
+  global.get $~lib/date/month
   i32.const 1
   i32.sub
  )
@@ -2557,7 +2653,7 @@
   i64.div_s
   i32.wrap_i64
   call $~lib/date/ymdFromEpochDays
-  i32.load offset=8
+  global.get $~lib/date/day
  )
  (func $~lib/date/Date#getUTCHours (param $0 i32) (result i32)
   local.get $0
@@ -2623,7 +2719,7 @@
   if
    i32.const 480
    i32.const 544
-   i32.const 193
+   i32.const 195
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -4089,17 +4185,7 @@
   end
  )
  (func $~lib/date/Date#setUTCDate (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i64)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
+  (local $2 i64)
   local.get $0
   i64.load
   global.get $~lib/date/MILLIS_PER_DAY
@@ -4107,14 +4193,10 @@
   i64.div_s
   i32.wrap_i64
   call $~lib/date/ymdFromEpochDays
-  local.tee $2
-  i32.store
   local.get $1
   i32.const 1
-  local.get $2
-  i32.load
-  local.get $2
-  i32.load offset=4
+  global.get $~lib/date/year
+  global.get $~lib/date/month
   call $~lib/date/lastDayOfMonth
   call $~lib/date/throwIfNotInRange
   local.get $0
@@ -4122,42 +4204,26 @@
   global.get $~lib/date/MILLIS_PER_DAY
   i64.extend_i32_s
   i64.rem_s
-  local.set $3
+  local.set $2
   local.get $0
-  local.get $2
-  i32.load
-  local.get $2
-  i32.load offset=4
+  global.get $~lib/date/year
+  global.get $~lib/date/month
   local.get $1
   call $~lib/date/daysSinceEpoch
   i64.extend_i32_s
   global.get $~lib/date/MILLIS_PER_DAY
   i64.extend_i32_s
   i64.mul
-  local.get $3
+  local.get $2
   i64.add
   call $~lib/date/Date#set:epochMillis
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/date/Date#setUTCMonth (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i64)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
+  (local $2 i64)
   local.get $1
   i32.const 1
   i32.const 12
   call $~lib/date/throwIfNotInRange
-  global.get $~lib/memory/__stack_pointer
   local.get $0
   i64.load
   global.get $~lib/date/MILLIS_PER_DAY
@@ -4165,47 +4231,29 @@
   i64.div_s
   i32.wrap_i64
   call $~lib/date/ymdFromEpochDays
-  local.tee $2
-  i32.store
   local.get $0
   i64.load
   global.get $~lib/date/MILLIS_PER_DAY
   i64.extend_i32_s
   i64.rem_s
-  local.set $3
+  local.set $2
   local.get $0
-  local.get $2
-  i32.load
+  global.get $~lib/date/year
   local.get $1
   i32.const 1
   i32.add
-  local.get $2
-  i32.load offset=8
+  global.get $~lib/date/day
   call $~lib/date/daysSinceEpoch
   i64.extend_i32_s
   global.get $~lib/date/MILLIS_PER_DAY
   i64.extend_i32_s
   i64.mul
-  local.get $3
+  local.get $2
   i64.add
   call $~lib/date/Date#set:epochMillis
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/date/Date#setUTCFullYear (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i64)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
+  (local $2 i64)
   local.get $0
   i64.load
   global.get $~lib/date/MILLIS_PER_DAY
@@ -4213,32 +4261,24 @@
   i64.div_s
   i32.wrap_i64
   call $~lib/date/ymdFromEpochDays
-  local.tee $2
-  i32.store
   local.get $0
   i64.load
   global.get $~lib/date/MILLIS_PER_DAY
   i64.extend_i32_s
   i64.rem_s
-  local.set $3
+  local.set $2
   local.get $0
   local.get $1
-  local.get $2
-  i32.load offset=4
-  local.get $2
-  i32.load offset=8
+  global.get $~lib/date/month
+  global.get $~lib/date/day
   call $~lib/date/daysSinceEpoch
   i64.extend_i32_s
   global.get $~lib/date/MILLIS_PER_DAY
   i64.extend_i32_s
   i64.mul
-  local.get $3
+  local.get $2
   i64.add
   call $~lib/date/Date#set:epochMillis
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
   local.get $0
@@ -5592,26 +5632,23 @@
   block $invalid
    block $~lib/array/Array<~lib/string/String>
     block $~lib/array/Array<i32>
-     block $~lib/date/YMD
-      block $~lib/date/Date
-       block $~lib/arraybuffer/ArrayBufferView
-        block $~lib/string/String
-         block $~lib/arraybuffer/ArrayBuffer
-          local.get $0
-          i32.const 8
-          i32.sub
-          i32.load
-          br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $~lib/date/YMD $~lib/array/Array<i32> $~lib/array/Array<~lib/string/String> $invalid
-         end
-         return
+     block $~lib/date/Date
+      block $~lib/arraybuffer/ArrayBufferView
+       block $~lib/string/String
+        block $~lib/arraybuffer/ArrayBuffer
+         local.get $0
+         i32.const 8
+         i32.sub
+         i32.load
+         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $~lib/array/Array<i32> $~lib/array/Array<~lib/string/String> $invalid
         end
         return
        end
-       local.get $0
-       local.get $1
-       call $~lib/arraybuffer/ArrayBufferView~visit
        return
       end
+      local.get $0
+      local.get $1
+      call $~lib/arraybuffer/ArrayBufferView~visit
       return
      end
      return
@@ -5653,9 +5690,8 @@
  (func $~lib/date/Date#toISOString (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 116
+  i32.const 112
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
@@ -5701,10 +5737,6 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store offset=104
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=112
-  global.get $~lib/memory/__stack_pointer
   local.get $0
   i64.load
   global.get $~lib/date/MILLIS_PER_DAY
@@ -5712,299 +5744,294 @@
   i64.div_s
   i32.wrap_i64
   call $~lib/date/ymdFromEpochDays
-  local.tee $1
-  i32.store
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.load
+  global.get $~lib/date/year
   i32.const 10
   call $~lib/number/I32#toString
-  local.tee $2
-  i32.store offset=4
-  local.get $2
+  local.tee $1
+  i32.store
+  local.get $1
   call $~lib/string/String#get:length
   i32.const 4
   i32.gt_s
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 2496
-   local.set $3
+   local.set $2
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=8
-   local.get $3
    local.get $2
+   i32.store offset=4
+   local.get $2
+   local.get $1
    i32.const 6
    i32.const 912
-   local.set $3
+   local.set $2
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=16
-   local.get $3
-   call $~lib/string/String#padStart
-   local.set $3
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $2
    i32.store offset=12
-   local.get $3
+   local.get $2
+   call $~lib/string/String#padStart
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
    call $~lib/string/String.__concat
-   local.tee $2
-   i32.store offset=4
+   local.tee $1
+   i32.store
   end
+  local.get $1
+  i32.const 2560
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=100
+  local.get $2
+  call $~lib/string/String.__concat
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=92
+  local.get $2
+  global.get $~lib/date/month
+  i32.const 10
+  call $~lib/number/I32#toString
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=104
+  local.get $2
+  i32.const 2
+  i32.const 912
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=108
+  local.get $2
+  call $~lib/string/String#padStart
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=96
+  local.get $2
+  call $~lib/string/String.__concat
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=84
   local.get $2
   i32.const 2560
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=104
-  local.get $3
-  call $~lib/string/String.__concat
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=96
-  local.get $3
-  local.get $1
-  i32.load offset=4
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=108
-  local.get $3
-  i32.const 2
-  i32.const 912
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=112
-  local.get $3
-  call $~lib/string/String#padStart
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=100
-  local.get $3
-  call $~lib/string/String.__concat
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=88
-  local.get $3
-  i32.const 2560
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=92
-  local.get $3
+  local.get $2
   call $~lib/string/String.__concat
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=80
-  local.get $3
-  local.get $1
-  i32.load offset=8
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=88
-  local.get $3
-  i32.const 2
-  i32.const 912
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=96
-  local.get $3
-  call $~lib/string/String#padStart
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=84
-  local.get $3
-  call $~lib/string/String.__concat
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=72
-  local.get $3
-  i32.const 2592
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=76
-  local.get $3
-  call $~lib/string/String.__concat
-  local.set $3
+  local.get $2
+  global.get $~lib/date/day
+  i32.const 10
+  call $~lib/number/I32#toString
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=64
-  local.get $3
+  local.get $2
+  i32.store offset=84
+  local.get $2
+  i32.const 2
+  i32.const 912
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=92
+  local.get $2
+  call $~lib/string/String#padStart
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=80
+  local.get $2
+  call $~lib/string/String.__concat
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=68
+  local.get $2
+  i32.const 2592
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=72
+  local.get $2
+  call $~lib/string/String.__concat
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store offset=60
+  local.get $2
   local.get $0
   call $~lib/date/Date#getUTCHours
   i32.const 10
   call $~lib/number/I32#toString
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=72
-  local.get $3
+  local.get $2
+  i32.store offset=68
+  local.get $2
   i32.const 2
   i32.const 912
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=80
-  local.get $3
+  local.get $2
+  i32.store offset=76
+  local.get $2
   call $~lib/string/String#padStart
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=68
-  local.get $3
+  local.get $2
+  i32.store offset=64
+  local.get $2
   call $~lib/string/String.__concat
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=56
-  local.get $3
+  local.get $2
+  i32.store offset=52
+  local.get $2
   i32.const 2624
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=60
-  local.get $3
+  local.get $2
+  i32.store offset=56
+  local.get $2
   call $~lib/string/String.__concat
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=48
-  local.get $3
+  local.get $2
+  i32.store offset=44
+  local.get $2
   local.get $0
   call $~lib/date/Date#getUTCMinutes
   i32.const 10
   call $~lib/number/I32#toString
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=56
-  local.get $3
+  local.get $2
+  i32.store offset=52
+  local.get $2
   i32.const 2
   i32.const 912
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=64
-  local.get $3
+  local.get $2
+  i32.store offset=60
+  local.get $2
   call $~lib/string/String#padStart
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=52
-  local.get $3
+  local.get $2
+  i32.store offset=48
+  local.get $2
   call $~lib/string/String.__concat
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=40
-  local.get $3
+  local.get $2
+  i32.store offset=36
+  local.get $2
   i32.const 2624
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=44
-  local.get $3
+  local.get $2
+  i32.store offset=40
+  local.get $2
   call $~lib/string/String.__concat
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=32
-  local.get $3
+  local.get $2
+  i32.store offset=28
+  local.get $2
   local.get $0
   call $~lib/date/Date#getUTCSeconds
   i32.const 10
   call $~lib/number/I32#toString
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=40
-  local.get $3
+  local.get $2
+  i32.store offset=36
+  local.get $2
   i32.const 2
   i32.const 912
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=48
-  local.get $3
+  local.get $2
+  i32.store offset=44
+  local.get $2
   call $~lib/string/String#padStart
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=36
-  local.get $3
+  local.get $2
+  i32.store offset=32
+  local.get $2
   call $~lib/string/String.__concat
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=16
-  local.get $3
+  local.get $2
+  i32.store offset=12
+  local.get $2
   i32.const 2656
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=28
-  local.get $3
+  local.get $2
+  i32.store offset=24
+  local.get $2
   call $~lib/string/String.__concat
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=20
-  local.get $3
+  local.get $2
+  i32.store offset=16
+  local.get $2
   local.get $0
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 10
   call $~lib/number/I32#toString
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=16
-  local.get $3
+  local.get $2
+  i32.store offset=12
+  local.get $2
   i32.const 3
   i32.const 912
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=32
-  local.get $3
+  local.get $2
+  i32.store offset=28
+  local.get $2
   call $~lib/string/String#padStart
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=24
-  local.get $3
+  local.get $2
+  i32.store offset=20
+  local.get $2
   call $~lib/string/String.__concat
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
+  local.get $2
+  i32.store offset=4
+  local.get $2
   i32.const 2688
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=12
-  local.get $3
+  local.get $2
+  i32.store offset=8
+  local.get $2
   call $~lib/string/String.__concat
-  local.set $3
+  local.set $2
   global.get $~lib/memory/__stack_pointer
-  i32.const 116
+  i32.const 112
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
  )
  (func $~lib/string/String#split (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -6039,7 +6066,7 @@
   if
    i32.const 0
    i32.const 2
-   i32.const 6
+   i32.const 5
    i32.const 0
    call $~lib/rt/__newArray
    local.set $15
@@ -6057,7 +6084,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1
    i32.const 2
-   i32.const 6
+   i32.const 5
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $3
@@ -6101,7 +6128,7 @@
    if
     i32.const 0
     i32.const 2
-    i32.const 6
+    i32.const 5
     i32.const 0
     call $~lib/rt/__newArray
     local.set $15
@@ -6124,7 +6151,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $5
    i32.const 2
-   i32.const 6
+   i32.const 5
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $3
@@ -6188,7 +6215,7 @@
     global.get $~lib/memory/__stack_pointer
     i32.const 1
     i32.const 2
-    i32.const 6
+    i32.const 5
     i32.const 0
     call $~lib/rt/__newArray
     local.tee $4
@@ -6210,7 +6237,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 2
-  i32.const 6
+  i32.const 5
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $10
@@ -6683,7 +6710,7 @@
    i32.const 0
    i32.const 32
    i32.const 3
-   i32.const 5
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6718,7 +6745,7 @@
    i32.const 0
    i32.const 32
    i32.const 4
-   i32.const 5
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6755,7 +6782,7 @@
    i32.const 0
    i32.const 32
    i32.const 7
-   i32.const 5
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6793,7 +6820,7 @@
    i32.const 0
    i32.const 32
    i32.const 15
-   i32.const 5
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6814,7 +6841,7 @@
    i32.const 0
    i32.const 32
    i32.const 17
-   i32.const 5
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6832,8 +6859,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 26
-   i32.const 5
+   i32.const 25
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6845,8 +6872,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 27
-   i32.const 5
+   i32.const 26
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6858,8 +6885,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 28
-   i32.const 5
+   i32.const 27
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6871,8 +6898,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 29
-   i32.const 5
+   i32.const 28
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6884,8 +6911,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 30
-   i32.const 5
+   i32.const 29
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6897,8 +6924,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 31
-   i32.const 5
+   i32.const 30
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6910,8 +6937,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 32
-   i32.const 5
+   i32.const 31
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6929,8 +6956,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 38
-   i32.const 5
+   i32.const 37
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6942,8 +6969,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 39
-   i32.const 5
+   i32.const 38
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6955,8 +6982,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 40
-   i32.const 5
+   i32.const 39
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6968,8 +6995,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 41
-   i32.const 5
+   i32.const 40
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6981,8 +7008,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 42
-   i32.const 5
+   i32.const 41
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -6994,8 +7021,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 43
-   i32.const 5
+   i32.const 42
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7007,8 +7034,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 44
-   i32.const 5
+   i32.const 43
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7026,8 +7053,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 50
-   i32.const 5
+   i32.const 49
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7042,8 +7069,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 52
-   i32.const 5
+   i32.const 51
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7058,8 +7085,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 54
-   i32.const 5
+   i32.const 53
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7083,8 +7110,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 63
-   i32.const 5
+   i32.const 62
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7099,8 +7126,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 65
-   i32.const 5
+   i32.const 64
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7115,8 +7142,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 67
-   i32.const 5
+   i32.const 66
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7140,8 +7167,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 76
-   i32.const 5
+   i32.const 75
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7156,8 +7183,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 78
-   i32.const 5
+   i32.const 77
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7172,8 +7199,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 80
-   i32.const 5
+   i32.const 79
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7197,8 +7224,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 89
-   i32.const 5
+   i32.const 88
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7213,8 +7240,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 91
-   i32.const 5
+   i32.const 90
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7229,8 +7256,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 93
-   i32.const 5
+   i32.const 92
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7254,8 +7281,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 102
-   i32.const 5
+   i32.const 101
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7267,8 +7294,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 103
-   i32.const 5
+   i32.const 102
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7283,8 +7310,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 107
-   i32.const 5
+   i32.const 106
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7299,8 +7326,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 109
-   i32.const 5
+   i32.const 108
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7345,8 +7372,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 131
-   i32.const 5
+   i32.const 130
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7361,8 +7388,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 133
-   i32.const 5
+   i32.const 132
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7377,8 +7404,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 135
-   i32.const 5
+   i32.const 134
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7402,8 +7429,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 144
-   i32.const 5
+   i32.const 143
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7418,8 +7445,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 146
-   i32.const 5
+   i32.const 145
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7434,8 +7461,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 148
-   i32.const 5
+   i32.const 147
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7463,8 +7490,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 154
-   i32.const 5
+   i32.const 153
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7492,8 +7519,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 156
-   i32.const 5
+   i32.const 155
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7521,8 +7548,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 158
-   i32.const 5
+   i32.const 157
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7544,8 +7571,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 165
-   i32.const 5
+   i32.const 164
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7567,8 +7594,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 167
-   i32.const 5
+   i32.const 166
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7590,8 +7617,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 169
-   i32.const 5
+   i32.const 168
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7626,8 +7653,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 172
-   i32.const 5
+   i32.const 171
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7649,8 +7676,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 176
-   i32.const 5
+   i32.const 178
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7672,8 +7699,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 180
-   i32.const 5
+   i32.const 182
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7695,8 +7722,8 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 184
-   i32.const 5
+   i32.const 186
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
@@ -7738,183 +7765,6 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $2
- )
- (func $~lib/date/YMD#constructor (param $0 i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-  end
-  local.get $0
-  i32.const 0
-  call $~lib/date/YMD#set:year
-  local.get $0
-  i32.const 0
-  call $~lib/date/YMD#set:month
-  local.get $0
-  i32.const 0
-  call $~lib/date/YMD#set:day
-  local.get $0
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $1
- )
- (func $~lib/date/ymdFromEpochDays (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 719468
-  i32.add
-  local.set $0
-  local.get $0
-  i32.const 0
-  i32.ge_s
-  if (result i32)
-   local.get $0
-  else
-   local.get $0
-   i32.const 146096
-   i32.sub
-  end
-  i32.const 146097
-  i32.div_s
-  local.set $1
-  local.get $0
-  local.get $1
-  i32.const 146097
-  i32.mul
-  i32.sub
-  local.set $2
-  local.get $2
-  local.get $2
-  i32.const 1460
-  i32.div_s
-  i32.sub
-  local.get $2
-  i32.const 36524
-  i32.div_s
-  i32.add
-  local.get $2
-  i32.const 146096
-  i32.div_s
-  i32.sub
-  i32.const 365
-  i32.div_s
-  local.set $3
-  local.get $3
-  local.get $1
-  i32.const 400
-  i32.mul
-  i32.add
-  local.set $4
-  local.get $2
-  i32.const 365
-  local.get $3
-  i32.mul
-  local.get $3
-  i32.const 4
-  i32.div_s
-  i32.add
-  local.get $3
-  i32.const 100
-  i32.div_s
-  i32.sub
-  i32.sub
-  local.set $5
-  i32.const 5
-  local.get $5
-  i32.mul
-  i32.const 2
-  i32.add
-  i32.const 153
-  i32.div_s
-  local.set $6
-  local.get $5
-  i32.const 153
-  local.get $6
-  i32.mul
-  i32.const 2
-  i32.add
-  i32.const 5
-  i32.div_s
-  i32.sub
-  i32.const 1
-  i32.add
-  local.set $7
-  local.get $6
-  local.get $6
-  i32.const 10
-  i32.lt_s
-  if (result i32)
-   i32.const 3
-  else
-   i32.const -9
-  end
-  i32.add
-  local.set $8
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  call $~lib/date/YMD#constructor
-  local.tee $9
-  i32.store
-  local.get $9
-  local.get $4
-  local.get $8
-  i32.const 2
-  i32.le_s
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  i32.add
-  call $~lib/date/YMD#set:year
-  local.get $9
-  local.get $8
-  call $~lib/date/YMD#set:month
-  local.get $9
-  local.get $7
-  call $~lib/date/YMD#set:day
-  local.get $9
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $10
  )
  (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
@@ -7983,7 +7833,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.const 2
-  i32.const 5
+  i32.const 4
   i32.const 592
   call $~lib/rt/__newArray
   local.tee $2

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -1,17 +1,22 @@
 (module
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
- (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_=>_none (func (param i32 i64)))
+ (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
+ (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
+ (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $i32_=>_i64 (func (param i32) (result i64)))
+ (type $i32_i32_i32_i32_i32_i32_i32_=>_i64 (func (param i32 i32 i32 i32 i32 i32 i32) (result i64)))
  (type $i32_i64_=>_i64 (func (param i32 i64) (result i64)))
  (type $i32_i32_i32_i32_i32_i32_f64_=>_f64 (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
  (import "Date" "UTC" (func $~lib/bindings/Date/UTC (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
@@ -30,7 +35,34 @@
  (data (i32.const 524) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00d\00a\00t\00e\00.\00t\00s\00\00\00\00\00")
  (data (i32.const 572) "L\00\00\00\00\00\00\00\00\00\00\00\00\00\00\000\00\00\00\1f\00\00\00\1c\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 652) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
- (data (i32.const 704) "\06\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\02\t\00\00\00\00\00\00")
+ (data (i32.const 700) "|\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00d\00\00\00t\00o\00S\00t\00r\00i\00n\00g\00(\00)\00 \00r\00a\00d\00i\00x\00 \00a\00r\00g\00u\00m\00e\00n\00t\00 \00m\00u\00s\00t\00 \00b\00e\00 \00b\00e\00t\00w\00e\00e\00n\00 \002\00 \00a\00n\00d\00 \003\006\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 828) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00u\00t\00i\00l\00/\00n\00u\00m\00b\00e\00r\00.\00t\00s\00\00\00\00\00\00\00")
+ (data (i32.const 892) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\000\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 924) "0\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\00")
+ (data (i32.const 1324) "\1c\04\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\04\00\000\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\000\00a\000\00b\000\00c\000\00d\000\00e\000\00f\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\001\00a\001\00b\001\00c\001\00d\001\00e\001\00f\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\002\00a\002\00b\002\00c\002\00d\002\00e\002\00f\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\003\00a\003\00b\003\00c\003\00d\003\00e\003\00f\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\004\00a\004\00b\004\00c\004\00d\004\00e\004\00f\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\005\00a\005\00b\005\00c\005\00d\005\00e\005\00f\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\006\00a\006\00b\006\00c\006\00d\006\00e\006\00f\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\007\00a\007\00b\007\00c\007\00d\007\00e\007\00f\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\008\00a\008\00b\008\00c\008\00d\008\00e\008\00f\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\009\00a\009\00b\009\00c\009\00d\009\00e\009\00f\00a\000\00a\001\00a\002\00a\003\00a\004\00a\005\00a\006\00a\007\00a\008\00a\009\00a\00a\00a\00b\00a\00c\00a\00d\00a\00e\00a\00f\00b\000\00b\001\00b\002\00b\003\00b\004\00b\005\00b\006\00b\007\00b\008\00b\009\00b\00a\00b\00b\00b\00c\00b\00d\00b\00e\00b\00f\00c\000\00c\001\00c\002\00c\003\00c\004\00c\005\00c\006\00c\007\00c\008\00c\009\00c\00a\00c\00b\00c\00c\00c\00d\00c\00e\00c\00f\00d\000\00d\001\00d\002\00d\003\00d\004\00d\005\00d\006\00d\007\00d\008\00d\009\00d\00a\00d\00b\00d\00c\00d\00d\00d\00e\00d\00f\00e\000\00e\001\00e\002\00e\003\00e\004\00e\005\00e\006\00e\007\00e\008\00e\009\00e\00a\00e\00b\00e\00c\00e\00d\00e\00e\00e\00f\00f\000\00f\001\00f\002\00f\003\00f\004\00f\005\00f\006\00f\007\00f\008\00f\009\00f\00a\00f\00b\00f\00c\00f\00d\00f\00e\00f\00f\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2380) "\\\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00H\00\00\000\001\002\003\004\005\006\007\008\009\00a\00b\00c\00d\00e\00f\00g\00h\00i\00j\00k\00l\00m\00n\00o\00p\00q\00r\00s\00t\00u\00v\00w\00x\00y\00z\00\00\00\00\00")
+ (data (i32.const 2476) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00+\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2508) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2540) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00-\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2572) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00T\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2604) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00:\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2636) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00.\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2668) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00Z\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2700) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\002\000\000\009\00-\000\001\00-\000\006\00T\000\008\00:\004\000\00:\003\001\00.\000\002\000\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2780) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\002\000\000\009\00-\000\001\00-\000\006\00T\000\008\00:\004\000\00:\003\001\00.\004\005\006\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2860) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\006\00\00\00+\000\001\002\001\008\004\00-\000\004\00-\000\008\00T\001\003\00:\000\007\00:\001\001\00.\000\002\000\00Z\00\00\00\00\00\00\00")
+ (data (i32.const 2940) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\001\009\007\006\00-\000\002\00-\000\002\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2988) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 3036) "|\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3164) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\04\00\00\001\009\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3196) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\10\00\00\001\009\007\006\00-\002\00-\002\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3244) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\002\003\004\005\00-\001\001\00-\000\004\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3292) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\001\009\007\006\00-\000\004\00-\000\002\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3340) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\10\00\00\007\006\00-\000\004\00-\000\002\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3388) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00&\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00\00\00\00\00\00\00")
+ (data (i32.const 3452) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00.\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3532) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3616) "\07\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\02\t\00\00\00\00\00\00\02A\00\00\00\00\00\00")
  (table $0 1 funcref)
  (global $~lib/date/MILLIS_PER_DAY i32 (i32.const 86400000))
  (global $~lib/date/MILLIS_PER_HOUR i32 (i32.const 3600000))
@@ -48,10 +80,11 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 704))
- (global $~lib/memory/__data_end i32 (i32.const 756))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 17140))
- (global $~lib/memory/__heap_base i32 (i32.const 17140))
+ (global $~lib/builtins/i32.MAX_VALUE i32 (i32.const 2147483647))
+ (global $~lib/rt/__rtti_base i32 (i32.const 3616))
+ (global $~lib/memory/__data_end i32 (i32.const 3676))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 20060))
+ (global $~lib/memory/__heap_base i32 (i32.const 20060))
  (global $~started (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
@@ -2486,7 +2519,7 @@
   if
    i32.const 480
    i32.const 544
-   i32.const 111
+   i32.const 195
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -4181,6 +4214,2425 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
+  local.get $0
+  i32.const 100000
+  i32.lt_u
+  if
+   local.get $0
+   i32.const 100
+   i32.lt_u
+   if
+    i32.const 1
+    local.get $0
+    i32.const 10
+    i32.ge_u
+    i32.add
+    return
+   else
+    i32.const 3
+    local.get $0
+    i32.const 10000
+    i32.ge_u
+    i32.add
+    local.get $0
+    i32.const 1000
+    i32.ge_u
+    i32.add
+    return
+   end
+   unreachable
+  else
+   local.get $0
+   i32.const 10000000
+   i32.lt_u
+   if
+    i32.const 6
+    local.get $0
+    i32.const 1000000
+    i32.ge_u
+    i32.add
+    return
+   else
+    i32.const 8
+    local.get $0
+    i32.const 1000000000
+    i32.ge_u
+    i32.add
+    local.get $0
+    i32.const 100000000
+    i32.ge_u
+    i32.add
+    return
+   end
+   unreachable
+  end
+  unreachable
+ )
+ (func $~lib/util/number/utoa32_dec_lut (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i64)
+  (local $10 i32)
+  (local $11 i32)
+  loop $while-continue|0
+   local.get $1
+   i32.const 10000
+   i32.ge_u
+   local.set $3
+   local.get $3
+   if
+    local.get $1
+    i32.const 10000
+    i32.div_u
+    local.set $4
+    local.get $1
+    i32.const 10000
+    i32.rem_u
+    local.set $5
+    local.get $4
+    local.set $1
+    local.get $5
+    i32.const 100
+    i32.div_u
+    local.set $6
+    local.get $5
+    i32.const 100
+    i32.rem_u
+    local.set $7
+    i32.const 924
+    local.get $6
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $8
+    i32.const 924
+    local.get $7
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $9
+    local.get $2
+    i32.const 4
+    i32.sub
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $8
+    local.get $9
+    i64.const 32
+    i64.shl
+    i64.or
+    i64.store
+    br $while-continue|0
+   end
+  end
+  local.get $1
+  i32.const 100
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 100
+   i32.div_u
+   local.set $3
+   local.get $1
+   i32.const 100
+   i32.rem_u
+   local.set $10
+   local.get $3
+   local.set $1
+   local.get $2
+   i32.const 2
+   i32.sub
+   local.set $2
+   i32.const 924
+   local.get $10
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load
+   local.set $11
+   local.get $0
+   local.get $2
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $11
+   i32.store
+  end
+  local.get $1
+  i32.const 10
+  i32.ge_u
+  if
+   local.get $2
+   i32.const 2
+   i32.sub
+   local.set $2
+   i32.const 924
+   local.get $1
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load
+   local.set $11
+   local.get $0
+   local.get $2
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $11
+   i32.store
+  else
+   local.get $2
+   i32.const 1
+   i32.sub
+   local.set $2
+   i32.const 48
+   local.get $1
+   i32.add
+   local.set $11
+   local.get $0
+   local.get $2
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $11
+   i32.store16
+  end
+ )
+ (func $~lib/util/number/utoa_hex_lut (param $0 i32) (param $1 i64) (param $2 i32)
+  (local $3 i32)
+  loop $while-continue|0
+   local.get $2
+   i32.const 2
+   i32.ge_u
+   local.set $3
+   local.get $3
+   if
+    local.get $2
+    i32.const 2
+    i32.sub
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.const 1344
+    local.get $1
+    i32.wrap_i64
+    i32.const 255
+    i32.and
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    i32.store
+    local.get $1
+    i64.const 8
+    i64.shr_u
+    local.set $1
+    br $while-continue|0
+   end
+  end
+  local.get $2
+  i32.const 1
+  i32.and
+  if
+   local.get $0
+   i32.const 1344
+   local.get $1
+   i32.wrap_i64
+   i32.const 6
+   i32.shl
+   i32.add
+   i32.load16_u
+   i32.store16
+  end
+ )
+ (func $~lib/util/number/ulog_base (param $0 i64) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.popcnt
+  i32.const 1
+  i32.eq
+  if
+   i32.const 63
+   local.get $0
+   i64.clz
+   i32.wrap_i64
+   i32.sub
+   i32.const 31
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.div_u
+   i32.const 1
+   i32.add
+   return
+  end
+  local.get $1
+  i64.extend_i32_s
+  local.set $3
+  local.get $3
+  local.set $4
+  i32.const 1
+  local.set $5
+  loop $while-continue|0
+   local.get $0
+   local.get $4
+   i64.ge_u
+   local.set $2
+   local.get $2
+   if
+    local.get $0
+    local.get $4
+    i64.div_u
+    local.set $0
+    local.get $4
+    local.get $4
+    i64.mul
+    local.set $4
+    local.get $5
+    i32.const 1
+    i32.shl
+    local.set $5
+    br $while-continue|0
+   end
+  end
+  loop $while-continue|1
+   local.get $0
+   i64.const 1
+   i64.ge_u
+   local.set $2
+   local.get $2
+   if
+    local.get $0
+    local.get $3
+    i64.div_u
+    local.set $0
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $while-continue|1
+   end
+  end
+  local.get $5
+  i32.const 1
+  i32.sub
+ )
+ (func $~lib/util/number/utoa64_any_core (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i32)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 i64)
+  (local $7 i32)
+  local.get $3
+  i64.extend_i32_s
+  local.set $4
+  local.get $3
+  local.get $3
+  i32.const 1
+  i32.sub
+  i32.and
+  i32.const 0
+  i32.eq
+  if
+   local.get $3
+   i32.ctz
+   i32.const 7
+   i32.and
+   i64.extend_i32_s
+   local.set $5
+   local.get $4
+   i64.const 1
+   i64.sub
+   local.set $6
+   loop $do-continue|0
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.const 2400
+    local.get $1
+    local.get $6
+    i64.and
+    i32.wrap_i64
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.load16_u
+    i32.store16
+    local.get $1
+    local.get $5
+    i64.shr_u
+    local.set $1
+    local.get $1
+    i64.const 0
+    i64.ne
+    local.set $7
+    local.get $7
+    br_if $do-continue|0
+   end
+  else
+   loop $do-continue|1
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    local.get $1
+    local.get $4
+    i64.div_u
+    local.set $6
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.const 2400
+    local.get $1
+    local.get $6
+    local.get $4
+    i64.mul
+    i64.sub
+    i32.wrap_i64
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.load16_u
+    i32.store16
+    local.get $6
+    local.set $1
+    local.get $1
+    i64.const 0
+    i64.ne
+    local.set $7
+    local.get $7
+    br_if $do-continue|1
+   end
+  end
+ )
+ (func $~lib/number/I32#toString (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  call $~lib/util/number/itoa32
+ )
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+ )
+ (func $~lib/memory/memory.repeat (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  i32.const 0
+  local.set $4
+  local.get $2
+  local.get $3
+  i32.mul
+  local.set $5
+  loop $while-continue|0
+   local.get $4
+   local.get $5
+   i32.lt_u
+   local.set $6
+   local.get $6
+   if
+    local.get $0
+    local.get $4
+    i32.add
+    local.get $1
+    local.get $2
+    call $~lib/memory/memory.copy
+    local.get $4
+    local.get $2
+    i32.add
+    local.set $4
+    br $while-continue|0
+   end
+  end
+ )
+ (func $~lib/string/String.__concat (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  call $~lib/string/String#concat
+ )
+ (func $~lib/util/string/compareImpl (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.set $5
+  local.get $2
+  local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
+  local.set $6
+  i32.const 0
+  i32.const 2
+  i32.lt_s
+  drop
+  local.get $4
+  i32.const 4
+  i32.ge_u
+  if (result i32)
+   local.get $5
+   i32.const 7
+   i32.and
+   local.get $6
+   i32.const 7
+   i32.and
+   i32.or
+   i32.eqz
+  else
+   i32.const 0
+  end
+  if
+   block $do-break|0
+    loop $do-continue|0
+     local.get $5
+     i64.load
+     local.get $6
+     i64.load
+     i64.ne
+     if
+      br $do-break|0
+     end
+     local.get $5
+     i32.const 8
+     i32.add
+     local.set $5
+     local.get $6
+     i32.const 8
+     i32.add
+     local.set $6
+     local.get $4
+     i32.const 4
+     i32.sub
+     local.set $4
+     local.get $4
+     i32.const 4
+     i32.ge_u
+     local.set $7
+     local.get $7
+     br_if $do-continue|0
+    end
+   end
+  end
+  loop $while-continue|1
+   local.get $4
+   local.tee $7
+   i32.const 1
+   i32.sub
+   local.set $4
+   local.get $7
+   local.set $7
+   local.get $7
+   if
+    local.get $5
+    i32.load16_u
+    local.set $8
+    local.get $6
+    i32.load16_u
+    local.set $9
+    local.get $8
+    local.get $9
+    i32.ne
+    if
+     local.get $8
+     local.get $9
+     i32.sub
+     return
+    end
+    local.get $5
+    i32.const 2
+    i32.add
+    local.set $5
+    local.get $6
+    i32.const 2
+    i32.add
+    local.set $6
+    br $while-continue|1
+   end
+  end
+  i32.const 0
+ )
+ (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  local.get $1
+  i32.eq
+  if
+   i32.const 1
+   return
+  end
+  local.get $0
+  i32.const 0
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   local.get $1
+   i32.const 0
+   i32.eq
+  end
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  call $~lib/string/String#get:length
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/string/String#get:length
+  i32.ne
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  i32.const 0
+  local.get $1
+  i32.const 0
+  local.get $2
+  call $~lib/util/string/compareImpl
+  i32.eqz
+ )
+ (func $~lib/string/String#indexOf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  call $~lib/string/String#get:length
+  local.set $3
+  local.get $3
+  i32.eqz
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  call $~lib/string/String#get:length
+  local.set $4
+  local.get $4
+  i32.eqz
+  if
+   i32.const -1
+   return
+  end
+  local.get $2
+  local.tee $5
+  i32.const 0
+  local.tee $6
+  local.get $5
+  local.get $6
+  i32.gt_s
+  select
+  local.tee $6
+  local.get $4
+  local.tee $5
+  local.get $6
+  local.get $5
+  i32.lt_s
+  select
+  local.set $7
+  local.get $4
+  local.get $3
+  i32.sub
+  local.set $4
+  loop $for-loop|0
+   local.get $7
+   local.get $4
+   i32.le_s
+   local.set $6
+   local.get $6
+   if
+    local.get $0
+    local.get $7
+    local.get $1
+    i32.const 0
+    local.get $3
+    call $~lib/util/string/compareImpl
+    i32.eqz
+    if
+     local.get $7
+     return
+    end
+    local.get $7
+    i32.const 1
+    i32.add
+    local.set $7
+    br $for-loop|0
+   end
+  end
+  i32.const -1
+ )
+ (func $~lib/string/String#includes (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/string/String#indexOf
+  i32.const -1
+  i32.ne
+ )
+ (func $~lib/array/Array<~lib/string/String>#__uset (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store
+  i32.const 1
+  drop
+  local.get $0
+  local.get $2
+  i32.const 1
+  call $~lib/rt/itcms/__link
+ )
+ (func $~lib/rt/itcms/__renew (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  local.set $2
+  local.get $1
+  local.get $2
+  i32.load
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.sub
+  i32.le_u
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/itcms/Object#set:rtSize
+   local.get $0
+   return
+  end
+  local.get $1
+  local.get $2
+  i32.load offset=12
+  call $~lib/rt/itcms/__new
+  local.set $3
+  local.get $3
+  local.get $0
+  local.get $1
+  local.tee $4
+  local.get $2
+  i32.load offset=16
+  local.tee $5
+  local.get $4
+  local.get $5
+  i32.lt_u
+  select
+  call $~lib/memory/memory.copy
+  local.get $3
+ )
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $3
+  local.get $1
+  local.get $3
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 1073741820
+   local.get $2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 3008
+    i32.const 672
+    i32.const 14
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   i32.load
+   local.set $4
+   local.get $1
+   local.get $2
+   i32.shl
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
+   local.get $3
+   i32.add
+   i32.const 0
+   local.get $5
+   local.get $3
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $6
+   local.get $4
+   i32.ne
+   if
+    local.get $0
+    local.get $6
+    i32.store
+    local.get $0
+    local.get $6
+    i32.store offset=4
+    local.get $0
+    local.get $6
+    i32.const 0
+    call $~lib/rt/itcms/__link
+   end
+   local.get $0
+   local.get $5
+   i32.store offset=8
+  end
+ )
+ (func $~lib/array/Array<~lib/string/String>#set:length_ (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $2
+  i32.const 1
+  i32.add
+  local.set $3
+  local.get $0
+  local.get $3
+  i32.const 2
+  call $~lib/array/ensureSize
+  i32.const 1
+  drop
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $1
+  i32.const 1
+  call $~lib/rt/itcms/__link
+  local.get $0
+  local.get $3
+  call $~lib/array/Array<~lib/string/String>#set:length_
+  local.get $3
+ )
+ (func $~lib/util/string/isSpace (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.const 5760
+  i32.lt_u
+  if
+   local.get $0
+   i32.const 128
+   i32.or
+   i32.const 160
+   i32.eq
+   local.get $0
+   i32.const 9
+   i32.sub
+   i32.const 13
+   i32.const 9
+   i32.sub
+   i32.le_u
+   i32.or
+   return
+  end
+  local.get $0
+  i32.const 8192
+  i32.sub
+  i32.const 8202
+  i32.const 8192
+  i32.sub
+  i32.le_u
+  if
+   i32.const 1
+   return
+  end
+  block $break|0
+   block $case6|0
+    block $case5|0
+     block $case4|0
+      block $case3|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          local.get $0
+          local.set $1
+          local.get $1
+          i32.const 5760
+          i32.eq
+          br_if $case0|0
+          local.get $1
+          i32.const 8232
+          i32.eq
+          br_if $case1|0
+          local.get $1
+          i32.const 8233
+          i32.eq
+          br_if $case2|0
+          local.get $1
+          i32.const 8239
+          i32.eq
+          br_if $case3|0
+          local.get $1
+          i32.const 8287
+          i32.eq
+          br_if $case4|0
+          local.get $1
+          i32.const 12288
+          i32.eq
+          br_if $case5|0
+          local.get $1
+          i32.const 65279
+          i32.eq
+          br_if $case6|0
+          br $break|0
+         end
+        end
+       end
+      end
+     end
+    end
+   end
+   i32.const 1
+   return
+  end
+  i32.const 0
+ )
+ (func $~lib/util/string/strtol<i32> (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  call $~lib/string/String#get:length
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   i32.const 0
+   drop
+   i32.const 0
+   return
+  end
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load16_u
+  local.set $4
+  loop $while-continue|0
+   local.get $4
+   call $~lib/util/string/isSpace
+   local.set $5
+   local.get $5
+   if
+    local.get $3
+    i32.const 2
+    i32.add
+    local.tee $3
+    i32.load16_u
+    local.set $4
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  i32.const 1
+  local.set $6
+  local.get $4
+  i32.const 45
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   local.get $4
+   i32.const 43
+   i32.eq
+  end
+  if
+   local.get $2
+   i32.const 1
+   i32.sub
+   local.tee $2
+   i32.eqz
+   if
+    i32.const 0
+    drop
+    i32.const 0
+    return
+   end
+   local.get $4
+   i32.const 45
+   i32.eq
+   if
+    i32.const -1
+    local.set $6
+   end
+   local.get $3
+   i32.const 2
+   i32.add
+   local.tee $3
+   i32.load16_u
+   local.set $4
+  end
+  local.get $1
+  if
+   local.get $1
+   i32.const 2
+   i32.lt_s
+   if (result i32)
+    i32.const 1
+   else
+    local.get $1
+    i32.const 36
+    i32.gt_s
+   end
+   if
+    i32.const 0
+    drop
+    i32.const 0
+    return
+   end
+   local.get $1
+   i32.const 16
+   i32.eq
+   if
+    local.get $2
+    i32.const 2
+    i32.gt_s
+    if (result i32)
+     local.get $4
+     i32.const 48
+     i32.eq
+    else
+     i32.const 0
+    end
+    if (result i32)
+     local.get $3
+     i32.load16_u offset=2
+     i32.const 32
+     i32.or
+     i32.const 120
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     i32.const 4
+     i32.add
+     local.set $3
+     local.get $2
+     i32.const 2
+     i32.sub
+     local.set $2
+    end
+   end
+  else
+   local.get $4
+   i32.const 48
+   i32.eq
+   if (result i32)
+    local.get $2
+    i32.const 2
+    i32.gt_s
+   else
+    i32.const 0
+   end
+   if
+    block $break|1
+     block $case2|1
+      block $case1|1
+       block $case0|1
+        local.get $3
+        i32.load16_u offset=2
+        i32.const 32
+        i32.or
+        local.set $5
+        local.get $5
+        i32.const 98
+        i32.eq
+        br_if $case0|1
+        local.get $5
+        i32.const 111
+        i32.eq
+        br_if $case1|1
+        local.get $5
+        i32.const 120
+        i32.eq
+        br_if $case2|1
+        br $break|1
+       end
+       local.get $3
+       i32.const 4
+       i32.add
+       local.set $3
+       local.get $2
+       i32.const 2
+       i32.sub
+       local.set $2
+       i32.const 2
+       local.set $1
+       br $break|1
+      end
+      local.get $3
+      i32.const 4
+      i32.add
+      local.set $3
+      local.get $2
+      i32.const 2
+      i32.sub
+      local.set $2
+      i32.const 8
+      local.set $1
+      br $break|1
+     end
+     local.get $3
+     i32.const 4
+     i32.add
+     local.set $3
+     local.get $2
+     i32.const 2
+     i32.sub
+     local.set $2
+     i32.const 16
+     local.set $1
+     br $break|1
+    end
+   end
+   local.get $1
+   i32.eqz
+   if
+    i32.const 10
+    local.set $1
+   end
+  end
+  i32.const 0
+  local.set $7
+  block $while-break|2
+   loop $while-continue|2
+    local.get $2
+    local.tee $5
+    i32.const 1
+    i32.sub
+    local.set $2
+    local.get $5
+    local.set $5
+    local.get $5
+    if
+     local.get $3
+     i32.load16_u
+     local.set $4
+     local.get $4
+     i32.const 48
+     i32.sub
+     i32.const 10
+     i32.lt_u
+     if
+      local.get $4
+      i32.const 48
+      i32.sub
+      local.set $4
+     else
+      local.get $4
+      i32.const 65
+      i32.sub
+      i32.const 90
+      i32.const 65
+      i32.sub
+      i32.le_u
+      if
+       local.get $4
+       i32.const 65
+       i32.const 10
+       i32.sub
+       i32.sub
+       local.set $4
+      else
+       local.get $4
+       i32.const 97
+       i32.sub
+       i32.const 122
+       i32.const 97
+       i32.sub
+       i32.le_u
+       if
+        local.get $4
+        i32.const 97
+        i32.const 10
+        i32.sub
+        i32.sub
+        local.set $4
+       end
+      end
+     end
+     local.get $4
+     local.get $1
+     i32.ge_u
+     if
+      local.get $7
+      i32.eqz
+      if
+       i32.const 0
+       drop
+       i32.const 0
+       return
+      end
+      br $while-break|2
+     end
+     local.get $7
+     local.get $1
+     i32.mul
+     local.get $4
+     i32.add
+     local.set $7
+     local.get $3
+     i32.const 2
+     i32.add
+     local.set $3
+     br $while-continue|2
+    end
+   end
+  end
+  local.get $6
+  local.get $7
+  i32.mul
+ )
+ (func $~lib/number/I32.parseInt (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  call $~lib/util/string/strtol<i32>
+ )
+ (func $~lib/date/epochMillis (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32) (param $6 i32) (result i64)
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.mul
+  local.get $3
+  global.get $~lib/date/MILLIS_PER_HOUR
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  local.get $4
+  global.get $~lib/date/MILLIS_PER_MINUTE
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  local.get $5
+  global.get $~lib/date/MILLIS_PER_SECOND
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  local.get $6
+  i64.extend_i32_s
+  i64.add
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  i32.const 272
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 480
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 3008
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 3056
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 80
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 1344
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 2400
+  local.get $0
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/itcms/__visit
+  end
+ )
+ (func $~lib/array/Array<i32>#__visit (param $0 i32) (param $1 i32)
+  i32.const 0
+  drop
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/array/Array<i32>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i32>#__visit
+ )
+ (func $~lib/array/Array<~lib/string/String>#__visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  i32.const 1
+  drop
+  local.get $0
+  i32.load offset=4
+  local.set $2
+  local.get $2
+  local.get $0
+  i32.load offset=12
+  i32.const 2
+  i32.shl
+  i32.add
+  local.set $3
+  loop $while-continue|0
+   local.get $2
+   local.get $3
+   i32.lt_u
+   local.set $4
+   local.get $4
+   if
+    local.get $2
+    i32.load
+    local.set $5
+    local.get $5
+    if
+     local.get $5
+     local.get $1
+     call $~lib/rt/itcms/__visit
+    end
+    local.get $2
+    i32.const 4
+    i32.add
+    local.set $2
+    br $while-continue|0
+   end
+  end
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/array/Array<~lib/string/String>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<~lib/string/String>#__visit
+ )
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
+  block $invalid
+   block $~lib/array/Array<~lib/string/String>
+    block $~lib/array/Array<i32>
+     block $~lib/date/YMD
+      block $~lib/date/Date
+       block $~lib/arraybuffer/ArrayBufferView
+        block $~lib/string/String
+         block $~lib/arraybuffer/ArrayBuffer
+          local.get $0
+          i32.const 8
+          i32.sub
+          i32.load
+          br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $~lib/date/YMD $~lib/array/Array<i32> $~lib/array/Array<~lib/string/String> $invalid
+         end
+         return
+        end
+        return
+       end
+       local.get $0
+       local.get $1
+       call $~lib/arraybuffer/ArrayBufferView~visit
+       return
+      end
+      return
+     end
+     return
+    end
+    local.get $0
+    local.get $1
+    call $~lib/array/Array<i32>~visit
+    return
+   end
+   local.get $0
+   local.get $1
+   call $~lib/array/Array<~lib/string/String>~visit
+   return
+  end
+  unreachable
+ )
+ (func $~start
+  global.get $~started
+  if
+   return
+  end
+  i32.const 1
+  global.set $~started
+  call $start:std/date
+ )
+ (func $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__data_end
+  i32.lt_s
+  if
+   i32.const 20080
+   i32.const 20128
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/date/Date#toISOString (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 116
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=16
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=24
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=32
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=40
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=48
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=56
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=64
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=72
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=80
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=88
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=96
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=104
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store offset=112
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.tee $1
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.load
+  i32.const 10
+  call $~lib/number/I32#toString
+  local.tee $2
+  i32.store offset=4
+  local.get $2
+  call $~lib/string/String#get:length
+  i32.const 4
+  i32.gt_s
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2496
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $2
+   i32.const 6
+   i32.const 912
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=16
+   local.get $3
+   call $~lib/string/String#padStart
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=12
+   local.get $3
+   call $~lib/string/String.__concat
+   local.tee $2
+   i32.store offset=4
+  end
+  local.get $2
+  i32.const 2560
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=104
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=96
+  local.get $3
+  local.get $1
+  i32.load offset=4
+  i32.const 10
+  call $~lib/number/I32#toString
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=108
+  local.get $3
+  i32.const 2
+  i32.const 912
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=112
+  local.get $3
+  call $~lib/string/String#padStart
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=100
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=88
+  local.get $3
+  i32.const 2560
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=92
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=80
+  local.get $3
+  local.get $1
+  i32.load offset=8
+  i32.const 10
+  call $~lib/number/I32#toString
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=88
+  local.get $3
+  i32.const 2
+  i32.const 912
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=96
+  local.get $3
+  call $~lib/string/String#padStart
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=84
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=72
+  local.get $3
+  i32.const 2592
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=76
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=64
+  local.get $3
+  local.get $0
+  call $~lib/date/Date#getUTCHours
+  i32.const 10
+  call $~lib/number/I32#toString
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=72
+  local.get $3
+  i32.const 2
+  i32.const 912
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=80
+  local.get $3
+  call $~lib/string/String#padStart
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=68
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=56
+  local.get $3
+  i32.const 2624
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=60
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=48
+  local.get $3
+  local.get $0
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 10
+  call $~lib/number/I32#toString
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=56
+  local.get $3
+  i32.const 2
+  i32.const 912
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=64
+  local.get $3
+  call $~lib/string/String#padStart
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=52
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=40
+  local.get $3
+  i32.const 2624
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=44
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=32
+  local.get $3
+  local.get $0
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 10
+  call $~lib/number/I32#toString
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=40
+  local.get $3
+  i32.const 2
+  i32.const 912
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=48
+  local.get $3
+  call $~lib/string/String#padStart
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=36
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=16
+  local.get $3
+  i32.const 2656
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=28
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=20
+  local.get $3
+  local.get $0
+  call $~lib/date/Date#getUTCMilliseconds
+  i32.const 10
+  call $~lib/number/I32#toString
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=16
+  local.get $3
+  i32.const 3
+  i32.const 912
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=32
+  local.get $3
+  call $~lib/string/String#padStart
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=24
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=8
+  local.get $3
+  i32.const 2688
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store offset=12
+  local.get $3
+  call $~lib/string/String.__concat
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  i32.const 116
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
+ )
+ (func $~lib/string/String#split (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 24
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=16
+  local.get $2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 2
+   i32.const 6
+   i32.const 0
+   call $~lib/rt/__newArray
+   local.set $15
+   global.get $~lib/memory/__stack_pointer
+   i32.const 24
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $15
+   return
+  end
+  local.get $1
+  i32.const 0
+  i32.eq
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1
+   i32.const 2
+   i32.const 6
+   i32.const 0
+   call $~lib/rt/__newArray
+   local.tee $3
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.load offset=4
+   local.tee $4
+   i32.store offset=4
+   local.get $3
+   i32.const 0
+   local.get $0
+   call $~lib/array/Array<~lib/string/String>#__uset
+   local.get $3
+   local.set $15
+   global.get $~lib/memory/__stack_pointer
+   i32.const 24
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $15
+   return
+  end
+  local.get $0
+  call $~lib/string/String#get:length
+  local.set $5
+  local.get $1
+  call $~lib/string/String#get:length
+  local.set $6
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   global.get $~lib/builtins/i32.MAX_VALUE
+   local.set $2
+  end
+  local.get $6
+  i32.eqz
+  if
+   local.get $5
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 2
+    i32.const 6
+    i32.const 0
+    call $~lib/rt/__newArray
+    local.set $15
+    global.get $~lib/memory/__stack_pointer
+    i32.const 24
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $15
+    return
+   end
+   local.get $5
+   local.tee $3
+   local.get $2
+   local.tee $4
+   local.get $3
+   local.get $4
+   i32.lt_s
+   select
+   local.set $5
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.const 2
+   i32.const 6
+   i32.const 0
+   call $~lib/rt/__newArray
+   local.tee $3
+   i32.store
+   local.get $3
+   i32.load offset=4
+   local.set $4
+   i32.const 0
+   local.set $7
+   loop $for-loop|0
+    local.get $7
+    local.get $5
+    i32.lt_s
+    local.set $8
+    local.get $8
+    if
+     global.get $~lib/memory/__stack_pointer
+     i32.const 2
+     i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $9
+     i32.store offset=8
+     local.get $9
+     local.get $0
+     local.get $7
+     i32.const 1
+     i32.shl
+     i32.add
+     i32.load16_u
+     i32.store16
+     local.get $4
+     local.get $7
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $9
+     i32.store
+     local.get $3
+     local.get $9
+     i32.const 1
+     call $~lib/rt/itcms/__link
+     local.get $7
+     i32.const 1
+     i32.add
+     local.set $7
+     br $for-loop|0
+    end
+   end
+   local.get $3
+   local.set $15
+   global.get $~lib/memory/__stack_pointer
+   i32.const 24
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $15
+   return
+  else
+   local.get $5
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1
+    i32.const 2
+    i32.const 6
+    i32.const 0
+    call $~lib/rt/__newArray
+    local.tee $4
+    i32.store offset=4
+    local.get $4
+    i32.load offset=4
+    i32.const 2528
+    i32.store
+    local.get $4
+    local.set $15
+    global.get $~lib/memory/__stack_pointer
+    i32.const 24
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $15
+    return
+   end
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 2
+  i32.const 6
+  i32.const 0
+  call $~lib/rt/__newArray
+  local.tee $10
+  i32.store offset=12
+  i32.const 0
+  local.set $11
+  i32.const 0
+  local.set $12
+  i32.const 0
+  local.set $13
+  loop $while-continue|1
+   local.get $0
+   local.get $1
+   local.get $12
+   call $~lib/string/String#indexOf
+   local.tee $11
+   i32.const -1
+   i32.xor
+   local.set $4
+   local.get $4
+   if
+    local.get $11
+    local.get $12
+    i32.sub
+    local.set $3
+    local.get $3
+    i32.const 0
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $3
+     i32.const 1
+     i32.shl
+     i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $7
+     i32.store offset=16
+     local.get $7
+     local.get $0
+     local.get $12
+     i32.const 1
+     i32.shl
+     i32.add
+     local.get $3
+     i32.const 1
+     i32.shl
+     call $~lib/memory/memory.copy
+     local.get $10
+     local.get $7
+     call $~lib/array/Array<~lib/string/String>#push
+     drop
+    else
+     local.get $10
+     i32.const 2528
+     local.set $15
+     global.get $~lib/memory/__stack_pointer
+     local.get $15
+     i32.store offset=20
+     local.get $15
+     call $~lib/array/Array<~lib/string/String>#push
+     drop
+    end
+    local.get $13
+    i32.const 1
+    i32.add
+    local.tee $13
+    local.get $2
+    i32.eq
+    if
+     local.get $10
+     local.set $15
+     global.get $~lib/memory/__stack_pointer
+     i32.const 24
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $15
+     return
+    end
+    local.get $11
+    local.get $6
+    i32.add
+    local.set $12
+    br $while-continue|1
+   end
+  end
+  local.get $12
+  i32.eqz
+  if
+   local.get $10
+   local.get $0
+   call $~lib/array/Array<~lib/string/String>#push
+   drop
+   local.get $10
+   local.set $15
+   global.get $~lib/memory/__stack_pointer
+   i32.const 24
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $15
+   return
+  end
+  local.get $5
+  local.get $12
+  i32.sub
+  local.set $14
+  local.get $14
+  i32.const 0
+  i32.gt_s
+  if
+   global.get $~lib/memory/__stack_pointer
+   local.get $14
+   i32.const 1
+   i32.shl
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $4
+   i32.store offset=4
+   local.get $4
+   local.get $0
+   local.get $12
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $14
+   i32.const 1
+   i32.shl
+   call $~lib/memory/memory.copy
+   local.get $10
+   local.get $4
+   call $~lib/array/Array<~lib/string/String>#push
+   drop
+  else
+   local.get $10
+   i32.const 2528
+   local.set $15
+   global.get $~lib/memory/__stack_pointer
+   local.get $15
+   i32.store offset=20
+   local.get $15
+   call $~lib/array/Array<~lib/string/String>#push
+   drop
+  end
+  local.get $10
+  local.set $15
+  global.get $~lib/memory/__stack_pointer
+  i32.const 24
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $15
+ )
+ (func $~lib/date/Date.fromString (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 32
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=16
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=24
+  i32.const 0
+  local.set $1
+  i32.const 0
+  local.set $2
+  i32.const 0
+  local.set $3
+  i32.const 0
+  local.set $4
+  local.get $0
+  i32.const 2592
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  local.get $10
+  i32.store
+  local.get $10
+  i32.const 0
+  call $~lib/string/String#includes
+  if
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.const 2592
+   local.set $10
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
+   i32.store
+   local.get $10
+   global.get $~lib/builtins/i32.MAX_VALUE
+   call $~lib/string/String#split
+   local.tee $6
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $6
+   i32.const 1
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.tee $7
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $7
+   i32.const 2624
+   local.set $10
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
+   i32.store
+   local.get $10
+   global.get $~lib/builtins/i32.MAX_VALUE
+   call $~lib/string/String#split
+   local.tee $8
+   i32.store offset=12
+   local.get $8
+   i32.const 0
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.set $10
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
+   i32.store offset=16
+   local.get $10
+   i32.const 0
+   call $~lib/number/I32.parseInt
+   local.set $1
+   local.get $8
+   i32.const 1
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.set $10
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
+   i32.store offset=16
+   local.get $10
+   i32.const 0
+   call $~lib/number/I32.parseInt
+   local.set $2
+   local.get $8
+   i32.const 2
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.set $10
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
+   i32.store offset=16
+   local.get $10
+   i32.const 2656
+   local.set $10
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
+   i32.store
+   local.get $10
+   i32.const 0
+   call $~lib/string/String#includes
+   if
+    global.get $~lib/memory/__stack_pointer
+    local.get $8
+    i32.const 2
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $10
+    global.get $~lib/memory/__stack_pointer
+    local.get $10
+    i32.store offset=16
+    local.get $10
+    i32.const 2656
+    local.set $10
+    global.get $~lib/memory/__stack_pointer
+    local.get $10
+    i32.store
+    local.get $10
+    global.get $~lib/builtins/i32.MAX_VALUE
+    call $~lib/string/String#split
+    local.tee $9
+    i32.store offset=20
+    local.get $9
+    i32.const 0
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $10
+    global.get $~lib/memory/__stack_pointer
+    local.get $10
+    i32.store offset=16
+    local.get $10
+    i32.const 0
+    call $~lib/number/I32.parseInt
+    local.set $3
+    local.get $9
+    i32.const 1
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $10
+    global.get $~lib/memory/__stack_pointer
+    local.get $10
+    i32.store offset=16
+    local.get $10
+    i32.const 0
+    call $~lib/number/I32.parseInt
+    local.set $4
+   else
+    local.get $8
+    i32.const 2
+    call $~lib/array/Array<~lib/string/String>#__get
+    local.set $10
+    global.get $~lib/memory/__stack_pointer
+    local.get $10
+    i32.store offset=16
+    local.get $10
+    i32.const 0
+    call $~lib/number/I32.parseInt
+    local.set $3
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $6
+   i32.const 0
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.tee $5
+   i32.store offset=24
+  else
+   local.get $0
+   local.set $5
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $5
+  i32.const 2560
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  local.get $10
+  i32.store
+  local.get $10
+  global.get $~lib/builtins/i32.MAX_VALUE
+  call $~lib/string/String#split
+  local.tee $8
+  i32.store offset=12
+  local.get $8
+  i32.const 0
+  call $~lib/array/Array<~lib/string/String>#__get
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  local.get $10
+  i32.store
+  local.get $10
+  call $~lib/string/String#get:length
+  i32.const 2
+  i32.eq
+  if (result i32)
+   i32.const 3184
+   local.set $10
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
+   i32.store
+   local.get $10
+   local.get $8
+   i32.const 0
+   call $~lib/array/Array<~lib/string/String>#__get
+   local.set $10
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
+   i32.store offset=28
+   local.get $10
+   call $~lib/string/String.__concat
+  else
+   local.get $8
+   i32.const 0
+   call $~lib/array/Array<~lib/string/String>#__get
+  end
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  local.get $10
+  i32.store offset=16
+  local.get $10
+  i32.const 0
+  call $~lib/number/I32.parseInt
+  local.set $7
+  local.get $8
+  i32.const 1
+  call $~lib/array/Array<~lib/string/String>#__get
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  local.get $10
+  i32.store offset=16
+  local.get $10
+  i32.const 0
+  call $~lib/number/I32.parseInt
+  local.set $6
+  local.get $8
+  i32.const 2
+  call $~lib/array/Array<~lib/string/String>#__get
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  local.get $10
+  i32.store offset=16
+  local.get $10
+  i32.const 0
+  call $~lib/number/I32.parseInt
+  local.set $9
+  i32.const 0
+  local.get $7
+  local.get $6
+  local.get $9
+  local.get $1
+  local.get $2
+  local.get $3
+  local.get $4
+  call $~lib/date/epochMillis
+  call $~lib/date/Date#constructor
+  local.set $10
+  global.get $~lib/memory/__stack_pointer
+  i32.const 32
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $10
+ )
  (func $start:std/date
   (local $0 i32)
   (local $1 i32)
@@ -4189,14 +6641,18 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i64)
+  (local $7 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 4
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.store
+  i32.store offset=8
   i32.const 1970
   local.set $2
   i32.const 0
@@ -4985,101 +7441,270 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
- )
- (func $~lib/rt/__visit_globals (param $0 i32)
-  (local $1 i32)
-  i32.const 272
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 480
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 80
-  local.get $0
-  call $~lib/rt/itcms/__visit
- )
- (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  local.get $0
-  i32.load
-  local.tee $2
-  if
-   local.get $2
-   local.get $1
-   call $~lib/rt/itcms/__visit
-  end
- )
- (func $~lib/array/Array<i32>#__visit (param $0 i32) (param $1 i32)
   i32.const 0
-  drop
-  local.get $0
-  i32.load
-  local.get $1
-  call $~lib/rt/itcms/__visit
- )
- (func $~lib/array/Array<i32>~visit (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  call $~lib/array/Array<i32>#__visit
- )
- (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
-  block $invalid
-   block $~lib/array/Array<i32>
-    block $~lib/date/YMD
-     block $~lib/date/Date
-      block $~lib/arraybuffer/ArrayBufferView
-       block $~lib/string/String
-        block $~lib/arraybuffer/ArrayBuffer
-         local.get $0
-         i32.const 8
-         i32.sub
-         i32.load
-         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $~lib/date/YMD $~lib/array/Array<i32> $invalid
-        end
-        return
-       end
-       return
-      end
-      local.get $0
-      local.get $1
-      call $~lib/arraybuffer/ArrayBufferView~visit
-      return
-     end
-     return
-    end
-    return
-   end
-   local.get $0
-   local.get $1
-   call $~lib/array/Array<i32>~visit
-   return
-  end
-  unreachable
- )
- (func $~start
-  global.get $~started
-  if
-   return
-  end
-  i32.const 1
-  global.set $~started
-  call $start:std/date
- )
- (func $~stack_check
+  i64.const 1231231231020
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#toISOString
+  local.set $7
   global.get $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__data_end
-  i32.lt_s
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  i32.const 2720
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=8
+  local.get $7
+  call $~lib/string/String.__eq
+  i32.eqz
   if
-   i32.const 17168
-   i32.const 17216
-   i32.const 1
-   i32.const 1
+   i32.const 0
+   i32.const 32
+   i32.const 154
+   i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 1231231231456
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#toISOString
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  i32.const 2800
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=8
+  local.get $7
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 156
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 322331231231020
+  call $~lib/date/Date#constructor
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#toISOString
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  i32.const 2880
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=8
+  local.get $7
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 158
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2960
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  call $~lib/date/Date.fromString
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getTime
+  i64.const 192067200000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 165
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3216
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  call $~lib/date/Date.fromString
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getTime
+  i64.const 192067200000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 167
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3264
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  call $~lib/date/Date.fromString
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getTime
+  i64.const 11860387200000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 169
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 3312
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=8
+  local.get $7
+  call $~lib/date/Date.fromString
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  call $~lib/date/Date#getTime
+  i32.const 3360
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=8
+  local.get $7
+  call $~lib/date/Date.fromString
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  call $~lib/date/Date#getTime
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 172
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3408
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  call $~lib/date/Date.fromString
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getTime
+  i64.const 192112496000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 176
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3472
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  call $~lib/date/Date.fromString
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getTime
+  i64.const 192112496456
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 180
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 3552
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  local.get $7
+  i32.store offset=4
+  local.get $7
+  call $~lib/date/Date.fromString
+  local.tee $5
+  i32.store
+  local.get $5
+  call $~lib/date/Date#getTime
+  i64.const 192112496456
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 184
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/date/Date#constructor (param $0 i32) (param $1 i64) (result i32)
   (local $2 i32)
@@ -5369,6 +7994,404 @@
   i32.const 1
   i32.sub
   call $~lib/array/Array<i32>#__get
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
+ )
+ (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  i32.const 2
+  i32.lt_s
+  if (result i32)
+   i32.const 1
+  else
+   local.get $1
+   i32.const 36
+   i32.gt_s
+  end
+  if
+   i32.const 720
+   i32.const 848
+   i32.const 373
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.eqz
+  if
+   i32.const 912
+   local.set $8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $8
+   return
+  end
+  local.get $0
+  i32.const 31
+  i32.shr_u
+  local.set $2
+  local.get $2
+  if
+   i32.const 0
+   local.get $0
+   i32.sub
+   local.set $0
+  end
+  local.get $1
+  i32.const 10
+  i32.eq
+  if
+   local.get $0
+   call $~lib/util/number/decimalCount32
+   local.get $2
+   i32.add
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
+   local.get $4
+   i32.const 1
+   i32.shl
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $3
+   i32.store
+   local.get $3
+   local.set $7
+   local.get $0
+   local.set $6
+   local.get $4
+   local.set $5
+   i32.const 0
+   i32.const 1
+   i32.ge_s
+   drop
+   local.get $7
+   local.get $6
+   local.get $5
+   call $~lib/util/number/utoa32_dec_lut
+  else
+   local.get $1
+   i32.const 16
+   i32.eq
+   if
+    i32.const 31
+    local.get $0
+    i32.clz
+    i32.sub
+    i32.const 2
+    i32.shr_s
+    i32.const 1
+    i32.add
+    local.get $2
+    i32.add
+    local.set $4
+    global.get $~lib/memory/__stack_pointer
+    local.get $4
+    i32.const 1
+    i32.shl
+    i32.const 1
+    call $~lib/rt/itcms/__new
+    local.tee $3
+    i32.store
+    local.get $3
+    local.set $7
+    local.get $0
+    local.set $6
+    local.get $4
+    local.set $5
+    i32.const 0
+    i32.const 1
+    i32.ge_s
+    drop
+    local.get $7
+    local.get $6
+    i64.extend_i32_u
+    local.get $5
+    call $~lib/util/number/utoa_hex_lut
+   else
+    local.get $0
+    local.set $4
+    local.get $4
+    i64.extend_i32_u
+    local.get $1
+    call $~lib/util/number/ulog_base
+    local.get $2
+    i32.add
+    local.set $7
+    global.get $~lib/memory/__stack_pointer
+    local.get $7
+    i32.const 1
+    i32.shl
+    i32.const 1
+    call $~lib/rt/itcms/__new
+    local.tee $3
+    i32.store
+    local.get $3
+    local.get $4
+    i64.extend_i32_u
+    local.get $7
+    local.get $1
+    call $~lib/util/number/utoa64_any_core
+   end
+  end
+  local.get $2
+  if
+   local.get $3
+   i32.const 45
+   i32.store16
+  end
+  local.get $3
+  local.set $8
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $8
+ )
+ (func $~lib/string/String#padStart (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  call $~lib/string/String#get:length
+  i32.const 1
+  i32.shl
+  local.set $3
+  local.get $1
+  i32.const 1
+  i32.shl
+  local.set $4
+  local.get $2
+  call $~lib/string/String#get:length
+  i32.const 1
+  i32.shl
+  local.set $5
+  local.get $4
+  local.get $3
+  i32.lt_u
+  if (result i32)
+   i32.const 1
+  else
+   local.get $5
+   i32.eqz
+  end
+  if
+   local.get $0
+   local.set $11
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $11
+   return
+  end
+  local.get $4
+  local.get $3
+  i32.sub
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.const 1
+  call $~lib/rt/itcms/__new
+  local.tee $7
+  i32.store
+  local.get $6
+  local.get $5
+  i32.gt_u
+  if
+   local.get $6
+   i32.const 2
+   i32.sub
+   local.get $5
+   i32.div_u
+   local.set $8
+   local.get $8
+   local.get $5
+   i32.mul
+   local.set $9
+   local.get $6
+   local.get $9
+   i32.sub
+   local.set $10
+   local.get $7
+   local.get $2
+   local.get $5
+   local.get $8
+   call $~lib/memory/memory.repeat
+   local.get $7
+   local.get $9
+   i32.add
+   local.get $2
+   local.get $10
+   call $~lib/memory/memory.copy
+  else
+   local.get $7
+   local.get $2
+   local.get $6
+   call $~lib/memory/memory.copy
+  end
+  local.get $7
+  local.get $6
+  i32.add
+  local.get $0
+  local.get $3
+  call $~lib/memory/memory.copy
+  local.get $7
+  local.set $11
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $11
+ )
+ (func $~lib/string/String#concat (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  call $~lib/string/String#get:length
+  i32.const 1
+  i32.shl
+  local.set $2
+  local.get $1
+  call $~lib/string/String#get:length
+  i32.const 1
+  i32.shl
+  local.set $3
+  local.get $2
+  local.get $3
+  i32.add
+  local.set $4
+  local.get $4
+  i32.const 0
+  i32.eq
+  if
+   i32.const 2528
+   local.set $6
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $6
+   return
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.const 1
+  call $~lib/rt/itcms/__new
+  local.tee $5
+  i32.store
+  local.get $5
+  local.get $0
+  local.get $2
+  call $~lib/memory/memory.copy
+  local.get $5
+  local.get $2
+  i32.add
+  local.get $1
+  local.get $3
+  call $~lib/memory/memory.copy
+  local.get $5
+  local.set $6
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $6
+ )
+ (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 272
+   i32.const 672
+   i32.const 92
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.tee $2
+  i32.store
+  i32.const 1
+  drop
+  i32.const 0
+  i32.eqz
+  drop
+  local.get $2
+  i32.eqz
+  if
+   i32.const 3056
+   i32.const 672
+   i32.const 96
+   i32.const 40
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
   local.set $3
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -31,36 +31,35 @@
  (data (i32.const 396) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 460) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00V\00a\00l\00u\00e\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00\00\00\00\00\00\00\00\00")
  (data (i32.const 524) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00d\00a\00t\00e\00.\00t\00s\00\00\00\00\00")
- (data (i32.const 572) "L\00\00\00\00\00\00\00\00\00\00\00\00\00\00\000\00\00\00\1f\00\00\00\1c\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\1e\00\00\00\1f\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 652) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
- (data (i32.const 700) "|\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00d\00\00\00t\00o\00S\00t\00r\00i\00n\00g\00(\00)\00 \00r\00a\00d\00i\00x\00 \00a\00r\00g\00u\00m\00e\00n\00t\00 \00m\00u\00s\00t\00 \00b\00e\00 \00b\00e\00t\00w\00e\00e\00n\00 \002\00 \00a\00n\00d\00 \003\006\00\00\00\00\00\00\00\00\00")
- (data (i32.const 828) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00u\00t\00i\00l\00/\00n\00u\00m\00b\00e\00r\00.\00t\00s\00\00\00\00\00\00\00")
- (data (i32.const 892) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\000\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 924) "0\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\00")
- (data (i32.const 1324) "\1c\04\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\04\00\000\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\000\00a\000\00b\000\00c\000\00d\000\00e\000\00f\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\001\00a\001\00b\001\00c\001\00d\001\00e\001\00f\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\002\00a\002\00b\002\00c\002\00d\002\00e\002\00f\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\003\00a\003\00b\003\00c\003\00d\003\00e\003\00f\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\004\00a\004\00b\004\00c\004\00d\004\00e\004\00f\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\005\00a\005\00b\005\00c\005\00d\005\00e\005\00f\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\006\00a\006\00b\006\00c\006\00d\006\00e\006\00f\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\007\00a\007\00b\007\00c\007\00d\007\00e\007\00f\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\008\00a\008\00b\008\00c\008\00d\008\00e\008\00f\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\009\00a\009\00b\009\00c\009\00d\009\00e\009\00f\00a\000\00a\001\00a\002\00a\003\00a\004\00a\005\00a\006\00a\007\00a\008\00a\009\00a\00a\00a\00b\00a\00c\00a\00d\00a\00e\00a\00f\00b\000\00b\001\00b\002\00b\003\00b\004\00b\005\00b\006\00b\007\00b\008\00b\009\00b\00a\00b\00b\00b\00c\00b\00d\00b\00e\00b\00f\00c\000\00c\001\00c\002\00c\003\00c\004\00c\005\00c\006\00c\007\00c\008\00c\009\00c\00a\00c\00b\00c\00c\00c\00d\00c\00e\00c\00f\00d\000\00d\001\00d\002\00d\003\00d\004\00d\005\00d\006\00d\007\00d\008\00d\009\00d\00a\00d\00b\00d\00c\00d\00d\00d\00e\00d\00f\00e\000\00e\001\00e\002\00e\003\00e\004\00e\005\00e\006\00e\007\00e\008\00e\009\00e\00a\00e\00b\00e\00c\00e\00d\00e\00e\00e\00f\00f\000\00f\001\00f\002\00f\003\00f\004\00f\005\00f\006\00f\007\00f\008\00f\009\00f\00a\00f\00b\00f\00c\00f\00d\00f\00e\00f\00f\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2380) "\\\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00H\00\00\000\001\002\003\004\005\006\007\008\009\00a\00b\00c\00d\00e\00f\00g\00h\00i\00j\00k\00l\00m\00n\00o\00p\00q\00r\00s\00t\00u\00v\00w\00x\00y\00z\00\00\00\00\00")
- (data (i32.const 2476) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00+\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2508) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2540) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00-\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2572) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00T\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2604) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00:\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2636) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00.\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2668) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00Z\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2700) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\002\000\000\009\00-\000\001\00-\000\006\00T\000\008\00:\004\000\00:\003\001\00.\000\002\000\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2780) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\002\000\000\009\00-\000\001\00-\000\006\00T\000\008\00:\004\000\00:\003\001\00.\004\005\006\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2860) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\006\00\00\00+\000\001\002\001\008\004\00-\000\004\00-\000\008\00T\001\003\00:\000\007\00:\001\001\00.\000\002\000\00Z\00\00\00\00\00\00\00")
- (data (i32.const 2940) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\001\009\007\006\00-\000\002\00-\000\002\00\00\00\00\00\00\00\00\00")
- (data (i32.const 2988) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 3036) "|\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 3164) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\04\00\00\001\009\00\00\00\00\00\00\00\00\00")
- (data (i32.const 3196) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\10\00\00\001\009\007\006\00-\002\00-\002\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 3244) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\002\003\004\005\00-\001\001\00-\000\004\00\00\00\00\00\00\00\00\00")
- (data (i32.const 3292) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\001\009\007\006\00-\000\004\00-\000\002\00\00\00\00\00\00\00\00\00")
- (data (i32.const 3340) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\10\00\00\007\006\00-\000\004\00-\000\002\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 3388) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00&\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00\00\00\00\00\00\00")
- (data (i32.const 3452) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00.\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 3532) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 3616) "\06\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00\02\t\00\00\00\00\00\00\02A\00\00\00\00\00\00")
+ (data (i32.const 572) "|\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00d\00\00\00t\00o\00S\00t\00r\00i\00n\00g\00(\00)\00 \00r\00a\00d\00i\00x\00 \00a\00r\00g\00u\00m\00e\00n\00t\00 \00m\00u\00s\00t\00 \00b\00e\00 \00b\00e\00t\00w\00e\00e\00n\00 \002\00 \00a\00n\00d\00 \003\006\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 700) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00u\00t\00i\00l\00/\00n\00u\00m\00b\00e\00r\00.\00t\00s\00\00\00\00\00\00\00")
+ (data (i32.const 764) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\000\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 796) "0\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\00")
+ (data (i32.const 1196) "\1c\04\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\04\00\000\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\000\00a\000\00b\000\00c\000\00d\000\00e\000\00f\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\001\00a\001\00b\001\00c\001\00d\001\00e\001\00f\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\002\00a\002\00b\002\00c\002\00d\002\00e\002\00f\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\003\00a\003\00b\003\00c\003\00d\003\00e\003\00f\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\004\00a\004\00b\004\00c\004\00d\004\00e\004\00f\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\005\00a\005\00b\005\00c\005\00d\005\00e\005\00f\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\006\00a\006\00b\006\00c\006\00d\006\00e\006\00f\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\007\00a\007\00b\007\00c\007\00d\007\00e\007\00f\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\008\00a\008\00b\008\00c\008\00d\008\00e\008\00f\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\009\00a\009\00b\009\00c\009\00d\009\00e\009\00f\00a\000\00a\001\00a\002\00a\003\00a\004\00a\005\00a\006\00a\007\00a\008\00a\009\00a\00a\00a\00b\00a\00c\00a\00d\00a\00e\00a\00f\00b\000\00b\001\00b\002\00b\003\00b\004\00b\005\00b\006\00b\007\00b\008\00b\009\00b\00a\00b\00b\00b\00c\00b\00d\00b\00e\00b\00f\00c\000\00c\001\00c\002\00c\003\00c\004\00c\005\00c\006\00c\007\00c\008\00c\009\00c\00a\00c\00b\00c\00c\00c\00d\00c\00e\00c\00f\00d\000\00d\001\00d\002\00d\003\00d\004\00d\005\00d\006\00d\007\00d\008\00d\009\00d\00a\00d\00b\00d\00c\00d\00d\00d\00e\00d\00f\00e\000\00e\001\00e\002\00e\003\00e\004\00e\005\00e\006\00e\007\00e\008\00e\009\00e\00a\00e\00b\00e\00c\00e\00d\00e\00e\00e\00f\00f\000\00f\001\00f\002\00f\003\00f\004\00f\005\00f\006\00f\007\00f\008\00f\009\00f\00a\00f\00b\00f\00c\00f\00d\00f\00e\00f\00f\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2252) "\\\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00H\00\00\000\001\002\003\004\005\006\007\008\009\00a\00b\00c\00d\00e\00f\00g\00h\00i\00j\00k\00l\00m\00n\00o\00p\00q\00r\00s\00t\00u\00v\00w\00x\00y\00z\00\00\00\00\00")
+ (data (i32.const 2348) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00+\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2380) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2412) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00-\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2444) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00T\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2476) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00:\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2508) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00.\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2540) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00Z\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2572) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\002\000\000\009\00-\000\001\00-\000\006\00T\000\008\00:\004\000\00:\003\001\00.\000\002\000\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2652) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\002\000\000\009\00-\000\001\00-\000\006\00T\000\008\00:\004\000\00:\003\001\00.\004\005\006\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2732) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\006\00\00\00+\000\001\002\001\008\004\00-\000\004\00-\000\008\00T\001\003\00:\000\007\00:\001\001\00.\000\002\000\00Z\00\00\00\00\00\00\00")
+ (data (i32.const 2812) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\001\009\007\006\00-\000\002\00-\000\002\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 2860) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 2908) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
+ (data (i32.const 2956) "|\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3084) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\04\00\00\001\009\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3116) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\10\00\00\001\009\007\006\00-\002\00-\002\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3164) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\002\003\004\005\00-\001\001\00-\000\004\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3212) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\001\009\007\006\00-\000\004\00-\000\002\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3260) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\10\00\00\007\006\00-\000\004\00-\000\002\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3308) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00&\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00\00\00\00\00\00\00")
+ (data (i32.const 3372) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00.\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3452) "L\00\00\00\00\00\00\00\00\00\00\00\01\00\00\000\00\00\001\009\007\006\00-\000\002\00-\000\002\00T\001\002\00:\003\004\00:\005\006\00.\004\005\006\00Z\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 3536) "\06\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00\02A\00\00\00\00\00\00\02\t\00\00\00\00\00\00")
  (table $0 1 funcref)
  (global $~lib/date/MILLIS_PER_DAY i32 (i32.const 86400000))
  (global $~lib/date/MILLIS_PER_HOUR i32 (i32.const 3600000))
@@ -82,10 +81,10 @@
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $~lib/builtins/i32.MAX_VALUE i32 (i32.const 2147483647))
- (global $~lib/rt/__rtti_base i32 (i32.const 3616))
- (global $~lib/memory/__data_end i32 (i32.const 3668))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 20052))
- (global $~lib/memory/__heap_base i32 (i32.const 20052))
+ (global $~lib/rt/__rtti_base i32 (i32.const 3536))
+ (global $~lib/memory/__data_end i32 (i32.const 3588))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 19972))
+ (global $~lib/memory/__heap_base i32 (i32.const 19972))
  (global $~started (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
@@ -2804,6 +2803,553 @@
    i32.const 0
   end
  )
+ (func $~lib/date/daysInMonth (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  i32.const 2
+  i32.eq
+  if (result i32)
+   i32.const 28
+   local.get $0
+   call $~lib/date/isLeap
+   i32.add
+  else
+   i32.const 30
+   local.get $1
+   local.get $1
+   i32.const 8
+   i32.ge_s
+   i32.add
+   i32.const 1
+   i32.and
+   i32.add
+  end
+ )
+ (func $~lib/date/Date#setUTCDate (param $0 i32) (param $1 i32)
+  (local $2 i64)
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.get $1
+  i32.const 1
+  global.get $~lib/date/year
+  global.get $~lib/date/month
+  call $~lib/date/daysInMonth
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.rem_s
+  local.set $2
+  local.get $0
+  global.get $~lib/date/year
+  global.get $~lib/date/month
+  local.get $1
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.mul
+  local.get $2
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+ )
+ (func $~lib/date/Date#setUTCMonth (param $0 i32) (param $1 i32)
+  (local $2 i64)
+  local.get $1
+  i32.const 1
+  i32.const 12
+  call $~lib/date/throwIfNotInRange
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.rem_s
+  local.set $2
+  local.get $0
+  global.get $~lib/date/year
+  local.get $1
+  i32.const 1
+  i32.add
+  global.get $~lib/date/day
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.mul
+  local.get $2
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+ )
+ (func $~lib/date/Date#setUTCFullYear (param $0 i32) (param $1 i32)
+  (local $2 i64)
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.div_s
+  i32.wrap_i64
+  call $~lib/date/ymdFromEpochDays
+  local.get $0
+  i64.load
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.rem_s
+  local.set $2
+  local.get $0
+  local.get $1
+  global.get $~lib/date/month
+  global.get $~lib/date/day
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.mul
+  local.get $2
+  i64.add
+  call $~lib/date/Date#set:epochMillis
+ )
+ (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
+  local.get $0
+  i32.const 100000
+  i32.lt_u
+  if
+   local.get $0
+   i32.const 100
+   i32.lt_u
+   if
+    i32.const 1
+    local.get $0
+    i32.const 10
+    i32.ge_u
+    i32.add
+    return
+   else
+    i32.const 3
+    local.get $0
+    i32.const 10000
+    i32.ge_u
+    i32.add
+    local.get $0
+    i32.const 1000
+    i32.ge_u
+    i32.add
+    return
+   end
+   unreachable
+  else
+   local.get $0
+   i32.const 10000000
+   i32.lt_u
+   if
+    i32.const 6
+    local.get $0
+    i32.const 1000000
+    i32.ge_u
+    i32.add
+    return
+   else
+    i32.const 8
+    local.get $0
+    i32.const 1000000000
+    i32.ge_u
+    i32.add
+    local.get $0
+    i32.const 100000000
+    i32.ge_u
+    i32.add
+    return
+   end
+   unreachable
+  end
+  unreachable
+ )
+ (func $~lib/util/number/utoa32_dec_lut (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i64)
+  (local $10 i32)
+  (local $11 i32)
+  loop $while-continue|0
+   local.get $1
+   i32.const 10000
+   i32.ge_u
+   local.set $3
+   local.get $3
+   if
+    local.get $1
+    i32.const 10000
+    i32.div_u
+    local.set $4
+    local.get $1
+    i32.const 10000
+    i32.rem_u
+    local.set $5
+    local.get $4
+    local.set $1
+    local.get $5
+    i32.const 100
+    i32.div_u
+    local.set $6
+    local.get $5
+    i32.const 100
+    i32.rem_u
+    local.set $7
+    i32.const 796
+    local.get $6
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $8
+    i32.const 796
+    local.get $7
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $9
+    local.get $2
+    i32.const 4
+    i32.sub
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $8
+    local.get $9
+    i64.const 32
+    i64.shl
+    i64.or
+    i64.store
+    br $while-continue|0
+   end
+  end
+  local.get $1
+  i32.const 100
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 100
+   i32.div_u
+   local.set $3
+   local.get $1
+   i32.const 100
+   i32.rem_u
+   local.set $10
+   local.get $3
+   local.set $1
+   local.get $2
+   i32.const 2
+   i32.sub
+   local.set $2
+   i32.const 796
+   local.get $10
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load
+   local.set $11
+   local.get $0
+   local.get $2
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $11
+   i32.store
+  end
+  local.get $1
+  i32.const 10
+  i32.ge_u
+  if
+   local.get $2
+   i32.const 2
+   i32.sub
+   local.set $2
+   i32.const 796
+   local.get $1
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load
+   local.set $11
+   local.get $0
+   local.get $2
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $11
+   i32.store
+  else
+   local.get $2
+   i32.const 1
+   i32.sub
+   local.set $2
+   i32.const 48
+   local.get $1
+   i32.add
+   local.set $11
+   local.get $0
+   local.get $2
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $11
+   i32.store16
+  end
+ )
+ (func $~lib/util/number/utoa_hex_lut (param $0 i32) (param $1 i64) (param $2 i32)
+  (local $3 i32)
+  loop $while-continue|0
+   local.get $2
+   i32.const 2
+   i32.ge_u
+   local.set $3
+   local.get $3
+   if
+    local.get $2
+    i32.const 2
+    i32.sub
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.const 1216
+    local.get $1
+    i32.wrap_i64
+    i32.const 255
+    i32.and
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    i32.store
+    local.get $1
+    i64.const 8
+    i64.shr_u
+    local.set $1
+    br $while-continue|0
+   end
+  end
+  local.get $2
+  i32.const 1
+  i32.and
+  if
+   local.get $0
+   i32.const 1216
+   local.get $1
+   i32.wrap_i64
+   i32.const 6
+   i32.shl
+   i32.add
+   i32.load16_u
+   i32.store16
+  end
+ )
+ (func $~lib/util/number/ulog_base (param $0 i64) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 i32)
+  local.get $1
+  local.set $2
+  local.get $2
+  i32.popcnt
+  i32.const 1
+  i32.eq
+  if
+   i32.const 63
+   local.get $0
+   i64.clz
+   i32.wrap_i64
+   i32.sub
+   i32.const 31
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.div_u
+   i32.const 1
+   i32.add
+   return
+  end
+  local.get $1
+  i64.extend_i32_s
+  local.set $3
+  local.get $3
+  local.set $4
+  i32.const 1
+  local.set $5
+  loop $while-continue|0
+   local.get $0
+   local.get $4
+   i64.ge_u
+   local.set $2
+   local.get $2
+   if
+    local.get $0
+    local.get $4
+    i64.div_u
+    local.set $0
+    local.get $4
+    local.get $4
+    i64.mul
+    local.set $4
+    local.get $5
+    i32.const 1
+    i32.shl
+    local.set $5
+    br $while-continue|0
+   end
+  end
+  loop $while-continue|1
+   local.get $0
+   i64.const 1
+   i64.ge_u
+   local.set $2
+   local.get $2
+   if
+    local.get $0
+    local.get $3
+    i64.div_u
+    local.set $0
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $while-continue|1
+   end
+  end
+  local.get $5
+  i32.const 1
+  i32.sub
+ )
+ (func $~lib/util/number/utoa64_any_core (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i32)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 i64)
+  (local $7 i32)
+  local.get $3
+  i64.extend_i32_s
+  local.set $4
+  local.get $3
+  local.get $3
+  i32.const 1
+  i32.sub
+  i32.and
+  i32.const 0
+  i32.eq
+  if
+   local.get $3
+   i32.ctz
+   i32.const 7
+   i32.and
+   i64.extend_i32_s
+   local.set $5
+   local.get $4
+   i64.const 1
+   i64.sub
+   local.set $6
+   loop $do-continue|0
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.const 2272
+    local.get $1
+    local.get $6
+    i64.and
+    i32.wrap_i64
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.load16_u
+    i32.store16
+    local.get $1
+    local.get $5
+    i64.shr_u
+    local.set $1
+    local.get $1
+    i64.const 0
+    i64.ne
+    local.set $7
+    local.get $7
+    br_if $do-continue|0
+   end
+  else
+   loop $do-continue|1
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    local.get $1
+    local.get $4
+    i64.div_u
+    local.set $6
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.const 2272
+    local.get $1
+    local.get $6
+    local.get $4
+    i64.mul
+    i64.sub
+    i32.wrap_i64
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.load16_u
+    i32.store16
+    local.get $6
+    local.set $1
+    local.get $1
+    i64.const 0
+    i64.ne
+    local.set $7
+    local.get $7
+    br_if $do-continue|1
+   end
+  end
+ )
+ (func $~lib/number/I32#toString (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  call $~lib/util/number/itoa32
+ )
+ (func $~lib/string/String#get:length (param $0 i32) (result i32)
+  local.get $0
+  i32.const 20
+  i32.sub
+  i32.load offset=16
+  i32.const 1
+  i32.shr_u
+ )
  (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4057,659 +4603,6 @@
    end
   end
  )
- (func $~lib/rt/__newBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  local.get $0
-  local.get $1
-  call $~lib/rt/itcms/__new
-  local.set $3
-  local.get $2
-  if
-   local.get $3
-   local.get $2
-   local.get $0
-   call $~lib/memory/memory.copy
-  end
-  local.get $3
- )
- (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  local.get $1
-  i32.eqz
-  if
-   return
-  end
-  i32.const 1
-  drop
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 144
-   i32.const 294
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  i32.const 20
-  i32.sub
-  local.set $3
-  local.get $3
-  call $~lib/rt/itcms/Object#get:color
-  global.get $~lib/rt/itcms/white
-  i32.eq
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   local.set $4
-   local.get $4
-   call $~lib/rt/itcms/Object#get:color
-   local.set $5
-   local.get $5
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.eq
-   if
-    local.get $2
-    if
-     local.get $4
-     call $~lib/rt/itcms/Object#makeGray
-    else
-     local.get $3
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   else
-    local.get $5
-    i32.const 3
-    i32.eq
-    if (result i32)
-     global.get $~lib/rt/itcms/state
-     i32.const 1
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     local.get $3
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   end
-  end
- )
- (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  local.get $1
-  local.get $0
-  i32.load offset=12
-  i32.ge_u
-  if
-   i32.const 272
-   i32.const 672
-   i32.const 92
-   i32.const 42
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load
-  local.set $2
-  i32.const 0
-  drop
-  local.get $2
- )
- (func $~lib/date/lastDayOfMonth (param $0 i32) (param $1 i32) (result i32)
-  local.get $1
-  i32.const 2
-  i32.ne
-  if (result i32)
-   i32.const 1
-  else
-   local.get $0
-   call $~lib/date/isLeap
-   i32.eqz
-  end
-  if (result i32)
-   local.get $1
-   call $~lib/date/lastDayOfMonthNonLeapYear
-  else
-   i32.const 29
-  end
- )
- (func $~lib/date/Date#setUTCDate (param $0 i32) (param $1 i32)
-  (local $2 i64)
-  local.get $0
-  i64.load
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.div_s
-  i32.wrap_i64
-  call $~lib/date/ymdFromEpochDays
-  local.get $1
-  i32.const 1
-  global.get $~lib/date/year
-  global.get $~lib/date/month
-  call $~lib/date/lastDayOfMonth
-  call $~lib/date/throwIfNotInRange
-  local.get $0
-  i64.load
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.rem_s
-  local.set $2
-  local.get $0
-  global.get $~lib/date/year
-  global.get $~lib/date/month
-  local.get $1
-  call $~lib/date/daysSinceEpoch
-  i64.extend_i32_s
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.mul
-  local.get $2
-  i64.add
-  call $~lib/date/Date#set:epochMillis
- )
- (func $~lib/date/Date#setUTCMonth (param $0 i32) (param $1 i32)
-  (local $2 i64)
-  local.get $1
-  i32.const 1
-  i32.const 12
-  call $~lib/date/throwIfNotInRange
-  local.get $0
-  i64.load
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.div_s
-  i32.wrap_i64
-  call $~lib/date/ymdFromEpochDays
-  local.get $0
-  i64.load
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.rem_s
-  local.set $2
-  local.get $0
-  global.get $~lib/date/year
-  local.get $1
-  i32.const 1
-  i32.add
-  global.get $~lib/date/day
-  call $~lib/date/daysSinceEpoch
-  i64.extend_i32_s
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.mul
-  local.get $2
-  i64.add
-  call $~lib/date/Date#set:epochMillis
- )
- (func $~lib/date/Date#setUTCFullYear (param $0 i32) (param $1 i32)
-  (local $2 i64)
-  local.get $0
-  i64.load
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.div_s
-  i32.wrap_i64
-  call $~lib/date/ymdFromEpochDays
-  local.get $0
-  i64.load
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.rem_s
-  local.set $2
-  local.get $0
-  local.get $1
-  global.get $~lib/date/month
-  global.get $~lib/date/day
-  call $~lib/date/daysSinceEpoch
-  i64.extend_i32_s
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.mul
-  local.get $2
-  i64.add
-  call $~lib/date/Date#set:epochMillis
- )
- (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
-  local.get $0
-  i32.const 100000
-  i32.lt_u
-  if
-   local.get $0
-   i32.const 100
-   i32.lt_u
-   if
-    i32.const 1
-    local.get $0
-    i32.const 10
-    i32.ge_u
-    i32.add
-    return
-   else
-    i32.const 3
-    local.get $0
-    i32.const 10000
-    i32.ge_u
-    i32.add
-    local.get $0
-    i32.const 1000
-    i32.ge_u
-    i32.add
-    return
-   end
-   unreachable
-  else
-   local.get $0
-   i32.const 10000000
-   i32.lt_u
-   if
-    i32.const 6
-    local.get $0
-    i32.const 1000000
-    i32.ge_u
-    i32.add
-    return
-   else
-    i32.const 8
-    local.get $0
-    i32.const 1000000000
-    i32.ge_u
-    i32.add
-    local.get $0
-    i32.const 100000000
-    i32.ge_u
-    i32.add
-    return
-   end
-   unreachable
-  end
-  unreachable
- )
- (func $~lib/util/number/utoa32_dec_lut (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i64)
-  (local $9 i64)
-  (local $10 i32)
-  (local $11 i32)
-  loop $while-continue|0
-   local.get $1
-   i32.const 10000
-   i32.ge_u
-   local.set $3
-   local.get $3
-   if
-    local.get $1
-    i32.const 10000
-    i32.div_u
-    local.set $4
-    local.get $1
-    i32.const 10000
-    i32.rem_u
-    local.set $5
-    local.get $4
-    local.set $1
-    local.get $5
-    i32.const 100
-    i32.div_u
-    local.set $6
-    local.get $5
-    i32.const 100
-    i32.rem_u
-    local.set $7
-    i32.const 924
-    local.get $6
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $8
-    i32.const 924
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $9
-    local.get $2
-    i32.const 4
-    i32.sub
-    local.set $2
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $8
-    local.get $9
-    i64.const 32
-    i64.shl
-    i64.or
-    i64.store
-    br $while-continue|0
-   end
-  end
-  local.get $1
-  i32.const 100
-  i32.ge_u
-  if
-   local.get $1
-   i32.const 100
-   i32.div_u
-   local.set $3
-   local.get $1
-   i32.const 100
-   i32.rem_u
-   local.set $10
-   local.get $3
-   local.set $1
-   local.get $2
-   i32.const 2
-   i32.sub
-   local.set $2
-   i32.const 924
-   local.get $10
-   i32.const 2
-   i32.shl
-   i32.add
-   i32.load
-   local.set $11
-   local.get $0
-   local.get $2
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $11
-   i32.store
-  end
-  local.get $1
-  i32.const 10
-  i32.ge_u
-  if
-   local.get $2
-   i32.const 2
-   i32.sub
-   local.set $2
-   i32.const 924
-   local.get $1
-   i32.const 2
-   i32.shl
-   i32.add
-   i32.load
-   local.set $11
-   local.get $0
-   local.get $2
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $11
-   i32.store
-  else
-   local.get $2
-   i32.const 1
-   i32.sub
-   local.set $2
-   i32.const 48
-   local.get $1
-   i32.add
-   local.set $11
-   local.get $0
-   local.get $2
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $11
-   i32.store16
-  end
- )
- (func $~lib/util/number/utoa_hex_lut (param $0 i32) (param $1 i64) (param $2 i32)
-  (local $3 i32)
-  loop $while-continue|0
-   local.get $2
-   i32.const 2
-   i32.ge_u
-   local.set $3
-   local.get $3
-   if
-    local.get $2
-    i32.const 2
-    i32.sub
-    local.set $2
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.const 1344
-    local.get $1
-    i32.wrap_i64
-    i32.const 255
-    i32.and
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    i32.store
-    local.get $1
-    i64.const 8
-    i64.shr_u
-    local.set $1
-    br $while-continue|0
-   end
-  end
-  local.get $2
-  i32.const 1
-  i32.and
-  if
-   local.get $0
-   i32.const 1344
-   local.get $1
-   i32.wrap_i64
-   i32.const 6
-   i32.shl
-   i32.add
-   i32.load16_u
-   i32.store16
-  end
- )
- (func $~lib/util/number/ulog_base (param $0 i64) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i64)
-  (local $4 i64)
-  (local $5 i32)
-  local.get $1
-  local.set $2
-  local.get $2
-  i32.popcnt
-  i32.const 1
-  i32.eq
-  if
-   i32.const 63
-   local.get $0
-   i64.clz
-   i32.wrap_i64
-   i32.sub
-   i32.const 31
-   local.get $1
-   i32.clz
-   i32.sub
-   i32.div_u
-   i32.const 1
-   i32.add
-   return
-  end
-  local.get $1
-  i64.extend_i32_s
-  local.set $3
-  local.get $3
-  local.set $4
-  i32.const 1
-  local.set $5
-  loop $while-continue|0
-   local.get $0
-   local.get $4
-   i64.ge_u
-   local.set $2
-   local.get $2
-   if
-    local.get $0
-    local.get $4
-    i64.div_u
-    local.set $0
-    local.get $4
-    local.get $4
-    i64.mul
-    local.set $4
-    local.get $5
-    i32.const 1
-    i32.shl
-    local.set $5
-    br $while-continue|0
-   end
-  end
-  loop $while-continue|1
-   local.get $0
-   i64.const 1
-   i64.ge_u
-   local.set $2
-   local.get $2
-   if
-    local.get $0
-    local.get $3
-    i64.div_u
-    local.set $0
-    local.get $5
-    i32.const 1
-    i32.add
-    local.set $5
-    br $while-continue|1
-   end
-  end
-  local.get $5
-  i32.const 1
-  i32.sub
- )
- (func $~lib/util/number/utoa64_any_core (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i32)
-  (local $4 i64)
-  (local $5 i64)
-  (local $6 i64)
-  (local $7 i32)
-  local.get $3
-  i64.extend_i32_s
-  local.set $4
-  local.get $3
-  local.get $3
-  i32.const 1
-  i32.sub
-  i32.and
-  i32.const 0
-  i32.eq
-  if
-   local.get $3
-   i32.ctz
-   i32.const 7
-   i32.and
-   i64.extend_i32_s
-   local.set $5
-   local.get $4
-   i64.const 1
-   i64.sub
-   local.set $6
-   loop $do-continue|0
-    local.get $2
-    i32.const 1
-    i32.sub
-    local.set $2
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.const 2400
-    local.get $1
-    local.get $6
-    i64.and
-    i32.wrap_i64
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_u
-    i32.store16
-    local.get $1
-    local.get $5
-    i64.shr_u
-    local.set $1
-    local.get $1
-    i64.const 0
-    i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
-   end
-  else
-   loop $do-continue|1
-    local.get $2
-    i32.const 1
-    i32.sub
-    local.set $2
-    local.get $1
-    local.get $4
-    i64.div_u
-    local.set $6
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.const 2400
-    local.get $1
-    local.get $6
-    local.get $4
-    i64.mul
-    i64.sub
-    i32.wrap_i64
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_u
-    i32.store16
-    local.get $6
-    local.set $1
-    local.get $1
-    i64.const 0
-    i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
-   end
-  end
- )
- (func $~lib/number/I32#toString (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  local.get $1
-  call $~lib/util/number/itoa32
- )
- (func $~lib/string/String#get:length (param $0 i32) (result i32)
-  local.get $0
-  i32.const 20
-  i32.sub
-  i32.load offset=16
-  i32.const 1
-  i32.shr_u
- )
  (func $~lib/memory/memory.repeat (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4974,6 +4867,89 @@
   i32.const -1
   i32.ne
  )
+ (func $~lib/rt/__newBuffer (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  local.get $1
+  call $~lib/rt/itcms/__new
+  local.set $3
+  local.get $2
+  if
+   local.get $3
+   local.get $2
+   local.get $0
+   call $~lib/memory/memory.copy
+  end
+  local.get $3
+ )
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.eqz
+  if
+   return
+  end
+  i32.const 1
+  drop
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 144
+   i32.const 294
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 20
+  i32.sub
+  local.set $3
+  local.get $3
+  call $~lib/rt/itcms/Object#get:color
+  global.get $~lib/rt/itcms/white
+  i32.eq
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   local.set $4
+   local.get $4
+   call $~lib/rt/itcms/Object#get:color
+   local.set $5
+   local.get $5
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $2
+    if
+     local.get $4
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $3
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   else
+    local.get $5
+    i32.const 3
+    i32.eq
+    if (result i32)
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
  (func $~lib/array/Array<~lib/string/String>#__uset (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
@@ -5055,8 +5031,8 @@
    i32.shr_u
    i32.gt_u
    if
-    i32.const 3008
-    i32.const 672
+    i32.const 2880
+    i32.const 2928
     i32.const 14
     i32.const 48
     call $~lib/builtins/abort
@@ -5538,19 +5514,19 @@
   i32.const 480
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 3008
+  i32.const 2880
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 3056
+  i32.const 2976
   local.get $0
   call $~lib/rt/itcms/__visit
   i32.const 80
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 1344
+  i32.const 1216
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 2400
+  i32.const 2272
   local.get $0
   call $~lib/rt/itcms/__visit
  )
@@ -5564,19 +5540,6 @@
    local.get $1
    call $~lib/rt/itcms/__visit
   end
- )
- (func $~lib/array/Array<i32>#__visit (param $0 i32) (param $1 i32)
-  i32.const 0
-  drop
-  local.get $0
-  i32.load
-  local.get $1
-  call $~lib/rt/itcms/__visit
- )
- (func $~lib/array/Array<i32>~visit (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  call $~lib/array/Array<i32>#__visit
  )
  (func $~lib/array/Array<~lib/string/String>#__visit (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -5628,10 +5591,23 @@
   local.get $1
   call $~lib/array/Array<~lib/string/String>#__visit
  )
+ (func $~lib/array/Array<i32>#__visit (param $0 i32) (param $1 i32)
+  i32.const 0
+  drop
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/array/Array<i32>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i32>#__visit
+ )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid
-   block $~lib/array/Array<~lib/string/String>
-    block $~lib/array/Array<i32>
+   block $~lib/array/Array<i32>
+    block $~lib/array/Array<~lib/string/String>
      block $~lib/date/Date
       block $~lib/arraybuffer/ArrayBufferView
        block $~lib/string/String
@@ -5640,7 +5616,7 @@
          i32.const 8
          i32.sub
          i32.load
-         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $~lib/array/Array<i32> $~lib/array/Array<~lib/string/String> $invalid
+         br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/date/Date $~lib/array/Array<~lib/string/String> $~lib/array/Array<i32> $invalid
         end
         return
        end
@@ -5655,12 +5631,12 @@
     end
     local.get $0
     local.get $1
-    call $~lib/array/Array<i32>~visit
+    call $~lib/array/Array<~lib/string/String>~visit
     return
    end
    local.get $0
    local.get $1
-   call $~lib/array/Array<~lib/string/String>~visit
+   call $~lib/array/Array<i32>~visit
    return
   end
   unreachable
@@ -5679,8 +5655,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 20080
-   i32.const 20128
+   i32.const 20000
+   i32.const 20048
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -5756,7 +5732,7 @@
   i32.gt_s
   if
    global.get $~lib/memory/__stack_pointer
-   i32.const 2496
+   i32.const 2368
    local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $2
@@ -5764,7 +5740,7 @@
    local.get $2
    local.get $1
    i32.const 6
-   i32.const 912
+   i32.const 784
    local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $2
@@ -5781,7 +5757,7 @@
    i32.store
   end
   local.get $1
-  i32.const 2560
+  i32.const 2432
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5802,7 +5778,7 @@
   i32.store offset=104
   local.get $2
   i32.const 2
-  i32.const 912
+  i32.const 784
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5820,7 +5796,7 @@
   local.get $2
   i32.store offset=84
   local.get $2
-  i32.const 2560
+  i32.const 2432
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5841,7 +5817,7 @@
   i32.store offset=84
   local.get $2
   i32.const 2
-  i32.const 912
+  i32.const 784
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5859,7 +5835,7 @@
   local.get $2
   i32.store offset=68
   local.get $2
-  i32.const 2592
+  i32.const 2464
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5881,7 +5857,7 @@
   i32.store offset=68
   local.get $2
   i32.const 2
-  i32.const 912
+  i32.const 784
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5899,7 +5875,7 @@
   local.get $2
   i32.store offset=52
   local.get $2
-  i32.const 2624
+  i32.const 2496
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5921,7 +5897,7 @@
   i32.store offset=52
   local.get $2
   i32.const 2
-  i32.const 912
+  i32.const 784
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5939,7 +5915,7 @@
   local.get $2
   i32.store offset=36
   local.get $2
-  i32.const 2624
+  i32.const 2496
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5961,7 +5937,7 @@
   i32.store offset=36
   local.get $2
   i32.const 2
-  i32.const 912
+  i32.const 784
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -5979,7 +5955,7 @@
   local.get $2
   i32.store offset=12
   local.get $2
-  i32.const 2656
+  i32.const 2528
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -6001,7 +5977,7 @@
   i32.store offset=12
   local.get $2
   i32.const 3
-  i32.const 912
+  i32.const 784
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -6019,7 +5995,7 @@
   local.get $2
   i32.store offset=4
   local.get $2
-  i32.const 2688
+  i32.const 2560
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
@@ -6066,7 +6042,7 @@
   if
    i32.const 0
    i32.const 2
-   i32.const 5
+   i32.const 4
    i32.const 0
    call $~lib/rt/__newArray
    local.set $15
@@ -6084,7 +6060,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1
    i32.const 2
-   i32.const 5
+   i32.const 4
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $3
@@ -6128,7 +6104,7 @@
    if
     i32.const 0
     i32.const 2
-    i32.const 5
+    i32.const 4
     i32.const 0
     call $~lib/rt/__newArray
     local.set $15
@@ -6151,7 +6127,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $5
    i32.const 2
-   i32.const 5
+   i32.const 4
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $3
@@ -6215,14 +6191,14 @@
     global.get $~lib/memory/__stack_pointer
     i32.const 1
     i32.const 2
-    i32.const 5
+    i32.const 4
     i32.const 0
     call $~lib/rt/__newArray
     local.tee $4
     i32.store offset=4
     local.get $4
     i32.load offset=4
-    i32.const 2528
+    i32.const 2400
     i32.store
     local.get $4
     local.set $15
@@ -6237,7 +6213,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 2
-  i32.const 5
+  i32.const 4
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $10
@@ -6291,7 +6267,7 @@
      drop
     else
      local.get $10
-     i32.const 2528
+     i32.const 2400
      local.set $15
      global.get $~lib/memory/__stack_pointer
      local.get $15
@@ -6371,7 +6347,7 @@
    drop
   else
    local.get $10
-   i32.const 2528
+   i32.const 2400
    local.set $15
    global.get $~lib/memory/__stack_pointer
    local.get $15
@@ -6425,7 +6401,7 @@
   i32.const 0
   local.set $4
   local.get $0
-  i32.const 2592
+  i32.const 2464
   local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $10
@@ -6436,7 +6412,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.const 2592
+   i32.const 2464
    local.set $10
    global.get $~lib/memory/__stack_pointer
    local.get $10
@@ -6454,7 +6430,7 @@
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $7
-   i32.const 2624
+   i32.const 2496
    local.set $10
    global.get $~lib/memory/__stack_pointer
    local.get $10
@@ -6494,7 +6470,7 @@
    local.get $10
    i32.store offset=16
    local.get $10
-   i32.const 2656
+   i32.const 2528
    local.set $10
    global.get $~lib/memory/__stack_pointer
    local.get $10
@@ -6512,7 +6488,7 @@
     local.get $10
     i32.store offset=16
     local.get $10
-    i32.const 2656
+    i32.const 2528
     local.set $10
     global.get $~lib/memory/__stack_pointer
     local.get $10
@@ -6569,7 +6545,7 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.const 2560
+  i32.const 2432
   local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $10
@@ -6591,7 +6567,7 @@
   i32.const 2
   i32.eq
   if (result i32)
-   i32.const 3184
+   i32.const 3104
    local.set $10
    global.get $~lib/memory/__stack_pointer
    local.get $10
@@ -7479,7 +7455,7 @@
   local.get $8
   i32.store offset=4
   local.get $8
-  i32.const 2720
+  i32.const 2592
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7508,7 +7484,7 @@
   local.get $8
   i32.store offset=4
   local.get $8
-  i32.const 2800
+  i32.const 2672
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7537,7 +7513,7 @@
   local.get $8
   i32.store offset=4
   local.get $8
-  i32.const 2880
+  i32.const 2752
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7554,7 +7530,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 2960
+  i32.const 2832
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7577,7 +7553,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 3216
+  i32.const 3136
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7600,7 +7576,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 3264
+  i32.const 3184
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7622,7 +7598,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 3312
+  i32.const 3232
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7635,7 +7611,7 @@
   i32.store offset=4
   local.get $8
   call $~lib/date/Date#getTime
-  i32.const 3360
+  i32.const 3280
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7659,7 +7635,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 3408
+  i32.const 3328
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7682,7 +7658,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 3472
+  i32.const 3392
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7705,7 +7681,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 3552
+  i32.const 3472
   local.set $8
   global.get $~lib/memory/__stack_pointer
   local.get $8
@@ -7766,90 +7742,6 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
- (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  local.get $0
-  local.get $1
-  i32.shl
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.const 0
-  local.get $3
-  call $~lib/rt/__newBuffer
-  local.tee $5
-  i32.store
-  i32.const 16
-  local.get $2
-  call $~lib/rt/itcms/__new
-  local.set $6
-  local.get $6
-  local.get $5
-  i32.store
-  local.get $6
-  local.get $5
-  i32.const 0
-  call $~lib/rt/itcms/__link
-  local.get $6
-  local.get $5
-  i32.store offset=4
-  local.get $6
-  local.get $4
-  i32.store offset=8
-  local.get $6
-  local.get $0
-  i32.store offset=12
-  local.get $6
-  local.set $7
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $7
- )
- (func $~lib/date/lastDayOfMonthNonLeapYear (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
-  i32.const 2
-  i32.const 4
-  i32.const 592
-  call $~lib/rt/__newArray
-  local.tee $2
-  i32.store
-  local.get $2
-  local.get $0
-  i32.const 1
-  i32.sub
-  call $~lib/array/Array<i32>#__get
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $3
- )
  (func $~lib/util/number/itoa32 (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -7877,8 +7769,8 @@
    i32.gt_s
   end
   if
+   i32.const 592
    i32.const 720
-   i32.const 848
    i32.const 373
    i32.const 5
    call $~lib/builtins/abort
@@ -7887,7 +7779,7 @@
   local.get $0
   i32.eqz
   if
-   i32.const 912
+   i32.const 784
    local.set $8
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -8159,7 +8051,7 @@
   i32.const 0
   i32.eq
   if
-   i32.const 2528
+   i32.const 2400
    local.set $6
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -8192,6 +8084,58 @@
   global.set $~lib/memory/__stack_pointer
   local.get $6
  )
+ (func $~lib/rt/__newArray (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  local.get $1
+  i32.shl
+  local.set $4
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.const 0
+  local.get $3
+  call $~lib/rt/__newBuffer
+  local.tee $5
+  i32.store
+  i32.const 16
+  local.get $2
+  call $~lib/rt/itcms/__new
+  local.set $6
+  local.get $6
+  local.get $5
+  i32.store
+  local.get $6
+  local.get $5
+  i32.const 0
+  call $~lib/rt/itcms/__link
+  local.get $6
+  local.get $5
+  i32.store offset=4
+  local.get $6
+  local.get $4
+  i32.store offset=8
+  local.get $6
+  local.get $0
+  i32.store offset=12
+  local.get $6
+  local.set $7
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $7
+ )
  (func $~lib/array/Array<~lib/string/String>#__get (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -8209,7 +8153,7 @@
   i32.ge_u
   if
    i32.const 272
-   i32.const 672
+   i32.const 2928
    i32.const 92
    i32.const 42
    call $~lib/builtins/abort
@@ -8233,8 +8177,8 @@
   local.get $2
   i32.eqz
   if
-   i32.const 3056
-   i32.const 672
+   i32.const 2976
+   i32.const 2928
    i32.const 96
    i32.const 40
    call $~lib/builtins/abort

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -18,8 +18,6 @@
  (type $i32_=>_i64 (func (param i32) (result i64)))
  (type $i32_i32_i32_i32_i32_i32_i32_=>_i64 (func (param i32 i32 i32 i32 i32 i32 i32) (result i64)))
  (type $i32_i64_=>_i64 (func (param i32 i64) (result i64)))
- (type $i32_i32_i32_i32_i32_i32_f64_=>_f64 (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
- (import "Date" "UTC" (func $~lib/bindings/Date/UTC (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 12) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\16\00\00\00s\00t\00d\00/\00d\00a\00t\00e\00.\00t\00s\00\00\00\00\00\00\00")
@@ -88,6 +86,112 @@
  (global $~started (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
+ (func $~lib/date/daysSinceEpoch (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  local.get $1
+  i32.const 2
+  i32.le_s
+  if (result i32)
+   i32.const 1
+  else
+   i32.const 0
+  end
+  i32.sub
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.ge_s
+  if (result i32)
+   local.get $0
+  else
+   local.get $0
+   i32.const 399
+   i32.sub
+  end
+  i32.const 400
+  i32.div_s
+  local.set $3
+  local.get $0
+  local.get $3
+  i32.const 400
+  i32.mul
+  i32.sub
+  local.set $4
+  i32.const 153
+  local.get $1
+  local.get $1
+  i32.const 2
+  i32.gt_s
+  if (result i32)
+   i32.const -3
+  else
+   i32.const 9
+  end
+  i32.add
+  i32.mul
+  i32.const 2
+  i32.add
+  i32.const 5
+  i32.div_s
+  local.get $2
+  i32.add
+  i32.const 1
+  i32.sub
+  local.set $5
+  local.get $4
+  i32.const 365
+  i32.mul
+  local.get $4
+  i32.const 4
+  i32.div_s
+  i32.add
+  local.get $4
+  i32.const 100
+  i32.div_s
+  i32.sub
+  local.get $5
+  i32.add
+  local.set $6
+  local.get $3
+  i32.const 146097
+  i32.mul
+  local.get $6
+  i32.add
+  i32.const 719468
+  i32.sub
+ )
+ (func $~lib/date/epochMillis (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32) (param $6 i32) (result i64)
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/date/daysSinceEpoch
+  i64.extend_i32_s
+  global.get $~lib/date/MILLIS_PER_DAY
+  i64.extend_i32_s
+  i64.mul
+  local.get $3
+  global.get $~lib/date/MILLIS_PER_HOUR
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  local.get $4
+  global.get $~lib/date/MILLIS_PER_MINUTE
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  local.get $5
+  global.get $~lib/date/MILLIS_PER_SECOND
+  i32.mul
+  i64.extend_i32_s
+  i64.add
+  local.get $6
+  i64.extend_i32_s
+  i64.add
+ )
  (func $~lib/date/Date#set:epochMillis (param $0 i32) (param $1 i64)
   local.get $0
   local.get $1
@@ -2519,7 +2623,7 @@
   if
    i32.const 480
    i32.const 544
-   i32.const 195
+   i32.const 193
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -3984,84 +4088,6 @@
    i32.const 29
   end
  )
- (func $~lib/date/daysSinceEpoch (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  local.get $0
-  local.get $1
-  i32.const 2
-  i32.le_s
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
-  i32.sub
-  local.set $0
-  local.get $0
-  i32.const 0
-  i32.ge_s
-  if (result i32)
-   local.get $0
-  else
-   local.get $0
-   i32.const 399
-   i32.sub
-  end
-  i32.const 400
-  i32.div_s
-  local.set $3
-  local.get $0
-  local.get $3
-  i32.const 400
-  i32.mul
-  i32.sub
-  local.set $4
-  i32.const 153
-  local.get $1
-  local.get $1
-  i32.const 2
-  i32.gt_s
-  if (result i32)
-   i32.const -3
-  else
-   i32.const 9
-  end
-  i32.add
-  i32.mul
-  i32.const 2
-  i32.add
-  i32.const 5
-  i32.div_s
-  local.get $2
-  i32.add
-  i32.const 1
-  i32.sub
-  local.set $5
-  local.get $4
-  i32.const 365
-  i32.mul
-  local.get $4
-  i32.const 4
-  i32.div_s
-  i32.add
-  local.get $4
-  i32.const 100
-  i32.div_s
-  i32.sub
-  local.get $5
-  i32.add
-  local.set $6
-  local.get $3
-  i32.const 146097
-  i32.mul
-  local.get $6
-  i32.add
-  i32.const 719468
-  i32.sub
- )
  (func $~lib/date/Date#setUTCDate (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i64)
@@ -5464,34 +5490,6 @@
   local.get $1
   call $~lib/util/string/strtol<i32>
  )
- (func $~lib/date/epochMillis (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32) (param $6 i32) (result i64)
-  local.get $0
-  local.get $1
-  local.get $2
-  call $~lib/date/daysSinceEpoch
-  i64.extend_i32_s
-  global.get $~lib/date/MILLIS_PER_DAY
-  i64.extend_i32_s
-  i64.mul
-  local.get $3
-  global.get $~lib/date/MILLIS_PER_HOUR
-  i32.mul
-  i64.extend_i32_s
-  i64.add
-  local.get $4
-  global.get $~lib/date/MILLIS_PER_MINUTE
-  i32.mul
-  i64.extend_i32_s
-  i64.add
-  local.get $5
-  global.get $~lib/date/MILLIS_PER_SECOND
-  i32.mul
-  i64.extend_i32_s
-  i64.add
-  local.get $6
-  i64.extend_i32_s
-  i64.add
- )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
   i32.const 272
@@ -6640,8 +6638,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i64)
-  (local $7 i32)
+  (local $6 i32)
+  (local $7 i64)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -6665,18 +6664,18 @@
   local.set $4
   i32.const 0
   local.set $5
-  i64.const 0
+  i32.const 0
   local.set $6
   local.get $2
   local.get $1
+  i32.const 1
+  i32.add
   local.get $0
   local.get $3
   local.get $4
   local.get $5
   local.get $6
-  f64.convert_i64_s
-  call $~lib/bindings/Date/UTC
-  i64.trunc_f64_s
+  call $~lib/date/epochMillis
   i64.const 0
   i64.eq
   i32.eqz
@@ -6689,10 +6688,12 @@
    unreachable
   end
   i32.const 1970
-  local.set $5
+  local.set $6
   i32.const 0
-  local.set $4
+  local.set $5
   i32.const 1
+  local.set $4
+  i32.const 0
   local.set $3
   i32.const 0
   local.set $2
@@ -6700,18 +6701,16 @@
   local.set $1
   i32.const 0
   local.set $0
-  i64.const 0
-  local.set $6
+  local.get $6
   local.get $5
+  i32.const 1
+  i32.add
   local.get $4
   local.get $3
   local.get $2
   local.get $1
   local.get $0
-  local.get $6
-  f64.convert_i64_s
-  call $~lib/bindings/Date/UTC
-  i64.trunc_f64_s
+  call $~lib/date/epochMillis
   i64.const 0
   i64.eq
   i32.eqz
@@ -6724,31 +6723,31 @@
    unreachable
   end
   i32.const 2018
+  local.set $6
+  i32.const 10
   local.set $5
   i32.const 10
   local.set $4
-  i32.const 10
-  local.set $3
   i32.const 11
+  local.set $3
+  i32.const 0
   local.set $2
   i32.const 0
   local.set $1
-  i32.const 0
+  i32.const 1
   local.set $0
-  i64.const 1
-  local.set $6
+  local.get $6
   local.get $5
+  i32.const 1
+  i32.add
   local.get $4
   local.get $3
   local.get $2
   local.get $1
   local.get $0
-  local.get $6
-  f64.convert_i64_s
-  call $~lib/bindings/Date/UTC
-  i64.trunc_f64_s
-  local.set $6
-  local.get $6
+  call $~lib/date/epochMillis
+  local.set $7
+  local.get $7
   i64.const 1541847600001
   i64.eq
   i32.eqz
@@ -6778,16 +6777,16 @@
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/fromSpace
   i64.const 1541847600001
-  local.set $6
+  local.set $7
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  local.get $6
+  local.get $7
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
-  call $~lib/date/Date#getTime
   local.get $6
+  call $~lib/date/Date#getTime
+  local.get $7
   i64.eq
   i32.eqz
   if
@@ -6798,15 +6797,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
   local.get $6
+  local.get $7
   i64.const 1
   i64.add
   call $~lib/date/Date#setTime
   drop
-  local.get $5
-  call $~lib/date/Date#getTime
   local.get $6
+  call $~lib/date/Date#getTime
+  local.get $7
   i64.const 1
   i64.add
   i64.eq
@@ -6823,9 +6822,9 @@
   i32.const 0
   i64.const 5918283958183706
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCFullYear
   i32.const 189512
   i32.eq
@@ -6838,7 +6837,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMonth
   i32.const 11
   i32.eq
@@ -6851,7 +6850,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCDate
   i32.const 14
   i32.eq
@@ -6864,7 +6863,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCHours
   i32.const 22
   i32.eq
@@ -6877,7 +6876,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMinutes
   i32.const 9
   i32.eq
@@ -6890,7 +6889,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCSeconds
   i32.const 43
   i32.eq
@@ -6903,7 +6902,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 706
   i32.eq
@@ -6920,9 +6919,9 @@
   i32.const 0
   i64.const 123814991274
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCFullYear
   i32.const 1973
   i32.eq
@@ -6935,7 +6934,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMonth
   i32.const 11
   i32.eq
@@ -6948,7 +6947,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCDate
   i32.const 4
   i32.eq
@@ -6961,7 +6960,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCHours
   i32.const 1
   i32.eq
@@ -6974,7 +6973,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMinutes
   i32.const 3
   i32.eq
@@ -6987,7 +6986,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCSeconds
   i32.const 11
   i32.eq
@@ -7000,7 +6999,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 274
   i32.eq
@@ -7017,9 +7016,9 @@
   i32.const 0
   i64.const 399464523963984
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 984
   i32.eq
@@ -7032,10 +7031,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 12
   call $~lib/date/Date#setUTCMilliseconds
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 12
   i32.eq
@@ -7048,10 +7047,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 568
   call $~lib/date/Date#setUTCMilliseconds
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 568
   i32.eq
@@ -7064,19 +7063,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 0
   call $~lib/date/Date#setUTCMilliseconds
-  local.get $5
+  local.get $6
   i32.const 999
   call $~lib/date/Date#setUTCMilliseconds
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 372027318331986
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCSeconds
   i32.const 31
   i32.eq
@@ -7089,10 +7088,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 12
   call $~lib/date/Date#setUTCSeconds
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCSeconds
   i32.const 12
   i32.eq
@@ -7105,10 +7104,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 50
   call $~lib/date/Date#setUTCSeconds
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCSeconds
   i32.const 50
   i32.eq
@@ -7121,19 +7120,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 0
   call $~lib/date/Date#setUTCSeconds
-  local.get $5
+  local.get $6
   i32.const 59
   call $~lib/date/Date#setUTCSeconds
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 372027318331986
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMinutes
   i32.const 45
   i32.eq
@@ -7146,10 +7145,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 12
   call $~lib/date/Date#setUTCMinutes
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMinutes
   i32.const 12
   i32.eq
@@ -7162,10 +7161,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 50
   call $~lib/date/Date#setUTCMinutes
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMinutes
   i32.const 50
   i32.eq
@@ -7178,19 +7177,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 0
   call $~lib/date/Date#setUTCMinutes
-  local.get $5
+  local.get $6
   i32.const 59
   call $~lib/date/Date#setUTCMinutes
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 372027318331986
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCHours
   i32.const 17
   i32.eq
@@ -7203,10 +7202,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 12
   call $~lib/date/Date#setUTCHours
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCHours
   i32.const 12
   i32.eq
@@ -7219,10 +7218,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 2
   call $~lib/date/Date#setUTCHours
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCHours
   i32.const 2
   i32.eq
@@ -7235,19 +7234,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 0
   call $~lib/date/Date#setUTCHours
-  local.get $5
+  local.get $6
   i32.const 23
   call $~lib/date/Date#setUTCHours
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 123814991274
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCFullYear
   i32.const 1973
   i32.eq
@@ -7260,7 +7259,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMonth
   i32.const 11
   i32.eq
@@ -7273,10 +7272,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 12
   call $~lib/date/Date#setUTCDate
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCDate
   i32.const 12
   i32.eq
@@ -7289,10 +7288,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 2
   call $~lib/date/Date#setUTCDate
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCDate
   i32.const 2
   i32.eq
@@ -7305,40 +7304,40 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 1
   call $~lib/date/Date#setUTCDate
-  local.get $5
+  local.get $6
   i32.const 30
   call $~lib/date/Date#setUTCDate
-  local.get $5
+  local.get $6
   i32.const 1
   call $~lib/date/Date#setUTCMonth
-  local.get $5
+  local.get $6
   i32.const 1
   call $~lib/date/Date#setUTCDate
-  local.get $5
+  local.get $6
   i32.const 31
   call $~lib/date/Date#setUTCDate
-  local.get $5
+  local.get $6
   i32.const 2024
   call $~lib/date/Date#setUTCFullYear
-  local.get $5
+  local.get $6
   i32.const 2
   call $~lib/date/Date#setUTCMonth
-  local.get $5
+  local.get $6
   i32.const 1
   call $~lib/date/Date#setUTCDate
-  local.get $5
+  local.get $6
   i32.const 29
   call $~lib/date/Date#setUTCDate
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 7899943856218720
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMonth
   i32.const 3
   i32.eq
@@ -7351,10 +7350,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 10
   call $~lib/date/Date#setUTCMonth
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMonth
   i32.const 10
   i32.eq
@@ -7367,10 +7366,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 2
   call $~lib/date/Date#setUTCMonth
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCMonth
   i32.const 2
   i32.eq
@@ -7383,19 +7382,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 1
   call $~lib/date/Date#setUTCMonth
-  local.get $5
+  local.get $6
   i32.const 12
   call $~lib/date/Date#setUTCMonth
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 7941202527925698
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCFullYear
   i32.const 253616
   i32.eq
@@ -7408,10 +7407,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 1976
   call $~lib/date/Date#setUTCFullYear
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCFullYear
   i32.const 1976
   i32.eq
@@ -7424,10 +7423,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.const 20212
   call $~lib/date/Date#setUTCFullYear
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getUTCFullYear
   i32.const 20212
   i32.eq
@@ -7444,21 +7443,21 @@
   i32.const 0
   i64.const 1231231231020
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#toISOString
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   i32.const 2720
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $8
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7473,21 +7472,21 @@
   i32.const 0
   i64.const 1231231231456
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#toISOString
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   i32.const 2800
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $8
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7502,21 +7501,21 @@
   i32.const 0
   i64.const 322331231231020
   call $~lib/date/Date#constructor
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#toISOString
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   i32.const 2880
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $8
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7529,15 +7528,15 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 2960
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   call $~lib/date/Date.fromString
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getTime
   i64.const 192067200000
   i64.eq
@@ -7552,15 +7551,15 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 3216
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   call $~lib/date/Date.fromString
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getTime
   i64.const 192067200000
   i64.eq
@@ -7575,15 +7574,15 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 3264
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   call $~lib/date/Date.fromString
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getTime
   i64.const 11860387200000
   i64.eq
@@ -7597,30 +7596,30 @@
    unreachable
   end
   i32.const 3312
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $8
   call $~lib/date/Date.fromString
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   call $~lib/date/Date#getTime
   i32.const 3360
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=8
-  local.get $7
+  local.get $8
   call $~lib/date/Date.fromString
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   call $~lib/date/Date#getTime
   i64.eq
   i32.eqz
@@ -7634,15 +7633,15 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 3408
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   call $~lib/date/Date.fromString
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getTime
   i64.const 192112496000
   i64.eq
@@ -7657,15 +7656,15 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 3472
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   call $~lib/date/Date.fromString
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getTime
   i64.const 192112496456
   i64.eq
@@ -7680,15 +7679,15 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 3552
-  local.set $7
+  local.set $8
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  local.get $8
   i32.store offset=4
-  local.get $7
+  local.get $8
   call $~lib/date/Date.fromString
-  local.tee $5
+  local.tee $6
   i32.store
-  local.get $5
+  local.get $6
   call $~lib/date/Date#getTime
   i64.const 192112496456
   i64.eq


### PR DESCRIPTION
This PR adds
 -  getters / setters for UTC dates (I don't plan to add any local-time related functionality)
 - `fromString`, as a substitute for the `new Date("2345-11-04")` style constructor - I resisted the temptation to use [as-regex](https://github.com/ColinEberhardt/assemblyscript-regex) for this task 😆 
 - `toISOString`

I've also modified `Date.UTC` so that it no longer calls out to the JS host.


