### PR TITLE
fix: readFileNode return string | null

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -1149,7 +1149,7 @@ exports.main = function main(argv, options, callback) {
   function readFileNode(filename, baseDir) {
     let name = path.resolve(baseDir, filename);
     try {
-      let text;
+      let text = null;
       stats.readCount++;
       stats.readTime += measure(() => {
         text = fs.readFileSync(name, "utf8");


### PR DESCRIPTION
The d.ts:

```ts
 /** Reads a file from disk (or memory). */
  readFile?: (filename: string, baseDir: string) => string | null;
```