### PR TITLE
fix: internalPath  in parseFile is not same with Source

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -136,7 +136,7 @@ export class Parser extends DiagnosticEmitter {
   ): void {
     // the frontend gives us paths with file extensions
     var normalizedPath = normalizePath(path);
-    var internalPath = mangleInternalPath(path);
+    var internalPath = mangleInternalPath(normalizedPath);
 
     // check if already processed
     if (this.donelog.has(internalPath)) return;


### PR DESCRIPTION
in Souce:
```ts
var internalPath = mangleInternalPath(normalizedPath);
```

in parseFile:
```ts
var normalizedPath = normalizePath(path);
 var internalPath = mangleInternalPath(path);
```

I got two path string:
- ./examples/foo
- examples/foo