### PR TITLE
Fix invalid store offsets in memset polyfill

### DIFF
--- a/std/assembly/util/memory.ts
+++ b/std/assembly/util/memory.ts
@@ -201,17 +201,16 @@ export function memset(dest: usize, c: u8, n: usize): void { // see: musl/src/st
   } else {
     // fill head and tail with minimal branching
     if (!n) return;
-    let dend = dest + n - 4;
     store<u8>(dest, c);
-    store<u8>(dend, c, 3);
+    store<u8>(dest + n - 1, c);
     if (n <= 2) return;
-    store<u8>(dest, c, 1);
-    store<u8>(dest, c, 2);
-    store<u8>(dend, c, 2);
-    store<u8>(dend, c, 1);
+    store<u8>(dest + 1, c);
+    store<u8>(dest + 2, c);
+    store<u8>(dest + n - 2, c);
+    store<u8>(dest + n - 3, c);
     if (n <= 6) return;
-    store<u8>(dest, c, 3);
-    store<u8>(dend, c);
+    store<u8>(dest + 3, c);
+    store<u8>(dest + n - 4, c);
     if (n <= 8) return;
 
     // advance pointer to align it at 4-byte boundary
@@ -223,23 +222,22 @@ export function memset(dest: usize, c: u8, n: usize): void { // see: musl/src/st
     let c32: u32 = <u32>-1 / 255 * c;
 
     // fill head/tail up to 28 bytes each in preparation
-    dend = dest + n - 28;
     store<u32>(dest, c32);
-    store<u32>(dend, c32, 24);
+    store<u32>(dest + n - 4, c32);
     if (n <= 8) return;
-    store<u32>(dest, c32, 4);
-    store<u32>(dest, c32, 8);
-    store<u32>(dend, c32, 16);
-    store<u32>(dend, c32, 20);
+    store<u32>(dest + 4, c32);
+    store<u32>(dest + 8, c32);
+    store<u32>(dest + n - 12, c32);
+    store<u32>(dest + n - 8, c32);
     if (n <= 24) return;
-    store<u32>(dest, c32, 12);
-    store<u32>(dest, c32, 16);
-    store<u32>(dest, c32, 20);
-    store<u32>(dest, c32, 24);
-    store<u32>(dend, c32);
-    store<u32>(dend, c32, 4);
-    store<u32>(dend, c32, 8);
-    store<u32>(dend, c32, 12);
+    store<u32>(dest + 12, c32);
+    store<u32>(dest + 16, c32);
+    store<u32>(dest + 20, c32);
+    store<u32>(dest + 24, c32);
+    store<u32>(dest + n - 28, c32);
+    store<u32>(dest + n - 24, c32);
+    store<u32>(dest + n - 20, c32);
+    store<u32>(dest + n - 16, c32);
 
     // align to a multiple of 8
     k = 24 + (dest & 4);
@@ -250,9 +248,9 @@ export function memset(dest: usize, c: u8, n: usize): void { // see: musl/src/st
     let c64: u64 = <u64>c32 | (<u64>c32 << 32);
     while (n >= 32) {
       store<u64>(dest, c64);
-      store<u64>(dest, c64, 8);
-      store<u64>(dest, c64, 16);
-      store<u64>(dest, c64, 24);
+      store<u64>(dest + 8, c64);
+      store<u64>(dest + 16, c64);
+      store<u64>(dest + 24, c64);
       n -= 32;
       dest += 32;
     }

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -1449,11 +1449,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1464,12 +1463,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1477,7 +1483,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1501,14 +1511,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1518,13 +1527,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1540,29 +1556,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -2067,9 +2067,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2087,17 +2086,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2105,17 +2102,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2123,9 +2132,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2139,13 +2154,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2159,19 +2174,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2179,17 +2192,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2197,70 +2222,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/class-implements.untouched.wat
+++ b/tests/compiler/class-implements.untouched.wat
@@ -2077,9 +2077,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2097,17 +2096,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2115,17 +2112,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2133,9 +2142,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2149,13 +2164,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2169,19 +2184,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2189,17 +2202,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2207,70 +2232,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -2083,9 +2083,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2103,17 +2102,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2121,17 +2118,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2139,9 +2148,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2155,13 +2170,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2175,19 +2190,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2195,17 +2208,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2213,70 +2238,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -1456,11 +1456,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1471,12 +1470,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1484,7 +1490,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1508,14 +1518,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1525,13 +1534,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1547,29 +1563,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2179,9 +2179,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2199,17 +2198,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2217,17 +2214,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2235,9 +2244,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2251,13 +2266,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2271,19 +2286,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2291,17 +2304,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2309,70 +2334,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/constructor.optimized.wat
+++ b/tests/compiler/constructor.optimized.wat
@@ -1517,11 +1517,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1532,12 +1531,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1545,7 +1551,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1569,14 +1579,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1586,13 +1595,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1608,29 +1624,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -2077,9 +2077,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2097,17 +2096,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2115,17 +2112,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2133,9 +2142,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2149,13 +2164,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2169,19 +2184,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2189,17 +2202,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2207,70 +2232,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -2480,9 +2480,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2500,17 +2499,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2518,17 +2515,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2536,9 +2545,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2552,13 +2567,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2572,19 +2587,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2592,17 +2605,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2610,70 +2635,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/empty-exportruntime.optimized.wat
+++ b/tests/compiler/empty-exportruntime.optimized.wat
@@ -1467,11 +1467,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1482,12 +1481,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1495,7 +1501,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1519,14 +1529,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1536,13 +1545,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1558,29 +1574,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/empty-exportruntime.untouched.wat
+++ b/tests/compiler/empty-exportruntime.untouched.wat
@@ -2073,9 +2073,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2093,17 +2092,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2111,17 +2108,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2129,9 +2138,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2145,13 +2160,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2165,19 +2180,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2185,17 +2198,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2203,70 +2228,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/empty-new.untouched.wat
+++ b/tests/compiler/empty-new.untouched.wat
@@ -2066,9 +2066,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2086,17 +2085,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2104,17 +2101,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2122,9 +2131,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2138,13 +2153,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2158,19 +2173,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2178,17 +2191,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2196,70 +2221,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -1436,20 +1436,29 @@
   i32.const 0
   i32.store8
   local.get $0
+  i32.const 4
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=2
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=1
+  i32.store8
   local.get $0
  )
  (func $export/mul (param $0 i32) (param $1 i32) (result i32)

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -2130,9 +2130,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2150,17 +2149,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2168,17 +2165,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2186,9 +2195,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2202,13 +2217,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2222,19 +2237,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2242,17 +2255,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2260,70 +2285,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/exportstar-rereexport.optimized.wat
+++ b/tests/compiler/exportstar-rereexport.optimized.wat
@@ -1360,6 +1360,7 @@
  )
  (func $~lib/rt/itcms/__new (result i32)
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
@@ -1437,20 +1438,29 @@
   i32.const 0
   i32.store8
   local.get $0
+  i32.const 4
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=2
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=1
+  i32.store8
   local.get $0
  )
  (func $export-default/theDefault

--- a/tests/compiler/exportstar-rereexport.untouched.wat
+++ b/tests/compiler/exportstar-rereexport.untouched.wat
@@ -2111,9 +2111,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2131,17 +2130,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2149,17 +2146,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2167,9 +2176,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2183,13 +2198,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2203,19 +2218,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2223,17 +2236,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2241,70 +2266,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1463,11 +1463,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1478,12 +1477,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1491,7 +1497,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1515,14 +1525,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1532,13 +1541,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1554,29 +1570,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -2075,9 +2075,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2095,17 +2094,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2113,17 +2110,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2131,9 +2140,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2147,13 +2162,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2167,19 +2182,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2187,17 +2200,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2205,70 +2230,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/extends-recursive.optimized.wat
+++ b/tests/compiler/extends-recursive.optimized.wat
@@ -1389,20 +1389,29 @@
   i32.const 0
   i32.store8
   local.get $0
+  i32.const 4
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=2
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=1
+  i32.store8
   local.get $0
  )
  (func $extends-recursive/Parent#set:child (param $0 i32) (param $1 i32)

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -2071,9 +2071,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2091,17 +2090,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2109,17 +2106,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2127,9 +2136,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2143,13 +2158,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2163,19 +2178,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2183,17 +2196,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2201,70 +2226,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/field-initialization.optimized.wat
+++ b/tests/compiler/field-initialization.optimized.wat
@@ -1469,11 +1469,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1484,12 +1483,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1497,7 +1503,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1521,14 +1531,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1538,13 +1547,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1560,29 +1576,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/field-initialization.untouched.wat
+++ b/tests/compiler/field-initialization.untouched.wat
@@ -2075,9 +2075,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2095,17 +2094,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2113,17 +2110,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2131,9 +2140,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2147,13 +2162,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2167,19 +2182,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2187,17 +2200,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2205,70 +2230,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -2493,9 +2493,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2513,17 +2512,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2531,17 +2528,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2549,9 +2558,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2565,13 +2580,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2585,19 +2600,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2605,17 +2618,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2623,70 +2648,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/function-call.untouched.wat
+++ b/tests/compiler/function-call.untouched.wat
@@ -2102,9 +2102,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2122,17 +2121,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2140,17 +2137,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2158,9 +2167,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2174,13 +2189,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2194,19 +2209,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2214,17 +2227,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2232,70 +2257,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -1376,6 +1376,7 @@
  )
  (func $~lib/rt/itcms/__new (result i32)
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
@@ -1453,20 +1454,29 @@
   i32.const 0
   i32.store8
   local.get $0
+  i32.const 4
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=2
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=1
+  i32.store8
   local.get $0
  )
  (func $function-expression/semanticallyAnonymous~fnDecl|0 (param $0 i64) (result i64)

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -2258,9 +2258,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2278,17 +2277,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2296,17 +2293,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2314,9 +2323,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2330,13 +2345,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2350,19 +2365,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2370,17 +2383,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2388,70 +2413,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -2070,9 +2070,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2090,17 +2089,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2108,17 +2105,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2126,9 +2135,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2142,13 +2157,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2162,19 +2177,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2182,17 +2195,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2200,70 +2225,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/implicit-getter-setter.optimized.wat
+++ b/tests/compiler/implicit-getter-setter.optimized.wat
@@ -1395,20 +1395,29 @@
   i32.const 0
   i32.store8
   local.get $0
+  i32.const 4
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=2
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=1
+  i32.store8
   local.get $0
  )
  (func $implicit-getter-setter/Managed#set:foo (param $0 i32) (param $1 i32)

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -2076,9 +2076,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2096,17 +2095,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2114,17 +2111,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2132,9 +2141,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2148,13 +2163,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2168,19 +2183,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2188,17 +2201,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2206,70 +2231,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -1484,11 +1484,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1499,12 +1498,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1512,7 +1518,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1536,14 +1546,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1553,13 +1562,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1575,29 +1591,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -2085,9 +2085,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2105,17 +2104,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2123,17 +2120,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2141,9 +2150,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2157,13 +2172,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2177,19 +2192,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2197,17 +2210,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2215,70 +2240,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/infer-generic.optimized.wat
+++ b/tests/compiler/infer-generic.optimized.wat
@@ -1334,6 +1334,7 @@
  )
  (func $~lib/rt/itcms/__new (result i32)
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
@@ -1411,20 +1412,29 @@
   i32.const 0
   i32.store8
   local.get $0
+  i32.const 4
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=2
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=1
+  i32.store8
   local.get $0
  )
  (func $infer-generic/test1 (param $0 f32) (result f32)

--- a/tests/compiler/infer-generic.untouched.wat
+++ b/tests/compiler/infer-generic.untouched.wat
@@ -2156,9 +2156,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2176,17 +2175,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2194,17 +2191,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2212,9 +2221,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2228,13 +2243,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2248,19 +2263,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2268,17 +2281,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2286,70 +2311,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -1460,11 +1460,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1475,12 +1474,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1488,7 +1494,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1512,14 +1522,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1529,13 +1538,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1551,29 +1567,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -2276,9 +2276,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2296,17 +2295,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2314,17 +2311,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2332,9 +2341,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2348,13 +2363,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2368,19 +2383,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2388,17 +2401,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2406,70 +2431,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -2069,9 +2069,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2089,17 +2088,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2107,17 +2104,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2125,9 +2134,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2141,13 +2156,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2161,19 +2176,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2181,17 +2194,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2199,70 +2224,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -1312,6 +1312,7 @@
  )
  (func $~lib/rt/itcms/__new (result i32)
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
@@ -1389,20 +1390,29 @@
   i32.const 0
   i32.store8
   local.get $0
+  i32.const 4
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=2
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=1
+  i32.store8
   local.get $0
  )
  (func $issues/1095/Foo#set:bar (param $0 i32) (param $1 i32)

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -2069,9 +2069,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2089,17 +2088,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2107,17 +2104,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2125,9 +2134,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2141,13 +2156,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2161,19 +2176,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2181,17 +2194,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2199,70 +2224,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/issues/1225.optimized.wat
+++ b/tests/compiler/issues/1225.optimized.wat
@@ -1324,28 +1324,37 @@
    i32.const 0
    i32.store8
    local.get $0
-   i32.const 8
+   i32.const 12
    i32.add
+   local.tee $1
+   i32.const 1
+   i32.sub
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $0
    i32.const 0
    i32.store8 offset=1
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $0
+   local.get $1
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=10
-   local.get $0
+   i32.store8
+   local.get $1
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=9
+   i32.store8
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $0
+   local.get $1
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store8 offset=8
+   i32.store8
    local.get $0
    i32.const 0
    local.get $0
@@ -1363,14 +1372,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1380,13 +1388,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1402,29 +1417,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/issues/1225.untouched.wat
+++ b/tests/compiler/issues/1225.untouched.wat
@@ -2080,9 +2080,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2100,17 +2099,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2118,17 +2115,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2136,9 +2145,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2152,13 +2167,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2172,19 +2187,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2192,17 +2205,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2210,70 +2235,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -1459,11 +1459,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1474,12 +1473,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1487,7 +1493,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1511,14 +1521,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1528,13 +1537,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1550,29 +1566,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -2070,9 +2070,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2090,17 +2089,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2108,17 +2105,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2126,9 +2135,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2142,13 +2157,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2162,19 +2177,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2182,17 +2195,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2200,70 +2225,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -2092,9 +2092,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2112,17 +2111,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2130,17 +2127,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2148,9 +2157,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2164,13 +2179,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2184,19 +2199,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2204,17 +2217,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2222,70 +2247,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -2069,9 +2069,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2089,17 +2088,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2107,17 +2104,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2125,9 +2134,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2141,13 +2156,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2161,19 +2176,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2181,17 +2194,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2199,70 +2224,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/new.untouched.wat
+++ b/tests/compiler/new.untouched.wat
@@ -2072,9 +2072,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2092,17 +2091,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2110,17 +2107,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2128,9 +2137,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2144,13 +2159,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2164,19 +2179,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2184,17 +2197,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2202,70 +2227,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -1534,11 +1534,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1549,12 +1548,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1562,7 +1568,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1586,14 +1596,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1603,13 +1612,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1625,29 +1641,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -2170,9 +2170,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2190,17 +2189,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2208,17 +2205,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2226,9 +2235,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2242,13 +2257,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2262,19 +2277,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2282,17 +2295,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2300,70 +2325,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -1544,11 +1544,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1559,12 +1558,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1572,7 +1578,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1596,14 +1606,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1613,13 +1622,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1635,29 +1651,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -2159,9 +2159,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2179,17 +2178,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2197,17 +2194,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2215,9 +2224,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2231,13 +2246,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2251,19 +2266,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2271,17 +2284,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2289,70 +2314,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -2075,9 +2075,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2095,17 +2094,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2113,17 +2110,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2131,9 +2140,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2147,13 +2162,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2167,19 +2182,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2187,17 +2200,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2205,70 +2230,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -1475,20 +1475,29 @@
   i32.const 0
   i32.store8
   local.get $0
+  i32.const 4
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=2
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=1
+  i32.store8
   local.get $0
  )
  (func $export/sub (param $0 i32) (param $1 i32) (result i32)

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -2159,9 +2159,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2179,17 +2178,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2197,17 +2194,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2215,9 +2224,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2231,13 +2246,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2251,19 +2266,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2271,17 +2284,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2289,70 +2314,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/rereexport.optimized.wat
+++ b/tests/compiler/rereexport.optimized.wat
@@ -1360,6 +1360,7 @@
  )
  (func $~lib/rt/itcms/__new (result i32)
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
@@ -1437,20 +1438,29 @@
   i32.const 0
   i32.store8
   local.get $0
+  i32.const 4
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=2
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=1
+  i32.store8
   local.get $0
  )
  (func $export-default/theDefault

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -2111,9 +2111,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2131,17 +2130,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2149,17 +2146,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2167,9 +2176,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2183,13 +2198,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2203,19 +2218,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2223,17 +2236,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2241,70 +2266,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -1465,11 +1465,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1480,12 +1479,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1493,7 +1499,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1517,14 +1527,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1534,13 +1543,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1556,29 +1572,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -2085,9 +2085,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2105,17 +2104,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2123,17 +2120,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2141,9 +2150,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2157,13 +2172,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2177,19 +2192,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2197,17 +2210,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2215,70 +2240,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -1696,11 +1696,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1711,12 +1710,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1724,7 +1730,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1748,14 +1758,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1765,13 +1774,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1787,29 +1803,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -2345,9 +2345,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2365,17 +2364,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2383,17 +2380,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2401,9 +2410,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2417,13 +2432,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2437,19 +2452,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2457,17 +2470,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2475,70 +2500,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -1516,11 +1516,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1531,12 +1530,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1544,7 +1550,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1568,14 +1578,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1585,13 +1594,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1607,29 +1623,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -2108,9 +2108,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2128,17 +2127,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2146,17 +2143,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2164,9 +2173,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2180,13 +2195,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2200,19 +2215,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2220,17 +2233,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2238,70 +2263,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -1483,11 +1483,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1498,12 +1497,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1511,7 +1517,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1535,14 +1545,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1552,13 +1561,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1574,29 +1590,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -2153,9 +2153,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2173,17 +2172,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2191,17 +2188,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2209,9 +2218,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2225,13 +2240,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2245,19 +2260,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2265,17 +2278,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2283,70 +2308,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/resolve-nested.untouched.wat
+++ b/tests/compiler/resolve-nested.untouched.wat
@@ -2091,9 +2091,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2111,17 +2110,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2129,17 +2126,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2147,9 +2156,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2163,13 +2178,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2183,19 +2198,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2203,17 +2216,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2221,70 +2246,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/resolve-new.untouched.wat
+++ b/tests/compiler/resolve-new.untouched.wat
@@ -2067,9 +2067,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2087,17 +2086,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2105,17 +2102,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2123,9 +2132,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2139,13 +2154,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2159,19 +2174,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2179,17 +2192,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2197,70 +2222,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -1483,11 +1483,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1498,12 +1497,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1511,7 +1517,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1535,14 +1545,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1552,13 +1561,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1574,29 +1590,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -2153,9 +2153,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2173,17 +2172,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2191,17 +2188,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2209,9 +2218,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2225,13 +2240,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2245,19 +2260,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2265,17 +2278,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2283,70 +2308,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -1529,11 +1529,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1544,12 +1543,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1557,7 +1563,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1581,14 +1591,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1598,13 +1607,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1620,29 +1636,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -2161,9 +2161,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2181,17 +2180,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2199,17 +2196,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2217,9 +2226,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2233,13 +2248,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2253,19 +2268,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2273,17 +2286,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2291,70 +2316,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -1503,11 +1503,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1518,12 +1517,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1531,7 +1537,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1555,14 +1565,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1572,13 +1581,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1594,29 +1610,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -2150,9 +2150,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2170,17 +2169,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2188,17 +2185,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2206,9 +2215,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2222,13 +2237,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2242,19 +2257,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2262,17 +2275,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2280,70 +2305,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -2090,9 +2090,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2110,17 +2109,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2128,17 +2125,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2146,9 +2155,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2162,13 +2177,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2182,19 +2197,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2202,17 +2215,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2220,70 +2245,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -2077,9 +2077,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2097,17 +2096,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2115,17 +2112,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2133,9 +2142,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2149,13 +2164,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2169,19 +2184,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2189,17 +2202,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2207,70 +2232,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/rt/runtime-incremental-export.optimized.wat
+++ b/tests/compiler/rt/runtime-incremental-export.optimized.wat
@@ -1467,11 +1467,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1482,12 +1481,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1495,7 +1501,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1519,14 +1529,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1536,13 +1545,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1558,29 +1574,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/rt/runtime-incremental-export.untouched.wat
+++ b/tests/compiler/rt/runtime-incremental-export.untouched.wat
@@ -2073,9 +2073,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2093,17 +2092,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2111,17 +2108,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2129,9 +2138,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2145,13 +2160,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2165,19 +2180,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2185,17 +2198,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2203,70 +2228,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std-wasi/console.optimized.wat
+++ b/tests/compiler/std-wasi/console.optimized.wat
@@ -2601,11 +2601,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -2616,12 +2615,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -2629,7 +2635,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -2653,14 +2663,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -2670,13 +2679,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -2692,29 +2708,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std-wasi/console.untouched.wat
+++ b/tests/compiler/std-wasi/console.untouched.wat
@@ -3587,9 +3587,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -3607,17 +3606,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -3625,17 +3622,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -3643,9 +3652,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -3659,13 +3674,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -3679,19 +3694,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -3699,17 +3712,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -3717,70 +3742,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std-wasi/crypto.optimized.wat
+++ b/tests/compiler/std-wasi/crypto.optimized.wat
@@ -2024,11 +2024,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -2039,12 +2038,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -2052,7 +2058,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -2076,14 +2086,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -2093,13 +2102,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -2115,29 +2131,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std-wasi/crypto.untouched.wat
+++ b/tests/compiler/std-wasi/crypto.untouched.wat
@@ -2621,9 +2621,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2641,17 +2640,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2659,17 +2656,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2677,9 +2686,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2693,13 +2708,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2713,19 +2728,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2733,17 +2746,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2751,70 +2776,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -2620,11 +2620,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -2635,12 +2634,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -2648,7 +2654,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -2672,14 +2682,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -2689,13 +2698,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -2711,29 +2727,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -3586,9 +3586,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -3606,17 +3605,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -3624,17 +3621,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -3642,9 +3651,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -3658,13 +3673,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -3678,19 +3693,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -3698,17 +3711,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -3716,70 +3741,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -1543,11 +1543,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1558,12 +1557,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1571,7 +1577,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1595,14 +1605,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1612,13 +1621,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1634,29 +1650,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -2143,9 +2143,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2163,17 +2162,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2181,17 +2178,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2199,9 +2208,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2215,13 +2230,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2235,19 +2250,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2255,17 +2268,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2273,70 +2298,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2118,11 +2118,10 @@
    local.get $0
    local.get $2
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $3
    local.get $1
-   i32.store8 offset=3
+   i32.store8
    local.get $2
    i32.const 2
    i32.le_u
@@ -2133,12 +2132,19 @@
    local.get $0
    local.get $1
    i32.store8 offset=2
-   local.get $3
+   local.get $0
+   local.get $2
+   i32.add
+   local.tee $3
+   i32.const 2
+   i32.sub
    local.get $1
-   i32.store8 offset=2
+   i32.store8
    local.get $3
+   i32.const 3
+   i32.sub
    local.get $1
-   i32.store8 offset=1
+   i32.store8
    local.get $2
    i32.const 6
    i32.le_u
@@ -2146,7 +2152,11 @@
    local.get $0
    local.get $1
    i32.store8 offset=3
-   local.get $3
+   local.get $0
+   local.get $2
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $1
    i32.store8
    local.get $2
@@ -2177,11 +2187,10 @@
    i32.and
    local.tee $2
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.tee $1
    local.get $0
-   i32.store offset=24
+   i32.store
    local.get $2
    i32.const 8
    i32.le_u
@@ -2192,12 +2201,19 @@
    local.get $3
    local.get $0
    i32.store offset=8
-   local.get $1
+   local.get $2
+   local.get $3
+   i32.add
+   local.tee $1
+   i32.const 12
+   i32.sub
    local.get $0
-   i32.store offset=16
+   i32.store
    local.get $1
+   i32.const 8
+   i32.sub
    local.get $0
-   i32.store offset=20
+   i32.store
    local.get $2
    i32.const 24
    i32.le_u
@@ -2214,18 +2230,29 @@
    local.get $3
    local.get $0
    i32.store offset=24
-   local.get $1
+   local.get $2
+   local.get $3
+   i32.add
+   local.tee $1
+   i32.const 28
+   i32.sub
    local.get $0
    i32.store
    local.get $1
+   i32.const 24
+   i32.sub
    local.get $0
-   i32.store offset=4
+   i32.store
    local.get $1
+   i32.const 20
+   i32.sub
    local.get $0
-   i32.store offset=8
+   i32.store
    local.get $1
+   i32.const 16
+   i32.sub
    local.get $0
-   i32.store offset=12
+   i32.store
    local.get $3
    local.get $3
    i32.const 4

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -2457,9 +2457,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2477,17 +2476,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2495,17 +2492,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2513,9 +2522,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2529,13 +2544,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2549,19 +2564,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2569,17 +2582,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2587,70 +2612,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1460,11 +1460,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1475,12 +1474,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1488,7 +1494,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1512,14 +1522,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1529,13 +1538,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1551,29 +1567,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -2073,9 +2073,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2093,17 +2092,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2111,17 +2108,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2129,9 +2138,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2145,13 +2160,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2165,19 +2180,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2185,17 +2198,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2203,70 +2228,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -1467,11 +1467,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1482,12 +1481,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1495,7 +1501,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1519,14 +1529,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1536,13 +1545,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1558,29 +1574,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -2080,9 +2080,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2100,17 +2099,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2118,17 +2115,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2136,9 +2145,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2152,13 +2167,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2172,19 +2187,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2192,17 +2205,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2210,70 +2235,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -1321,6 +1321,7 @@
  )
  (func $~lib/rt/itcms/__new (result i32)
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
@@ -1398,28 +1399,37 @@
   i32.const 0
   i32.store8
   local.get $0
-  i32.const 4
+  i32.const 8
   i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=6
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=5
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=3
-  local.get $0
+  local.get $1
+  i32.const 4
+  i32.sub
   i32.const 0
-  i32.store8 offset=4
+  i32.store8
   local.get $0
  )
  (func $~lib/rt/__visit_members (param $0 i32)

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -2082,9 +2082,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2102,17 +2101,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2120,17 +2117,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2138,9 +2147,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2154,13 +2169,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2174,19 +2189,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2194,17 +2207,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2212,70 +2237,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1483,11 +1483,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1498,12 +1497,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1511,7 +1517,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1535,14 +1545,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1552,13 +1561,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1574,29 +1590,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -2093,9 +2093,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2113,17 +2112,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2131,17 +2128,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2149,9 +2158,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2165,13 +2180,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2185,19 +2200,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2205,17 +2218,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2223,70 +2248,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -1314,6 +1314,7 @@
  )
  (func $~lib/rt/itcms/__new (result i32)
   (local $0 i32)
+  (local $1 i32)
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
@@ -1391,28 +1392,37 @@
   i32.const 0
   i32.store8
   local.get $0
-  i32.const 4
+  i32.const 8
   i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=6
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=5
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=3
-  local.get $0
+  local.get $1
+  i32.const 4
+  i32.sub
   i32.const 0
-  i32.store8 offset=4
+  i32.store8
   local.get $0
  )
  (func $~lib/rt/__visit_members (param $0 i32)

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -2080,9 +2080,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2100,17 +2099,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2118,17 +2115,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2136,9 +2145,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2152,13 +2167,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2172,19 +2187,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2192,17 +2205,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2210,70 +2235,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -1450,28 +1450,37 @@
   i32.const 0
   i32.store8
   local.get $0
-  i32.const 4
+  i32.const 8
   i32.add
+  local.tee $1
+  i32.const 1
+  i32.sub
   i32.const 0
-  i32.store8 offset=3
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=1
   local.get $0
   i32.const 0
   i32.store8 offset=2
-  local.get $0
+  local.get $1
+  i32.const 2
+  i32.sub
   i32.const 0
-  i32.store8 offset=6
-  local.get $0
+  i32.store8
+  local.get $1
+  i32.const 3
+  i32.sub
   i32.const 0
-  i32.store8 offset=5
+  i32.store8
   local.get $0
   i32.const 0
   i32.store8 offset=3
-  local.get $0
+  local.get $1
+  i32.const 4
+  i32.sub
   i32.const 0
-  i32.store8 offset=4
+  i32.store8
   local.get $0
  )
  (func $~lib/math/ipow32 (param $0 i32) (param $1 i32) (result i32)

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -2134,9 +2134,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2154,17 +2153,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2172,17 +2169,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2190,9 +2199,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2206,13 +2221,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2226,19 +2241,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2246,17 +2259,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2264,70 +2289,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/pointer.optimized.wat
+++ b/tests/compiler/std/pointer.optimized.wat
@@ -361,28 +361,37 @@
    i32.const 0
    i32.store8
    local.get $0
-   i32.const 4
+   i32.const 8
    i32.add
+   local.tee $1
+   i32.const 1
+   i32.sub
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $0
    i32.const 0
    i32.store8 offset=1
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $0
+   local.get $1
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=6
-   local.get $0
+   i32.store8
+   local.get $1
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=5
+   i32.store8
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $0
+   local.get $1
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store8 offset=4
+   i32.store8
   end
   global.get $std/pointer/one
   global.get $std/pointer/two

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -35,9 +35,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -55,17 +54,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -73,17 +70,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -91,9 +100,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -107,13 +122,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -127,19 +142,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -147,17 +160,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -165,70 +190,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1474,11 +1474,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1489,12 +1488,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1502,7 +1508,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1526,14 +1536,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1543,13 +1552,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1565,29 +1581,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -2088,9 +2088,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2108,17 +2107,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2126,17 +2123,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2144,9 +2153,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2160,13 +2175,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2180,19 +2195,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2200,17 +2213,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2218,70 +2243,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -1504,11 +1504,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1519,12 +1518,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1532,7 +1538,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1556,14 +1566,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1573,13 +1582,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1595,29 +1611,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -2117,9 +2117,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2137,17 +2136,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2155,17 +2152,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2173,9 +2182,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2189,13 +2204,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2209,19 +2224,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2229,17 +2242,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2247,70 +2272,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -1595,11 +1595,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1610,12 +1609,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1623,7 +1629,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1647,14 +1657,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1664,13 +1673,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1686,29 +1702,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -2178,9 +2178,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2198,17 +2197,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2216,17 +2213,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2234,9 +2243,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2250,13 +2265,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2270,19 +2285,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2290,17 +2303,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2308,70 +2333,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -1894,11 +1894,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1909,12 +1908,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1922,7 +1928,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1946,14 +1956,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1963,13 +1972,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1985,29 +2001,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -2255,9 +2255,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2275,17 +2274,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2293,17 +2290,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2311,9 +2320,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2327,13 +2342,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2347,19 +2362,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2367,17 +2380,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2385,70 +2410,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -1475,11 +1475,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1490,12 +1489,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1503,7 +1509,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1527,14 +1537,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1544,13 +1553,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1566,29 +1582,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -2088,9 +2088,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2108,17 +2107,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2126,17 +2123,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2144,9 +2153,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2160,13 +2175,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2180,19 +2195,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2200,17 +2213,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2218,70 +2243,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -2488,11 +2488,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -2503,12 +2502,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -2516,7 +2522,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -2540,14 +2550,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -2557,13 +2566,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -2579,29 +2595,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -2791,9 +2791,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2811,17 +2810,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2829,17 +2826,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2847,9 +2856,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2863,13 +2878,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2883,19 +2898,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2903,17 +2916,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2921,70 +2946,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -1565,11 +1565,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1580,12 +1579,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1593,7 +1599,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1617,14 +1627,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1634,13 +1643,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1656,29 +1672,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -2125,9 +2125,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2145,17 +2144,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2163,17 +2160,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2181,9 +2190,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2197,13 +2212,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2217,19 +2232,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2237,17 +2250,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2255,70 +2280,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -2085,11 +2085,10 @@
    local.get $0
    local.get $2
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $3
    local.get $1
-   i32.store8 offset=3
+   i32.store8
    local.get $2
    i32.const 2
    i32.le_u
@@ -2100,12 +2099,19 @@
    local.get $0
    local.get $1
    i32.store8 offset=2
-   local.get $3
+   local.get $0
+   local.get $2
+   i32.add
+   local.tee $3
+   i32.const 2
+   i32.sub
    local.get $1
-   i32.store8 offset=2
+   i32.store8
    local.get $3
+   i32.const 3
+   i32.sub
    local.get $1
-   i32.store8 offset=1
+   i32.store8
    local.get $2
    i32.const 6
    i32.le_u
@@ -2113,7 +2119,11 @@
    local.get $0
    local.get $1
    i32.store8 offset=3
-   local.get $3
+   local.get $0
+   local.get $2
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $1
    i32.store8
    local.get $2
@@ -2144,11 +2154,10 @@
    i32.and
    local.tee $2
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.tee $1
    local.get $0
-   i32.store offset=24
+   i32.store
    local.get $2
    i32.const 8
    i32.le_u
@@ -2159,12 +2168,19 @@
    local.get $3
    local.get $0
    i32.store offset=8
-   local.get $1
+   local.get $2
+   local.get $3
+   i32.add
+   local.tee $1
+   i32.const 12
+   i32.sub
    local.get $0
-   i32.store offset=16
+   i32.store
    local.get $1
+   i32.const 8
+   i32.sub
    local.get $0
-   i32.store offset=20
+   i32.store
    local.get $2
    i32.const 24
    i32.le_u
@@ -2181,18 +2197,29 @@
    local.get $3
    local.get $0
    i32.store offset=24
-   local.get $1
+   local.get $2
+   local.get $3
+   i32.add
+   local.tee $1
+   i32.const 28
+   i32.sub
    local.get $0
    i32.store
    local.get $1
+   i32.const 24
+   i32.sub
    local.get $0
-   i32.store offset=4
+   i32.store
    local.get $1
+   i32.const 20
+   i32.sub
    local.get $0
-   i32.store offset=8
+   i32.store
    local.get $1
+   i32.const 16
+   i32.sub
    local.get $0
-   i32.store offset=12
+   i32.store
    local.get $3
    local.get $3
    i32.const 4

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -2412,9 +2412,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2432,17 +2431,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2450,17 +2447,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2468,9 +2477,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2484,13 +2499,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2504,19 +2519,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2524,17 +2537,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2542,70 +2567,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/super-inline.untouched.wat
+++ b/tests/compiler/super-inline.untouched.wat
@@ -2068,9 +2068,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2088,17 +2087,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2106,17 +2103,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2124,9 +2133,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2140,13 +2155,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2160,19 +2175,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2180,17 +2193,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2198,70 +2223,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/templateliteral.optimized.wat
+++ b/tests/compiler/templateliteral.optimized.wat
@@ -1604,11 +1604,10 @@
    local.get $0
    local.get $1
    i32.add
-   i32.const 4
+   i32.const 1
    i32.sub
-   local.tee $2
    i32.const 0
-   i32.store8 offset=3
+   i32.store8
    local.get $1
    i32.const 2
    i32.le_u
@@ -1619,12 +1618,19 @@
    local.get $0
    i32.const 0
    i32.store8 offset=2
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
    i32.const 0
-   i32.store8 offset=2
+   i32.store8
    local.get $2
+   i32.const 3
+   i32.sub
    i32.const 0
-   i32.store8 offset=1
+   i32.store8
    local.get $1
    i32.const 6
    i32.le_u
@@ -1632,7 +1638,11 @@
    local.get $0
    i32.const 0
    i32.store8 offset=3
-   local.get $2
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
    i32.store8
    local.get $1
@@ -1656,14 +1666,13 @@
    i32.sub
    i32.const -4
    i32.and
-   local.tee $2
-   i32.add
-   i32.const 28
-   i32.sub
    local.tee $1
+   i32.add
+   i32.const 4
+   i32.sub
    i32.const 0
-   i32.store offset=24
-   local.get $2
+   i32.store
+   local.get $1
    i32.const 8
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1673,13 +1682,20 @@
    local.get $0
    i32.const 0
    i32.store offset=8
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
    i32.const 0
-   i32.store offset=16
-   local.get $1
-   i32.const 0
-   i32.store offset=20
+   i32.store
    local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
    i32.const 24
    i32.le_u
    br_if $~lib/util/memory/memset|inlined.0
@@ -1695,29 +1711,40 @@
    local.get $0
    i32.const 0
    i32.store offset=24
+   local.get $0
    local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
    i32.const 0
    i32.store
-   local.get $1
+   local.get $2
+   i32.const 24
+   i32.sub
    i32.const 0
-   i32.store offset=4
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
    i32.const 0
-   i32.store offset=8
-   local.get $1
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
    i32.const 0
-   i32.store offset=12
+   i32.store
    local.get $0
    local.get $0
    i32.const 4
    i32.and
    i32.const 24
    i32.add
-   local.tee $1
+   local.tee $2
    i32.add
    local.set $0
-   local.get $2
    local.get $1
+   local.get $2
    i32.sub
    local.set $1
    loop $while-continue|0

--- a/tests/compiler/templateliteral.untouched.wat
+++ b/tests/compiler/templateliteral.untouched.wat
@@ -2225,9 +2225,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2245,17 +2244,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2263,17 +2260,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2281,9 +2290,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2297,13 +2312,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2317,19 +2332,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2337,17 +2350,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2355,70 +2380,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -2247,9 +2247,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2267,17 +2266,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2285,17 +2282,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2303,9 +2312,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2319,13 +2334,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2339,19 +2354,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2359,17 +2372,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2377,70 +2402,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -2522,9 +2522,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i64)
-  (local $10 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $0
    local.set $5
@@ -2542,17 +2541,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.set $6
-   local.get $5
    local.get $4
    i32.store8
-   local.get $6
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
    local.get $4
-   i32.store8 offset=3
+   i32.store8
    local.get $3
    i32.const 2
    i32.le_u
@@ -2560,17 +2557,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 1
+   i32.add
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $5
+   i32.const 2
+   i32.add
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
    local.get $4
-   i32.store8 offset=2
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
    local.get $4
-   i32.store8 offset=1
+   i32.store8
    local.get $3
    i32.const 6
    i32.le_u
@@ -2578,9 +2587,15 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
+   i32.const 3
+   i32.add
    local.get $4
-   i32.store8 offset=3
-   local.get $6
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
    local.get $4
    i32.store8
    local.get $3
@@ -2594,13 +2609,13 @@
    i32.sub
    i32.const 3
    i32.and
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
    local.get $3
@@ -2614,19 +2629,17 @@
    i32.const 255
    i32.and
    i32.mul
-   local.set $8
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
    local.get $5
    local.get $3
    i32.add
-   i32.const 28
+   i32.const 4
    i32.sub
-   local.set $6
-   local.get $5
-   local.get $8
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=24
    local.get $3
    i32.const 8
    i32.le_u
@@ -2634,17 +2647,29 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=4
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
    local.get $5
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=16
-   local.get $6
-   local.get $8
-   i32.store offset=20
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
    local.get $3
    i32.const 24
    i32.le_u
@@ -2652,70 +2677,100 @@
     br $~lib/util/memory/memset|inlined.0
    end
    local.get $5
-   local.get $8
-   i32.store offset=12
-   local.get $5
-   local.get $8
-   i32.store offset=16
-   local.get $5
-   local.get $8
-   i32.store offset=20
-   local.get $5
-   local.get $8
-   i32.store offset=24
-   local.get $6
-   local.get $8
+   i32.const 12
+   i32.add
+   local.get $7
    i32.store
-   local.get $6
-   local.get $8
-   i32.store offset=4
-   local.get $6
-   local.get $8
-   i32.store offset=8
-   local.get $6
-   local.get $8
-   i32.store offset=12
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
    i32.const 24
    local.get $5
    i32.const 4
    i32.and
    i32.add
-   local.set $7
+   local.set $6
    local.get $5
-   local.get $7
+   local.get $6
    i32.add
    local.set $5
    local.get $3
-   local.get $7
+   local.get $6
    i32.sub
    local.set $3
-   local.get $8
+   local.get $7
    i64.extend_i32_u
-   local.get $8
+   local.get $7
    i64.extend_i32_u
    i64.const 32
    i64.shl
    i64.or
-   local.set $9
+   local.set $8
    loop $while-continue|0
     local.get $3
     i32.const 32
     i32.ge_u
-    local.set $10
-    local.get $10
+    local.set $9
+    local.get $9
     if
      local.get $5
-     local.get $9
+     local.get $8
      i64.store
      local.get $5
-     local.get $9
-     i64.store offset=8
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=16
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
      local.get $5
-     local.get $9
-     i64.store offset=24
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
      local.get $3
      i32.const 32
      i32.sub


### PR DESCRIPTION
Some of the stores in `memset` are invalid for certain arguments due to enforcing a constant offset where we'd instead want the whole offset to wrap around. Traced this back to https://github.com/AssemblyScript/assemblyscript/pull/1103 where I assumed that we'd be using lowMemoryUnused anyhow (i.e. never storing to the low 1024 bytes of memory), which actually isn't always the case in `memset`.

Discovered in https://github.com/AssemblyScript/assemblyscript/issues/1785.

- [x] I've read the contributing guidelines