### PR TITLE
fix: Fix assert when calling a setter property

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6335,7 +6335,16 @@ export class Compiler extends DiagnosticEmitter {
       }
       case ElementKind.PROPERTY: {
         let propertyInstance = <Property>target;
-        let getterInstance = assert(propertyInstance.getterInstance);
+        let getterInstance = propertyInstance.getterInstance;
+
+        if (!getterInstance) {
+          this.error(
+            DiagnosticCode.Cannot_invoke_an_expression_whose_type_lacks_a_call_signature_Type_0_has_no_compatible_call_signatures,
+            expression.range, this.currentType.toString()
+          );
+          return module.unreachable();
+        }
+
         let thisArg: ExpressionRef = 0;
         if (propertyInstance.is(CommonFlags.INSTANCE)) {
           thisArg = this.compileExpression(

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6336,11 +6336,12 @@ export class Compiler extends DiagnosticEmitter {
       case ElementKind.PROPERTY: {
         let propertyInstance = <Property>target;
         let getterInstance = propertyInstance.getterInstance;
+        let type = assert(this.resolver.getTypeOfElement(target));
 
         if (!getterInstance) {
           this.error(
             DiagnosticCode.Cannot_invoke_an_expression_whose_type_lacks_a_call_signature_Type_0_has_no_compatible_call_signatures,
-            expression.range, this.currentType.toString()
+            expression.range, type.toString()
           );
           return module.unreachable();
         }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -877,7 +877,6 @@ export class Resolver extends DiagnosticEmitter {
     }
     if (isTypedElement(kind)) {
       let type = (<TypedElement>element).type;
-      assert(type != Type.void);
       let classReference = type.getClassOrWrapper(this.program);
       if (classReference) {
         let wrappedType = classReference.wrappedType;


### PR DESCRIPTION
Emits an error diagnostic when calling a setter property. This case should be treated in the same way getters are treated. The issue is reproducible with the following code:

```ts
class B {
  set prop(a: i32) {}
}

export function add(): void {
  // Actual: assert
  // Expected: error diagnostic specifying that this expression is not callable. 
  (new B()).prop(1);
}
```

I emitted the diagnostic early, I'm assuming that there's no point in compiling the expression when this case is met as the setter expression is compiled when an assignment expression is found (might be wrong about this).

- [x] I've read the contributing guidelines