### PR TITLE
Add definitions for ASC_VERSION_*

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -90,6 +90,12 @@ declare const ASC_FEATURE_MULTI_VALUE: bool;
 declare const ASC_FEATURE_GC: bool;
 /** Whether the memory64 feature is enabled. */
 declare const ASC_FEATURE_MEMORY64: bool;
+/** Major version of the compiler. */
+declare const ASC_VERSION_MAJOR: i32;
+/** Minor version of the compiler. */
+declare const ASC_VERSION_MINOR: i32;
+/** Patch version of the compiler. */
+declare const ASC_VERSION_PATCH: i32;
 
 // Builtins
 


### PR DESCRIPTION
Missed these during review and only noticed after pulling the changes and looking at the test, whoops.

- [x] I've read the contributing guidelines