### PR TITLE
add createCompoundNameType function

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -187,7 +187,7 @@ export abstract class Node {
     let result = node;
     for (let i = 1; i < length; i++) {
       let next = identifiers[i];
-      let nextNode = new TypeName(next, null, next.range)
+      let nextNode = new TypeName(next, null, next.range);
       node.next = nextNode;
       node = nextNode;
     }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -174,6 +174,30 @@ export abstract class Node {
     return new TypeParameterNode(name, extendsType, defaultType, range);
   }
 
+  static createCompoundNamedType(
+    identifiers: IdentifierExpression[],
+    typeParameters: TypeNode[] | null,
+    isNullable: bool,
+    range: Range
+  ): NamedTypeNode {
+    let length = identifiers.length;
+    if (length == 0) throw new Error(); // how should errors be handled?
+    let first = identifiers[0];
+    let node = new TypeName(first, null, first.range);
+    let result = node;
+    for (let i = 1; i < length; i++) {
+      let next = identifiers[i];
+      let nextNode = new TypeName(next, null, next.range)
+      node.next = nextNode;
+      node = nextNode;
+    }
+    return this.createNamedType(
+      result,
+      typeParameters,
+      isNullable,
+      range
+    );
+  }
   static createParameter(
     parameterKind: ParameterKind,
     name: IdentifierExpression,


### PR DESCRIPTION
This pull request adds a simple function for creating a compound named type with type parameters using an array of `IdentifierExpression` objects

- [x] I've read the contributing guidelines

Question: How should we handle errors for this function?