### PR TITLE
Multiple overloads for same (binary) operator

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4064,7 +4064,9 @@ export class Compiler extends DiagnosticEmitter {
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
         if (classReference) {
-          let overload = classReference.lookupOverload(OperatorKind.ADD);
+          // This breaks the compiler
+          let operatorType = this.resolver.resolveExpression(right, this.currentFlow, this.currentType);
+          let overload = classReference.lookupOverload(OperatorKind.ADD, false, operatorType);
           if (overload) {
             expr = this.compileBinaryOverload(overload, left, leftExpr, right, expression);
             break;

--- a/src/program.ts
+++ b/src/program.ts
@@ -1991,7 +1991,7 @@ export class Program extends DiagnosticEmitter {
                       firstArg.range
                     );
                   } else {
-                    const protos = kindOverloads || [];
+                    const protos = kindOverloads || [];
                     protos.push(prototype);
                     overloads.set(kind, protos);
                     prototype.operatorKind = kind;

--- a/src/program.ts
+++ b/src/program.ts
@@ -4345,7 +4345,7 @@ export class Class extends TypedElement {
   }
 
   /** Looks up the operator overload of the specified kind. */
-  lookupOverload(kind: OperatorKind, unchecked: bool = false, rightType?: Type): Function | null {
+  lookupOverload(kind: OperatorKind, unchecked: bool = false, rightType?: Type | null): Function | null {
     if (unchecked) {
       switch (kind) {
         case OperatorKind.INDEXED_GET: {

--- a/src/program.ts
+++ b/src/program.ts
@@ -1991,7 +1991,7 @@ export class Program extends DiagnosticEmitter {
                     );
                   } else {
                     prototype.operatorKind = kind;
-                    overloads.set(kind, prototype);
+                    overloads.set(kind, [prototype]);
                   }
                 }
               } else {
@@ -4033,7 +4033,7 @@ export class ClassPrototype extends DeclaredElement {
   /** Constructor prototype. */
   constructorPrototype: FunctionPrototype | null = null;
   /** Operator overload prototypes. */
-  overloadPrototypes: Map<OperatorKind, FunctionPrototype> = new Map();
+  overloadPrototypes: Map<OperatorKind, FunctionPrototype[]> = new Map();
   /** Already resolved instances. */
   instances: Map<string,Class> | null = null;
   /** Classes extending this class. */

--- a/src/program.ts
+++ b/src/program.ts
@@ -3555,6 +3555,7 @@ export class FunctionPrototype extends DeclaredElement {
 
   /* Checks if this function cannot co-exist with existing overloads given as param */
   hasOverloadConflict(kindOverloads: FunctionPrototype[]): boolean {
+    // TODO: implement checks
     return true;
   }
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1973,11 +1973,11 @@ export class Resolver extends DiagnosticEmitter {
         let leftType = this.resolveExpression(left, ctxFlow, ctxType, reportMode);
         if (!leftType) return null;
         let classReference = leftType.getClassOrWrapper(this.program);
+        let rightType = this.resolveExpression(right, ctxFlow, leftType, reportMode);
         if (classReference) {
-          let overload = classReference.lookupOverload(OperatorKind.fromBinaryToken(operator));
+          let overload = classReference.lookupOverload(OperatorKind.fromBinaryToken(operator), false, rightType);
           if (overload) return overload.signature.returnType;
         }
-        let rightType = this.resolveExpression(right, ctxFlow, leftType, reportMode);
         if (!rightType) return null;
         let commonType = Type.commonDenominator(leftType, rightType, false);
         if (!commonType) {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -3187,7 +3187,7 @@ export class Resolver extends DiagnosticEmitter {
       let kindOverloadPrototypes = assert(overloadPrototypes.get(overloadKind));
       assert(overloadKind != OperatorKind.INVALID);
       for (let j = 0, m = kindOverloadPrototypes.length; j < m; j++) {
-        const overloadPrototype = unchecked(kindOverloadPrototypes[j])
+        const overloadPrototype = unchecked(kindOverloadPrototypes[j]);
         let operatorInstance: Function | null;
         if (overloadPrototype.is(CommonFlags.INSTANCE)) {
           let boundPrototype = overloadPrototype.toBound(instance);

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -3230,21 +3230,7 @@ export class Resolver extends DiagnosticEmitter {
           }
         }
         const kindOverloads = overloads.get(overloadKind) || [];
-        const hasConflict = (current: Function) => {
-          if (!kindOverloads.length) return false;
-          return kindOverloads.some((existing) => {
-            if (existing.is(CommonFlags.STATIC) && current.is(CommonFlags.STATIC)) {
-              return true;
-            }
-            const existingPT = existing.signature.parameterTypes;
-            const currentPT = current.signature.parameterTypes;
-            if (existingPT.length != 1 || currentPT.length != 1) {
-              return true;
-            }
-            return existingPT[0] === currentPT[0];
-          });
-        }
-        if (!hasConflict(operatorInstance)) {
+        if (!operatorInstance.hasOverloadConflict(kindOverloads)) {
           kindOverloads.push(operatorInstance);
           overloads.set(overloadKind, kindOverloads);
           if (overloadKind == OperatorKind.INDEXED_GET || overloadKind == OperatorKind.INDEXED_SET) {


### PR DESCRIPTION
- [x] I've read the contributing guidelines

### Use case
It would be useful if we could have multiple overloads for the same operator, allowing eg. Vector class that can be multiplied both by scalar and another Vector:
```typescript
class Vec3 {
    constructor(public x: f32 = 0, public y: f32 = 0, public z: f32 = 0) {}

    @operator('*')
    multScalar(right: f32): Vec3 {
        return new Vec3(this.x * right, this.y * right, this.z * right)
    }
    @operator('*')
    multVector(right: Vec3): Vec3 {
        return new Vec3(this.x * right.x, this.y * right.y, this.z * right.z)
    }
}
```
Currently the compiler complains "ERROR TS2393: Duplicate function implementation."

### Approach
- Change `Class` and `ClassPrototype` so that overloads is an array
- When compiling/resolving, choose the correct method implementation from the array based on right hand side type
- When adding overloads to array, check that combinations are allowed:
  - Allow multiple overloads only for binary operators
  - Allow multiple overloads only for instance (not static) methods
  - Allow only one implantation per right hand side type

### Progress
This is a draft PR. I'm currently implementing the above for ADD operator as proof of concept. I'm calling `resolver.resolveExpression(...)` in compiler.ts, line 4068 to find the type for the right hand side, but the call itself is causing the compiler to fail seemingly unrelated tests. So I'm guessing the method cannot be called in this phase of compilation or I'm calling it the wrong way?

Does this approache seem feasible in general?
