### PR TITLE
fix: pass arg to Duplicate_identifier_0 for markVirtuals

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -1509,7 +1509,8 @@ export class Program extends DiagnosticEmitter {
                 this.errorRelated(
                   DiagnosticCode.Duplicate_identifier_0,
                   thisMember.identifierNode.range,
-                  baseMember.identifierNode.range
+                  baseMember.identifierNode.range,
+                  baseMember.identifierNode.text
                 );
               }
             }


### PR DESCRIPTION
Now, the error message is not format normally.
```
ERROR TS2300: Duplicate identifier '{0}'.

     foo: number;
```