### PR TITLE
feat: make Array.buffer public

### DIFF
--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -33,7 +33,7 @@ export class Array<T> {
   // `dataStart` (equals `buffer`) and `byteLength` (equals computed `buffer.byteLength`), but the
   // block is 16 bytes anyway so it's fine to have a couple extra fields in there.
 
-  private buffer: ArrayBuffer;
+  readonly buffer: ArrayBuffer;
   private dataStart: usize;
   private byteLength: i32;
 

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1575,11 +1575,12 @@ declare class Array<T> {
   static isArray<U>(value: any): value is Array<any>;
 
   [key: number]: T;
+  /** The {@link ArrayBuffer} referenced by this view. */
+  readonly buffer: ArrayBuffer;
   /** Current length of the array. */
   length: i32;
   /** Constructs a new array. */
   constructor(capacity?: i32);
-
   at(index: i32): T;
   fill(value: T, start?: i32, end?: i32): this;
   every(callbackfn: (element: T, index: i32, array?: Array<T>) => bool): bool;


### PR DESCRIPTION
ArrayBuffer is often needed to pass arrays when interacting with host function, but only Array does not expose buffer properties. It is unacceptable to get the copy overhead of ArrayBuffer every time it is converted to other Array types.