### PR TITLE
docs: change "capacity" to "length" for argument in Array's constructor

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1578,8 +1578,7 @@ declare class Array<T> {
   /** Current length of the array. */
   length: i32;
   /** Constructs a new array. */
-  constructor(capacity?: i32);
-
+  constructor(length?: i32);
   at(index: i32): T;
   fill(value: T, start?: i32, end?: i32): this;
   every(callbackfn: (element: T, index: i32, array?: Array<T>) => bool): bool;


### PR DESCRIPTION
I think the current description of `capacity` and `length` is not be equivalent, and the implementation here is `length`