### PR TITLE
Fix assertion when trying to assign to a method

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5837,7 +5837,10 @@ export class Compiler extends DiagnosticEmitter {
         break;
       }
       default: {
-        assert(false);
+        this.error(
+          DiagnosticCode.Cannot_assign_to_0_because_it_is_a_constant_or_a_read_only_property,
+          expression.range, target.internalName
+        );
         return this.module.unreachable();
       }
     }


### PR DESCRIPTION
Emits a diagnostic instead of hitting an assertion when trying to assign to an uncommon property like a method that is not a field.

fixes #1795

- [x] I've read the contributing guidelines