### PR TITLE
fix: Fix growing factor for capacity in Array

### DIFF
--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -11,15 +11,15 @@ import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_ILLEGALGENTYPE, E_EMPTYARRAY, E_H
 
 // NOTE: n should be greater than zero
 // @ts-ignore: decorator
-@inline function nextPowerOf2<T extends number>(n: T): T {
-  return 1 << (32 - clz<T>(n - 1 as T)) as T;
+@inline function nextPowerOf2(n: usize): usize {
+  return 1 << 32 - clz(n - 1);
 }
 
 /** Ensures that the given array has _at least_ the specified backing size. */
 function ensureCapacity(array: usize, minSize: usize, alignLog2: u32, canGrow: bool = true): void {
   // Depends on the fact that Arrays mimic ArrayBufferView
-  var oldCapacity = changetype<ArrayBufferView>(array).byteLength;
-  if (minSize > <usize>oldCapacity >>> alignLog2) {
+  var oldCapacity = <usize>changetype<ArrayBufferView>(array).byteLength;
+  if (minSize > oldCapacity >>> alignLog2) {
     if (minSize > BLOCK_MAXSIZE >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
     let oldData = changetype<usize>(changetype<ArrayBufferView>(array).buffer);
     let newCapacity = max<usize>(MIN_CAPACITY, minSize) << alignLog2;
@@ -36,7 +36,7 @@ function ensureCapacity(array: usize, minSize: usize, alignLog2: u32, canGrow: b
       store<usize>(array, newData, offsetof<ArrayBufferView>("dataStart"));
       __link(array, changetype<usize>(newData), false);
     }
-    store<u32>(array, newCapacity, offsetof<ArrayBufferView>("byteLength"));
+    store<u32>(array, <u32>newCapacity, offsetof<ArrayBufferView>("byteLength"));
   }
 }
 

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -7,7 +7,7 @@ import { idof, isArray as builtin_isArray } from "./builtins";
 import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_ILLEGALGENTYPE, E_EMPTYARRAY, E_HOLEYARRAY } from "./util/error";
 
 // @ts-ignore: decorator
-@inline @lazy const MIN_CAPACITY = 8;
+@inline @lazy const MIN_SIZE = 8;
 
 // NOTE: n should fix in range (1; 1 << 31]
 // @ts-ignore: decorator
@@ -16,13 +16,13 @@ import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_ILLEGALGENTYPE, E_EMPTYARRAY, E_H
 }
 
 /** Ensures that the given array has _at least_ the specified backing size. */
-function ensureCapacity(array: usize, minSize: usize, alignLog2: u32, canGrow: bool = true): void {
+function ensureCapacity(array: usize, mewSize: usize, alignLog2: u32, canGrow: bool = true): void {
   // Depends on the fact that Arrays mimic ArrayBufferView
   var oldCapacity = <usize>changetype<ArrayBufferView>(array).byteLength;
-  if (minSize > oldCapacity >>> alignLog2) {
-    if (minSize > BLOCK_MAXSIZE >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
+  if (mewSize > oldCapacity >>> alignLog2) {
+    if (mewSize > BLOCK_MAXSIZE >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
     let oldData = changetype<usize>(changetype<ArrayBufferView>(array).buffer);
-    let newCapacity = max<usize>(minSize, MIN_CAPACITY) << alignLog2;
+    let newCapacity = max<usize>(mewSize, MIN_SIZE) << alignLog2;
     if (canGrow) {
       // Find next power of two size. It usually grows old capacity by factor of two.
       // Make sure we don't reach BLOCK_MAXSIZE for new growed capacity.
@@ -70,8 +70,8 @@ export class Array<T> {
 
   constructor(length: i32 = 0) {
     if (<u32>length > <u32>BLOCK_MAXSIZE >>> alignof<T>()) throw new RangeError(E_INVALIDLENGTH);
-    // reserve capacity for at least MIN_CAPACITY elements
-    var bufferSize = <usize>max(length, MIN_CAPACITY) << alignof<T>();
+    // reserve capacity for at least MIN_SIZE elements
+    var bufferSize = <usize>max(length, MIN_SIZE) << alignof<T>();
     var buffer = changetype<ArrayBuffer>(__new(bufferSize, idof<ArrayBuffer>()));
     memory.fill(changetype<usize>(buffer), 0, bufferSize);
     this.buffer = buffer; // links
@@ -496,7 +496,7 @@ export class Array<T> {
     }
 
     // calculate the byteLength of the resulting backing ArrayBuffer
-    var byteLength = <usize>max(size, MIN_CAPACITY) << usize(alignof<valueof<T>>());
+    var byteLength = <usize>max(size, MIN_SIZE) << usize(alignof<valueof<T>>());
     var outBuffer = changetype<ArrayBuffer>(__new(byteLength, idof<ArrayBuffer>()));
 
     // create the return value and initialize it

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -9,9 +9,10 @@ import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_ILLEGALGENTYPE, E_EMPTYARRAY, E_H
 // @ts-ignore: decorator
 @inline @lazy const MIN_CAPACITY = 8;
 
+// NOTE: n should be greate than zero
 // @ts-ignore: decorator
 @inline function nextPowerOf2<T extends number>(n: T): T {
-  return n == 0 ? MIN_CAPACITY as T : 1 << (32 - clz<T>(n - 1 as T)) as T;
+  return 1 << (32 - clz<T>(n - 1 as T)) as T;
 }
 
 /** Ensures that the given array has _at least_ the specified backing size. */
@@ -22,7 +23,7 @@ function ensureCapacity(array: usize, minSize: usize, alignLog2: u32): void {
     if (minSize > BLOCK_MAXSIZE >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
     let oldData = changetype<usize>(changetype<ArrayBufferView>(array).buffer);
     // find next power of two size. It usually grows old capacity by factor of two
-    let newCapacity = nextPowerOf2(minSize << alignLog2);
+    let newCapacity = nextPowerOf2<usize>(max<usize>(MIN_CAPACITY, minSize) << alignLog2);
     let newData = __renew(oldData, newCapacity);
     memory.fill(newData + oldCapacity, 0, newCapacity - oldCapacity);
     if (newData !== oldData) { // oldData has been free'd

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -25,7 +25,7 @@ function ensureCapacity(array: usize, minSize: usize, alignLog2: u32, canGrow: b
     let newCapacity = max<usize>(MIN_CAPACITY, minSize) << alignLog2;
     if (canGrow) {
       // Find next power of two size. It usually grows old capacity by factor of two.
-      // Make sure we don't reach BLOCK_MAXSIZE for new capacity after growing.
+      // Make sure we don't reach BLOCK_MAXSIZE for new growed capacity.
       newCapacity = min<usize>(nextPowerOf2(newCapacity), BLOCK_MAXSIZE);
       if (minSize > newCapacity >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
     }

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -22,7 +22,7 @@ function ensureCapacity(array: usize, minSize: usize, alignLog2: u32, canGrow: b
   if (minSize > oldCapacity >>> alignLog2) {
     if (minSize > BLOCK_MAXSIZE >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
     let oldData = changetype<usize>(changetype<ArrayBufferView>(array).buffer);
-    let newCapacity = max<usize>(MIN_CAPACITY, minSize) << alignLog2;
+    let newCapacity = max<usize>(minSize, MIN_CAPACITY) << alignLog2;
     if (canGrow) {
       // Find next power of two size. It usually grows old capacity by factor of two.
       // Make sure we don't reach BLOCK_MAXSIZE for new growed capacity.
@@ -71,7 +71,7 @@ export class Array<T> {
   constructor(length: i32 = 0) {
     if (<u32>length > <u32>BLOCK_MAXSIZE >>> alignof<T>()) throw new RangeError(E_INVALIDLENGTH);
     // reserve capacity for at least MIN_CAPACITY elements
-    var bufferSize = <usize>max(MIN_CAPACITY, length) << alignof<T>();
+    var bufferSize = <usize>max(length, MIN_CAPACITY) << alignof<T>();
     var buffer = changetype<ArrayBuffer>(__new(bufferSize, idof<ArrayBuffer>()));
     memory.fill(changetype<usize>(buffer), 0, bufferSize);
     this.buffer = buffer; // links
@@ -496,7 +496,7 @@ export class Array<T> {
     }
 
     // calculate the byteLength of the resulting backing ArrayBuffer
-    var byteLength = <usize>size << usize(alignof<valueof<T>>());
+    var byteLength = <usize>max(size, MIN_CAPACITY) << usize(alignof<valueof<T>>());
     var outBuffer = changetype<ArrayBuffer>(__new(byteLength, idof<ArrayBuffer>()));
 
     // create the return value and initialize it

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -9,7 +9,7 @@ import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_ILLEGALGENTYPE, E_EMPTYARRAY, E_H
 // @ts-ignore: decorator
 @inline @lazy const MIN_CAPACITY = 8;
 
-// NOTE: n should be greater than zero
+// NOTE: n should be greater than one
 // @ts-ignore: decorator
 @inline function nextPowerOf2(n: usize): usize {
   return 1 << 32 - clz(n - 1);

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -15,12 +15,13 @@ import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_ILLEGALGENTYPE, E_EMPTYARRAY, E_H
 }
 
 /** Ensures that the given array has _at least_ the specified backing size. */
-function ensureSize(array: usize, minSize: usize, alignLog2: u32): void {
+function ensureCapacity(array: usize, minSize: usize, alignLog2: u32): void {
   // depends on the fact that Arrays mimic ArrayBufferView
   var oldCapacity = changetype<ArrayBufferView>(array).byteLength;
   if (minSize > <usize>oldCapacity >>> alignLog2) {
     if (minSize > BLOCK_MAXSIZE >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
     let oldData = changetype<usize>(changetype<ArrayBufferView>(array).buffer);
+    // find next power of two size. It usually grows old capacity by factor of two
     let newCapacity = nextPowerOf2(minSize << alignLog2);
     let newData = __renew(oldData, newCapacity);
     memory.fill(newData + oldCapacity, 0, newCapacity - oldCapacity);
@@ -79,7 +80,7 @@ export class Array<T> {
   }
 
   set length(newLength: i32) {
-    ensureSize(changetype<usize>(this), newLength, alignof<T>());
+    ensureCapacity(changetype<usize>(this), newLength, alignof<T>());
     this.length_ = newLength;
   }
 
@@ -115,7 +116,7 @@ export class Array<T> {
   @operator("[]=") private __set(index: i32, value: T): void {
     if (<u32>index >= <u32>this.length_) {
       if (index < 0) throw new RangeError(E_INDEXOUTOFRANGE);
-      ensureSize(changetype<usize>(this), index + 1, alignof<T>());
+      ensureCapacity(changetype<usize>(this), index + 1, alignof<T>());
       this.length_ = index + 1;
     }
     this.__uset(index, value);
@@ -213,8 +214,7 @@ export class Array<T> {
   push(value: T): i32 {
     var length = this.length_;
     var newLength = length + 1;
-    // growFactor == 1 means new capacity will increase by factor of 2
-    ensureSize(changetype<usize>(this), newLength, alignof<T>());
+    ensureCapacity(changetype<usize>(this), newLength, alignof<T>());
     if (isManaged<T>()) {
       store<usize>(this.dataStart + (<usize>length << alignof<T>()), changetype<usize>(value));
       __link(changetype<usize>(this), changetype<usize>(value), true);
@@ -363,7 +363,7 @@ export class Array<T> {
 
   unshift(value: T): i32 {
     var newLength = this.length_ + 1;
-    ensureSize(changetype<usize>(this), newLength, alignof<T>());
+    ensureCapacity(changetype<usize>(this), newLength, alignof<T>());
     var dataStart = this.dataStart;
     memory.copy(
       dataStart + sizeof<T>(),

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -9,7 +9,7 @@ import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_ILLEGALGENTYPE, E_EMPTYARRAY, E_H
 // @ts-ignore: decorator
 @inline @lazy const MIN_CAPACITY = 8;
 
-// NOTE: n should be greater than one
+// NOTE: n should fix in range (1; 1 << 31]
 // @ts-ignore: decorator
 @inline function nextPowerOf2(n: usize): usize {
   return 1 << 32 - clz(n - 1);
@@ -27,7 +27,6 @@ function ensureCapacity(array: usize, minSize: usize, alignLog2: u32, canGrow: b
       // Find next power of two size. It usually grows old capacity by factor of two.
       // Make sure we don't reach BLOCK_MAXSIZE for new growed capacity.
       newCapacity = min<usize>(nextPowerOf2(newCapacity), BLOCK_MAXSIZE);
-      if (minSize > newCapacity >>> alignLog2) throw new RangeError(E_INVALIDLENGTH);
     }
     let newData = __renew(oldData, newCapacity);
     memory.fill(newData + oldCapacity, 0, newCapacity - oldCapacity);

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -488,7 +488,7 @@ export class Array<T> {
     }
 
     // calculate the byteLength of the resulting backing ArrayBuffer
-    var byteLength = <usize>max(size, MIN_SIZE) << usize(alignof<valueof<T>>());
+    var byteLength = <usize>size << usize(alignof<valueof<T>>());
     var outBuffer = changetype<ArrayBuffer>(__new(byteLength, idof<ArrayBuffer>()));
 
     // create the return value and initialize it

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -9,7 +9,7 @@ import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_ILLEGALGENTYPE, E_EMPTYARRAY, E_H
 // @ts-ignore: decorator
 @inline @lazy const MIN_CAPACITY = 8;
 
-// NOTE: n should be greate than zero
+// NOTE: n should be greater than zero
 // @ts-ignore: decorator
 @inline function nextPowerOf2<T extends number>(n: T): T {
   return 1 << (32 - clz<T>(n - 1 as T)) as T;

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -58,7 +58,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -212,7 +212,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -228,7 +228,7 @@
   if
    i32.const 1296
    i32.const 1248
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -58,7 +58,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -212,7 +212,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -228,7 +228,7 @@
   if
    i32.const 1296
    i32.const 1248
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -58,7 +58,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -212,7 +212,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -228,7 +228,7 @@
   if
    i32.const 1296
    i32.const 1248
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -58,7 +58,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -212,7 +212,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -228,7 +228,7 @@
   if
    i32.const 1296
    i32.const 1248
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -58,7 +58,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -212,7 +212,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -228,7 +228,7 @@
   if
    i32.const 1296
    i32.const 1248
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -58,7 +58,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -212,7 +212,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -228,7 +228,7 @@
   if
    i32.const 1296
    i32.const 1248
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -58,7 +58,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -212,7 +212,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -228,7 +228,7 @@
   if
    i32.const 1296
    i32.const 1248
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -309,7 +309,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -334,7 +334,7 @@
   if
    i32.const 272
    i32.const 224
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -365,7 +365,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -309,7 +309,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -334,7 +334,7 @@
   if
    i32.const 272
    i32.const 224
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -365,7 +365,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -309,7 +309,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -334,7 +334,7 @@
   if
    i32.const 272
    i32.const 224
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -365,7 +365,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -309,7 +309,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -334,7 +334,7 @@
   if
    i32.const 272
    i32.const 224
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -365,7 +365,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -309,7 +309,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -334,7 +334,7 @@
   if
    i32.const 272
    i32.const 224
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -365,7 +365,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -309,7 +309,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -334,7 +334,7 @@
   if
    i32.const 272
    i32.const 224
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -365,7 +365,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -309,7 +309,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -334,7 +334,7 @@
   if
    i32.const 272
    i32.const 224
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -365,7 +365,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -1820,13 +1820,13 @@
   i32.const 0
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  i32.const 0
+  i32.const 32
   i32.const 0
   call $~lib/rt/itcms/__new
   local.tee $1
   i32.store offset=4
   local.get $1
-  i32.const 0
+  i32.const 32
   call $~lib/memory/memory.fill
   local.get $0
   local.get $1
@@ -1835,7 +1835,7 @@
   local.get $1
   i32.store offset=4
   local.get $0
-  i32.const 0
+  i32.const 32
   i32.store offset=8
   local.get $0
   i32.const 0

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2728,9 +2728,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2723,7 +2723,7 @@
   if
    i32.const 432
    i32.const 480
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2723,7 +2723,7 @@
   if
    i32.const 432
    i32.const 480
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2723,7 +2723,7 @@
   if
    i32.const 432
    i32.const 480
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2723,7 +2723,7 @@
   if
    i32.const 432
    i32.const 480
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2723,7 +2723,7 @@
   if
    i32.const 432
    i32.const 480
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2723,7 +2723,7 @@
   if
    i32.const 432
    i32.const 480
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2683,6 +2683,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -2721,44 +2723,51 @@
   if
    i32.const 432
    i32.const 480
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i32>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i32>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i32>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $class/GenericInitializer<i32>#constructor (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1,8 +1,8 @@
 (module
  (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -1962,6 +1962,132 @@
    end
   end
  )
+ (func $~lib/array/ensureCapacity (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.const 1176
+  i32.load
+  local.tee $5
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 268435455
+   i32.gt_u
+   if
+    i32.const 1616
+    i32.const 1664
+    i32.const 23
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   i32.const 1168
+   i32.load
+   local.set $1
+   local.get $0
+   i32.const 1
+   i32.const 32
+   i32.const 8
+   local.get $0
+   local.get $0
+   i32.const 8
+   i32.lt_u
+   select
+   i32.const 2
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.tee $0
+   i32.const 1073741820
+   local.get $0
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
+   i32.const 2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 1616
+    i32.const 1664
+    i32.const 30
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $3
+    local.get $1
+    local.tee $0
+    i32.const 20
+    i32.sub
+    local.tee $4
+    i32.load
+    i32.const -4
+    i32.and
+    i32.const 16
+    i32.sub
+    i32.le_u
+    if
+     local.get $4
+     local.get $3
+     i32.store offset=16
+     br $__inlined_func$~lib/rt/itcms/__renew
+    end
+    local.get $3
+    local.get $4
+    i32.load offset=12
+    call $~lib/rt/itcms/__new
+    local.tee $2
+    local.get $0
+    local.get $3
+    local.get $4
+    i32.load offset=16
+    local.tee $0
+    local.get $0
+    local.get $3
+    i32.gt_u
+    select
+    call $~lib/memory/memory.copy
+    local.get $2
+    local.set $0
+   end
+   local.get $0
+   local.get $5
+   i32.add
+   local.get $3
+   local.get $5
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $0
+   local.get $1
+   i32.ne
+   if
+    i32.const 1168
+    local.get $0
+    i32.store
+    i32.const 1172
+    local.get $0
+    i32.store
+    i32.const 1168
+    local.get $0
+    i32.const 0
+    call $~lib/rt/itcms/__link
+   end
+   i32.const 1176
+   local.get $3
+   i32.store
+  end
+ )
  (func $~lib/rt/__visit_members (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2054,13 +2180,6 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -2101,7 +2220,7 @@
   i32.const 20
   i32.const 6
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -2112,26 +2231,26 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  local.get $2
+  local.get $0
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 20
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $2
+   local.tee $0
    i32.store
   end
-  local.get $2
+  local.get $0
   f64.const 0
   f64.store
-  local.get $2
+  local.get $0
   f64.const 0
   f64.store offset=8
-  local.get $2
+  local.get $0
   i32.const 0
   i32.store offset=16
-  local.get $2
+  local.get $0
   i32.const 0
   i32.const 0
   call $~lib/rt/itcms/__link
@@ -2139,136 +2258,36 @@
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $0
   i32.store offset=4
   i32.const 1180
   i32.load
-  local.tee $8
+  local.tee $2
   i32.const 1
   i32.add
-  local.tee $9
   local.tee $1
-  i32.const 1176
-  i32.load
-  local.tee $5
-  i32.const 2
-  i32.shr_u
-  i32.gt_u
-  if
-   local.get $1
-   i32.const 268435455
-   i32.gt_u
-   if
-    i32.const 1616
-    i32.const 1664
-    i32.const 23
-    i32.const 48
-    call $~lib/builtins/abort
-    unreachable
-   end
-   i32.const 1168
-   i32.load
-   local.tee $6
-   local.set $0
-   block $__inlined_func$~lib/rt/itcms/__renew
-    i32.const 1
-    i32.const 32
-    i32.const 8
-    local.get $1
-    local.get $1
-    i32.const 8
-    i32.lt_u
-    select
-    i32.const 2
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-    local.tee $7
-    local.tee $3
-    local.get $6
-    i32.const 20
-    i32.sub
-    local.tee $4
-    i32.load
-    i32.const -4
-    i32.and
-    i32.const 16
-    i32.sub
-    i32.le_u
-    if
-     local.get $4
-     local.get $3
-     i32.store offset=16
-     br $__inlined_func$~lib/rt/itcms/__renew
-    end
-    local.get $3
-    local.get $4
-    i32.load offset=12
-    call $~lib/rt/itcms/__new
-    local.tee $1
-    local.get $0
-    local.get $3
-    local.get $4
-    i32.load offset=16
-    local.tee $0
-    local.get $0
-    local.get $3
-    i32.gt_u
-    select
-    call $~lib/memory/memory.copy
-    local.get $1
-    local.set $0
-   end
-   local.get $0
-   local.get $5
-   i32.add
-   local.get $7
-   local.get $5
-   i32.sub
-   call $~lib/memory/memory.fill
-   local.get $0
-   local.get $6
-   i32.ne
-   if
-    i32.const 1168
-    local.get $0
-    i32.store
-    i32.const 1172
-    local.get $0
-    i32.store
-    i32.const 1168
-    local.get $0
-    i32.const 0
-    call $~lib/rt/itcms/__link
-   end
-   i32.const 1176
-   local.get $7
-   i32.store
-  end
+  call $~lib/array/ensureCapacity
   i32.const 1172
   i32.load
-  local.get $8
+  local.get $2
   i32.const 2
   i32.shl
   i32.add
-  local.get $2
+  local.get $0
   i32.store
   i32.const 1168
-  local.get $2
+  local.get $0
   i32.const 1
   call $~lib/rt/itcms/__link
   i32.const 1180
-  local.get $9
+  local.get $1
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -2150,15 +2150,14 @@
   i32.store offset=4
   i32.const 1180
   i32.load
-  local.tee $9
+  local.tee $8
   i32.const 1
   i32.add
-  local.tee $5
-  local.set $1
-  local.get $5
+  local.tee $9
+  local.tee $1
   i32.const 1176
   i32.load
-  local.tee $6
+  local.tee $5
   i32.const 2
   i32.shr_u
   i32.gt_u
@@ -2169,33 +2168,34 @@
    if
     i32.const 1616
     i32.const 1664
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    i32.const 1168
    i32.load
-   local.tee $7
+   local.tee $6
    local.set $0
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
     i32.const 32
+    i32.const 8
     local.get $1
+    local.get $1
+    i32.const 8
+    i32.lt_u
+    select
     i32.const 2
     i32.shl
-    local.tee $1
     i32.const 1
     i32.sub
     i32.clz
     i32.sub
     i32.shl
-    i32.const 8
-    local.get $1
-    select
-    local.tee $8
+    local.tee $7
     local.tee $3
-    local.get $7
+    local.get $6
     i32.const 20
     i32.sub
     local.tee $4
@@ -2230,14 +2230,14 @@
     local.set $0
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.add
-   local.get $8
-   local.get $6
+   local.get $7
+   local.get $5
    i32.sub
    call $~lib/memory/memory.fill
    local.get $0
-   local.get $7
+   local.get $6
    i32.ne
    if
     i32.const 1168
@@ -2252,12 +2252,12 @@
     call $~lib/rt/itcms/__link
    end
    i32.const 1176
-   local.get $8
+   local.get $7
    i32.store
   end
   i32.const 1172
   i32.load
-  local.get $9
+  local.get $8
   i32.const 2
   i32.shl
   i32.add
@@ -2268,7 +2268,7 @@
   i32.const 1
   call $~lib/rt/itcms/__link
   i32.const 1180
-  local.get $5
+  local.get $9
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -2157,7 +2157,7 @@
   local.tee $1
   i32.const 1176
   i32.load
-  local.tee $5
+  local.tee $4
   i32.const 2
   i32.shr_u
   i32.gt_u
@@ -2168,7 +2168,7 @@
    if
     i32.const 1616
     i32.const 1664
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -2178,8 +2178,16 @@
    local.tee $6
    local.set $0
    block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $4
     i32.const 1
-    i32.const 32
+    i32.shl
+    local.tee $3
+    i32.const 1073741820
+    local.get $3
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $3
     local.get $1
     i32.const 8
     local.get $1
@@ -2188,15 +2196,9 @@
     select
     i32.const 2
     i32.shl
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
     local.tee $1
-    i32.const 1073741820
     local.get $1
-    i32.const 1073741820
+    local.get $3
     i32.lt_u
     select
     local.tee $7
@@ -2204,7 +2206,7 @@
     local.get $6
     i32.const 20
     i32.sub
-    local.tee $4
+    local.tee $5
     i32.load
     i32.const -4
     i32.and
@@ -2212,19 +2214,19 @@
     i32.sub
     i32.le_u
     if
-     local.get $4
+     local.get $5
      local.get $3
      i32.store offset=16
      br $__inlined_func$~lib/rt/itcms/__renew
     end
     local.get $3
-    local.get $4
+    local.get $5
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $1
     local.get $0
     local.get $3
-    local.get $4
+    local.get $5
     i32.load offset=16
     local.tee $0
     local.get $0
@@ -2236,10 +2238,10 @@
     local.set $0
    end
    local.get $0
-   local.get $5
+   local.get $4
    i32.add
    local.get $7
-   local.get $5
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
    local.get $0

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -2169,7 +2169,7 @@
    if
     i32.const 1616
     i32.const 1664
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -2179,9 +2179,20 @@
    local.tee $7
    local.set $0
    block $__inlined_func$~lib/rt/itcms/__renew
+    i32.const 1
+    i32.const 32
     local.get $1
-    i32.const 3
+    i32.const 2
     i32.shl
+    local.tee $1
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 8
+    local.get $1
+    select
     local.tee $8
     local.tee $3
     local.get $7

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -2180,11 +2180,11 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
     i32.const 32
-    i32.const 8
-    local.get $1
     local.get $1
     i32.const 8
-    i32.lt_u
+    local.get $1
+    i32.const 8
+    i32.gt_u
     select
     i32.const 2
     i32.shl

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1,8 +1,8 @@
 (module
  (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -1962,132 +1962,6 @@
    end
   end
  )
- (func $~lib/array/ensureCapacity (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  local.get $0
-  i32.const 1176
-  i32.load
-  local.tee $5
-  i32.const 2
-  i32.shr_u
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 268435455
-   i32.gt_u
-   if
-    i32.const 1616
-    i32.const 1664
-    i32.const 23
-    i32.const 48
-    call $~lib/builtins/abort
-    unreachable
-   end
-   i32.const 1168
-   i32.load
-   local.set $1
-   local.get $0
-   i32.const 1
-   i32.const 32
-   i32.const 8
-   local.get $0
-   local.get $0
-   i32.const 8
-   i32.lt_u
-   select
-   i32.const 2
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.tee $0
-   i32.const 1073741820
-   local.get $0
-   i32.const 1073741820
-   i32.lt_u
-   select
-   local.tee $3
-   i32.const 2
-   i32.shr_u
-   i32.gt_u
-   if
-    i32.const 1616
-    i32.const 1664
-    i32.const 30
-    i32.const 48
-    call $~lib/builtins/abort
-    unreachable
-   end
-   block $__inlined_func$~lib/rt/itcms/__renew
-    local.get $3
-    local.get $1
-    local.tee $0
-    i32.const 20
-    i32.sub
-    local.tee $4
-    i32.load
-    i32.const -4
-    i32.and
-    i32.const 16
-    i32.sub
-    i32.le_u
-    if
-     local.get $4
-     local.get $3
-     i32.store offset=16
-     br $__inlined_func$~lib/rt/itcms/__renew
-    end
-    local.get $3
-    local.get $4
-    i32.load offset=12
-    call $~lib/rt/itcms/__new
-    local.tee $2
-    local.get $0
-    local.get $3
-    local.get $4
-    i32.load offset=16
-    local.tee $0
-    local.get $0
-    local.get $3
-    i32.gt_u
-    select
-    call $~lib/memory/memory.copy
-    local.get $2
-    local.set $0
-   end
-   local.get $0
-   local.get $5
-   i32.add
-   local.get $3
-   local.get $5
-   i32.sub
-   call $~lib/memory/memory.fill
-   local.get $0
-   local.get $1
-   i32.ne
-   if
-    i32.const 1168
-    local.get $0
-    i32.store
-    i32.const 1172
-    local.get $0
-    i32.store
-    i32.const 1168
-    local.get $0
-    i32.const 0
-    call $~lib/rt/itcms/__link
-   end
-   i32.const 1176
-   local.get $3
-   i32.store
-  end
- )
  (func $~lib/rt/__visit_members (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2180,6 +2054,13 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -2220,7 +2101,7 @@
   i32.const 20
   i32.const 6
   call $~lib/rt/itcms/__new
-  local.tee $0
+  local.tee $2
   i32.store
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -2231,26 +2112,26 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  local.get $0
+  local.get $2
   i32.eqz
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 20
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $2
    i32.store
   end
-  local.get $0
+  local.get $2
   f64.const 0
   f64.store
-  local.get $0
+  local.get $2
   f64.const 0
   f64.store offset=8
-  local.get $0
+  local.get $2
   i32.const 0
   i32.store offset=16
-  local.get $0
+  local.get $2
   i32.const 0
   i32.const 0
   call $~lib/rt/itcms/__link
@@ -2258,36 +2139,142 @@
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $2
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  local.get $0
+  local.get $2
   i32.store offset=4
   i32.const 1180
   i32.load
-  local.tee $2
+  local.tee $8
   i32.const 1
   i32.add
+  local.tee $9
   local.tee $1
-  call $~lib/array/ensureCapacity
+  i32.const 1176
+  i32.load
+  local.tee $5
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 268435455
+   i32.gt_u
+   if
+    i32.const 1616
+    i32.const 1664
+    i32.const 23
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   i32.const 1168
+   i32.load
+   local.tee $6
+   local.set $0
+   block $__inlined_func$~lib/rt/itcms/__renew
+    i32.const 1
+    i32.const 32
+    i32.const 8
+    local.get $1
+    local.get $1
+    i32.const 8
+    i32.lt_u
+    select
+    i32.const 2
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $1
+    i32.const 1073741820
+    local.get $1
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $7
+    local.tee $3
+    local.get $6
+    i32.const 20
+    i32.sub
+    local.tee $4
+    i32.load
+    i32.const -4
+    i32.and
+    i32.const 16
+    i32.sub
+    i32.le_u
+    if
+     local.get $4
+     local.get $3
+     i32.store offset=16
+     br $__inlined_func$~lib/rt/itcms/__renew
+    end
+    local.get $3
+    local.get $4
+    i32.load offset=12
+    call $~lib/rt/itcms/__new
+    local.tee $1
+    local.get $0
+    local.get $3
+    local.get $4
+    i32.load offset=16
+    local.tee $0
+    local.get $0
+    local.get $3
+    i32.gt_u
+    select
+    call $~lib/memory/memory.copy
+    local.get $1
+    local.set $0
+   end
+   local.get $0
+   local.get $5
+   i32.add
+   local.get $7
+   local.get $5
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $0
+   local.get $6
+   i32.ne
+   if
+    i32.const 1168
+    local.get $0
+    i32.store
+    i32.const 1172
+    local.get $0
+    i32.store
+    i32.const 1168
+    local.get $0
+    i32.const 0
+    call $~lib/rt/itcms/__link
+   end
+   i32.const 1176
+   local.get $7
+   i32.store
+  end
   i32.const 1172
   i32.load
-  local.get $2
+  local.get $8
   i32.const 2
   i32.shl
   i32.add
-  local.get $0
+  local.get $2
   i32.store
   i32.const 1168
-  local.get $0
+  local.get $2
   i32.const 1
   call $~lib/rt/itcms/__link
   i32.const 1180
-  local.get $1
+  local.get $9
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 8

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -2169,7 +2169,7 @@
    if
     i32.const 1616
     i32.const 1664
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -2180,7 +2180,7 @@
    local.set $0
    block $__inlined_func$~lib/rt/itcms/__renew
     local.get $1
-    i32.const 2
+    i32.const 3
     i32.shl
     local.tee $8
     local.tee $3

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -3760,7 +3760,7 @@
    if
     i32.const 592
     i32.const 640
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -3781,15 +3781,8 @@
    local.set $6
    local.get $3
    if
-    local.get $6
-    local.set $7
+    local.get $4
     i32.const 1
-    i32.const 32
-    local.get $7
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
     local.tee $7
     i32.const 1073741820
@@ -3798,13 +3791,20 @@
     local.get $8
     i32.lt_u
     select
+    local.tee $8
+    local.get $6
+    local.tee $7
+    local.get $8
+    local.get $7
+    i32.gt_u
+    select
     local.set $6
    end
    local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    local.get $4
    i32.add
    i32.const 0
@@ -3812,18 +3812,18 @@
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
+   local.get $8
    local.get $5
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $8
     i32.store
     local.get $0
-    local.get $7
+    local.get $8
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 0
     call $~lib/rt/itcms/__link
    end

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -3768,9 +3768,9 @@
    local.get $0
    i32.load
    local.set $5
-   i32.const 8
-   local.tee $6
    local.get $1
+   local.tee $6
+   i32.const 8
    local.tee $7
    local.get $6
    local.get $7

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -3799,19 +3799,6 @@
     i32.lt_u
     select
     local.set $6
-    local.get $1
-    local.get $6
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 592
-     i32.const 640
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
    end
    local.get $5
    local.get $6

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -3759,7 +3759,7 @@
    if
     i32.const 592
     i32.const 640
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -3767,55 +3767,55 @@
    local.get $0
    i32.load
    local.set $4
+   i32.const 8
+   local.tee $5
    local.get $1
+   local.tee $6
+   local.get $5
+   local.get $6
+   i32.gt_u
+   select
    local.get $2
    i32.shl
-   local.set $5
-   local.get $5
-   i32.const 0
-   i32.eq
-   if (result i32)
-    i32.const 8
-   else
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-   end
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
    local.set $6
+   i32.const 1
+   i32.const 32
    local.get $6
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.set $6
+   local.get $4
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $5
+   local.get $5
    local.get $3
    i32.add
    i32.const 0
-   local.get $5
+   local.get $6
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $6
+   local.get $5
    local.get $4
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $5
     i32.store
     local.get $0
-    local.get $6
+    local.get $5
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $5
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -5,8 +5,8 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_f64_=>_none (func (param i32 f64)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_f64_=>_none (func (param i32 f64)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -3737,16 +3737,17 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -3766,51 +3767,76 @@
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    i32.const 8
-   local.tee $5
-   local.get $1
    local.tee $6
-   local.get $5
+   local.get $1
+   local.tee $7
    local.get $6
+   local.get $7
    i32.gt_u
    select
    local.get $2
    i32.shl
    local.set $6
-   i32.const 1
-   i32.const 32
-   local.get $6
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.set $6
-   local.get $4
+   local.get $3
+   if
+    local.get $6
+    local.set $7
+    i32.const 1
+    i32.const 32
+    local.get $7
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $7
+    i32.const 1073741820
+    local.tee $8
+    local.get $7
+    local.get $8
+    i32.lt_u
+    select
+    local.set $6
+    local.get $1
+    local.get $6
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 592
+     i32.const 640
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $5
-   local.get $5
-   local.get $3
+   local.set $7
+   local.get $7
+   local.get $4
    i32.add
    i32.const 0
    local.get $6
-   local.get $3
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $7
    local.get $5
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $5
+    local.get $7
     i32.store
     local.get $0
-    local.get $5
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $5
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -3837,6 +3863,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   i32.const 1
   drop

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -5,8 +5,8 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_f64_=>_none (func (param i32 f64)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_f64_=>_none (func (param i32 f64)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -3737,16 +3737,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -3759,47 +3759,49 @@
    if
     i32.const 592
     i32.const 640
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    local.get $1
    local.get $2
-   i32.shl
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
-   local.set $6
-   local.get $6
    local.get $3
    i32.add
-   i32.const 0
+   i32.shl
+   local.set $6
    local.get $5
-   local.get $3
-   i32.sub
-   call $~lib/memory/memory.fill
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $7
+   local.get $7
+   local.get $4
+   i32.add
+   i32.const 0
    local.get $6
    local.get $4
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $7
+   local.get $5
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.store
     local.get $0
-    local.get $6
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -3821,6 +3823,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureSize
   i32.const 1
   drop

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -3737,7 +3737,7 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3837,7 +3837,7 @@
   local.get $0
   local.get $3
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   i32.const 1
   drop
   local.get $0

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -5,8 +5,8 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_f64_=>_none (func (param i32 f64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -3737,16 +3737,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
-  local.get $4
+  local.get $3
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -3759,49 +3759,63 @@
    if
     i32.const 592
     i32.const 640
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $5
+   local.set $4
    local.get $1
    local.get $2
+   i32.shl
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 8
+   else
+    i32.const 1
+    i32.const 32
+    local.get $5
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+   end
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
    local.get $3
    i32.add
-   i32.shl
-   local.set $6
-   local.get $5
-   local.get $6
-   call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.add
    i32.const 0
-   local.get $6
-   local.get $4
+   local.get $5
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.store
     local.get $0
-    local.get $7
+    local.get $6
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.store offset=8
   end
  )
@@ -3823,7 +3837,6 @@
   local.get $0
   local.get $3
   i32.const 2
-  i32.const 1
   call $~lib/array/ensureSize
   i32.const 1
   drop

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -2260,7 +2260,7 @@
   end
   i32.const 1280
   i32.const 1488
-  i32.const 102
+  i32.const 103
   i32.const 42
   call $~lib/builtins/abort
   unreachable

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -2260,7 +2260,7 @@
   end
   i32.const 1280
   i32.const 1488
-  i32.const 108
+  i32.const 107
   i32.const 42
   call $~lib/builtins/abort
   unreachable

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -2260,7 +2260,7 @@
   end
   i32.const 1280
   i32.const 1488
-  i32.const 103
+  i32.const 108
   i32.const 42
   call $~lib/builtins/abort
   unreachable

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -2260,7 +2260,7 @@
   end
   i32.const 1280
   i32.const 1488
-  i32.const 96
+  i32.const 101
   i32.const 42
   call $~lib/builtins/abort
   unreachable

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -2260,7 +2260,7 @@
   end
   i32.const 1280
   i32.const 1488
-  i32.const 92
+  i32.const 96
   i32.const 42
   call $~lib/builtins/abort
   unreachable

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -2260,7 +2260,7 @@
   end
   i32.const 1280
   i32.const 1488
-  i32.const 101
+  i32.const 102
   i32.const 42
   call $~lib/builtins/abort
   unreachable

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -2260,7 +2260,7 @@
   end
   i32.const 1280
   i32.const 1488
-  i32.const 107
+  i32.const 99
   i32.const 42
   call $~lib/builtins/abort
   unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3733,7 +3733,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3759,7 +3759,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3785,7 +3785,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3827,7 +3827,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4603,7 +4603,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4649,7 +4649,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4695,7 +4695,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4720,7 +4720,7 @@
   if
    i32.const 976
    i32.const 464
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3733,7 +3733,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3759,7 +3759,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3785,7 +3785,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3827,7 +3827,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4603,7 +4603,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4649,7 +4649,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4695,7 +4695,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4720,7 +4720,7 @@
   if
    i32.const 976
    i32.const 464
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3733,7 +3733,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3759,7 +3759,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3785,7 +3785,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3827,7 +3827,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4603,7 +4603,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4649,7 +4649,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4695,7 +4695,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4720,7 +4720,7 @@
   if
    i32.const 976
    i32.const 464
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3733,7 +3733,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3759,7 +3759,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3785,7 +3785,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3827,7 +3827,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4603,7 +4603,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4649,7 +4649,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4695,7 +4695,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4720,7 +4720,7 @@
   if
    i32.const 976
    i32.const 464
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3733,7 +3733,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3759,7 +3759,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3785,7 +3785,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3827,7 +3827,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4603,7 +4603,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4649,7 +4649,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4695,7 +4695,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4720,7 +4720,7 @@
   if
    i32.const 976
    i32.const 464
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3733,7 +3733,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3759,7 +3759,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3785,7 +3785,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3827,7 +3827,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4603,7 +4603,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4649,7 +4649,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4695,7 +4695,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4720,7 +4720,7 @@
   if
    i32.const 976
    i32.const 464
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3733,7 +3733,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3759,7 +3759,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3785,7 +3785,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3827,7 +3827,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4603,7 +4603,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4649,7 +4649,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4695,7 +4695,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4720,7 +4720,7 @@
   if
    i32.const 976
    i32.const 464
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -1987,7 +1987,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2406,7 +2406,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2426,7 +2426,7 @@
   if
    i32.const 1552
    i32.const 1104
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -1967,15 +1967,134 @@
    end
   end
  )
- (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#__set (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=8
+  local.tee $6
+  i32.const 2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 268435455
+   i32.gt_u
+   if
+    i32.const 1056
+    i32.const 1104
+    i32.const 23
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   i32.load
+   local.set $2
+   local.get $1
+   i32.const 1
+   i32.const 32
+   i32.const 8
+   local.get $1
+   local.get $1
+   i32.const 8
+   i32.lt_u
+   select
+   i32.const 2
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.tee $1
+   i32.const 1073741820
+   local.get $1
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $4
+   i32.const 2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 1056
+    i32.const 1104
+    i32.const 30
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $4
+    local.get $2
+    local.tee $1
+    i32.const 20
+    i32.sub
+    local.tee $5
+    i32.load
+    i32.const -4
+    i32.and
+    i32.const 16
+    i32.sub
+    i32.le_u
+    if
+     local.get $5
+     local.get $4
+     i32.store offset=16
+     br $__inlined_func$~lib/rt/itcms/__renew
+    end
+    local.get $4
+    local.get $5
+    i32.load offset=12
+    call $~lib/rt/itcms/__new
+    local.tee $3
+    local.get $1
+    local.get $4
+    local.get $5
+    i32.load offset=16
+    local.tee $1
+    local.get $1
+    local.get $4
+    i32.gt_u
+    select
+    call $~lib/memory/memory.copy
+    local.get $3
+    local.set $1
+   end
+   local.get $1
+   local.get $6
+   i32.add
+   local.get $4
+   local.get $6
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $1
+   local.get $2
+   i32.ne
+   if
+    local.get $0
+    local.get $1
+    i32.store
+    local.get $0
+    local.get $1
+    i32.store offset=4
+    local.get $0
+    local.get $1
+    i32.const 0
+    call $~lib/rt/itcms/__link
+   end
+   local.get $0
+   local.get $4
+   i32.store offset=8
+  end
+ )
+ (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#__set (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -1987,118 +2106,19 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
    local.get $1
    i32.const 1
    i32.add
-   local.tee $10
-   local.tee $4
+   local.tee $3
+   call $~lib/array/ensureCapacity
    local.get $0
-   i32.load offset=8
-   local.tee $7
-   i32.const 2
-   i32.shr_u
-   i32.gt_u
-   if
-    local.get $4
-    i32.const 268435455
-    i32.gt_u
-    if
-     i32.const 1056
-     i32.const 1104
-     i32.const 23
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    i32.load
-    local.tee $8
-    local.set $3
-    block $__inlined_func$~lib/rt/itcms/__renew
-     i32.const 1
-     i32.const 32
-     i32.const 8
-     local.get $4
-     local.get $4
-     i32.const 8
-     i32.lt_u
-     select
-     i32.const 2
-     i32.shl
-     i32.const 1
-     i32.sub
-     i32.clz
-     i32.sub
-     i32.shl
-     local.tee $9
-     local.tee $5
-     local.get $8
-     i32.const 20
-     i32.sub
-     local.tee $6
-     i32.load
-     i32.const -4
-     i32.and
-     i32.const 16
-     i32.sub
-     i32.le_u
-     if
-      local.get $6
-      local.get $5
-      i32.store offset=16
-      br $__inlined_func$~lib/rt/itcms/__renew
-     end
-     local.get $5
-     local.get $6
-     i32.load offset=12
-     call $~lib/rt/itcms/__new
-     local.tee $4
-     local.get $3
-     local.get $5
-     local.get $6
-     i32.load offset=16
-     local.tee $3
-     local.get $3
-     local.get $5
-     i32.gt_u
-     select
-     call $~lib/memory/memory.copy
-     local.get $4
-     local.set $3
-    end
-    local.get $3
-    local.get $7
-    i32.add
-    local.get $9
-    local.get $7
-    i32.sub
-    call $~lib/memory/memory.fill
-    local.get $3
-    local.get $8
-    i32.ne
-    if
-     local.get $0
-     local.get $3
-     i32.store
-     local.get $0
-     local.get $3
-     i32.store offset=4
-     local.get $0
-     local.get $3
-     i32.const 0
-     call $~lib/rt/itcms/__link
-    end
-    local.get $0
-    local.get $9
-    i32.store offset=8
-   end
-   local.get $0
-   local.get $10
+   local.get $3
    i32.store offset=12
   end
   local.get $0
@@ -2406,7 +2426,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2426,7 +2446,7 @@
   if
    i32.const 1552
    i32.const 1104
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -1987,7 +1987,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -1999,7 +1999,7 @@
    local.tee $4
    local.get $0
    i32.load offset=8
-   local.tee $7
+   local.tee $6
    i32.const 2
    i32.shr_u
    i32.gt_u
@@ -2010,7 +2010,7 @@
     if
      i32.const 1056
      i32.const 1104
-     i32.const 23
+     i32.const 17
      i32.const 48
      call $~lib/builtins/abort
      unreachable
@@ -2020,8 +2020,16 @@
     local.tee $8
     local.set $3
     block $__inlined_func$~lib/rt/itcms/__renew
+     local.get $6
      i32.const 1
-     i32.const 32
+     i32.shl
+     local.tee $5
+     i32.const 1073741820
+     local.get $5
+     i32.const 1073741820
+     i32.lt_u
+     select
+     local.tee $5
      local.get $4
      i32.const 8
      local.get $4
@@ -2030,15 +2038,9 @@
      select
      i32.const 2
      i32.shl
-     i32.const 1
-     i32.sub
-     i32.clz
-     i32.sub
-     i32.shl
      local.tee $4
-     i32.const 1073741820
      local.get $4
-     i32.const 1073741820
+     local.get $5
      i32.lt_u
      select
      local.tee $9
@@ -2046,7 +2048,7 @@
      local.get $8
      i32.const 20
      i32.sub
-     local.tee $6
+     local.tee $7
      i32.load
      i32.const -4
      i32.and
@@ -2054,19 +2056,19 @@
      i32.sub
      i32.le_u
      if
-      local.get $6
+      local.get $7
       local.get $5
       i32.store offset=16
       br $__inlined_func$~lib/rt/itcms/__renew
      end
      local.get $5
-     local.get $6
+     local.get $7
      i32.load offset=12
      call $~lib/rt/itcms/__new
      local.tee $4
      local.get $3
      local.get $5
-     local.get $6
+     local.get $7
      i32.load offset=16
      local.tee $3
      local.get $3
@@ -2078,10 +2080,10 @@
      local.set $3
     end
     local.get $3
-    local.get $7
+    local.get $6
     i32.add
     local.get $9
-    local.get $7
+    local.get $6
     i32.sub
     call $~lib/memory/memory.fill
     local.get $3
@@ -2412,7 +2414,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2432,7 +2434,7 @@
   if
    i32.const 1552
    i32.const 1104
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -1967,134 +1967,15 @@
    end
   end
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
-  (local $2 i32)
+ (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#__set (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  local.tee $6
-  i32.const 2
-  i32.shr_u
-  i32.gt_u
-  if
-   local.get $1
-   i32.const 268435455
-   i32.gt_u
-   if
-    i32.const 1056
-    i32.const 1104
-    i32.const 23
-    i32.const 48
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $0
-   i32.load
-   local.set $2
-   local.get $1
-   i32.const 1
-   i32.const 32
-   i32.const 8
-   local.get $1
-   local.get $1
-   i32.const 8
-   i32.lt_u
-   select
-   i32.const 2
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.tee $1
-   i32.const 1073741820
-   local.get $1
-   i32.const 1073741820
-   i32.lt_u
-   select
-   local.tee $4
-   i32.const 2
-   i32.shr_u
-   i32.gt_u
-   if
-    i32.const 1056
-    i32.const 1104
-    i32.const 30
-    i32.const 48
-    call $~lib/builtins/abort
-    unreachable
-   end
-   block $__inlined_func$~lib/rt/itcms/__renew
-    local.get $4
-    local.get $2
-    local.tee $1
-    i32.const 20
-    i32.sub
-    local.tee $5
-    i32.load
-    i32.const -4
-    i32.and
-    i32.const 16
-    i32.sub
-    i32.le_u
-    if
-     local.get $5
-     local.get $4
-     i32.store offset=16
-     br $__inlined_func$~lib/rt/itcms/__renew
-    end
-    local.get $4
-    local.get $5
-    i32.load offset=12
-    call $~lib/rt/itcms/__new
-    local.tee $3
-    local.get $1
-    local.get $4
-    local.get $5
-    i32.load offset=16
-    local.tee $1
-    local.get $1
-    local.get $4
-    i32.gt_u
-    select
-    call $~lib/memory/memory.copy
-    local.get $3
-    local.set $1
-   end
-   local.get $1
-   local.get $6
-   i32.add
-   local.get $4
-   local.get $6
-   i32.sub
-   call $~lib/memory/memory.fill
-   local.get $1
-   local.get $2
-   i32.ne
-   if
-    local.get $0
-    local.get $1
-    i32.store
-    local.get $0
-    local.get $1
-    i32.store offset=4
-    local.get $0
-    local.get $1
-    i32.const 0
-    call $~lib/rt/itcms/__link
-   end
-   local.get $0
-   local.get $4
-   i32.store offset=8
-  end
- )
- (func $~lib/array/Array<issues/1699/MultiAssignmentTest>#__set (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -2106,19 +1987,124 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
    local.get $1
    i32.const 1
    i32.add
-   local.tee $3
-   call $~lib/array/ensureCapacity
+   local.tee $10
+   local.tee $4
    local.get $0
-   local.get $3
+   i32.load offset=8
+   local.tee $7
+   i32.const 2
+   i32.shr_u
+   i32.gt_u
+   if
+    local.get $4
+    i32.const 268435455
+    i32.gt_u
+    if
+     i32.const 1056
+     i32.const 1104
+     i32.const 23
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    i32.load
+    local.tee $8
+    local.set $3
+    block $__inlined_func$~lib/rt/itcms/__renew
+     i32.const 1
+     i32.const 32
+     i32.const 8
+     local.get $4
+     local.get $4
+     i32.const 8
+     i32.lt_u
+     select
+     i32.const 2
+     i32.shl
+     i32.const 1
+     i32.sub
+     i32.clz
+     i32.sub
+     i32.shl
+     local.tee $4
+     i32.const 1073741820
+     local.get $4
+     i32.const 1073741820
+     i32.lt_u
+     select
+     local.tee $9
+     local.tee $5
+     local.get $8
+     i32.const 20
+     i32.sub
+     local.tee $6
+     i32.load
+     i32.const -4
+     i32.and
+     i32.const 16
+     i32.sub
+     i32.le_u
+     if
+      local.get $6
+      local.get $5
+      i32.store offset=16
+      br $__inlined_func$~lib/rt/itcms/__renew
+     end
+     local.get $5
+     local.get $6
+     i32.load offset=12
+     call $~lib/rt/itcms/__new
+     local.tee $4
+     local.get $3
+     local.get $5
+     local.get $6
+     i32.load offset=16
+     local.tee $3
+     local.get $3
+     local.get $5
+     i32.gt_u
+     select
+     call $~lib/memory/memory.copy
+     local.get $4
+     local.set $3
+    end
+    local.get $3
+    local.get $7
+    i32.add
+    local.get $9
+    local.get $7
+    i32.sub
+    call $~lib/memory/memory.fill
+    local.get $3
+    local.get $8
+    i32.ne
+    if
+     local.get $0
+     local.get $3
+     i32.store
+     local.get $0
+     local.get $3
+     i32.store offset=4
+     local.get $0
+     local.get $3
+     i32.const 0
+     call $~lib/rt/itcms/__link
+    end
+    local.get $0
+    local.get $9
+    i32.store offset=8
+   end
+   local.get $0
+   local.get $10
    i32.store offset=12
   end
   local.get $0
@@ -2426,7 +2412,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2446,7 +2432,7 @@
   if
    i32.const 1552
    i32.const 1104
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -1987,7 +1987,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2011,7 +2011,7 @@
     if
      i32.const 1056
      i32.const 1104
-     i32.const 17
+     i32.const 22
      i32.const 48
      call $~lib/builtins/abort
      unreachable
@@ -2021,9 +2021,20 @@
     local.tee $9
     local.set $3
     block $__inlined_func$~lib/rt/itcms/__renew
+     i32.const 1
+     i32.const 32
      local.get $4
-     i32.const 3
+     i32.const 2
      i32.shl
+     local.tee $4
+     i32.const 1
+     i32.sub
+     i32.clz
+     i32.sub
+     i32.shl
+     i32.const 8
+     local.get $4
+     select
      local.tee $10
      local.tee $5
      local.get $9
@@ -2395,7 +2406,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2415,7 +2426,7 @@
   if
    i32.const 1552
    i32.const 1104
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -1987,7 +1987,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -1995,12 +1995,11 @@
    local.get $1
    i32.const 1
    i32.add
-   local.tee $7
-   local.set $4
-   local.get $7
+   local.tee $10
+   local.tee $4
    local.get $0
    i32.load offset=8
-   local.tee $8
+   local.tee $7
    i32.const 2
    i32.shr_u
    i32.gt_u
@@ -2011,33 +2010,34 @@
     if
      i32.const 1056
      i32.const 1104
-     i32.const 22
+     i32.const 23
      i32.const 48
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
     i32.load
-    local.tee $9
+    local.tee $8
     local.set $3
     block $__inlined_func$~lib/rt/itcms/__renew
      i32.const 1
      i32.const 32
+     i32.const 8
      local.get $4
+     local.get $4
+     i32.const 8
+     i32.lt_u
+     select
      i32.const 2
      i32.shl
-     local.tee $4
      i32.const 1
      i32.sub
      i32.clz
      i32.sub
      i32.shl
-     i32.const 8
-     local.get $4
-     select
-     local.tee $10
+     local.tee $9
      local.tee $5
-     local.get $9
+     local.get $8
      i32.const 20
      i32.sub
      local.tee $6
@@ -2072,14 +2072,14 @@
      local.set $3
     end
     local.get $3
-    local.get $8
+    local.get $7
     i32.add
-    local.get $10
-    local.get $8
+    local.get $9
+    local.get $7
     i32.sub
     call $~lib/memory/memory.fill
     local.get $3
-    local.get $9
+    local.get $8
     i32.ne
     if
      local.get $0
@@ -2094,11 +2094,11 @@
      call $~lib/rt/itcms/__link
     end
     local.get $0
-    local.get $10
+    local.get $9
     i32.store offset=8
    end
    local.get $0
-   local.get $7
+   local.get $10
    i32.store offset=12
   end
   local.get $0
@@ -2406,7 +2406,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2426,7 +2426,7 @@
   if
    i32.const 1552
    i32.const 1104
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -1987,7 +1987,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2011,7 +2011,7 @@
     if
      i32.const 1056
      i32.const 1104
-     i32.const 14
+     i32.const 17
      i32.const 48
      call $~lib/builtins/abort
      unreachable
@@ -2022,7 +2022,7 @@
     local.set $3
     block $__inlined_func$~lib/rt/itcms/__renew
      local.get $4
-     i32.const 2
+     i32.const 3
      i32.shl
      local.tee $10
      local.tee $5
@@ -2245,13 +2245,13 @@
   i32.const 0
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 32
   i32.const 0
   call $~lib/rt/itcms/__new
   local.tee $1
   i32.store offset=4
   local.get $1
-  i32.const 12
+  i32.const 32
   call $~lib/memory/memory.fill
   local.get $0
   local.get $1
@@ -2260,7 +2260,7 @@
   local.get $1
   i32.store offset=4
   local.get $0
-  i32.const 12
+  i32.const 32
   i32.store offset=8
   local.get $0
   i32.const 3
@@ -2395,7 +2395,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2415,7 +2415,7 @@
   if
    i32.const 1552
    i32.const 1104
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -2022,11 +2022,11 @@
     block $__inlined_func$~lib/rt/itcms/__renew
      i32.const 1
      i32.const 32
-     i32.const 8
-     local.get $4
      local.get $4
      i32.const 8
-     i32.lt_u
+     local.get $4
+     i32.const 8
+     i32.gt_u
      select
      i32.const 2
      i32.shl

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -3742,16 +3742,17 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -3771,51 +3772,76 @@
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    i32.const 8
-   local.tee $5
-   local.get $1
    local.tee $6
-   local.get $5
+   local.get $1
+   local.tee $7
    local.get $6
+   local.get $7
    i32.gt_u
    select
    local.get $2
    i32.shl
    local.set $6
-   i32.const 1
-   i32.const 32
-   local.get $6
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.set $6
-   local.get $4
+   local.get $3
+   if
+    local.get $6
+    local.set $7
+    i32.const 1
+    i32.const 32
+    local.get $7
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $7
+    i32.const 1073741820
+    local.tee $8
+    local.get $7
+    local.get $8
+    i32.lt_u
+    select
+    local.set $6
+    local.get $1
+    local.get $6
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 32
+     i32.const 80
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $5
-   local.get $5
-   local.get $3
+   local.set $7
+   local.get $7
+   local.get $4
    i32.add
    i32.const 0
    local.get $6
-   local.get $3
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $7
    local.get $5
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $5
+    local.get $7
     i32.store
     local.get $0
-    local.get $5
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $5
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -3852,7 +3878,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3862,6 +3888,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -4179,7 +4206,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4274,7 +4301,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4299,7 +4326,7 @@
   if
    i32.const 528
    i32.const 80
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -3773,9 +3773,9 @@
    local.get $0
    i32.load
    local.set $5
-   i32.const 8
-   local.tee $6
    local.get $1
+   local.tee $6
+   i32.const 8
    local.tee $7
    local.get $6
    local.get $7
@@ -4198,9 +4198,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -3804,19 +3804,6 @@
     i32.lt_u
     select
     local.set $6
-    local.get $1
-    local.get $6
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 32
-     i32.const 80
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
    end
    local.get $5
    local.get $6
@@ -3878,7 +3865,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4206,7 +4193,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4301,7 +4288,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4326,7 +4313,7 @@
   if
    i32.const 528
    i32.const 80
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -3742,7 +3742,7 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3852,7 +3852,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3862,7 +3862,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -4179,7 +4179,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4274,7 +4274,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4299,7 +4299,7 @@
   if
    i32.const 528
    i32.const 80
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -3742,16 +3742,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
-  local.get $4
+  local.get $3
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -3764,49 +3764,63 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $5
+   local.set $4
    local.get $1
    local.get $2
+   i32.shl
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 8
+   else
+    i32.const 1
+    i32.const 32
+    local.get $5
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+   end
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
    local.get $3
    i32.add
-   i32.shl
-   local.set $6
-   local.get $5
-   local.get $6
-   call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.add
    i32.const 0
-   local.get $6
-   local.get $4
+   local.get $5
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.store
     local.get $0
-    local.get $7
+    local.get $6
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.store offset=8
   end
  )
@@ -3838,7 +3852,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3848,7 +3862,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4166,7 +4179,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4261,7 +4274,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4286,7 +4299,7 @@
   if
    i32.const 528
    i32.const 80
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -3742,16 +3742,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -3764,47 +3764,49 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    local.get $1
    local.get $2
-   i32.shl
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
-   local.set $6
-   local.get $6
    local.get $3
    i32.add
-   i32.const 0
+   i32.shl
+   local.set $6
    local.get $5
-   local.get $3
-   i32.sub
-   call $~lib/memory/memory.fill
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $7
+   local.get $7
+   local.get $4
+   i32.add
+   i32.const 0
    local.get $6
    local.get $4
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $7
+   local.get $5
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.store
     local.get $0
-    local.get $6
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -3836,7 +3838,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3846,6 +3848,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4123,6 +4126,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -4161,44 +4166,51 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $issues/1699/MultiAssignmentTest#constructor (param $0 i32) (result i32)
   (local $1 i32)
@@ -4249,7 +4261,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4274,7 +4286,7 @@
   if
    i32.const 528
    i32.const 80
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -3765,7 +3765,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -3786,15 +3786,8 @@
    local.set $6
    local.get $3
    if
-    local.get $6
-    local.set $7
+    local.get $4
     i32.const 1
-    i32.const 32
-    local.get $7
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
     local.tee $7
     i32.const 1073741820
@@ -3803,13 +3796,20 @@
     local.get $8
     i32.lt_u
     select
+    local.tee $8
+    local.get $6
+    local.tee $7
+    local.get $8
+    local.get $7
+    i32.gt_u
+    select
     local.set $6
    end
    local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    local.get $4
    i32.add
    i32.const 0
@@ -3817,18 +3817,18 @@
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
+   local.get $8
    local.get $5
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $8
     i32.store
     local.get $0
-    local.get $7
+    local.get $8
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -3865,7 +3865,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4193,7 +4193,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4288,7 +4288,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4313,7 +4313,7 @@
   if
    i32.const 528
    i32.const 80
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -3764,7 +3764,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -3772,55 +3772,55 @@
    local.get $0
    i32.load
    local.set $4
+   i32.const 8
+   local.tee $5
    local.get $1
+   local.tee $6
+   local.get $5
+   local.get $6
+   i32.gt_u
+   select
    local.get $2
    i32.shl
-   local.set $5
-   local.get $5
-   i32.const 0
-   i32.eq
-   if (result i32)
-    i32.const 8
-   else
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-   end
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
    local.set $6
+   i32.const 1
+   i32.const 32
    local.get $6
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.set $6
+   local.get $4
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $5
+   local.get $5
    local.get $3
    i32.add
    i32.const 0
-   local.get $5
+   local.get $6
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $6
+   local.get $5
    local.get $4
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $5
     i32.store
     local.get $0
-    local.get $6
+    local.get $5
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $5
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -3852,7 +3852,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4179,7 +4179,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4274,7 +4274,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4299,7 +4299,7 @@
   if
    i32.const 528
    i32.const 80
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -2266,7 +2266,7 @@
   if
    i32.const 1280
    i32.const 1488
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -2266,7 +2266,7 @@
   if
    i32.const 1280
    i32.const 1488
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -2266,7 +2266,7 @@
   if
    i32.const 1280
    i32.const 1488
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -2266,7 +2266,7 @@
   if
    i32.const 1280
    i32.const 1488
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -2266,7 +2266,7 @@
   if
    i32.const 1280
    i32.const 1488
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -2266,7 +2266,7 @@
   if
    i32.const 1280
    i32.const 1488
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -2266,7 +2266,7 @@
   if
    i32.const 1280
    i32.const 1488
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -3707,7 +3707,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -3178,7 +3178,7 @@
    if
     i32.const 4448
     i32.const 4496
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/wasi/index/abort
     unreachable
@@ -3189,18 +3189,19 @@
    local.tee $4
    i32.const 1
    i32.const 32
+   i32.const 8
    local.get $1
+   local.get $1
+   i32.const 8
+   i32.lt_u
+   select
    i32.const 2
    i32.shl
-   local.tee $1
    i32.const 1
    i32.sub
    i32.clz
    i32.sub
    i32.shl
-   i32.const 8
-   local.get $1
-   select
    local.tee $3
    call $~lib/rt/itcms/__renew
    local.tee $1
@@ -3242,7 +3243,7 @@
    if
     i32.const 4672
     i32.const 4496
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -4714,7 +4715,7 @@
   if
    i32.const 4448
    i32.const 4496
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -5076,7 +5077,7 @@
   if
    i32.const 4672
    i32.const 4496
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -5096,7 +5097,7 @@
   if
    i32.const 4912
    i32.const 4496
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -3163,11 +3163,10 @@
  (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $4
+  local.tee $3
   i32.const 2
   i32.shr_u
   i32.gt_u
@@ -3183,9 +3182,6 @@
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $0
-   i32.load
-   local.set $5
    i32.const 8
    local.get $1
    local.get $1
@@ -3194,13 +3190,15 @@
    select
    i32.const 2
    i32.shl
-   local.set $3
+   local.set $1
+   local.get $0
+   i32.load
+   local.tee $4
    local.get $2
    if
-    local.get $1
     i32.const 1
     i32.const 32
-    local.get $3
+    local.get $1
     i32.const 1
     i32.sub
     i32.clz
@@ -3212,46 +3210,34 @@
     i32.const 1073741820
     i32.lt_u
     select
-    local.tee $3
-    i32.const 2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 4448
-     i32.const 4496
-     i32.const 30
-     i32.const 48
-     call $~lib/wasi/index/abort
-     unreachable
-    end
+    local.set $1
    end
-   local.get $4
-   local.get $5
-   local.get $3
+   local.get $1
    call $~lib/rt/itcms/__renew
-   local.tee $1
-   i32.add
+   local.tee $2
    local.get $3
-   local.get $4
+   i32.add
+   local.get $1
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $1
+    local.get $2
     i32.store
     local.get $0
-    local.get $1
+    local.get $2
     i32.store offset=4
     local.get $0
-    local.get $1
+    local.get $2
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $3
+   local.get $1
    i32.store offset=8
   end
  )
@@ -3268,7 +3254,7 @@
    if
     i32.const 4672
     i32.const 4496
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -4742,7 +4728,7 @@
   if
    i32.const 4448
    i32.const 4496
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -5104,7 +5090,7 @@
   if
    i32.const 4672
    i32.const 4496
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -5124,7 +5110,7 @@
   if
    i32.const 4912
    i32.const 4496
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -3182,11 +3182,11 @@
     call $~lib/wasi/index/abort
     unreachable
    end
-   i32.const 8
-   local.get $1
    local.get $1
    i32.const 8
-   i32.lt_u
+   local.get $1
+   i32.const 8
+   i32.gt_u
    select
    i32.const 2
    i32.shl
@@ -4734,11 +4734,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $0
   local.get $0
   i32.const 8
-  i32.lt_s
+  local.get $0
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -3160,7 +3160,7 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3242,7 +3242,7 @@
    if
     i32.const 4672
     i32.const 4496
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -3252,7 +3252,7 @@
    i32.const 1
    i32.add
    local.tee $3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -4421,7 +4421,7 @@
   end
   local.get $2
   local.get $0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $2
   local.get $0
   i32.store offset=12
@@ -4714,7 +4714,7 @@
   if
    i32.const 4448
    i32.const 4496
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -5076,7 +5076,7 @@
   if
    i32.const 4672
    i32.const 4496
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -5096,7 +5096,7 @@
   if
    i32.const 4912
    i32.const 4496
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
@@ -3160,14 +3160,14 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
-  (local $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $2
+  local.tee $4
   i32.const 2
   i32.shr_u
   i32.gt_u
@@ -3183,12 +3183,9 @@
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $2
    local.get $0
    i32.load
-   local.tee $4
-   i32.const 1
-   i32.const 32
+   local.set $5
    i32.const 8
    local.get $1
    local.get $1
@@ -3197,21 +3194,49 @@
    select
    i32.const 2
    i32.shl
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.tee $3
+   local.set $3
+   local.get $2
+   if
+    local.get $1
+    i32.const 1
+    i32.const 32
+    local.get $3
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $1
+    i32.const 1073741820
+    local.get $1
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $3
+    i32.const 2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 4448
+     i32.const 4496
+     i32.const 30
+     i32.const 48
+     call $~lib/wasi/index/abort
+     unreachable
+    end
+   end
+   local.get $4
+   local.get $5
+   local.get $3
    call $~lib/rt/itcms/__renew
    local.tee $1
    i32.add
    local.get $3
-   local.get $2
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $4
+   local.get $5
    i32.ne
    if
     local.get $0
@@ -3243,7 +3268,7 @@
    if
     i32.const 4672
     i32.const 4496
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -3253,6 +3278,7 @@
    i32.const 1
    i32.add
    local.tee $3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
@@ -4422,6 +4448,7 @@
   end
   local.get $2
   local.get $0
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $2
   local.get $0
@@ -4715,7 +4742,7 @@
   if
    i32.const 4448
    i32.const 4496
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -5077,7 +5104,7 @@
   if
    i32.const 4672
    i32.const 4496
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -5097,7 +5124,7 @@
   if
    i32.const 4912
    i32.const 4496
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
@@ -3160,13 +3160,14 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $2
   i32.const 2
   i32.shr_u
   i32.gt_u
@@ -3177,26 +3178,35 @@
    if
     i32.const 4448
     i32.const 4496
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $3
+   local.get $2
    local.get $0
    i32.load
    local.tee $4
+   i32.const 1
+   i32.const 32
    local.get $1
-   local.get $2
    i32.const 2
-   i32.add
    i32.shl
-   local.tee $2
+   local.tee $1
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 8
+   local.get $1
+   select
+   local.tee $3
    call $~lib/rt/itcms/__renew
    local.tee $1
    i32.add
-   local.get $2
    local.get $3
+   local.get $2
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
@@ -3215,7 +3225,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $2
+   local.get $3
    i32.store offset=8
   end
  )
@@ -3232,7 +3242,7 @@
    if
     i32.const 4672
     i32.const 4496
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -3242,7 +3252,6 @@
    i32.const 1
    i32.add
    local.tee $3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -4412,7 +4421,6 @@
   end
   local.get $2
   local.get $0
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $2
   local.get $0
@@ -4706,7 +4714,7 @@
   if
    i32.const 4448
    i32.const 4496
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -5068,7 +5076,7 @@
   if
    i32.const 4672
    i32.const 4496
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -5088,7 +5096,7 @@
   if
    i32.const 4912
    i32.const 4496
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
@@ -3160,14 +3160,13 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32)
-  (local $2 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $2
+  local.tee $3
   i32.const 2
   i32.shr_u
   i32.gt_u
@@ -3178,24 +3177,26 @@
    if
     i32.const 4448
     i32.const 4496
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $2
+   local.get $3
    local.get $0
    i32.load
    local.tee $4
    local.get $1
+   local.get $2
    i32.const 2
+   i32.add
    i32.shl
-   local.tee $3
+   local.tee $2
    call $~lib/rt/itcms/__renew
    local.tee $1
    i32.add
-   local.get $3
    local.get $2
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
@@ -3214,7 +3215,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $3
+   local.get $2
    i32.store offset=8
   end
  )
@@ -3231,7 +3232,7 @@
    if
     i32.const 4672
     i32.const 4496
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -3241,6 +3242,7 @@
    i32.const 1
    i32.add
    local.tee $3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -4410,6 +4412,7 @@
   end
   local.get $2
   local.get $0
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $2
   local.get $0
@@ -4703,13 +4706,18 @@
   if
    i32.const 4448
    i32.const 4496
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $0
+  local.get $0
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
   local.tee $3
@@ -5060,7 +5068,7 @@
   if
    i32.const 4672
    i32.const 4496
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -5080,7 +5088,7 @@
   if
    i32.const 4912
    i32.const 4496
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -3177,7 +3177,7 @@
    if
     i32.const 4448
     i32.const 4496
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/wasi/index/abort
     unreachable
@@ -3196,18 +3196,19 @@
    local.tee $4
    local.get $2
    if
+    local.get $3
     i32.const 1
-    i32.const 32
-    local.get $1
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
-    local.tee $1
+    local.tee $2
     i32.const 1073741820
+    local.get $2
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $2
     local.get $1
-    i32.const 1073741820
+    local.get $1
+    local.get $2
     i32.lt_u
     select
     local.set $1
@@ -3254,7 +3255,7 @@
    if
     i32.const 4672
     i32.const 4496
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -4728,7 +4729,7 @@
   if
    i32.const 4448
    i32.const 4496
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -5090,7 +5091,7 @@
   if
    i32.const 4672
    i32.const 4496
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -5110,7 +5111,7 @@
   if
    i32.const 4912
    i32.const 4496
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -9,9 +9,9 @@
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $none_=>_i64 (func (result i64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
@@ -5253,16 +5253,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
-  local.get $4
+  local.get $3
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -5275,49 +5275,63 @@
    if
     i32.const 3424
     i32.const 3472
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/wasi/index/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $5
+   local.set $4
    local.get $1
    local.get $2
+   i32.shl
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 8
+   else
+    i32.const 1
+    i32.const 32
+    local.get $5
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+   end
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
    local.get $3
    i32.add
-   i32.shl
-   local.set $6
-   local.get $5
-   local.get $6
-   call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.add
    i32.const 0
-   local.get $6
-   local.get $4
+   local.get $5
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.store
     local.get $0
-    local.get $7
+    local.get $6
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.store offset=8
   end
  )
@@ -5349,7 +5363,7 @@
    if
     i32.const 3648
     i32.const 3472
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -5359,7 +5373,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -6050,7 +6063,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -7685,7 +7697,7 @@
   if
    i32.const 3424
    i32.const 3472
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -8112,7 +8124,7 @@
   if
    i32.const 3648
    i32.const 3472
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -8137,7 +8149,7 @@
   if
    i32.const 3888
    i32.const 3472
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -5253,7 +5253,7 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5363,7 +5363,7 @@
    if
     i32.const 3648
     i32.const 3472
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -5373,7 +5373,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -6063,7 +6063,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String>#set:length_
@@ -7697,7 +7697,7 @@
   if
    i32.const 3424
    i32.const 3472
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -8124,7 +8124,7 @@
   if
    i32.const 3648
    i32.const 3472
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -8149,7 +8149,7 @@
   if
    i32.const 3888
    i32.const 3472
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -5275,7 +5275,7 @@
    if
     i32.const 3424
     i32.const 3472
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/wasi/index/abort
     unreachable
@@ -5283,55 +5283,55 @@
    local.get $0
    i32.load
    local.set $4
+   i32.const 8
+   local.tee $5
    local.get $1
+   local.tee $6
+   local.get $5
+   local.get $6
+   i32.gt_u
+   select
    local.get $2
    i32.shl
-   local.set $5
-   local.get $5
-   i32.const 0
-   i32.eq
-   if (result i32)
-    i32.const 8
-   else
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-   end
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
    local.set $6
+   i32.const 1
+   i32.const 32
    local.get $6
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.set $6
+   local.get $4
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $5
+   local.get $5
    local.get $3
    i32.add
    i32.const 0
-   local.get $5
+   local.get $6
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $6
+   local.get $5
    local.get $4
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $5
     i32.store
     local.get $0
-    local.get $6
+    local.get $5
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $5
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -5363,7 +5363,7 @@
    if
     i32.const 3648
     i32.const 3472
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -7697,7 +7697,7 @@
   if
    i32.const 3424
    i32.const 3472
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -8124,7 +8124,7 @@
   if
    i32.const 3648
    i32.const 3472
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -8149,7 +8149,7 @@
   if
    i32.const 3888
    i32.const 3472
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -5284,9 +5284,9 @@
    local.get $0
    i32.load
    local.set $5
-   i32.const 8
-   local.tee $6
    local.get $1
+   local.tee $6
+   i32.const 8
    local.tee $7
    local.get $6
    local.get $7
@@ -7717,9 +7717,9 @@
    call $~lib/wasi/index/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -5315,19 +5315,6 @@
     i32.lt_u
     select
     local.set $6
-    local.get $1
-    local.get $6
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 3424
-     i32.const 3472
-     i32.const 30
-     i32.const 48
-     call $~lib/wasi/index/abort
-     unreachable
-    end
    end
    local.get $5
    local.get $6
@@ -5389,7 +5376,7 @@
    if
     i32.const 3648
     i32.const 3472
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -7725,7 +7712,7 @@
   if
    i32.const 3424
    i32.const 3472
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -8152,7 +8139,7 @@
   if
    i32.const 3648
    i32.const 3472
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -8177,7 +8164,7 @@
   if
    i32.const 3888
    i32.const 3472
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -9,9 +9,9 @@
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $none_=>_i64 (func (result i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
@@ -5253,16 +5253,17 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -5282,51 +5283,76 @@
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    i32.const 8
-   local.tee $5
-   local.get $1
    local.tee $6
-   local.get $5
+   local.get $1
+   local.tee $7
    local.get $6
+   local.get $7
    i32.gt_u
    select
    local.get $2
    i32.shl
    local.set $6
-   i32.const 1
-   i32.const 32
-   local.get $6
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.set $6
-   local.get $4
+   local.get $3
+   if
+    local.get $6
+    local.set $7
+    i32.const 1
+    i32.const 32
+    local.get $7
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $7
+    i32.const 1073741820
+    local.tee $8
+    local.get $7
+    local.get $8
+    i32.lt_u
+    select
+    local.set $6
+    local.get $1
+    local.get $6
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 3424
+     i32.const 3472
+     i32.const 30
+     i32.const 48
+     call $~lib/wasi/index/abort
+     unreachable
+    end
+   end
+   local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $5
-   local.get $5
-   local.get $3
+   local.set $7
+   local.get $7
+   local.get $4
    i32.add
    i32.const 0
    local.get $6
-   local.get $3
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $7
    local.get $5
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $5
+    local.get $7
     i32.store
     local.get $0
-    local.get $5
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $5
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -5363,7 +5389,7 @@
    if
     i32.const 3648
     i32.const 3472
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -5373,6 +5399,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -6063,6 +6090,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -7697,7 +7725,7 @@
   if
    i32.const 3424
    i32.const 3472
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -8124,7 +8152,7 @@
   if
    i32.const 3648
    i32.const 3472
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -8149,7 +8177,7 @@
   if
    i32.const 3888
    i32.const 3472
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -5276,7 +5276,7 @@
    if
     i32.const 3424
     i32.const 3472
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/wasi/index/abort
     unreachable
@@ -5297,15 +5297,8 @@
    local.set $6
    local.get $3
    if
-    local.get $6
-    local.set $7
+    local.get $4
     i32.const 1
-    i32.const 32
-    local.get $7
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
     local.tee $7
     i32.const 1073741820
@@ -5314,13 +5307,20 @@
     local.get $8
     i32.lt_u
     select
+    local.tee $8
+    local.get $6
+    local.tee $7
+    local.get $8
+    local.get $7
+    i32.gt_u
+    select
     local.set $6
    end
    local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    local.get $4
    i32.add
    i32.const 0
@@ -5328,18 +5328,18 @@
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
+   local.get $8
    local.get $5
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $8
     i32.store
     local.get $0
-    local.get $7
+    local.get $8
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -5376,7 +5376,7 @@
    if
     i32.const 3648
     i32.const 3472
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -7712,7 +7712,7 @@
   if
    i32.const 3424
    i32.const 3472
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
@@ -8139,7 +8139,7 @@
   if
    i32.const 3648
    i32.const 3472
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -8164,7 +8164,7 @@
   if
    i32.const 3888
    i32.const 3472
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -9,9 +9,9 @@
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $none_=>_i64 (func (result i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32 i32) (result i32)))
@@ -5253,16 +5253,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -5275,47 +5275,49 @@
    if
     i32.const 3424
     i32.const 3472
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/wasi/index/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    local.get $1
    local.get $2
-   i32.shl
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
-   local.set $6
-   local.get $6
    local.get $3
    i32.add
-   i32.const 0
+   i32.shl
+   local.set $6
    local.get $5
-   local.get $3
-   i32.sub
-   call $~lib/memory/memory.fill
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $7
+   local.get $7
+   local.get $4
+   i32.add
+   i32.const 0
    local.get $6
    local.get $4
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $7
+   local.get $5
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.store
     local.get $0
-    local.get $6
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -5347,7 +5349,7 @@
    if
     i32.const 3648
     i32.const 3472
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/wasi/index/abort
     unreachable
@@ -5357,6 +5359,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -6047,6 +6050,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -7641,6 +7645,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -7679,44 +7685,51 @@
   if
    i32.const 3424
    i32.const 3472
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/wasi/index/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<~lib/string/String>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<~lib/string/String>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<~lib/string/String>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/string/String.UTF8.decodeUnsafe (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -8099,7 +8112,7 @@
   if
    i32.const 3648
    i32.const 3472
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/wasi/index/abort
    unreachable
@@ -8124,7 +8137,7 @@
   if
    i32.const 3888
    i32.const 3472
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -161,7 +161,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -181,7 +181,7 @@
   if
    i32.const 1168
    i32.const 1120
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -223,7 +223,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -161,7 +161,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -181,7 +181,7 @@
   if
    i32.const 1168
    i32.const 1120
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -223,7 +223,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -161,7 +161,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -181,7 +181,7 @@
   if
    i32.const 1168
    i32.const 1120
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -223,7 +223,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -161,7 +161,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -181,7 +181,7 @@
   if
    i32.const 1168
    i32.const 1120
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -223,7 +223,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -161,7 +161,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -181,7 +181,7 @@
   if
    i32.const 1168
    i32.const 1120
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -223,7 +223,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -161,7 +161,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -181,7 +181,7 @@
   if
    i32.const 1168
    i32.const 1120
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -223,7 +223,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -161,7 +161,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -181,7 +181,7 @@
   if
    i32.const 1168
    i32.const 1120
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -223,7 +223,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -31,7 +31,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -401,7 +401,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -457,7 +457,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -482,7 +482,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -513,7 +513,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -538,7 +538,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -31,7 +31,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -401,7 +401,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -457,7 +457,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -482,7 +482,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -513,7 +513,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -538,7 +538,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -31,7 +31,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -401,7 +401,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -457,7 +457,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -482,7 +482,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -513,7 +513,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -538,7 +538,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -31,7 +31,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -401,7 +401,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -457,7 +457,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -482,7 +482,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -513,7 +513,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -538,7 +538,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -31,7 +31,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -401,7 +401,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -457,7 +457,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -482,7 +482,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -513,7 +513,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -538,7 +538,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -31,7 +31,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -401,7 +401,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -457,7 +457,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -482,7 +482,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -513,7 +513,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -538,7 +538,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -31,7 +31,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -401,7 +401,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -426,7 +426,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -457,7 +457,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -482,7 +482,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -513,7 +513,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -538,7 +538,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -64,7 +64,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -83,7 +83,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -64,7 +64,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -83,7 +83,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -64,7 +64,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -83,7 +83,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -64,7 +64,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -83,7 +83,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -64,7 +64,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -83,7 +83,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -64,7 +64,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -83,7 +83,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -64,7 +64,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -83,7 +83,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -68,7 +68,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -98,7 +98,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -68,7 +68,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -98,7 +98,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -68,7 +68,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -98,7 +98,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -68,7 +68,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -98,7 +98,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -68,7 +68,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -98,7 +98,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -68,7 +68,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -98,7 +98,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -68,7 +68,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -98,7 +98,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2711,7 +2711,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2849,7 +2849,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2914,7 +2914,7 @@
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2932,9 +2932,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
-   i32.load
-   local.set $4
    i32.const 8
    local.get $1
    local.get $1
@@ -2943,41 +2940,35 @@
    select
    local.get $2
    i32.shl
+   local.set $1
+   local.get $4
    local.set $5
-   local.get $3
-   if
-    local.get $1
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-    local.tee $1
-    i32.const 1073741820
-    local.get $1
-    i32.const 1073741820
-    i32.lt_u
-    select
-    local.tee $5
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 1056
-     i32.const 1104
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
-   end
+   local.get $0
+   i32.load
+   local.tee $6
+   local.set $4
    block $__inlined_func$~lib/rt/itcms/__renew
-    local.get $5
+    local.get $3
+    if (result i32)
+     i32.const 1
+     i32.const 32
+     local.get $1
+     i32.const 1
+     i32.sub
+     i32.clz
+     i32.sub
+     i32.shl
+     local.tee $1
+     i32.const 1073741820
+     local.get $1
+     i32.const 1073741820
+     i32.lt_u
+     select
+    else
+     local.get $1
+    end
+    local.tee $2
     local.get $4
-    local.tee $1
     i32.const 20
     i32.sub
     local.tee $3
@@ -2989,38 +2980,38 @@
     i32.le_u
     if
      local.get $3
-     local.get $5
+     local.get $2
      i32.store offset=16
+     local.get $4
+     local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $5
+    local.get $2
     local.get $3
     i32.load offset=12
     call $~lib/rt/itcms/__new
-    local.tee $2
-    local.get $1
-    local.get $5
+    local.tee $1
+    local.get $4
+    local.get $2
     local.get $3
     i32.load offset=16
-    local.tee $1
-    local.get $1
-    local.get $5
-    i32.gt_u
+    local.tee $3
+    local.get $2
+    local.get $3
+    i32.lt_u
     select
     call $~lib/memory/memory.copy
-    local.get $2
-    local.set $1
    end
    local.get $1
-   local.get $6
+   local.get $5
    i32.add
    i32.const 0
+   local.get $2
    local.get $5
-   local.get $6
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $4
+   local.get $6
    i32.ne
    if
     local.get $0
@@ -3035,7 +3026,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $2
    i32.store offset=8
   end
  )
@@ -3073,7 +3064,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3097,7 +3088,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 285
+   i32.const 284
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -3158,7 +3149,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 141
+   i32.const 140
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -3501,7 +3492,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3934,7 +3925,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5071,7 +5062,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5939,7 +5930,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8557,7 +8548,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8674,7 +8665,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12122,7 +12113,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 344
+   i32.const 343
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -18606,7 +18597,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18782,7 +18773,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 238
+   i32.const 237
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19135,7 +19126,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19155,7 +19146,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -19274,7 +19265,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19664,7 +19655,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21986,7 +21977,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 238
+   i32.const 237
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22528,7 +22519,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 141
+   i32.const 140
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -22786,7 +22777,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 238
+   i32.const 237
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22879,7 +22870,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 285
+   i32.const 284
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23065,7 +23056,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 344
+   i32.const 343
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23385,7 +23376,7 @@
   i32.store
   i32.const 13120
   i32.const 1104
-  i32.const 486
+  i32.const 485
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -23600,7 +23591,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 141
+   i32.const 140
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -23856,7 +23847,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 238
+   i32.const 237
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23944,7 +23935,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 285
+   i32.const 284
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24123,7 +24114,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 344
+   i32.const 343
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24832,7 +24823,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 141
+   i32.const 140
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -24852,7 +24843,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 145
+   i32.const 144
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -25229,7 +25220,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 285
+   i32.const 284
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -25449,7 +25440,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 344
+   i32.const 343
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2711,7 +2711,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2849,7 +2849,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2929,7 +2929,7 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -2941,18 +2941,19 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
     i32.const 32
+    i32.const 8
     local.get $1
+    local.get $1
+    i32.const 8
+    i32.lt_u
+    select
     local.get $2
     i32.shl
-    local.tee $1
     i32.const 1
     i32.sub
     i32.clz
     i32.sub
     i32.shl
-    i32.const 8
-    local.get $1
-    select
     local.tee $7
     local.tee $4
     local.get $6
@@ -3050,7 +3051,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3074,7 +3075,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 279
+   i32.const 280
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -3134,7 +3135,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 135
+   i32.const 136
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -3476,7 +3477,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3908,7 +3909,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5045,7 +5046,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5913,7 +5914,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8528,7 +8529,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8645,7 +8646,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12093,7 +12094,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 338
+   i32.const 339
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -18577,7 +18578,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18753,7 +18754,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 232
+   i32.const 233
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19106,7 +19107,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19126,7 +19127,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -19245,7 +19246,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19635,7 +19636,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21957,7 +21958,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 232
+   i32.const 233
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22499,7 +22500,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 135
+   i32.const 136
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -22757,7 +22758,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 232
+   i32.const 233
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22850,7 +22851,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 279
+   i32.const 280
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23036,7 +23037,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 338
+   i32.const 339
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23356,7 +23357,7 @@
   i32.store
   i32.const 13120
   i32.const 1104
-  i32.const 480
+  i32.const 481
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -23570,7 +23571,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 135
+   i32.const 136
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -23826,7 +23827,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 232
+   i32.const 233
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23914,7 +23915,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 279
+   i32.const 280
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24093,7 +24094,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 338
+   i32.const 339
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24801,7 +24802,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 135
+   i32.const 136
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -24821,7 +24822,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 139
+   i32.const 140
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -25198,7 +25199,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 279
+   i32.const 280
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -25418,7 +25419,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 338
+   i32.const 339
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2711,7 +2711,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2849,7 +2849,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2927,7 +2927,7 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -2950,18 +2950,19 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     local.get $3
     if (result i32)
+     local.get $5
      i32.const 1
-     i32.const 32
-     local.get $1
-     i32.const 1
-     i32.sub
-     i32.clz
-     i32.sub
      i32.shl
-     local.tee $1
+     local.tee $2
      i32.const 1073741820
+     local.get $2
+     i32.const 1073741820
+     i32.lt_u
+     select
+     local.tee $2
      local.get $1
-     i32.const 1073741820
+     local.get $1
+     local.get $2
      i32.lt_u
      select
     else
@@ -3064,7 +3065,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3088,7 +3089,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 284
+   i32.const 276
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -3149,7 +3150,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 140
+   i32.const 132
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -3492,7 +3493,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3925,7 +3926,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5062,7 +5063,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5930,7 +5931,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8548,7 +8549,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8665,7 +8666,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12113,7 +12114,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 343
+   i32.const 335
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -18597,7 +18598,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18773,7 +18774,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 237
+   i32.const 229
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19126,7 +19127,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19146,7 +19147,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -19265,7 +19266,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19655,7 +19656,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21987,7 +21988,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 237
+   i32.const 229
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22529,7 +22530,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 140
+   i32.const 132
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -22787,7 +22788,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 237
+   i32.const 229
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22880,7 +22881,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 284
+   i32.const 276
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23066,7 +23067,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 343
+   i32.const 335
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23386,7 +23387,7 @@
   i32.store
   i32.const 13120
   i32.const 1104
-  i32.const 485
+  i32.const 477
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -23601,7 +23602,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 140
+   i32.const 132
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -23857,7 +23858,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 237
+   i32.const 229
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23945,7 +23946,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 284
+   i32.const 276
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24124,7 +24125,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 343
+   i32.const 335
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24833,7 +24834,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 140
+   i32.const 132
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -24853,7 +24854,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 144
+   i32.const 136
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -25230,7 +25231,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 284
+   i32.const 276
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -25450,7 +25451,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 343
+   i32.const 335
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2932,11 +2932,11 @@
     call $~lib/builtins/abort
     unreachable
    end
-   i32.const 8
-   local.get $1
    local.get $1
    i32.const 8
-   i32.lt_u
+   local.get $1
+   i32.const 8
+   i32.gt_u
    select
    local.get $2
    i32.shl
@@ -8554,11 +8554,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $1
   local.get $1
   i32.const 8
-  i32.lt_s
+  local.get $1
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl
@@ -8671,11 +8671,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $1
   local.get $1
   i32.const 8
-  i32.lt_s
+  local.get $1
+  i32.const 8
+  i32.gt_s
   select
   local.tee $3
   i32.const 0
@@ -18603,11 +18603,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $0
   local.get $0
   i32.const 8
-  i32.lt_s
+  local.get $0
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl
@@ -19661,11 +19661,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $1
   local.get $1
   i32.const 8
-  i32.lt_s
+  local.get $1
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl
@@ -21410,12 +21410,12 @@
   i32.load offset=4
   local.set $6
   loop $for-loop|0
-   local.get $2
+   local.get $3
    local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $2
+    local.get $3
     i32.const 2
     i32.shl
     i32.add
@@ -21427,24 +21427,29 @@
     else
      i32.const 0
     end
-    local.get $3
-    i32.add
-    local.set $3
     local.get $2
-    i32.const 1
     i32.add
     local.set $2
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
+  i32.const 8
+  local.get $2
+  i32.const 8
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.tee $2
+  local.tee $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $3
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -21453,19 +21458,19 @@
   local.tee $0
   i32.store offset=4
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=12
   local.get $0
-  local.get $2
+  local.get $4
   i32.store offset=8
   local.get $0
-  local.get $4
+  local.get $3
   i32.store offset=4
   local.get $0
-  local.get $4
+  local.get $3
   i32.store
   local.get $0
-  local.get $4
+  local.get $3
   i32.const 0
   call $~lib/rt/itcms/__link
   i32.const 0
@@ -21481,19 +21486,19 @@
     i32.shl
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     if
      local.get $1
-     local.get $4
+     local.get $3
      i32.add
-     local.get $3
+     local.get $4
      i32.load offset=4
-     local.get $3
+     local.get $4
      i32.load offset=8
-     local.tee $3
+     local.tee $4
      call $~lib/memory/memory.copy
      local.get $1
-     local.get $3
+     local.get $4
      i32.add
      local.set $1
     end
@@ -21562,12 +21567,17 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $4
+  i32.const 8
+  local.get $4
+  i32.const 8
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.tee $2
+  local.tee $0
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $0
+  local.tee $2
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -21579,35 +21589,35 @@
   local.get $4
   i32.store offset=12
   local.get $3
-  local.get $2
+  local.get $0
   i32.store offset=8
   local.get $3
-  local.get $0
+  local.get $2
   i32.store offset=4
   local.get $3
-  local.get $0
+  local.get $2
   i32.store
   local.get $3
-  local.get $0
+  local.get $2
   i32.const 0
   call $~lib/rt/itcms/__link
   i32.const 0
-  local.set $2
+  local.set $0
   loop $for-loop|1
-   local.get $2
+   local.get $0
    local.get $6
    i32.lt_s
    if
     local.get $7
-    local.get $2
+    local.get $0
     i32.const 2
     i32.shl
     i32.add
     i32.load
     local.tee $5
     if
-     local.get $0
      local.get $1
+     local.get $2
      i32.add
      local.get $5
      i32.load offset=4
@@ -21620,33 +21630,33 @@
      i32.add
      local.set $1
     end
-    local.get $2
+    local.get $0
     i32.const 1
     i32.add
-    local.set $2
+    local.set $0
     br $for-loop|1
    end
   end
   i32.const 0
-  local.set $2
+  local.set $0
   loop $for-loop|2
-   local.get $2
+   local.get $0
    local.get $4
    i32.lt_s
    if
-    local.get $0
-    local.get $0
     local.get $2
+    local.get $2
+    local.get $0
     i32.const 2
     i32.shl
     i32.add
     i32.load
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $2
+    local.get $0
     i32.const 1
     i32.add
-    local.set $2
+    local.set $0
     br $for-loop|2
    end
   end

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2711,7 +2711,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2849,7 +2849,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2907,7 +2907,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3028,7 +3028,7 @@
   i32.add
   local.tee $2
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
   local.get $3
@@ -3050,7 +3050,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3111,7 +3111,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -3134,7 +3134,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 134
+   i32.const 135
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -3308,7 +3308,7 @@
   i32.add
   local.tee $2
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
   local.tee $3
@@ -3476,7 +3476,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3487,7 +3487,7 @@
    i32.add
    local.tee $3
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -3908,7 +3908,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5045,7 +5045,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5913,7 +5913,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5924,7 +5924,7 @@
    i32.add
    local.tee $3
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -7951,7 +7951,7 @@
   i32.add
   local.tee $2
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $3
   local.get $0
   i32.load offset=4
@@ -8440,7 +8440,7 @@
   i32.add
   local.tee $2
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
   local.get $3
@@ -8528,7 +8528,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8645,7 +8645,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18577,7 +18577,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19106,7 +19106,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19126,7 +19126,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -19245,7 +19245,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19635,7 +19635,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22499,7 +22499,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 134
+   i32.const 135
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -23406,7 +23406,7 @@
   local.get $0
   local.get $1
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -23570,7 +23570,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 134
+   i32.const 135
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -24204,7 +24204,7 @@
   i32.add
   local.tee $2
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
   local.tee $3
@@ -24801,7 +24801,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 134
+   i32.const 135
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -24821,7 +24821,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 138
+   i32.const 139
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -25564,7 +25564,7 @@
   i32.add
   local.tee $2
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
   local.tee $3

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -10,13 +10,13 @@
  (type $f32_f32_=>_i32 (func (param f32 f32) (result i32)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $none_=>_f64 (func (result f64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
  (type $i64_=>_none (func (param i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
@@ -2711,7 +2711,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2849,7 +2849,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2907,8 +2907,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2916,7 +2915,7 @@
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2929,22 +2928,24 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.tee $6
-   local.set $3
+   local.tee $7
+   local.set $4
    block $__inlined_func$~lib/rt/itcms/__renew
     local.get $1
     local.get $2
+    local.get $3
+    i32.add
     i32.shl
-    local.tee $7
-    local.tee $4
-    local.get $6
+    local.tee $3
+    local.tee $5
+    local.get $7
     i32.const 20
     i32.sub
     local.tee $2
@@ -2956,38 +2957,38 @@
     i32.le_u
     if
      local.get $2
-     local.get $4
+     local.get $5
      i32.store offset=16
-     local.get $3
+     local.get $4
      local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $4
+    local.get $5
     local.get $2
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $1
-    local.get $3
     local.get $4
+    local.get $5
     local.get $2
     i32.load offset=16
     local.tee $2
     local.get $2
-    local.get $4
+    local.get $5
     i32.gt_u
     select
     call $~lib/memory/memory.copy
    end
    local.get $1
-   local.get $5
+   local.get $6
    i32.add
    i32.const 0
-   local.get $7
-   local.get $5
+   local.get $3
+   local.get $6
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $6
+   local.get $7
    i32.ne
    if
     local.get $0
@@ -3002,7 +3003,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $7
+   local.get $3
    i32.store offset=8
   end
  )
@@ -3017,6 +3018,7 @@
   i32.add
   local.tee $2
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -3039,7 +3041,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3063,7 +3065,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 269
+   i32.const 274
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -3100,6 +3102,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -3123,7 +3126,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 125
+   i32.const 129
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -3297,6 +3300,7 @@
   i32.add
   local.tee $2
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -3465,7 +3469,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3476,6 +3480,7 @@
    i32.add
    local.tee $3
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -3897,7 +3902,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5034,7 +5039,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5902,7 +5907,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5913,6 +5918,7 @@
    i32.add
    local.tee $3
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -7940,6 +7946,7 @@
   i32.add
   local.tee $2
   i32.const 0
+  i32.const 1
   call $~lib/array/ensureSize
   local.get $3
   local.get $0
@@ -8429,6 +8436,7 @@
   i32.add
   local.tee $2
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -8517,13 +8525,18 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $1
+  local.get $1
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
   local.tee $3
@@ -8562,6 +8575,7 @@
  (func $std/array/ArrayU8#constructor@varargs (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8628,20 +8642,26 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $1
+  local.get $1
+  i32.const 8
+  i32.lt_s
+  select
+  local.tee $3
   i32.const 0
   call $~lib/rt/itcms/__new
   local.tee $2
   i32.store offset=4
   local.get $2
   i32.const 0
-  local.get $1
+  local.get $3
   call $~lib/memory/memory.fill
   local.get $0
   local.get $2
@@ -8650,7 +8670,7 @@
   local.get $2
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $3
   i32.store offset=8
   local.get $0
   local.get $1
@@ -10609,6 +10629,8 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
+  i32.const 8
+  i32.ne
   if
    i32.const 0
    i32.const 1552
@@ -10664,7 +10686,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 1
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -10710,7 +10732,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 1
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -10750,7 +10772,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 1
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -10807,7 +10829,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 2
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -10881,7 +10903,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 3
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -11061,7 +11083,7 @@
   i32.store
   local.get $2
   call $std/array/internalCapacity<i32>
-  i32.const 3
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -11118,7 +11140,7 @@
   i32.store
   local.get $2
   call $std/array/internalCapacity<i32>
-  i32.const 3
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -11191,7 +11213,7 @@
   i32.store
   local.get $2
   call $std/array/internalCapacity<i32>
-  i32.const 3
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -11853,7 +11875,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 4
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -11961,7 +11983,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -12068,7 +12090,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 328
+   i32.const 333
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -12131,7 +12153,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -12249,7 +12271,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -12617,7 +12639,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -13451,7 +13473,7 @@
   i32.store
   local.get $0
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.ne
   if
    i32.const 0
@@ -16969,14 +16991,14 @@
   i32.const 0
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 32
   i32.const 0
   call $~lib/rt/itcms/__new
   local.tee $2
   i32.store offset=4
   local.get $2
   i32.const 0
-  i32.const 8
+  i32.const 32
   call $~lib/memory/memory.fill
   local.get $0
   local.get $2
@@ -16985,7 +17007,7 @@
   local.get $2
   i32.store offset=4
   local.get $0
-  i32.const 8
+  i32.const 32
   i32.store offset=8
   local.get $0
   i32.const 2
@@ -18552,13 +18574,18 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $0
+  local.get $0
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
   local.tee $3
@@ -18723,7 +18750,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 222
+   i32.const 227
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19076,7 +19103,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19096,7 +19123,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -19215,7 +19242,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19605,13 +19632,18 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $1
+  local.get $1
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
   local.tee $3
@@ -21922,7 +21954,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 222
+   i32.const 227
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22464,7 +22496,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 125
+   i32.const 129
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -22722,7 +22754,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 222
+   i32.const 227
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22815,7 +22847,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 269
+   i32.const 274
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23001,7 +23033,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 328
+   i32.const 333
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23321,7 +23353,7 @@
   i32.store
   i32.const 13120
   i32.const 1104
-  i32.const 470
+  i32.const 475
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -23370,6 +23402,7 @@
   i32.store
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -23535,7 +23568,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 125
+   i32.const 129
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -23791,7 +23824,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 222
+   i32.const 227
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23879,7 +23912,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 269
+   i32.const 274
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24058,7 +24091,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 328
+   i32.const 333
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24168,6 +24201,7 @@
   i32.const 1
   i32.add
   local.tee $2
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -24766,7 +24800,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 125
+   i32.const 129
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -24786,7 +24820,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 129
+   i32.const 133
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -25163,7 +25197,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 269
+   i32.const 274
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -25383,7 +25417,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 328
+   i32.const 333
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -25529,6 +25563,7 @@
   i32.add
   local.tee $2
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -21411,12 +21411,12 @@
   i32.load offset=4
   local.set $6
   loop $for-loop|0
-   local.get $3
+   local.get $2
    local.get $5
    i32.lt_s
    if
     local.get $6
-    local.get $3
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -21428,29 +21428,24 @@
     else
      i32.const 0
     end
-    local.get $2
-    i32.add
-    local.set $2
     local.get $3
-    i32.const 1
     i32.add
     local.set $3
+    local.get $2
+    i32.const 1
+    i32.add
+    local.set $2
     br $for-loop|0
    end
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.const 8
-  local.get $2
-  i32.const 8
-  i32.gt_s
-  select
+  local.get $3
   i32.const 2
   i32.shl
-  local.tee $4
+  local.tee $2
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $4
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -21459,19 +21454,19 @@
   local.tee $0
   i32.store offset=4
   local.get $0
-  local.get $2
+  local.get $3
   i32.store offset=12
   local.get $0
-  local.get $4
+  local.get $2
   i32.store offset=8
   local.get $0
-  local.get $3
+  local.get $4
   i32.store offset=4
   local.get $0
-  local.get $3
+  local.get $4
   i32.store
   local.get $0
-  local.get $3
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__link
   i32.const 0
@@ -21487,19 +21482,19 @@
     i32.shl
     i32.add
     i32.load
-    local.tee $4
+    local.tee $3
     if
      local.get $1
-     local.get $3
+     local.get $4
      i32.add
-     local.get $4
+     local.get $3
      i32.load offset=4
-     local.get $4
+     local.get $3
      i32.load offset=8
-     local.tee $4
+     local.tee $3
      call $~lib/memory/memory.copy
      local.get $1
-     local.get $4
+     local.get $3
      i32.add
      local.set $1
     end
@@ -21568,17 +21563,12 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.const 8
-  local.get $4
-  i32.const 8
-  i32.gt_s
-  select
   i32.const 2
   i32.shl
-  local.tee $0
+  local.tee $2
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 16
@@ -21590,35 +21580,35 @@
   local.get $4
   i32.store offset=12
   local.get $3
-  local.get $0
+  local.get $2
   i32.store offset=8
   local.get $3
-  local.get $2
+  local.get $0
   i32.store offset=4
   local.get $3
-  local.get $2
+  local.get $0
   i32.store
   local.get $3
-  local.get $2
+  local.get $0
   i32.const 0
   call $~lib/rt/itcms/__link
   i32.const 0
-  local.set $0
+  local.set $2
   loop $for-loop|1
-   local.get $0
+   local.get $2
    local.get $6
    i32.lt_s
    if
     local.get $7
-    local.get $0
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
     local.tee $5
     if
+     local.get $0
      local.get $1
-     local.get $2
      i32.add
      local.get $5
      i32.load offset=4
@@ -21631,33 +21621,33 @@
      i32.add
      local.set $1
     end
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|1
    end
   end
   i32.const 0
-  local.set $0
+  local.set $2
   loop $for-loop|2
-   local.get $0
+   local.get $2
    local.get $4
    i32.lt_s
    if
-    local.get $2
-    local.get $2
     local.get $0
+    local.get $0
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $0
+    local.get $2
     i32.const 1
     i32.add
-    local.set $0
+    local.set $2
     br $for-loop|2
    end
   end

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -10,13 +10,13 @@
  (type $f32_f32_=>_i32 (func (param f32 f32) (result i32)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $none_=>_f64 (func (result f64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
  (type $i64_=>_none (func (param i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
@@ -2711,7 +2711,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2849,7 +2849,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2907,16 +2907,14 @@
   end
   i32.const 1
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2936,30 +2934,53 @@
    end
    local.get $0
    i32.load
-   local.tee $6
-   local.set $3
-   block $__inlined_func$~lib/rt/itcms/__renew
+   local.set $4
+   i32.const 8
+   local.get $1
+   local.get $1
+   i32.const 8
+   i32.lt_u
+   select
+   local.get $2
+   i32.shl
+   local.set $5
+   local.get $3
+   if
+    local.get $1
     i32.const 1
     i32.const 32
-    i32.const 8
-    local.get $1
-    local.get $1
-    i32.const 8
-    i32.lt_u
-    select
-    local.get $2
-    i32.shl
+    local.get $5
     i32.const 1
     i32.sub
     i32.clz
     i32.sub
     i32.shl
-    local.tee $7
-    local.tee $4
-    local.get $6
+    local.tee $1
+    i32.const 1073741820
+    local.get $1
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $5
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 1056
+     i32.const 1104
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $5
+    local.get $4
+    local.tee $1
     i32.const 20
     i32.sub
-    local.tee $2
+    local.tee $3
     i32.load
     i32.const -4
     i32.and
@@ -2967,39 +2988,39 @@
     i32.sub
     i32.le_u
     if
-     local.get $2
-     local.get $4
-     i32.store offset=16
      local.get $3
-     local.set $1
+     local.get $5
+     i32.store offset=16
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $4
-    local.get $2
+    local.get $5
+    local.get $3
     i32.load offset=12
     call $~lib/rt/itcms/__new
-    local.tee $1
-    local.get $3
-    local.get $4
-    local.get $2
-    i32.load offset=16
     local.tee $2
-    local.get $2
-    local.get $4
+    local.get $1
+    local.get $5
+    local.get $3
+    i32.load offset=16
+    local.tee $1
+    local.get $1
+    local.get $5
     i32.gt_u
     select
     call $~lib/memory/memory.copy
+    local.get $2
+    local.set $1
    end
    local.get $1
-   local.get $5
+   local.get $6
    i32.add
    i32.const 0
-   local.get $7
    local.get $5
+   local.get $6
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
@@ -3014,7 +3035,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $7
+   local.get $5
    i32.store offset=8
   end
  )
@@ -3029,6 +3050,7 @@
   i32.add
   local.tee $2
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
@@ -3051,7 +3073,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3075,7 +3097,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 280
+   i32.const 285
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -3112,6 +3134,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -3135,7 +3158,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 136
+   i32.const 141
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -3309,6 +3332,7 @@
   i32.add
   local.tee $2
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
@@ -3477,7 +3501,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3488,6 +3512,7 @@
    i32.add
    local.tee $3
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
@@ -3909,7 +3934,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5046,7 +5071,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5914,7 +5939,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5925,6 +5950,7 @@
    i32.add
    local.tee $3
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
@@ -7952,6 +7978,7 @@
   i32.add
   local.tee $2
   i32.const 0
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $3
   local.get $0
@@ -8441,6 +8468,7 @@
   i32.add
   local.tee $2
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
@@ -8529,7 +8557,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8646,7 +8674,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12094,7 +12122,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 339
+   i32.const 344
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -18578,7 +18606,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18754,7 +18782,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 233
+   i32.const 238
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19107,7 +19135,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19127,7 +19155,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -19246,7 +19274,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19636,7 +19664,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21958,7 +21986,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 233
+   i32.const 238
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22500,7 +22528,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 136
+   i32.const 141
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -22758,7 +22786,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 233
+   i32.const 238
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22851,7 +22879,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 280
+   i32.const 285
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23037,7 +23065,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 339
+   i32.const 344
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23357,7 +23385,7 @@
   i32.store
   i32.const 13120
   i32.const 1104
-  i32.const 481
+  i32.const 486
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -23406,6 +23434,7 @@
   i32.store
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
@@ -23571,7 +23600,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 136
+   i32.const 141
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -23827,7 +23856,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 233
+   i32.const 238
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23915,7 +23944,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 280
+   i32.const 285
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24094,7 +24123,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 339
+   i32.const 344
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24205,6 +24234,7 @@
   i32.add
   local.tee $2
   i32.const 0
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
@@ -24802,7 +24832,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 136
+   i32.const 141
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -24822,7 +24852,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 140
+   i32.const 145
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -25199,7 +25229,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 280
+   i32.const 285
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -25419,7 +25449,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 339
+   i32.const 344
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -25565,6 +25595,7 @@
   i32.add
   local.tee $2
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -10,13 +10,13 @@
  (type $f32_f32_=>_i32 (func (param f32 f32) (result i32)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $none_=>_f64 (func (result f64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
  (type $i64_=>_none (func (param i64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_i32_i64_i32_i64_i32_=>_i32 (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
@@ -2711,7 +2711,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2849,7 +2849,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2907,7 +2907,8 @@
   end
   i32.const 1
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2915,7 +2916,7 @@
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2928,24 +2929,33 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.tee $7
-   local.set $4
+   local.tee $6
+   local.set $3
    block $__inlined_func$~lib/rt/itcms/__renew
+    i32.const 1
+    i32.const 32
     local.get $1
     local.get $2
-    local.get $3
-    i32.add
     i32.shl
-    local.tee $3
-    local.tee $5
-    local.get $7
+    local.tee $1
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 8
+    local.get $1
+    select
+    local.tee $7
+    local.tee $4
+    local.get $6
     i32.const 20
     i32.sub
     local.tee $2
@@ -2957,38 +2967,38 @@
     i32.le_u
     if
      local.get $2
-     local.get $5
-     i32.store offset=16
      local.get $4
+     i32.store offset=16
+     local.get $3
      local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $5
+    local.get $4
     local.get $2
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $1
+    local.get $3
     local.get $4
-    local.get $5
     local.get $2
     i32.load offset=16
     local.tee $2
     local.get $2
-    local.get $5
+    local.get $4
     i32.gt_u
     select
     call $~lib/memory/memory.copy
    end
    local.get $1
-   local.get $6
+   local.get $5
    i32.add
    i32.const 0
-   local.get $3
-   local.get $6
+   local.get $7
+   local.get $5
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $7
+   local.get $6
    i32.ne
    if
     local.get $0
@@ -3003,7 +3013,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $3
+   local.get $7
    i32.store offset=8
   end
  )
@@ -3018,7 +3028,6 @@
   i32.add
   local.tee $2
   i32.const 2
-  i32.const 1
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -3041,7 +3050,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3065,7 +3074,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 274
+   i32.const 279
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -3102,7 +3111,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -3126,7 +3134,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 129
+   i32.const 134
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -3300,7 +3308,6 @@
   i32.add
   local.tee $2
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -3469,7 +3476,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3480,7 +3487,6 @@
    i32.add
    local.tee $3
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -3902,7 +3908,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5039,7 +5045,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5907,7 +5913,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5918,7 +5924,6 @@
    i32.add
    local.tee $3
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -7946,7 +7951,6 @@
   i32.add
   local.tee $2
   i32.const 0
-  i32.const 1
   call $~lib/array/ensureSize
   local.get $3
   local.get $0
@@ -8436,7 +8440,6 @@
   i32.add
   local.tee $2
   i32.const 2
-  i32.const 1
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -8525,7 +8528,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8642,7 +8645,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12090,7 +12093,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 333
+   i32.const 338
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -18574,7 +18577,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18750,7 +18753,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 227
+   i32.const 232
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19103,7 +19106,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19123,7 +19126,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -19242,7 +19245,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -19632,7 +19635,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21954,7 +21957,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 227
+   i32.const 232
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22496,7 +22499,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 129
+   i32.const 134
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -22754,7 +22757,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 227
+   i32.const 232
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22847,7 +22850,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 274
+   i32.const 279
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23033,7 +23036,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 333
+   i32.const 338
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -23353,7 +23356,7 @@
   i32.store
   i32.const 13120
   i32.const 1104
-  i32.const 475
+  i32.const 480
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -23402,7 +23405,6 @@
   i32.store
   local.get $0
   local.get $1
-  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -23568,7 +23570,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 129
+   i32.const 134
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -23824,7 +23826,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 227
+   i32.const 232
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23912,7 +23914,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 274
+   i32.const 279
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24091,7 +24093,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 333
+   i32.const 338
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -24201,7 +24203,6 @@
   i32.const 1
   i32.add
   local.tee $2
-  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -24800,7 +24801,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 129
+   i32.const 134
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -24820,7 +24821,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 133
+   i32.const 138
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -25197,7 +25198,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 274
+   i32.const 279
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -25417,7 +25418,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 333
+   i32.const 338
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -25563,7 +25564,6 @@
   i32.add
   local.tee $2
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4

--- a/tests/compiler/std/array.ts
+++ b/tests/compiler/std/array.ts
@@ -95,37 +95,37 @@ class Ref {
 
 {
   assert(arr.length == 0);
-  assert(internalCapacity<i32>(arr) == 0);
+  assert(internalCapacity<i32>(arr) == 8);
 
   arr.push(42);
 
   assert(arr[0] == 42);
   assert(arr.length == 1);
-  assert(internalCapacity<i32>(arr) == 1);
+  assert(internalCapacity<i32>(arr) == 8);
 
   let i = arr.pop();
 
   assert(i == 42);
   assert(arr.length == 0);
-  assert(internalCapacity<i32>(arr) == 1);
+  assert(internalCapacity<i32>(arr) == 8);
 
   arr.push(43);
 
   assert(arr.length == 1);
-  assert(internalCapacity<i32>(arr) == 1);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr[0] == 43);
 
   arr.push(44);
 
   assert(arr.length == 2);
-  assert(internalCapacity<i32>(arr) == 2);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr[0] == 43);
   assert(arr[1] == 44);
 
   arr.push(45);
 
   assert(arr.length == 3);
-  assert(internalCapacity<i32>(arr) == 3);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr[0] == 43);
   assert(arr[1] == 44);
   assert(arr[2] == 45);
@@ -156,12 +156,12 @@ class Ref {
   let other = new Array<i32>();
 
   let out = arr.concat(other);
-  assert(internalCapacity<i32>(arr) == 3);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr.length == 3);
   assert(out.length == 3);
 
   out.concat([]);
-  assert(internalCapacity<i32>(arr) == 3);
+  assert(internalCapacity<i32>(arr) == 8);
 
   assert(out[0] == 43);
   assert(out[1] == 44);
@@ -172,7 +172,7 @@ class Ref {
 
   out = arr.concat(other);
 
-  assert(internalCapacity<i32>(arr) == 3);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(other.length == 2);
   assert(out.length == 5);
   assert(out[0] == 43);
@@ -231,7 +231,7 @@ class Ref {
   arr.unshift(42);
 
   assert(arr.length == 4);
-  assert(internalCapacity<i32>(arr) == 4);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr[0] == 42);
   assert(arr[1] == 43);
   assert(arr[2] == 44);
@@ -240,7 +240,7 @@ class Ref {
   arr.unshift(41);
 
   assert(arr.length == 5);
-  assert(internalCapacity<i32>(arr) == 5);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr[0] == 41);
   assert(arr[1] == 42);
   assert(arr[2] == 43);
@@ -256,7 +256,7 @@ var i: i32;
 
   assert(i == 41);
   assert(arr.length == 4);
-  assert(internalCapacity<i32>(arr) == 5);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr[0] == 42);
   assert(arr[1] == 43);
   assert(arr[2] == 44);
@@ -266,7 +266,7 @@ var i: i32;
 
   assert(i == 45);
   assert(arr.length == 3);
-  assert(internalCapacity<i32>(arr) == 5);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr[0] == 42);
   assert(arr[1] == 43);
   assert(arr[2] == 44);
@@ -309,7 +309,7 @@ var i: i32;
   arr.reverse();
 
   assert(arr.length == 3);
-  assert(internalCapacity<i32>(arr) == 5);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr[0] == 44);
   assert(arr[1] == 43);
   assert(arr[2] == 42);
@@ -407,7 +407,7 @@ var i: i32;
   arr.splice(1, 1);
 
   assert(arr.length == 4);
-  assert(internalCapacity<i32>(arr) == 5);
+  assert(internalCapacity<i32>(arr) == 8);
   assert(arr[0] == 44);
   assert(arr[1] == 42);
 }

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -4269,7 +4269,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4445,7 +4445,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4573,7 +4573,7 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4668,7 +4668,7 @@
   local.get $0
   local.get $3
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   i32.const 0
   drop
   local.get $0
@@ -4693,7 +4693,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4768,7 +4768,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<std/array/Ref>#set:length_
@@ -4798,7 +4798,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 134
+   i32.const 135
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -5010,7 +5010,7 @@
   local.get $0
   local.get $2
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
   local.set $3
@@ -5660,7 +5660,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5670,7 +5670,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -6143,7 +6143,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7708,7 +7708,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8898,7 +8898,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8908,7 +8908,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -9097,7 +9097,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9107,7 +9107,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -9684,7 +9684,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9694,7 +9694,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -12948,7 +12948,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u32>#set:length_
@@ -13091,7 +13091,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13101,7 +13101,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -13134,7 +13134,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 134
+   i32.const 135
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -13308,7 +13308,7 @@
   local.get $0
   local.get $3
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   i32.const 0
   drop
   local.get $0
@@ -13646,7 +13646,7 @@
   local.get $0
   local.get $2
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
   local.set $3
@@ -13787,7 +13787,7 @@
   local.get $0
   local.get $1
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u8>#set:length_
@@ -13930,7 +13930,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13940,7 +13940,7 @@
    i32.const 1
    i32.add
    i32.const 0
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -13973,7 +13973,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 134
+   i32.const 135
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -14151,7 +14151,7 @@
   local.get $0
   local.get $3
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   i32.const 0
   drop
   local.get $0
@@ -14489,7 +14489,7 @@
   local.get $0
   local.get $2
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
   local.set $3
@@ -15060,7 +15060,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String>#set:length_
@@ -15188,7 +15188,7 @@
   local.get $0
   local.get $3
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   i32.const 1
   drop
   local.get $0
@@ -15347,7 +15347,7 @@
   local.get $0
   local.get $2
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
   local.set $3
@@ -27820,7 +27820,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28547,7 +28547,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -28572,7 +28572,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -28727,7 +28727,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29336,7 +29336,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29556,7 +29556,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29581,7 +29581,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29638,7 +29638,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29827,7 +29827,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29852,7 +29852,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29977,7 +29977,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30049,7 +30049,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -30319,7 +30319,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30344,7 +30344,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -33401,7 +33401,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33926,7 +33926,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34471,7 +34471,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 134
+   i32.const 135
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -34496,7 +34496,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 138
+   i32.const 139
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -4269,7 +4269,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4445,7 +4445,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4595,7 +4595,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -4603,55 +4603,55 @@
    local.get $0
    i32.load
    local.set $4
+   i32.const 8
+   local.tee $5
    local.get $1
+   local.tee $6
+   local.get $5
+   local.get $6
+   i32.gt_u
+   select
    local.get $2
    i32.shl
-   local.set $5
-   local.get $5
-   i32.const 0
-   i32.eq
-   if (result i32)
-    i32.const 8
-   else
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-   end
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
    local.set $6
+   i32.const 1
+   i32.const 32
    local.get $6
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.set $6
+   local.get $4
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $5
+   local.get $5
    local.get $3
    i32.add
    i32.const 0
-   local.get $5
+   local.get $6
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $6
+   local.get $5
    local.get $4
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $5
     i32.store
     local.get $0
-    local.get $6
+    local.get $5
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $5
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -4693,7 +4693,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4722,7 +4722,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 279
+   i32.const 280
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -4798,7 +4798,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 135
+   i32.const 136
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -5048,7 +5048,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 338
+   i32.const 339
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -5660,7 +5660,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6143,7 +6143,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7708,7 +7708,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8898,7 +8898,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9097,7 +9097,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9684,7 +9684,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13091,7 +13091,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13134,7 +13134,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 135
+   i32.const 136
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -13464,7 +13464,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 279
+   i32.const 280
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13546,7 +13546,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 338
+   i32.const 339
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13730,7 +13730,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 480
+  i32.const 481
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -13930,7 +13930,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13973,7 +13973,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 135
+   i32.const 136
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -14307,7 +14307,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 279
+   i32.const 280
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14389,7 +14389,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 338
+   i32.const 339
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -15027,7 +15027,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 480
+  i32.const 481
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -15408,7 +15408,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 480
+  i32.const 481
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -27820,7 +27820,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28123,7 +28123,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 232
+   i32.const 233
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28547,7 +28547,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -28572,7 +28572,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -28727,7 +28727,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29336,7 +29336,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29556,7 +29556,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29581,7 +29581,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29638,7 +29638,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29827,7 +29827,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29852,7 +29852,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29977,7 +29977,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30049,7 +30049,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -30319,7 +30319,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30344,7 +30344,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -33401,7 +33401,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33520,7 +33520,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 232
+   i32.const 233
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33926,7 +33926,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34045,7 +34045,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 232
+   i32.const 233
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34471,7 +34471,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 135
+   i32.const 136
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -34496,7 +34496,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 139
+   i32.const 140
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -34554,7 +34554,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 232
+   i32.const 233
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34679,7 +34679,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 279
+   i32.const 280
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -34813,7 +34813,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 338
+   i32.const 339
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -11,6 +11,7 @@
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_f64 (func (result f64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
@@ -18,7 +19,6 @@
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
  (type $i64_=>_none (func (param i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
@@ -4269,7 +4269,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4445,7 +4445,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4573,16 +4573,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -4595,47 +4595,49 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    local.get $1
    local.get $2
-   i32.shl
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
-   local.set $6
-   local.get $6
    local.get $3
    i32.add
-   i32.const 0
+   i32.shl
+   local.set $6
    local.get $5
-   local.get $3
-   i32.sub
-   call $~lib/memory/memory.fill
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $7
+   local.get $7
+   local.get $4
+   i32.add
+   i32.const 0
    local.get $6
    local.get $4
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $7
+   local.get $5
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.store
     local.get $0
-    local.get $6
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -4652,6 +4654,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureSize
   i32.const 0
   drop
@@ -4677,7 +4680,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4706,7 +4709,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 269
+   i32.const 274
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -4752,6 +4755,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -4782,7 +4786,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 125
+   i32.const 129
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -4994,6 +4998,7 @@
   local.get $0
   local.get $2
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -5032,7 +5037,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 328
+   i32.const 333
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -5644,7 +5649,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5654,6 +5659,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -6127,7 +6133,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7692,7 +7698,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8882,7 +8888,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8892,6 +8898,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -9081,7 +9088,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9091,6 +9098,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -9668,7 +9676,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9678,6 +9686,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -12932,6 +12941,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -13075,7 +13085,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13085,6 +13095,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -13118,7 +13129,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 125
+   i32.const 129
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -13292,6 +13303,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureSize
   i32.const 0
   drop
@@ -13448,7 +13460,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 269
+   i32.const 274
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13530,7 +13542,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 328
+   i32.const 333
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13630,6 +13642,7 @@
   local.get $0
   local.get $2
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -13714,7 +13727,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 470
+  i32.const 475
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -13770,6 +13783,7 @@
  (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -13914,7 +13928,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13924,6 +13938,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -13957,7 +13972,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 125
+   i32.const 129
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -14135,6 +14150,7 @@
   local.get $0
   local.get $3
   i32.const 0
+  i32.const 1
   call $~lib/array/ensureSize
   i32.const 0
   drop
@@ -14291,7 +14307,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 269
+   i32.const 274
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14373,7 +14389,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 328
+   i32.const 333
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14472,6 +14488,7 @@
   local.set $2
   local.get $0
   local.get $2
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -15011,7 +15028,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 470
+  i32.const 475
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -15044,6 +15061,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -15172,6 +15190,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureSize
   i32.const 1
   drop
@@ -15331,6 +15350,7 @@
   local.get $0
   local.get $2
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -15392,7 +15412,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 470
+  i32.const 475
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -19615,7 +19635,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 0
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -19679,7 +19699,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 1
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -19735,7 +19755,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 1
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -19780,7 +19800,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 1
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -19844,7 +19864,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 2
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -19927,7 +19947,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 3
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -20128,7 +20148,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 3
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -20190,7 +20210,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 3
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -20269,7 +20289,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 3
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -20952,7 +20972,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 4
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -21073,7 +21093,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -21224,7 +21244,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -21356,7 +21376,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -21701,7 +21721,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -22456,7 +22476,7 @@
   i32.store
   local.get $16
   call $std/array/internalCapacity<i32>
-  i32.const 5
+  i32.const 8
   i32.eq
   i32.eqz
   if
@@ -27764,6 +27784,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -27802,44 +27824,51 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i32>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i32>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i32>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $std/array/Ref#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -28098,7 +28127,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 222
+   i32.const 227
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28522,7 +28551,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -28547,7 +28576,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -28702,7 +28731,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29271,6 +29300,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -29309,44 +29340,51 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<~lib/array/Array<i32>>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<~lib/array/Array<i32>>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<~lib/array/Array<i32>>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/array/Array<i32>>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $std/array/createReverseOrderedNestedArray (param $0 i32) (result i32)
   (local $1 i32)
@@ -29522,7 +29560,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29547,7 +29585,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29564,6 +29602,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -29602,44 +29642,51 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<std/array/Proxy<i32>>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<std/array/Proxy<i32>>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<std/array/Proxy<i32>>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<std/array/Proxy<i32>>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $std/array/Proxy<i32>#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -29784,7 +29831,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29809,7 +29856,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29934,7 +29981,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29966,6 +30013,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -30004,44 +30053,51 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<~lib/string/String>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<~lib/string/String>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<~lib/string/String>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/string/String#charAt (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -30267,7 +30323,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30292,7 +30348,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -33309,6 +33365,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -33347,44 +33405,51 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u32>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u32>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u32>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u32>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $std/array/ArrayU32#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -33459,7 +33524,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 222
+   i32.const 227
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33825,6 +33890,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -33863,44 +33930,51 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 0
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u8>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u8>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u8>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u8>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $std/array/ArrayU8#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -33975,7 +34049,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 222
+   i32.const 227
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34401,7 +34475,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 125
+   i32.const 129
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -34426,7 +34500,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 129
+   i32.const 133
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -34484,7 +34558,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 222
+   i32.const 227
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34609,7 +34683,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 269
+   i32.const 274
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -34743,7 +34817,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 328
+   i32.const 333
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -33117,13 +33117,6 @@
    end
   end
   local.get $3
-  local.tee $6
-  i32.const 8
-  local.tee $4
-  local.get $6
-  local.get $4
-  i32.gt_s
-  select
   i32.const 2
   i32.shl
   local.set $7
@@ -33158,35 +33151,35 @@
   i32.const 0
   local.set $10
   i32.const 0
-  local.set $6
+  local.set $4
   loop $for-loop|1
-   local.get $6
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     block $for-continue|1
      local.get $2
-     local.get $6
+     local.get $4
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.set $5
-     local.get $5
+     local.set $6
+     local.get $6
      i32.const 0
      i32.eq
      if
       br $for-continue|1
      end
-     local.get $5
+     local.get $6
      i32.load offset=8
      local.set $11
      local.get $8
      local.get $10
      i32.add
-     local.get $5
+     local.get $6
      i32.load offset=4
      local.get $11
      call $~lib/memory/memory.copy
@@ -33195,10 +33188,10 @@
      i32.add
      local.set $10
     end
-    local.get $6
+    local.get $4
     i32.const 1
     i32.add
-    local.set $6
+    local.set $4
     br $for-loop|1
    end
   end
@@ -33280,13 +33273,6 @@
    end
   end
   local.get $3
-  local.tee $6
-  i32.const 8
-  local.tee $4
-  local.get $6
-  local.get $4
-  i32.gt_s
-  select
   i32.const 2
   i32.shl
   local.set $7
@@ -33321,35 +33307,35 @@
   i32.const 0
   local.set $10
   i32.const 0
-  local.set $6
+  local.set $4
   loop $for-loop|1
-   local.get $6
+   local.get $4
    local.get $1
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     block $for-continue|1
      local.get $2
-     local.get $6
+     local.get $4
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.set $5
-     local.get $5
+     local.set $6
+     local.get $6
      i32.const 0
      i32.eq
      if
       br $for-continue|1
      end
-     local.get $5
+     local.get $6
      i32.load offset=8
      local.set $11
      local.get $8
      local.get $10
      i32.add
-     local.get $5
+     local.get $6
      i32.load offset=4
      local.get $11
      call $~lib/memory/memory.copy
@@ -33358,26 +33344,26 @@
      i32.add
      local.set $10
     end
-    local.get $6
+    local.get $4
     i32.const 1
     i32.add
-    local.set $6
+    local.set $4
     br $for-loop|1
    end
   end
   i32.const 1
   drop
   i32.const 0
-  local.set $6
+  local.set $4
   loop $for-loop|2
-   local.get $6
+   local.get $4
    local.get $3
    i32.lt_s
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    if
     local.get $8
-    local.get $6
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
@@ -33387,10 +33373,10 @@
     local.get $11
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $6
+    local.get $4
     i32.const 1
     i32.add
-    local.set $6
+    local.set $4
     br $for-loop|2
    end
   end

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -4269,7 +4269,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4445,7 +4445,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4635,19 +4635,6 @@
     i32.lt_u
     select
     local.set $6
-    local.get $1
-    local.get $6
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 32
-     i32.const 80
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
    end
    local.get $5
    local.get $6
@@ -4720,7 +4707,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4749,7 +4736,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 285
+   i32.const 284
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -4826,7 +4813,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 141
+   i32.const 140
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -5077,7 +5064,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 344
+   i32.const 343
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -5689,7 +5676,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6173,7 +6160,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7738,7 +7725,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8928,7 +8915,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9128,7 +9115,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9716,7 +9703,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13125,7 +13112,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13169,7 +13156,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 141
+   i32.const 140
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -13500,7 +13487,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 285
+   i32.const 284
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13582,7 +13569,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 344
+   i32.const 343
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13767,7 +13754,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 486
+  i32.const 485
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -13968,7 +13955,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -14012,7 +13999,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 141
+   i32.const 140
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -14347,7 +14334,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 285
+   i32.const 284
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14429,7 +14416,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 344
+   i32.const 343
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -15068,7 +15055,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 486
+  i32.const 485
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -15452,7 +15439,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 486
+  i32.const 485
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -27864,7 +27851,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28167,7 +28154,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 238
+   i32.const 237
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28591,7 +28578,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -28616,7 +28603,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -28771,7 +28758,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29380,7 +29367,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29600,7 +29587,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29625,7 +29612,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29682,7 +29669,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29871,7 +29858,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29896,7 +29883,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -30021,7 +30008,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30093,7 +30080,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -30363,7 +30350,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30388,7 +30375,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -33445,7 +33432,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33564,7 +33551,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 238
+   i32.const 237
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33970,7 +33957,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34089,7 +34076,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 238
+   i32.const 237
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34515,7 +34502,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 141
+   i32.const 140
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -34540,7 +34527,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 145
+   i32.const 144
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -34598,7 +34585,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 238
+   i32.const 237
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34723,7 +34710,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 285
+   i32.const 284
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -34857,7 +34844,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 344
+   i32.const 343
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -11,6 +11,7 @@
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_f64 (func (result f64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
@@ -18,7 +19,6 @@
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
  (type $i64_=>_none (func (param i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
@@ -4269,7 +4269,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4445,7 +4445,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4573,16 +4573,17 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -4602,51 +4603,76 @@
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    i32.const 8
-   local.tee $5
-   local.get $1
    local.tee $6
-   local.get $5
+   local.get $1
+   local.tee $7
    local.get $6
+   local.get $7
    i32.gt_u
    select
    local.get $2
    i32.shl
    local.set $6
-   i32.const 1
-   i32.const 32
-   local.get $6
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.set $6
-   local.get $4
+   local.get $3
+   if
+    local.get $6
+    local.set $7
+    i32.const 1
+    i32.const 32
+    local.get $7
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $7
+    i32.const 1073741820
+    local.tee $8
+    local.get $7
+    local.get $8
+    i32.lt_u
+    select
+    local.set $6
+    local.get $1
+    local.get $6
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 32
+     i32.const 80
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $5
-   local.get $5
-   local.get $3
+   local.set $7
+   local.get $7
+   local.get $4
    i32.add
    i32.const 0
    local.get $6
-   local.get $3
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $7
    local.get $5
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $5
+    local.get $7
     i32.store
     local.get $0
-    local.get $5
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $5
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -4668,6 +4694,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   i32.const 0
   drop
@@ -4693,7 +4720,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4722,7 +4749,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 280
+   i32.const 285
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -4768,6 +4795,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -4798,7 +4826,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 136
+   i32.const 141
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -5010,6 +5038,7 @@
   local.get $0
   local.get $2
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
@@ -5048,7 +5077,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 339
+   i32.const 344
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -5660,7 +5689,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5670,6 +5699,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -6143,7 +6173,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7708,7 +7738,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8898,7 +8928,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8908,6 +8938,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -9097,7 +9128,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9107,6 +9138,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -9684,7 +9716,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9694,6 +9726,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -12948,6 +12981,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -13091,7 +13125,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13101,6 +13135,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -13134,7 +13169,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 136
+   i32.const 141
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -13308,6 +13343,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   i32.const 0
   drop
@@ -13464,7 +13500,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 280
+   i32.const 285
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13546,7 +13582,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 339
+   i32.const 344
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13646,6 +13682,7 @@
   local.get $0
   local.get $2
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
@@ -13730,7 +13767,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 481
+  i32.const 486
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -13786,6 +13823,7 @@
  (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
@@ -13930,7 +13968,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13940,6 +13978,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -13973,7 +14012,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 136
+   i32.const 141
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -14151,6 +14190,7 @@
   local.get $0
   local.get $3
   i32.const 0
+  i32.const 1
   call $~lib/array/ensureCapacity
   i32.const 0
   drop
@@ -14307,7 +14347,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 280
+   i32.const 285
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14389,7 +14429,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 339
+   i32.const 344
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14489,6 +14529,7 @@
   local.get $0
   local.get $2
   i32.const 0
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
@@ -15027,7 +15068,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 481
+  i32.const 486
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -15060,6 +15101,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -15188,6 +15230,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   i32.const 1
   drop
@@ -15347,6 +15390,7 @@
   local.get $0
   local.get $2
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
@@ -15408,7 +15452,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 481
+  i32.const 486
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -27820,7 +27864,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28123,7 +28167,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 233
+   i32.const 238
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28547,7 +28591,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -28572,7 +28616,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -28727,7 +28771,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29336,7 +29380,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29556,7 +29600,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29581,7 +29625,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29638,7 +29682,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29827,7 +29871,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29852,7 +29896,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29977,7 +30021,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30049,7 +30093,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -30319,7 +30363,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30344,7 +30388,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -33401,7 +33445,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33520,7 +33564,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 233
+   i32.const 238
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33926,7 +33970,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34045,7 +34089,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 233
+   i32.const 238
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34471,7 +34515,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 136
+   i32.const 141
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -34496,7 +34540,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 140
+   i32.const 145
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -34554,7 +34598,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 233
+   i32.const 238
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34679,7 +34723,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 280
+   i32.const 285
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -34813,7 +34857,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 339
+   i32.const 344
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -4269,7 +4269,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4445,7 +4445,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4596,7 +4596,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -4617,15 +4617,8 @@
    local.set $6
    local.get $3
    if
-    local.get $6
-    local.set $7
+    local.get $4
     i32.const 1
-    i32.const 32
-    local.get $7
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
     local.tee $7
     i32.const 1073741820
@@ -4634,13 +4627,20 @@
     local.get $8
     i32.lt_u
     select
+    local.tee $8
+    local.get $6
+    local.tee $7
+    local.get $8
+    local.get $7
+    i32.gt_u
+    select
     local.set $6
    end
    local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    local.get $4
    i32.add
    i32.const 0
@@ -4648,18 +4648,18 @@
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
+   local.get $8
    local.get $5
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $8
     i32.store
     local.get $0
-    local.get $7
+    local.get $8
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -4707,7 +4707,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4736,7 +4736,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 284
+   i32.const 276
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -4813,7 +4813,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 140
+   i32.const 132
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -5064,7 +5064,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 343
+   i32.const 335
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -5676,7 +5676,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6160,7 +6160,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7725,7 +7725,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8915,7 +8915,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9115,7 +9115,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9703,7 +9703,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13112,7 +13112,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13156,7 +13156,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 140
+   i32.const 132
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -13487,7 +13487,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 284
+   i32.const 276
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13569,7 +13569,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 343
+   i32.const 335
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13754,7 +13754,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 485
+  i32.const 477
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -13955,7 +13955,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13999,7 +13999,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 140
+   i32.const 132
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -14334,7 +14334,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 284
+   i32.const 276
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14416,7 +14416,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 343
+   i32.const 335
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -15055,7 +15055,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 485
+  i32.const 477
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -15439,7 +15439,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 485
+  i32.const 477
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -27851,7 +27851,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28154,7 +28154,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 237
+   i32.const 229
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28578,7 +28578,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -28603,7 +28603,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -28758,7 +28758,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29367,7 +29367,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29587,7 +29587,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29612,7 +29612,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29669,7 +29669,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29858,7 +29858,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29883,7 +29883,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -30008,7 +30008,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30080,7 +30080,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -30350,7 +30350,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30375,7 +30375,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -33446,7 +33446,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33565,7 +33565,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 237
+   i32.const 229
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33971,7 +33971,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34090,7 +34090,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 237
+   i32.const 229
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34516,7 +34516,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 140
+   i32.const 132
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -34541,7 +34541,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 144
+   i32.const 136
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -34599,7 +34599,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 237
+   i32.const 229
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34724,7 +34724,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 284
+   i32.const 276
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -34858,7 +34858,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 343
+   i32.const 335
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -4604,9 +4604,9 @@
    local.get $0
    i32.load
    local.set $5
-   i32.const 8
-   local.tee $6
    local.get $1
+   local.tee $6
+   i32.const 8
    local.tee $7
    local.get $6
    local.get $7
@@ -27856,9 +27856,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -29372,9 +29372,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -29674,9 +29674,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -30085,9 +30085,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -33117,6 +33117,13 @@
    end
   end
   local.get $3
+  local.tee $6
+  i32.const 8
+  local.tee $4
+  local.get $6
+  local.get $4
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
   local.set $7
@@ -33151,35 +33158,35 @@
   i32.const 0
   local.set $10
   i32.const 0
-  local.set $4
+  local.set $6
   loop $for-loop|1
-   local.get $4
+   local.get $6
    local.get $1
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $4
+   local.get $4
    if
     block $for-continue|1
      local.get $2
-     local.get $4
+     local.get $6
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.set $6
-     local.get $6
+     local.set $5
+     local.get $5
      i32.const 0
      i32.eq
      if
       br $for-continue|1
      end
-     local.get $6
+     local.get $5
      i32.load offset=8
      local.set $11
      local.get $8
      local.get $10
      i32.add
-     local.get $6
+     local.get $5
      i32.load offset=4
      local.get $11
      call $~lib/memory/memory.copy
@@ -33188,10 +33195,10 @@
      i32.add
      local.set $10
     end
-    local.get $4
+    local.get $6
     i32.const 1
     i32.add
-    local.set $4
+    local.set $6
     br $for-loop|1
    end
   end
@@ -33273,6 +33280,13 @@
    end
   end
   local.get $3
+  local.tee $6
+  i32.const 8
+  local.tee $4
+  local.get $6
+  local.get $4
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
   local.set $7
@@ -33307,35 +33321,35 @@
   i32.const 0
   local.set $10
   i32.const 0
-  local.set $4
+  local.set $6
   loop $for-loop|1
-   local.get $4
+   local.get $6
    local.get $1
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $4
+   local.get $4
    if
     block $for-continue|1
      local.get $2
-     local.get $4
+     local.get $6
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.set $6
-     local.get $6
+     local.set $5
+     local.get $5
      i32.const 0
      i32.eq
      if
       br $for-continue|1
      end
-     local.get $6
+     local.get $5
      i32.load offset=8
      local.set $11
      local.get $8
      local.get $10
      i32.add
-     local.get $6
+     local.get $5
      i32.load offset=4
      local.get $11
      call $~lib/memory/memory.copy
@@ -33344,26 +33358,26 @@
      i32.add
      local.set $10
     end
-    local.get $4
+    local.get $6
     i32.const 1
     i32.add
-    local.set $4
+    local.set $6
     br $for-loop|1
    end
   end
   i32.const 1
   drop
   i32.const 0
-  local.set $4
+  local.set $6
   loop $for-loop|2
-   local.get $4
+   local.get $6
    local.get $3
    i32.lt_s
-   local.set $5
-   local.get $5
+   local.set $4
+   local.get $4
    if
     local.get $8
-    local.get $4
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
@@ -33373,10 +33387,10 @@
     local.get $11
     i32.const 1
     call $~lib/rt/itcms/__link
-    local.get $4
+    local.get $6
     i32.const 1
     i32.add
-    local.set $4
+    local.set $6
     br $for-loop|2
    end
   end
@@ -33437,9 +33451,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -33962,9 +33976,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -11,7 +11,6 @@
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $none_=>_f64 (func (result f64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
@@ -19,6 +18,7 @@
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
  (type $i32_i32_i32_=>_f32 (func (param i32 i32 i32) (result f32)))
  (type $i64_=>_none (func (param i64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_i32_=>_none (func (param i32 i64 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
@@ -4269,7 +4269,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4445,7 +4445,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4573,16 +4573,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
-  local.get $4
+  local.get $3
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -4595,49 +4595,63 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $5
+   local.set $4
    local.get $1
    local.get $2
+   i32.shl
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 8
+   else
+    i32.const 1
+    i32.const 32
+    local.get $5
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+   end
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
    local.get $3
    i32.add
-   i32.shl
-   local.set $6
-   local.get $5
-   local.get $6
-   call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.add
    i32.const 0
-   local.get $6
-   local.get $4
+   local.get $5
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.store
     local.get $0
-    local.get $7
+    local.get $6
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.store offset=8
   end
  )
@@ -4654,7 +4668,6 @@
   local.get $0
   local.get $3
   i32.const 2
-  i32.const 1
   call $~lib/array/ensureSize
   i32.const 0
   drop
@@ -4680,7 +4693,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4709,7 +4722,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 274
+   i32.const 279
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -4755,7 +4768,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -4786,7 +4798,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 129
+   i32.const 134
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -4998,7 +5010,6 @@
   local.get $0
   local.get $2
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -5037,7 +5048,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 333
+   i32.const 338
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -5649,7 +5660,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5659,7 +5670,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -6133,7 +6143,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7698,7 +7708,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8888,7 +8898,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8898,7 +8908,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -9088,7 +9097,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9098,7 +9107,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -9676,7 +9684,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9686,7 +9694,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -12941,7 +12948,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -13085,7 +13091,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13095,7 +13101,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -13129,7 +13134,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 129
+   i32.const 134
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -13303,7 +13308,6 @@
   local.get $0
   local.get $3
   i32.const 2
-  i32.const 1
   call $~lib/array/ensureSize
   i32.const 0
   drop
@@ -13460,7 +13464,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 274
+   i32.const 279
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13542,7 +13546,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 333
+   i32.const 338
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13642,7 +13646,6 @@
   local.get $0
   local.get $2
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -13727,7 +13730,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 475
+  i32.const 480
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -13783,7 +13786,6 @@
  (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -13928,7 +13930,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13938,7 +13940,6 @@
    i32.const 1
    i32.add
    i32.const 0
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -13972,7 +13973,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 129
+   i32.const 134
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -14150,7 +14151,6 @@
   local.get $0
   local.get $3
   i32.const 0
-  i32.const 1
   call $~lib/array/ensureSize
   i32.const 0
   drop
@@ -14307,7 +14307,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 274
+   i32.const 279
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14389,7 +14389,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 333
+   i32.const 338
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14488,7 +14488,6 @@
   local.set $2
   local.get $0
   local.get $2
-  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -15028,7 +15027,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 475
+  i32.const 480
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -15061,7 +15060,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -15190,7 +15188,6 @@
   local.get $0
   local.get $3
   i32.const 2
-  i32.const 1
   call $~lib/array/ensureSize
   i32.const 1
   drop
@@ -15350,7 +15347,6 @@
   local.get $0
   local.get $2
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   i32.load offset=4
@@ -15412,7 +15408,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 475
+  i32.const 480
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -27824,7 +27820,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28127,7 +28123,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 227
+   i32.const 232
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28551,7 +28547,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -28576,7 +28572,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -28731,7 +28727,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29340,7 +29336,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29560,7 +29556,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29585,7 +29581,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29642,7 +29638,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29831,7 +29827,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29856,7 +29852,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29981,7 +29977,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30053,7 +30049,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -30323,7 +30319,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30348,7 +30344,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -33405,7 +33401,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33524,7 +33520,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 227
+   i32.const 232
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33930,7 +33926,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34049,7 +34045,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 227
+   i32.const 232
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34475,7 +34471,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 129
+   i32.const 134
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -34500,7 +34496,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 133
+   i32.const 138
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -34558,7 +34554,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 227
+   i32.const 232
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34683,7 +34679,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 274
+   i32.const 279
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -34817,7 +34813,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 333
+   i32.const 338
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -7684,7 +7684,7 @@
   if
    i32.const 1392
    i32.const 5040
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7704,7 +7704,7 @@
   if
    i32.const 5088
    i32.const 5040
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -3074,7 +3074,7 @@
    if
     i32.const 4992
     i32.const 5040
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -3084,9 +3084,20 @@
    local.tee $8
    local.set $2
    block $__inlined_func$~lib/rt/itcms/__renew
+    i32.const 1
+    i32.const 32
     local.get $3
-    i32.const 3
+    i32.const 2
     i32.shl
+    local.tee $3
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 8
+    local.get $3
+    select
     local.tee $9
     local.tee $4
     local.get $8
@@ -7673,7 +7684,7 @@
   if
    i32.const 1392
    i32.const 5040
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7693,7 +7704,7 @@
   if
    i32.const 5088
    i32.const 5040
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -3055,15 +3055,14 @@
   (local $10 i32)
   local.get $0
   i32.load offset=12
-  local.tee $10
+  local.tee $9
   i32.const 1
   i32.add
-  local.tee $6
-  local.set $3
-  local.get $6
+  local.tee $10
+  local.tee $3
   local.get $0
   i32.load offset=8
-  local.tee $7
+  local.tee $6
   i32.const 2
   i32.shr_u
   i32.gt_u
@@ -3074,33 +3073,34 @@
    if
     i32.const 4992
     i32.const 5040
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.tee $8
+   local.tee $7
    local.set $2
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
     i32.const 32
+    i32.const 8
     local.get $3
+    local.get $3
+    i32.const 8
+    i32.lt_u
+    select
     i32.const 2
     i32.shl
-    local.tee $3
     i32.const 1
     i32.sub
     i32.clz
     i32.sub
     i32.shl
-    i32.const 8
-    local.get $3
-    select
-    local.tee $9
+    local.tee $8
     local.tee $4
-    local.get $8
+    local.get $7
     i32.const 20
     i32.sub
     local.tee $5
@@ -3135,14 +3135,14 @@
     local.set $2
    end
    local.get $2
-   local.get $7
+   local.get $6
    i32.add
-   local.get $9
-   local.get $7
+   local.get $8
+   local.get $6
    i32.sub
    call $~lib/memory/memory.fill
    local.get $2
-   local.get $8
+   local.get $7
    i32.ne
    if
     local.get $0
@@ -3157,12 +3157,12 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $9
+   local.get $8
    i32.store offset=8
   end
   local.get $0
   i32.load offset=4
-  local.get $10
+  local.get $9
   i32.const 2
   i32.shl
   i32.add
@@ -3173,7 +3173,7 @@
   i32.const 1
   call $~lib/rt/itcms/__link
   local.get $0
-  local.get $6
+  local.get $10
   i32.store offset=12
  )
  (func $~lib/util/string/strtol<i32> (param $0 i32) (result i32)
@@ -7684,7 +7684,7 @@
   if
    i32.const 1392
    i32.const 5040
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7704,7 +7704,7 @@
   if
    i32.const 5088
    i32.const 5040
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -3043,13 +3043,23 @@
    end
   end
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  local.get $1
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  local.get $0
+  i32.load offset=12
+  local.tee $9
+  i32.const 1
+  i32.add
+  local.tee $10
+  local.tee $3
   local.get $0
   i32.load offset=8
   local.tee $6
@@ -3057,7 +3067,7 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $1
+   local.get $3
    i32.const 268435455
    i32.gt_u
    if
@@ -3070,45 +3080,33 @@
    end
    local.get $0
    i32.load
+   local.tee $7
    local.set $2
-   local.get $1
-   i32.const 1
-   i32.const 32
-   i32.const 8
-   local.get $1
-   local.get $1
-   i32.const 8
-   i32.lt_u
-   select
-   i32.const 2
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.tee $1
-   i32.const 1073741820
-   local.get $1
-   i32.const 1073741820
-   i32.lt_u
-   select
-   local.tee $4
-   i32.const 2
-   i32.shr_u
-   i32.gt_u
-   if
-    i32.const 4992
-    i32.const 5040
-    i32.const 30
-    i32.const 48
-    call $~lib/builtins/abort
-    unreachable
-   end
    block $__inlined_func$~lib/rt/itcms/__renew
-    local.get $4
-    local.get $2
-    local.tee $1
+    i32.const 1
+    i32.const 32
+    i32.const 8
+    local.get $3
+    local.get $3
+    i32.const 8
+    i32.lt_u
+    select
+    i32.const 2
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $3
+    i32.const 1073741820
+    local.get $3
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $8
+    local.tee $4
+    local.get $7
     i32.const 20
     i32.sub
     local.tee $5
@@ -3129,60 +3127,48 @@
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $3
-    local.get $1
+    local.get $2
     local.get $4
     local.get $5
     i32.load offset=16
-    local.tee $1
-    local.get $1
+    local.tee $2
+    local.get $2
     local.get $4
     i32.gt_u
     select
     call $~lib/memory/memory.copy
     local.get $3
-    local.set $1
+    local.set $2
    end
-   local.get $1
+   local.get $2
    local.get $6
    i32.add
-   local.get $4
+   local.get $8
    local.get $6
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $1
    local.get $2
+   local.get $7
    i32.ne
    if
     local.get $0
-    local.get $1
+    local.get $2
     i32.store
     local.get $0
-    local.get $1
+    local.get $2
     i32.store offset=4
     local.get $0
-    local.get $1
+    local.get $2
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $4
+   local.get $8
    i32.store offset=8
   end
- )
- (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $0
-  local.get $0
-  i32.load offset=12
-  local.tee $2
-  i32.const 1
-  i32.add
-  local.tee $3
-  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
-  local.get $2
+  local.get $9
   i32.const 2
   i32.shl
   i32.add
@@ -3193,7 +3179,7 @@
   i32.const 1
   call $~lib/rt/itcms/__link
   local.get $0
-  local.get $3
+  local.get $10
   i32.store offset=12
  )
  (func $~lib/util/string/strtol<i32> (param $0 i32) (result i32)
@@ -7704,7 +7690,7 @@
   if
    i32.const 1392
    i32.const 5040
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7724,7 +7710,7 @@
   if
    i32.const 5088
    i32.const 5040
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -3074,7 +3074,7 @@
    if
     i32.const 4992
     i32.const 5040
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -3085,7 +3085,7 @@
    local.set $2
    block $__inlined_func$~lib/rt/itcms/__renew
     local.get $3
-    i32.const 2
+    i32.const 3
     i32.shl
     local.tee $9
     local.tee $4
@@ -7673,7 +7673,7 @@
   if
    i32.const 1392
    i32.const 5040
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7693,7 +7693,7 @@
   if
    i32.const 5088
    i32.const 5040
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -3043,23 +3043,13 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  local.get $0
-  i32.load offset=12
-  local.tee $9
-  i32.const 1
-  i32.add
-  local.tee $10
-  local.tee $3
+  local.get $1
   local.get $0
   i32.load offset=8
   local.tee $6
@@ -3067,7 +3057,7 @@
   i32.shr_u
   i32.gt_u
   if
-   local.get $3
+   local.get $1
    i32.const 268435455
    i32.gt_u
    if
@@ -3080,27 +3070,45 @@
    end
    local.get $0
    i32.load
-   local.tee $7
    local.set $2
+   local.get $1
+   i32.const 1
+   i32.const 32
+   i32.const 8
+   local.get $1
+   local.get $1
+   i32.const 8
+   i32.lt_u
+   select
+   i32.const 2
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.tee $1
+   i32.const 1073741820
+   local.get $1
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $4
+   i32.const 2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 4992
+    i32.const 5040
+    i32.const 30
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
    block $__inlined_func$~lib/rt/itcms/__renew
-    i32.const 1
-    i32.const 32
-    i32.const 8
-    local.get $3
-    local.get $3
-    i32.const 8
-    i32.lt_u
-    select
-    i32.const 2
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-    local.tee $8
-    local.tee $4
-    local.get $7
+    local.get $4
+    local.get $2
+    local.tee $1
     i32.const 20
     i32.sub
     local.tee $5
@@ -3121,48 +3129,60 @@
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $3
-    local.get $2
+    local.get $1
     local.get $4
     local.get $5
     i32.load offset=16
-    local.tee $2
-    local.get $2
+    local.tee $1
+    local.get $1
     local.get $4
     i32.gt_u
     select
     call $~lib/memory/memory.copy
     local.get $3
-    local.set $2
+    local.set $1
    end
-   local.get $2
+   local.get $1
    local.get $6
    i32.add
-   local.get $8
+   local.get $4
    local.get $6
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $1
    local.get $2
-   local.get $7
    i32.ne
    if
     local.get $0
-    local.get $2
+    local.get $1
     i32.store
     local.get $0
-    local.get $2
+    local.get $1
     i32.store offset=4
     local.get $0
-    local.get $2
+    local.get $1
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $8
+   local.get $4
    i32.store offset=8
   end
+ )
+ (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  local.get $0
+  i32.load offset=12
+  local.tee $2
+  i32.const 1
+  i32.add
+  local.tee $3
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
-  local.get $9
+  local.get $2
   i32.const 2
   i32.shl
   i32.add
@@ -3173,7 +3193,7 @@
   i32.const 1
   call $~lib/rt/itcms/__link
   local.get $0
-  local.get $10
+  local.get $3
   i32.store offset=12
  )
  (func $~lib/util/string/strtol<i32> (param $0 i32) (result i32)
@@ -7684,7 +7704,7 @@
   if
    i32.const 1392
    i32.const 5040
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7704,7 +7724,7 @@
   if
    i32.const 5088
    i32.const 5040
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -3085,11 +3085,11 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
     i32.const 32
-    i32.const 8
-    local.get $3
     local.get $3
     i32.const 8
-    i32.lt_u
+    local.get $3
+    i32.const 8
+    i32.gt_u
     select
     i32.const 2
     i32.shl

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -3062,7 +3062,7 @@
   local.tee $3
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   i32.const 2
   i32.shr_u
   i32.gt_u
@@ -3073,7 +3073,7 @@
    if
     i32.const 4992
     i32.const 5040
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -3083,8 +3083,16 @@
    local.tee $7
    local.set $2
    block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $5
     i32.const 1
-    i32.const 32
+    i32.shl
+    local.tee $4
+    i32.const 1073741820
+    local.get $4
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $4
     local.get $3
     i32.const 8
     local.get $3
@@ -3093,15 +3101,9 @@
     select
     i32.const 2
     i32.shl
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
     local.tee $3
-    i32.const 1073741820
     local.get $3
-    i32.const 1073741820
+    local.get $4
     i32.lt_u
     select
     local.tee $8
@@ -3109,7 +3111,7 @@
     local.get $7
     i32.const 20
     i32.sub
-    local.tee $5
+    local.tee $6
     i32.load
     i32.const -4
     i32.and
@@ -3117,19 +3119,19 @@
     i32.sub
     i32.le_u
     if
-     local.get $5
+     local.get $6
      local.get $4
      i32.store offset=16
      br $__inlined_func$~lib/rt/itcms/__renew
     end
     local.get $4
-    local.get $5
+    local.get $6
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $3
     local.get $2
     local.get $4
-    local.get $5
+    local.get $6
     i32.load offset=16
     local.tee $2
     local.get $2
@@ -3141,10 +3143,10 @@
     local.set $2
    end
    local.get $2
-   local.get $6
+   local.get $5
    i32.add
    local.get $8
-   local.get $6
+   local.get $5
    i32.sub
    call $~lib/memory/memory.fill
    local.get $2
@@ -7690,7 +7692,7 @@
   if
    i32.const 1392
    i32.const 5040
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7710,7 +7712,7 @@
   if
    i32.const 5088
    i32.const 5040
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -5256,16 +5256,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
-  local.get $4
+  local.get $3
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -5278,49 +5278,63 @@
    if
     i32.const 5424
     i32.const 5472
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $5
+   local.set $4
    local.get $1
    local.get $2
+   i32.shl
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 8
+   else
+    i32.const 1
+    i32.const 32
+    local.get $5
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+   end
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
    local.get $3
    i32.add
-   i32.shl
-   local.set $6
-   local.get $5
-   local.get $6
-   call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.add
    i32.const 0
-   local.get $6
-   local.get $4
+   local.get $5
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.store
     local.get $0
-    local.get $7
+    local.get $6
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.store offset=8
   end
  )
@@ -5342,7 +5356,6 @@
   local.get $0
   local.get $3
   i32.const 2
-  i32.const 1
   call $~lib/array/ensureSize
   i32.const 1
   drop
@@ -11314,7 +11327,7 @@
   if
    i32.const 368
    i32.const 5472
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11339,7 +11352,7 @@
   if
    i32.const 5520
    i32.const 5472
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -5287,9 +5287,9 @@
    local.get $0
    i32.load
    local.set $5
-   i32.const 8
-   local.tee $6
    local.get $1
+   local.tee $6
+   i32.const 8
    local.tee $7
    local.get $6
    local.get $7

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -5318,19 +5318,6 @@
     i32.lt_u
     select
     local.set $6
-    local.get $1
-    local.get $6
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 5424
-     i32.const 5472
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
    end
    local.get $5
    local.get $6
@@ -11354,7 +11341,7 @@
   if
    i32.const 368
    i32.const 5472
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11379,7 +11366,7 @@
   if
    i32.const 5520
    i32.const 5472
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -5279,7 +5279,7 @@
    if
     i32.const 5424
     i32.const 5472
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -5300,15 +5300,8 @@
    local.set $6
    local.get $3
    if
-    local.get $6
-    local.set $7
+    local.get $4
     i32.const 1
-    i32.const 32
-    local.get $7
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
     local.tee $7
     i32.const 1073741820
@@ -5317,13 +5310,20 @@
     local.get $8
     i32.lt_u
     select
+    local.tee $8
+    local.get $6
+    local.tee $7
+    local.get $8
+    local.get $7
+    i32.gt_u
+    select
     local.set $6
    end
    local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    local.get $4
    i32.add
    i32.const 0
@@ -5331,18 +5331,18 @@
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
+   local.get $8
    local.get $5
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $8
     i32.store
     local.get $0
-    local.get $7
+    local.get $8
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -11341,7 +11341,7 @@
   if
    i32.const 368
    i32.const 5472
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11366,7 +11366,7 @@
   if
    i32.const 5520
    i32.const 5472
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -5256,16 +5256,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -5278,47 +5278,49 @@
    if
     i32.const 5424
     i32.const 5472
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    local.get $1
    local.get $2
-   i32.shl
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
-   local.set $6
-   local.get $6
    local.get $3
    i32.add
-   i32.const 0
+   i32.shl
+   local.set $6
    local.get $5
-   local.get $3
-   i32.sub
-   call $~lib/memory/memory.fill
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $7
+   local.get $7
+   local.get $4
+   i32.add
+   i32.const 0
    local.get $6
    local.get $4
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $7
+   local.get $5
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.store
     local.get $0
-    local.get $6
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -5340,6 +5342,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureSize
   i32.const 1
   drop
@@ -11311,7 +11314,7 @@
   if
    i32.const 368
    i32.const 5472
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11336,7 +11339,7 @@
   if
    i32.const 5520
    i32.const 5472
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -5256,7 +5256,7 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5356,7 +5356,7 @@
   local.get $0
   local.get $3
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   i32.const 1
   drop
   local.get $0
@@ -11327,7 +11327,7 @@
   if
    i32.const 368
    i32.const 5472
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11352,7 +11352,7 @@
   if
    i32.const 5520
    i32.const 5472
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -5256,16 +5256,17 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -5285,51 +5286,76 @@
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    i32.const 8
-   local.tee $5
-   local.get $1
    local.tee $6
-   local.get $5
+   local.get $1
+   local.tee $7
    local.get $6
+   local.get $7
    i32.gt_u
    select
    local.get $2
    i32.shl
    local.set $6
-   i32.const 1
-   i32.const 32
-   local.get $6
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.set $6
-   local.get $4
+   local.get $3
+   if
+    local.get $6
+    local.set $7
+    i32.const 1
+    i32.const 32
+    local.get $7
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $7
+    i32.const 1073741820
+    local.tee $8
+    local.get $7
+    local.get $8
+    i32.lt_u
+    select
+    local.set $6
+    local.get $1
+    local.get $6
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 5424
+     i32.const 5472
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $5
-   local.get $5
-   local.get $3
+   local.set $7
+   local.get $7
+   local.get $4
    i32.add
    i32.const 0
    local.get $6
-   local.get $3
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $7
    local.get $5
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $5
+    local.get $7
     i32.store
     local.get $0
-    local.get $5
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $5
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -5356,6 +5382,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   i32.const 1
   drop
@@ -11327,7 +11354,7 @@
   if
    i32.const 368
    i32.const 5472
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11352,7 +11379,7 @@
   if
    i32.const 5520
    i32.const 5472
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -5278,7 +5278,7 @@
    if
     i32.const 5424
     i32.const 5472
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -5286,55 +5286,55 @@
    local.get $0
    i32.load
    local.set $4
+   i32.const 8
+   local.tee $5
    local.get $1
+   local.tee $6
+   local.get $5
+   local.get $6
+   i32.gt_u
+   select
    local.get $2
    i32.shl
-   local.set $5
-   local.get $5
-   i32.const 0
-   i32.eq
-   if (result i32)
-    i32.const 8
-   else
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-   end
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
    local.set $6
+   i32.const 1
+   i32.const 32
    local.get $6
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.set $6
+   local.get $4
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $5
+   local.get $5
    local.get $3
    i32.add
    i32.const 0
-   local.get $5
+   local.get $6
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $6
+   local.get $5
    local.get $4
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $5
     i32.store
     local.get $0
-    local.get $6
+    local.get $5
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $5
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -11327,7 +11327,7 @@
   if
    i32.const 368
    i32.const 5472
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11352,7 +11352,7 @@
   if
    i32.const 5520
    i32.const 5472
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -2212,7 +2212,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2333,7 +2333,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2344,7 +2344,7 @@
    i32.add
    local.tee $3
    i32.const 0
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -2360,7 +2360,7 @@
   local.get $0
   local.get $1
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -2378,7 +2378,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2389,7 +2389,7 @@
    i32.add
    local.tee $3
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -2407,7 +2407,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -2420,7 +2420,7 @@
   if
    i32.const 1248
    i32.const 1728
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3116,7 +3116,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3259,7 +3259,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4147,7 +4147,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4290,7 +4290,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4769,7 +4769,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4780,7 +4780,7 @@
    i32.add
    local.tee $3
    i32.const 1
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -4798,7 +4798,7 @@
   local.get $0
   local.get $1
   i32.const 1
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -5276,7 +5276,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5421,7 +5421,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -6311,7 +6311,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6456,7 +6456,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -7911,7 +7911,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8056,7 +8056,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -8537,7 +8537,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8548,7 +8548,7 @@
    i32.add
    local.tee $3
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -8566,7 +8566,7 @@
   local.get $0
   local.get $1
   i32.const 3
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -9046,7 +9046,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9191,7 +9191,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -10072,7 +10072,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10217,7 +10217,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -11130,7 +11130,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -11200,7 +11200,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 117
+       i32.const 118
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -11211,7 +11211,7 @@
       i32.add
       local.tee $4
       i32.const 2
-      call $~lib/array/ensureSize
+      call $~lib/array/ensureCapacity
       local.get $3
       local.get $4
       i32.store offset=12
@@ -11308,7 +11308,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12235,7 +12235,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12305,7 +12305,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 117
+       i32.const 118
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -12316,7 +12316,7 @@
       i32.add
       local.tee $4
       i32.const 3
-      call $~lib/array/ensureSize
+      call $~lib/array/ensureCapacity
       local.get $3
       local.get $4
       i32.store offset=12
@@ -12413,7 +12413,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12945,7 +12945,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -7,6 +7,7 @@
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_i64_=>_none (func (param i32 i64 i64)))
@@ -14,7 +15,6 @@
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $i32_f32_i32_=>_none (func (param i32 f32 i32)))
@@ -2212,8 +2212,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2221,7 +2220,7 @@
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2234,22 +2233,24 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.tee $6
-   local.set $3
+   local.tee $7
+   local.set $4
    block $__inlined_func$~lib/rt/itcms/__renew
     local.get $1
     local.get $2
+    local.get $3
+    i32.add
     i32.shl
-    local.tee $7
-    local.tee $4
-    local.get $6
+    local.tee $3
+    local.tee $5
+    local.get $7
     i32.const 20
     i32.sub
     local.tee $2
@@ -2261,37 +2262,37 @@
     i32.le_u
     if
      local.get $2
-     local.get $4
+     local.get $5
      i32.store offset=16
-     local.get $3
+     local.get $4
      local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $4
+    local.get $5
     local.get $2
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $1
-    local.get $3
     local.get $4
+    local.get $5
     local.get $2
     i32.load offset=16
     local.tee $2
     local.get $2
-    local.get $4
+    local.get $5
     i32.gt_u
     select
     call $~lib/memory/memory.copy
    end
    local.get $1
-   local.get $5
+   local.get $6
    i32.add
-   local.get $7
-   local.get $5
+   local.get $3
+   local.get $6
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $6
+   local.get $7
    i32.ne
    if
     local.get $0
@@ -2305,7 +2306,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $7
+   local.get $3
    i32.store offset=8
   end
  )
@@ -2322,7 +2323,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2333,6 +2334,7 @@
    i32.add
    local.tee $3
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -2348,6 +2350,7 @@
  (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -2367,7 +2370,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2378,6 +2381,7 @@
    i32.add
    local.tee $3
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -2396,6 +2400,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -2409,7 +2414,7 @@
   if
    i32.const 1248
    i32.const 1728
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2819,6 +2824,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -3067,7 +3073,7 @@
   i32.store
   local.get $1
   i32.load offset=8
-  local.set $8
+  local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.load offset=16
@@ -3104,19 +3110,25 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
+  local.tee $7
   i32.const 0
   call $~lib/rt/itcms/__new
   local.tee $5
   i32.store offset=4
   local.get $5
-  local.get $4
+  local.get $7
   call $~lib/memory/memory.fill
   local.get $2
   local.get $5
@@ -3125,7 +3137,7 @@
   local.get $5
   i32.store offset=4
   local.get $2
-  local.get $4
+  local.get $7
   i32.store offset=8
   local.get $2
   local.get $4
@@ -3141,7 +3153,7 @@
    local.get $6
    i32.gt_s
    if
-    local.get $8
+    local.get $9
     local.get $6
     i32.const 12
     i32.mul
@@ -3241,7 +3253,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -3857,6 +3869,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -4091,7 +4104,7 @@
   i32.store
   local.get $1
   i32.load offset=8
-  local.set $8
+  local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.load offset=16
@@ -4128,19 +4141,25 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
+  local.tee $7
   i32.const 0
   call $~lib/rt/itcms/__new
   local.tee $5
   i32.store offset=4
   local.get $5
-  local.get $4
+  local.get $7
   call $~lib/memory/memory.fill
   local.get $2
   local.get $5
@@ -4149,7 +4168,7 @@
   local.get $5
   i32.store offset=4
   local.get $2
-  local.get $4
+  local.get $7
   i32.store offset=8
   local.get $2
   local.get $4
@@ -4165,7 +4184,7 @@
    local.get $6
    i32.gt_s
    if
-    local.get $8
+    local.get $9
     local.get $6
     i32.const 12
     i32.mul
@@ -4265,7 +4284,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4744,7 +4763,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4754,6 +4773,7 @@
    i32.const 1
    i32.add
    local.tee $3
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -4773,6 +4793,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -5251,13 +5272,18 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 1
   i32.shl
   local.tee $7
@@ -5391,7 +5417,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -6281,13 +6307,18 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 1
   i32.shl
   local.tee $7
@@ -6421,7 +6452,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -7876,13 +7907,18 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
   local.tee $7
@@ -8016,7 +8052,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -8497,7 +8533,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8508,6 +8544,7 @@
    i32.add
    local.tee $3
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -8526,6 +8563,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -9006,13 +9044,18 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 3
   i32.shl
   local.tee $8
@@ -9146,7 +9189,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -10027,13 +10070,18 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 3
   i32.shl
   local.tee $8
@@ -10167,7 +10215,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -11080,13 +11128,18 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $5
+  local.get $5
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
   local.tee $8
@@ -11145,7 +11198,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 108
+       i32.const 112
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -11156,6 +11209,7 @@
       i32.add
       local.tee $4
       i32.const 2
+      i32.const 1
       call $~lib/array/ensureSize
       local.get $3
       local.get $4
@@ -11253,7 +11307,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12180,13 +12234,18 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $5
+  local.get $5
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 3
   i32.shl
   local.tee $8
@@ -12245,7 +12304,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 108
+       i32.const 112
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -12256,6 +12315,7 @@
       i32.add
       local.tee $4
       i32.const 3
+      i32.const 1
       call $~lib/array/ensureSize
       local.get $3
       local.get $4
@@ -12353,7 +12413,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12885,13 +12945,18 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $0
+  local.get $0
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
   local.tee $3

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -2232,7 +2232,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -2255,18 +2255,19 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     local.get $3
     if (result i32)
+     local.get $5
      i32.const 1
-     i32.const 32
-     local.get $1
-     i32.const 1
-     i32.sub
-     i32.clz
-     i32.sub
      i32.shl
-     local.tee $1
+     local.tee $2
      i32.const 1073741820
+     local.get $2
+     i32.const 1073741820
+     i32.lt_u
+     select
+     local.tee $2
      local.get $1
-     i32.const 1073741820
+     local.get $1
+     local.get $2
      i32.lt_u
      select
     else
@@ -2346,7 +2347,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2393,7 +2394,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2437,7 +2438,7 @@
   if
    i32.const 1248
    i32.const 1728
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3133,7 +3134,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3276,7 +3277,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4164,7 +4165,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4307,7 +4308,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4786,7 +4787,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5295,7 +5296,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5440,7 +5441,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -6330,7 +6331,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6475,7 +6476,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -7930,7 +7931,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8075,7 +8076,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -8556,7 +8557,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9067,7 +9068,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9212,7 +9213,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -10093,7 +10094,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10238,7 +10239,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -11151,7 +11152,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -11221,7 +11222,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 123
+       i32.const 115
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -11330,7 +11331,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12257,7 +12258,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12327,7 +12328,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 123
+       i32.const 115
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -12436,7 +12437,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12968,7 +12969,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -7,6 +7,7 @@
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_i64_=>_none (func (param i32 i64 i64)))
@@ -14,7 +15,6 @@
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $i32_f32_i32_=>_none (func (param i32 f32 i32)))
@@ -2212,16 +2212,14 @@
    end
   end
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2241,30 +2239,53 @@
    end
    local.get $0
    i32.load
-   local.tee $6
-   local.set $3
-   block $__inlined_func$~lib/rt/itcms/__renew
+   local.set $4
+   i32.const 8
+   local.get $1
+   local.get $1
+   i32.const 8
+   i32.lt_u
+   select
+   local.get $2
+   i32.shl
+   local.set $5
+   local.get $3
+   if
+    local.get $1
     i32.const 1
     i32.const 32
-    i32.const 8
-    local.get $1
-    local.get $1
-    i32.const 8
-    i32.lt_u
-    select
-    local.get $2
-    i32.shl
+    local.get $5
     i32.const 1
     i32.sub
     i32.clz
     i32.sub
     i32.shl
-    local.tee $7
-    local.tee $4
-    local.get $6
+    local.tee $1
+    i32.const 1073741820
+    local.get $1
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $5
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 1456
+     i32.const 1728
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $5
+    local.get $4
+    local.tee $1
     i32.const 20
     i32.sub
-    local.tee $2
+    local.tee $3
     i32.load
     i32.const -4
     i32.and
@@ -2272,38 +2293,38 @@
     i32.sub
     i32.le_u
     if
-     local.get $2
-     local.get $4
-     i32.store offset=16
      local.get $3
-     local.set $1
+     local.get $5
+     i32.store offset=16
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $4
-    local.get $2
+    local.get $5
+    local.get $3
     i32.load offset=12
     call $~lib/rt/itcms/__new
-    local.tee $1
-    local.get $3
-    local.get $4
-    local.get $2
-    i32.load offset=16
     local.tee $2
-    local.get $2
-    local.get $4
+    local.get $1
+    local.get $5
+    local.get $3
+    i32.load offset=16
+    local.tee $1
+    local.get $1
+    local.get $5
     i32.gt_u
     select
     call $~lib/memory/memory.copy
+    local.get $2
+    local.set $1
    end
    local.get $1
-   local.get $5
+   local.get $6
    i32.add
-   local.get $7
    local.get $5
+   local.get $6
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
@@ -2317,7 +2338,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $7
+   local.get $5
    i32.store offset=8
   end
  )
@@ -2334,7 +2355,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2345,6 +2366,7 @@
    i32.add
    local.tee $3
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
@@ -2360,6 +2382,7 @@
  (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
@@ -2379,7 +2402,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2390,6 +2413,7 @@
    i32.add
    local.tee $3
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
@@ -2408,6 +2432,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -2421,7 +2446,7 @@
   if
    i32.const 1248
    i32.const 1728
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3117,7 +3142,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3260,7 +3285,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4148,7 +4173,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4291,7 +4316,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4770,7 +4795,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4780,6 +4805,7 @@
    i32.const 1
    i32.add
    local.tee $3
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
@@ -4799,6 +4825,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -5277,7 +5304,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5422,7 +5449,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -6312,7 +6339,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6457,7 +6484,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -7912,7 +7939,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8057,7 +8084,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -8538,7 +8565,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8549,6 +8576,7 @@
    i32.add
    local.tee $3
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
@@ -8567,6 +8595,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -9047,7 +9076,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9192,7 +9221,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -10073,7 +10102,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10218,7 +10247,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -11131,7 +11160,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -11201,7 +11230,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 119
+       i32.const 124
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -11212,6 +11241,7 @@
       i32.add
       local.tee $4
       i32.const 2
+      i32.const 1
       call $~lib/array/ensureCapacity
       local.get $3
       local.get $4
@@ -11309,7 +11339,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12236,7 +12266,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12306,7 +12336,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 119
+       i32.const 124
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -12317,6 +12347,7 @@
       i32.add
       local.tee $4
       i32.const 3
+      i32.const 1
       call $~lib/array/ensureCapacity
       local.get $3
       local.get $4
@@ -12414,7 +12445,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12946,7 +12977,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -7,7 +7,6 @@
  (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $i32_i64_i64_=>_none (func (param i32 i64 i64)))
@@ -15,6 +14,7 @@
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $i32_f32_i32_=>_none (func (param i32 f32 i32)))
@@ -2212,7 +2212,8 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2220,7 +2221,7 @@
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2233,24 +2234,33 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.tee $7
-   local.set $4
+   local.tee $6
+   local.set $3
    block $__inlined_func$~lib/rt/itcms/__renew
+    i32.const 1
+    i32.const 32
     local.get $1
     local.get $2
-    local.get $3
-    i32.add
     i32.shl
-    local.tee $3
-    local.tee $5
-    local.get $7
+    local.tee $1
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 8
+    local.get $1
+    select
+    local.tee $7
+    local.tee $4
+    local.get $6
     i32.const 20
     i32.sub
     local.tee $2
@@ -2262,37 +2272,37 @@
     i32.le_u
     if
      local.get $2
-     local.get $5
-     i32.store offset=16
      local.get $4
+     i32.store offset=16
+     local.get $3
      local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $5
+    local.get $4
     local.get $2
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $1
+    local.get $3
     local.get $4
-    local.get $5
     local.get $2
     i32.load offset=16
     local.tee $2
     local.get $2
-    local.get $5
+    local.get $4
     i32.gt_u
     select
     call $~lib/memory/memory.copy
    end
    local.get $1
-   local.get $6
+   local.get $5
    i32.add
-   local.get $3
-   local.get $6
+   local.get $7
+   local.get $5
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $7
+   local.get $6
    i32.ne
    if
     local.get $0
@@ -2306,7 +2316,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $3
+   local.get $7
    i32.store offset=8
   end
  )
@@ -2323,7 +2333,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2334,7 +2344,6 @@
    i32.add
    local.tee $3
    i32.const 0
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -2350,7 +2359,6 @@
  (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -2370,7 +2378,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2381,7 +2389,6 @@
    i32.add
    local.tee $3
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -2400,7 +2407,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -2414,7 +2420,7 @@
   if
    i32.const 1248
    i32.const 1728
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3110,7 +3116,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3253,7 +3259,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4141,7 +4147,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4284,7 +4290,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4763,7 +4769,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4773,7 +4779,6 @@
    i32.const 1
    i32.add
    local.tee $3
-   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -4793,7 +4798,6 @@
   local.get $0
   local.get $1
   i32.const 1
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -5272,7 +5276,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5417,7 +5421,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -6307,7 +6311,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6452,7 +6456,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -7907,7 +7911,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8052,7 +8056,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -8533,7 +8537,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8544,7 +8548,6 @@
    i32.add
    local.tee $3
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -8563,7 +8566,6 @@
   local.get $0
   local.get $1
   i32.const 3
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -9044,7 +9046,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9189,7 +9191,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -10070,7 +10072,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10215,7 +10217,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -11128,7 +11130,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -11198,7 +11200,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 112
+       i32.const 117
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -11209,7 +11211,6 @@
       i32.add
       local.tee $4
       i32.const 2
-      i32.const 1
       call $~lib/array/ensureSize
       local.get $3
       local.get $4
@@ -11307,7 +11308,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12234,7 +12235,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12304,7 +12305,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 112
+       i32.const 117
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -12315,7 +12316,6 @@
       i32.add
       local.tee $4
       i32.const 3
-      i32.const 1
       call $~lib/array/ensureSize
       local.get $3
       local.get $4
@@ -12413,7 +12413,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12945,7 +12945,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -2234,7 +2234,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -2246,18 +2246,19 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
     i32.const 32
+    i32.const 8
     local.get $1
+    local.get $1
+    i32.const 8
+    i32.lt_u
+    select
     local.get $2
     i32.shl
-    local.tee $1
     i32.const 1
     i32.sub
     i32.clz
     i32.sub
     i32.shl
-    i32.const 8
-    local.get $1
-    select
     local.tee $7
     local.tee $4
     local.get $6
@@ -2333,7 +2334,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2378,7 +2379,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2420,7 +2421,7 @@
   if
    i32.const 1248
    i32.const 1728
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3116,7 +3117,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3259,7 +3260,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4147,7 +4148,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4290,7 +4291,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4769,7 +4770,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5276,7 +5277,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5421,7 +5422,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -6311,7 +6312,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6456,7 +6457,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -7911,7 +7912,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8056,7 +8057,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -8537,7 +8538,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9046,7 +9047,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9191,7 +9192,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -10072,7 +10073,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10217,7 +10218,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -11130,7 +11131,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -11200,7 +11201,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 118
+       i32.const 119
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -11308,7 +11309,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12235,7 +12236,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12305,7 +12306,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 118
+       i32.const 119
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -12413,7 +12414,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12945,7 +12946,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -2219,7 +2219,7 @@
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2237,9 +2237,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
-   i32.load
-   local.set $4
    i32.const 8
    local.get $1
    local.get $1
@@ -2248,41 +2245,35 @@
    select
    local.get $2
    i32.shl
+   local.set $1
+   local.get $4
    local.set $5
-   local.get $3
-   if
-    local.get $1
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-    local.tee $1
-    i32.const 1073741820
-    local.get $1
-    i32.const 1073741820
-    i32.lt_u
-    select
-    local.tee $5
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 1456
-     i32.const 1728
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
-   end
+   local.get $0
+   i32.load
+   local.tee $6
+   local.set $4
    block $__inlined_func$~lib/rt/itcms/__renew
-    local.get $5
+    local.get $3
+    if (result i32)
+     i32.const 1
+     i32.const 32
+     local.get $1
+     i32.const 1
+     i32.sub
+     i32.clz
+     i32.sub
+     i32.shl
+     local.tee $1
+     i32.const 1073741820
+     local.get $1
+     i32.const 1073741820
+     i32.lt_u
+     select
+    else
+     local.get $1
+    end
+    local.tee $2
     local.get $4
-    local.tee $1
     i32.const 20
     i32.sub
     local.tee $3
@@ -2294,37 +2285,37 @@
     i32.le_u
     if
      local.get $3
-     local.get $5
+     local.get $2
      i32.store offset=16
+     local.get $4
+     local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $5
+    local.get $2
     local.get $3
     i32.load offset=12
     call $~lib/rt/itcms/__new
-    local.tee $2
-    local.get $1
-    local.get $5
+    local.tee $1
+    local.get $4
+    local.get $2
     local.get $3
     i32.load offset=16
-    local.tee $1
-    local.get $1
-    local.get $5
-    i32.gt_u
+    local.tee $3
+    local.get $2
+    local.get $3
+    i32.lt_u
     select
     call $~lib/memory/memory.copy
-    local.get $2
-    local.set $1
    end
    local.get $1
-   local.get $6
-   i32.add
    local.get $5
-   local.get $6
+   i32.add
+   local.get $2
+   local.get $5
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $4
+   local.get $6
    i32.ne
    if
     local.get $0
@@ -2338,7 +2329,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $2
    i32.store offset=8
   end
  )
@@ -2355,7 +2346,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2402,7 +2393,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2446,7 +2437,7 @@
   if
    i32.const 1248
    i32.const 1728
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3142,7 +3133,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3285,7 +3276,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4173,7 +4164,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4316,7 +4307,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4795,7 +4786,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5304,7 +5295,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5449,7 +5440,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -6339,7 +6330,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6484,7 +6475,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -7939,7 +7930,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8084,7 +8075,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -8565,7 +8556,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9076,7 +9067,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9221,7 +9212,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -10102,7 +10093,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10247,7 +10238,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -11160,7 +11151,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -11230,7 +11221,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 124
+       i32.const 123
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -11339,7 +11330,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12266,7 +12257,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -12336,7 +12327,7 @@
       if
        i32.const 1248
        i32.const 1728
-       i32.const 124
+       i32.const 123
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -12445,7 +12436,7 @@
     if
      i32.const 1248
      i32.const 1728
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -12977,7 +12968,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -2237,11 +2237,11 @@
     call $~lib/builtins/abort
     unreachable
    end
-   i32.const 8
-   local.get $1
    local.get $1
    i32.const 8
-   i32.lt_u
+   local.get $1
+   i32.const 8
+   i32.gt_u
    select
    local.get $2
    i32.shl
@@ -3139,11 +3139,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   local.tee $7
   i32.const 0
@@ -4170,11 +4170,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   local.tee $7
   i32.const 0
@@ -5301,11 +5301,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 1
   i32.shl
@@ -6336,11 +6336,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 1
   i32.shl
@@ -7936,11 +7936,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl
@@ -9073,11 +9073,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 3
   i32.shl
@@ -10099,11 +10099,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 3
   i32.shl
@@ -11157,11 +11157,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $5
   local.get $5
   i32.const 8
-  i32.lt_s
+  local.get $5
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl
@@ -12263,11 +12263,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $5
   local.get $5
   i32.const 8
-  i32.lt_s
+  local.get $5
+  i32.const 8
+  i32.gt_s
   select
   i32.const 3
   i32.shl
@@ -12974,11 +12974,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $0
   local.get $0
   i32.const 8
-  i32.lt_s
+  local.get $0
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -4139,9 +4139,9 @@
    local.get $0
    i32.load
    local.set $5
-   i32.const 8
-   local.tee $6
    local.get $1
+   local.tee $6
+   i32.const 8
    local.tee $7
    local.get $6
    local.get $7
@@ -17779,9 +17779,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -17951,9 +17951,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -18648,9 +18648,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -19252,9 +19252,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -19856,9 +19856,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -20624,9 +20624,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -21228,9 +21228,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -21832,9 +21832,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -22436,9 +22436,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -23040,9 +23040,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -16,12 +16,12 @@
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i64_i64_=>_i32 (func (param i32 i64 i64) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $f32_=>_i32 (func (param f32) (result i32)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
@@ -4108,16 +4108,17 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -4137,51 +4138,76 @@
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    i32.const 8
-   local.tee $5
-   local.get $1
    local.tee $6
-   local.get $5
+   local.get $1
+   local.tee $7
    local.get $6
+   local.get $7
    i32.gt_u
    select
    local.get $2
    i32.shl
    local.set $6
-   i32.const 1
-   i32.const 32
-   local.get $6
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.set $6
-   local.get $4
+   local.get $3
+   if
+    local.get $6
+    local.set $7
+    i32.const 1
+    i32.const 32
+    local.get $7
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $7
+    i32.const 1073741820
+    local.tee $8
+    local.get $7
+    local.get $8
+    i32.lt_u
+    select
+    local.set $6
+    local.get $1
+    local.get $6
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 432
+     i32.const 704
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $5
-   local.get $5
-   local.get $3
+   local.set $7
+   local.get $7
+   local.get $4
    i32.add
    i32.const 0
    local.get $6
-   local.get $3
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $7
    local.get $5
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $5
+    local.get $7
     i32.store
     local.get $0
-    local.get $5
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $5
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -4214,7 +4240,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4224,6 +4250,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -4239,6 +4266,7 @@
  (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
@@ -4293,7 +4321,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4303,6 +4331,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -4319,6 +4348,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -4413,7 +4443,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4439,7 +4469,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5955,7 +5985,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5965,6 +5995,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -5980,6 +6011,7 @@
  (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
@@ -6037,7 +6069,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7261,7 +7293,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7270,6 +7302,7 @@
    local.get $1
    i32.const 1
    i32.add
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
@@ -7287,6 +7320,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -7343,7 +7377,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8587,7 +8621,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8596,6 +8630,7 @@
    local.get $1
    i32.const 1
    i32.add
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
@@ -8613,6 +8648,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -8669,7 +8705,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10497,7 +10533,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10507,6 +10543,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -10523,6 +10560,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -10579,7 +10617,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11786,7 +11824,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11796,6 +11834,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -11812,6 +11851,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -11868,7 +11908,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13083,7 +13123,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13093,6 +13133,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -13109,6 +13150,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -13165,7 +13207,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14364,7 +14406,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -14374,6 +14416,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -14390,6 +14433,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -14446,7 +14490,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -15662,7 +15706,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -15672,6 +15716,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -15688,6 +15733,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -15744,7 +15790,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -17741,7 +17787,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -17913,7 +17959,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18610,7 +18656,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19214,7 +19260,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19818,7 +19864,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -20586,7 +20632,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21190,7 +21236,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21794,7 +21840,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22398,7 +22444,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23002,7 +23048,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -4130,7 +4130,7 @@
    if
     i32.const 432
     i32.const 704
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -4138,55 +4138,55 @@
    local.get $0
    i32.load
    local.set $4
+   i32.const 8
+   local.tee $5
    local.get $1
+   local.tee $6
+   local.get $5
+   local.get $6
+   i32.gt_u
+   select
    local.get $2
    i32.shl
-   local.set $5
-   local.get $5
-   i32.const 0
-   i32.eq
-   if (result i32)
-    i32.const 8
-   else
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-   end
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
    local.set $6
+   i32.const 1
+   i32.const 32
    local.get $6
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.set $6
+   local.get $4
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $5
+   local.get $5
    local.get $3
    i32.add
    i32.const 0
-   local.get $5
+   local.get $6
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $6
+   local.get $5
    local.get $4
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $5
     i32.store
     local.get $0
-    local.get $6
+    local.get $5
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $5
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -4214,7 +4214,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4293,7 +4293,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4413,7 +4413,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4439,7 +4439,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5955,7 +5955,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6037,7 +6037,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7261,7 +7261,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7343,7 +7343,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8587,7 +8587,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8669,7 +8669,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10497,7 +10497,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10579,7 +10579,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11786,7 +11786,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11868,7 +11868,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13083,7 +13083,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13165,7 +13165,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14364,7 +14364,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -14446,7 +14446,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -15662,7 +15662,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -15744,7 +15744,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -17741,7 +17741,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -17913,7 +17913,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18610,7 +18610,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19214,7 +19214,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19818,7 +19818,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -20586,7 +20586,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21190,7 +21190,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21794,7 +21794,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22398,7 +22398,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23002,7 +23002,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -16,12 +16,12 @@
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i64_i64_=>_i32 (func (param i32 i64 i64) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $f32_=>_i32 (func (param f32) (result i32)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
@@ -4108,16 +4108,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
-  local.get $4
+  local.get $3
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -4130,49 +4130,63 @@
    if
     i32.const 432
     i32.const 704
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $5
+   local.set $4
    local.get $1
    local.get $2
+   i32.shl
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 8
+   else
+    i32.const 1
+    i32.const 32
+    local.get $5
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+   end
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
    local.get $3
    i32.add
-   i32.shl
-   local.set $6
-   local.get $5
-   local.get $6
-   call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.add
    i32.const 0
-   local.get $6
-   local.get $4
+   local.get $5
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.store
     local.get $0
-    local.get $7
+    local.get $6
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.store offset=8
   end
  )
@@ -4200,7 +4214,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4210,7 +4224,6 @@
    i32.const 1
    i32.add
    i32.const 0
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4226,7 +4239,6 @@
  (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -4281,7 +4293,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4291,7 +4303,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4308,7 +4319,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -4403,7 +4413,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4429,7 +4439,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5945,7 +5955,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5955,7 +5965,6 @@
    i32.const 1
    i32.add
    i32.const 0
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -5971,7 +5980,6 @@
  (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -6029,7 +6037,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7253,7 +7261,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7262,7 +7270,6 @@
    local.get $1
    i32.const 1
    i32.add
-   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -7280,7 +7287,6 @@
   local.get $0
   local.get $1
   i32.const 1
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -7337,7 +7343,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8581,7 +8587,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8590,7 +8596,6 @@
    local.get $1
    i32.const 1
    i32.add
-   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -8608,7 +8613,6 @@
   local.get $0
   local.get $1
   i32.const 1
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -8665,7 +8669,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10493,7 +10497,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10503,7 +10507,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -10520,7 +10523,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -10577,7 +10579,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11784,7 +11786,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11794,7 +11796,6 @@
    i32.const 1
    i32.add
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -11811,7 +11812,6 @@
   local.get $0
   local.get $1
   i32.const 3
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -11868,7 +11868,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13083,7 +13083,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13093,7 +13093,6 @@
    i32.const 1
    i32.add
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -13110,7 +13109,6 @@
   local.get $0
   local.get $1
   i32.const 3
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -13167,7 +13165,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14366,7 +14364,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -14376,7 +14374,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -14393,7 +14390,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -14450,7 +14446,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -15666,7 +15662,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -15676,7 +15672,6 @@
    i32.const 1
    i32.add
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -15693,7 +15688,6 @@
   local.get $0
   local.get $1
   i32.const 3
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -15750,7 +15744,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -17747,7 +17741,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -17919,7 +17913,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18616,7 +18610,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19220,7 +19214,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19824,7 +19818,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -20592,7 +20586,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21196,7 +21190,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21800,7 +21794,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22404,7 +22398,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23008,7 +23002,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -4131,7 +4131,7 @@
    if
     i32.const 432
     i32.const 704
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -4152,15 +4152,8 @@
    local.set $6
    local.get $3
    if
-    local.get $6
-    local.set $7
+    local.get $4
     i32.const 1
-    i32.const 32
-    local.get $7
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
     local.tee $7
     i32.const 1073741820
@@ -4169,13 +4162,20 @@
     local.get $8
     i32.lt_u
     select
+    local.tee $8
+    local.get $6
+    local.tee $7
+    local.get $8
+    local.get $7
+    i32.gt_u
+    select
     local.set $6
    end
    local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    local.get $4
    i32.add
    i32.const 0
@@ -4183,18 +4183,18 @@
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
+   local.get $8
    local.get $5
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $8
     i32.store
     local.get $0
-    local.get $7
+    local.get $8
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -4227,7 +4227,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4308,7 +4308,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4430,7 +4430,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4456,7 +4456,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5972,7 +5972,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6056,7 +6056,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7280,7 +7280,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7364,7 +7364,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8608,7 +8608,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8692,7 +8692,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10520,7 +10520,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10604,7 +10604,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11811,7 +11811,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11895,7 +11895,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13110,7 +13110,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13194,7 +13194,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14393,7 +14393,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -14477,7 +14477,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -15693,7 +15693,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -15777,7 +15777,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -17774,7 +17774,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -17946,7 +17946,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18643,7 +18643,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19247,7 +19247,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19851,7 +19851,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -20619,7 +20619,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21223,7 +21223,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21827,7 +21827,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22431,7 +22431,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23035,7 +23035,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -4108,7 +4108,7 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4214,7 +4214,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4224,7 +4224,7 @@
    i32.const 1
    i32.add
    i32.const 0
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -4240,7 +4240,7 @@
   local.get $0
   local.get $1
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<i8>#set:length_
@@ -4293,7 +4293,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4303,7 +4303,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -4319,7 +4319,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#set:length_
@@ -4413,7 +4413,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4439,7 +4439,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5955,7 +5955,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5965,7 +5965,7 @@
    i32.const 1
    i32.add
    i32.const 0
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -5981,7 +5981,7 @@
   local.get $0
   local.get $1
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u8>#set:length_
@@ -6037,7 +6037,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7261,7 +7261,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7271,7 +7271,7 @@
    i32.const 1
    i32.add
    i32.const 1
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -7287,7 +7287,7 @@
   local.get $0
   local.get $1
   i32.const 1
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<i16>#set:length_
@@ -7343,7 +7343,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8587,7 +8587,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8597,7 +8597,7 @@
    i32.const 1
    i32.add
    i32.const 1
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -8613,7 +8613,7 @@
   local.get $0
   local.get $1
   i32.const 1
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u16>#set:length_
@@ -8669,7 +8669,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10497,7 +10497,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10507,7 +10507,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -10523,7 +10523,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u32>#set:length_
@@ -10579,7 +10579,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11786,7 +11786,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11796,7 +11796,7 @@
    i32.const 1
    i32.add
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -11812,7 +11812,7 @@
   local.get $0
   local.get $1
   i32.const 3
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<i64>#set:length_
@@ -11868,7 +11868,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13083,7 +13083,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13093,7 +13093,7 @@
    i32.const 1
    i32.add
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -13109,7 +13109,7 @@
   local.get $0
   local.get $1
   i32.const 3
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u64>#set:length_
@@ -13165,7 +13165,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14364,7 +14364,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -14374,7 +14374,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -14390,7 +14390,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<f32>#set:length_
@@ -14446,7 +14446,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -15662,7 +15662,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -15672,7 +15672,7 @@
    i32.const 1
    i32.add
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -15688,7 +15688,7 @@
   local.get $0
   local.get $1
   i32.const 3
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<f64>#set:length_
@@ -15744,7 +15744,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -17741,7 +17741,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -17913,7 +17913,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18610,7 +18610,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19214,7 +19214,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19818,7 +19818,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -20586,7 +20586,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21190,7 +21190,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21794,7 +21794,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22398,7 +22398,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23002,7 +23002,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -16,12 +16,12 @@
  (type $i32_f32_i32_=>_i32 (func (param i32 f32 i32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
  (type $i32_f64_i32_=>_i32 (func (param i32 f64 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i64_i64_=>_i32 (func (param i32 i64 i64) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $f32_=>_i32 (func (param f32) (result i32)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
@@ -4108,16 +4108,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -4130,47 +4130,49 @@
    if
     i32.const 432
     i32.const 704
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    local.get $1
    local.get $2
-   i32.shl
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
-   local.set $6
-   local.get $6
    local.get $3
    i32.add
-   i32.const 0
+   i32.shl
+   local.set $6
    local.get $5
-   local.get $3
-   i32.sub
-   call $~lib/memory/memory.fill
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $7
+   local.get $7
+   local.get $4
+   i32.add
+   i32.const 0
    local.get $6
    local.get $4
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $7
+   local.get $5
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.store
     local.get $0
-    local.get $6
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -4198,7 +4200,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4208,6 +4210,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4223,6 +4226,7 @@
  (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -4277,7 +4281,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4287,6 +4291,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4303,6 +4308,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -4397,7 +4403,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4423,7 +4429,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5939,7 +5945,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5949,6 +5955,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -5964,6 +5971,7 @@
  (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -6021,7 +6029,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7245,7 +7253,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7254,6 +7262,7 @@
    local.get $1
    i32.const 1
    i32.add
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -7271,6 +7280,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -7327,7 +7337,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8571,7 +8581,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8580,6 +8590,7 @@
    local.get $1
    i32.const 1
    i32.add
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -8597,6 +8608,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -8653,7 +8665,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10481,7 +10493,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10491,6 +10503,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -10507,6 +10520,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -10563,7 +10577,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11770,7 +11784,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11780,6 +11794,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -11796,6 +11811,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -11852,7 +11868,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13067,7 +13083,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13077,6 +13093,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -13093,6 +13110,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -13149,7 +13167,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14348,7 +14366,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -14358,6 +14376,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -14374,6 +14393,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -14430,7 +14450,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -15646,7 +15666,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -15656,6 +15676,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -15672,6 +15693,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -15728,7 +15750,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -17685,6 +17707,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -17723,44 +17747,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 0
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i8>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i8>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i8>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i8>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<i8,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
@@ -17848,6 +17879,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -17886,44 +17919,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i32>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i32>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i32>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<i8,i32>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -18536,6 +18576,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -18574,44 +18616,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 0
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u8>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u8>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u8>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u8>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<u8,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
@@ -19131,6 +19180,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -19169,44 +19220,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 1
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i16>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i16>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i16>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i16>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<i16,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
@@ -19726,6 +19784,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -19764,44 +19824,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 1
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u16>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u16>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u16>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u16>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<u16,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
@@ -20485,6 +20552,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -20523,44 +20592,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u32>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u32>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u32>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u32>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<u32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
@@ -21080,6 +21156,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -21118,44 +21196,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 3
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i64>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i64>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i64>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i64>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<i64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
@@ -21675,6 +21760,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -21713,44 +21800,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 3
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u64>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u64>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u64>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u64>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<u64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
@@ -22270,6 +22364,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -22308,44 +22404,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<f32>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<f32>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<f32>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<f32>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<f32,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)
@@ -22865,6 +22968,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -22903,44 +23008,51 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 3
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<f64>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<f64>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<f64>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<f64>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/map/Map<f64,i32>#keys (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -4170,19 +4170,6 @@
     i32.lt_u
     select
     local.set $6
-    local.get $1
-    local.get $6
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 432
-     i32.const 704
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
    end
    local.get $5
    local.get $6
@@ -4240,7 +4227,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4321,7 +4308,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4443,7 +4430,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4469,7 +4456,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5985,7 +5972,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6069,7 +6056,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7293,7 +7280,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7377,7 +7364,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8621,7 +8608,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8705,7 +8692,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10533,7 +10520,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10617,7 +10604,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11824,7 +11811,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11908,7 +11895,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13123,7 +13110,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13207,7 +13194,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14406,7 +14393,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -14490,7 +14477,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -15706,7 +15693,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -15790,7 +15777,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -17787,7 +17774,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -17959,7 +17946,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18656,7 +18643,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19260,7 +19247,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19864,7 +19851,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -20632,7 +20619,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21236,7 +21223,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21840,7 +21827,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22444,7 +22431,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23048,7 +23035,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -2281,7 +2281,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -2304,18 +2304,19 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     local.get $3
     if (result i32)
+     local.get $5
      i32.const 1
-     i32.const 32
-     local.get $1
-     i32.const 1
-     i32.sub
-     i32.clz
-     i32.sub
      i32.shl
-     local.tee $1
+     local.tee $2
      i32.const 1073741820
+     local.get $2
+     i32.const 1073741820
+     i32.lt_u
+     select
+     local.tee $2
      local.get $1
-     i32.const 1073741820
+     local.get $1
+     local.get $2
      i32.lt_u
      select
     else
@@ -2395,7 +2396,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2437,7 +2438,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2717,7 +2718,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3232,7 +3233,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3486,7 +3487,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4047,7 +4048,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4091,7 +4092,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4351,7 +4352,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4868,7 +4869,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5124,7 +5125,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5681,7 +5682,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5725,7 +5726,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5977,7 +5978,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6495,7 +6496,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6747,7 +6748,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -7314,7 +7315,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7358,7 +7359,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7634,7 +7635,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8153,7 +8154,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8407,7 +8408,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8958,7 +8959,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9212,7 +9213,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9282,7 +9283,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 123
+       i32.const 115
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -9811,7 +9812,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10065,7 +10066,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10135,7 +10136,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 123
+       i32.const 115
        i32.const 22
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -2261,7 +2261,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2382,7 +2382,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2393,7 +2393,7 @@
    i32.add
    local.tee $3
    i32.const 0
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -2409,7 +2409,7 @@
   local.get $0
   local.get $1
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -2422,7 +2422,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2702,7 +2702,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3217,7 +3217,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3471,7 +3471,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4032,7 +4032,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4043,7 +4043,7 @@
    i32.add
    local.tee $3
    i32.const 1
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -4061,7 +4061,7 @@
   local.get $0
   local.get $1
   i32.const 1
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -4074,7 +4074,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4334,7 +4334,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4851,7 +4851,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5107,7 +5107,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5664,7 +5664,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5675,7 +5675,7 @@
    i32.add
    local.tee $3
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -5693,7 +5693,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -5706,7 +5706,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5958,7 +5958,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6476,7 +6476,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6728,7 +6728,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -7295,7 +7295,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7306,7 +7306,7 @@
    i32.add
    local.tee $3
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
    i32.store offset=12
@@ -7324,7 +7324,7 @@
   local.get $0
   local.get $1
   i32.const 3
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   i32.store offset=12
@@ -7337,7 +7337,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7613,7 +7613,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8132,7 +8132,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8386,7 +8386,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8937,7 +8937,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9191,7 +9191,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9261,7 +9261,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 117
+       i32.const 118
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -9272,7 +9272,7 @@
       i32.add
       local.tee $4
       i32.const 2
-      call $~lib/array/ensureSize
+      call $~lib/array/ensureCapacity
       local.get $3
       local.get $4
       i32.store offset=12
@@ -9789,7 +9789,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10043,7 +10043,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10113,7 +10113,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 117
+       i32.const 118
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -10124,7 +10124,7 @@
       i32.add
       local.tee $4
       i32.const 3
-      call $~lib/array/ensureSize
+      call $~lib/array/ensureCapacity
       local.get $3
       local.get $4
       i32.store offset=12

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -2286,11 +2286,11 @@
     call $~lib/builtins/abort
     unreachable
    end
-   i32.const 8
-   local.get $1
    local.get $1
    i32.const 8
-   i32.lt_u
+   local.get $1
+   i32.const 8
+   i32.gt_u
    select
    local.get $2
    i32.shl
@@ -2723,11 +2723,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   local.tee $7
   i32.const 0
@@ -3492,11 +3492,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   local.tee $7
   i32.const 0
@@ -4357,11 +4357,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 1
   i32.shl
@@ -5130,11 +5130,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 1
   i32.shl
@@ -5983,11 +5983,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl
@@ -6753,11 +6753,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl
@@ -7640,11 +7640,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 3
   i32.shl
@@ -8413,11 +8413,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 3
   i32.shl
@@ -9218,11 +9218,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 2
   i32.shl
@@ -10071,11 +10071,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  local.get $4
   local.get $4
   i32.const 8
-  i32.lt_s
+  local.get $4
+  i32.const 8
+  i32.gt_s
   select
   i32.const 3
   i32.shl

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -3,17 +3,17 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $i32_f64_=>_none (func (param i32 f64)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $f32_=>_i32 (func (param f32) (result i32)))
@@ -2261,8 +2261,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2270,7 +2269,7 @@
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2283,22 +2282,24 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.tee $6
-   local.set $3
+   local.tee $7
+   local.set $4
    block $__inlined_func$~lib/rt/itcms/__renew
     local.get $1
     local.get $2
+    local.get $3
+    i32.add
     i32.shl
-    local.tee $7
-    local.tee $4
-    local.get $6
+    local.tee $3
+    local.tee $5
+    local.get $7
     i32.const 20
     i32.sub
     local.tee $2
@@ -2310,37 +2311,37 @@
     i32.le_u
     if
      local.get $2
-     local.get $4
+     local.get $5
      i32.store offset=16
-     local.get $3
+     local.get $4
      local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $4
+    local.get $5
     local.get $2
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $1
-    local.get $3
     local.get $4
+    local.get $5
     local.get $2
     i32.load offset=16
     local.tee $2
     local.get $2
-    local.get $4
+    local.get $5
     i32.gt_u
     select
     call $~lib/memory/memory.copy
    end
    local.get $1
-   local.get $5
+   local.get $6
    i32.add
-   local.get $7
-   local.get $5
+   local.get $3
+   local.get $6
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $6
+   local.get $7
    i32.ne
    if
     local.get $0
@@ -2354,7 +2355,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $7
+   local.get $3
    i32.store offset=8
   end
  )
@@ -2371,7 +2372,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2382,6 +2383,7 @@
    i32.add
    local.tee $3
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -2398,6 +2400,7 @@
   local.get $0
   local.get $1
   i32.const 0
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -2411,7 +2414,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2515,6 +2518,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -2652,11 +2656,11 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $8
+  local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $10
+  local.tee $11
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -2690,19 +2694,25 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
+  local.tee $7
   i32.const 0
   call $~lib/rt/itcms/__new
   local.tee $5
   i32.store offset=4
   local.get $5
-  local.get $4
+  local.get $7
   call $~lib/memory/memory.fill
   local.get $1
   local.get $5
@@ -2711,7 +2721,7 @@
   local.get $5
   i32.store offset=4
   local.get $1
-  local.get $4
+  local.get $7
   i32.store offset=8
   local.get $1
   local.get $4
@@ -2724,10 +2734,10 @@
   i32.store
   loop $for-loop|0
    local.get $6
-   local.get $10
+   local.get $11
    i32.lt_s
    if
-    local.get $8
+    local.get $9
     local.get $6
     i32.const 3
     i32.shl
@@ -3199,7 +3209,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3281,6 +3291,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
@@ -3414,11 +3425,11 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $8
+  local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $10
+  local.tee $11
   local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3452,19 +3463,25 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 8
   local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
+  local.tee $7
   i32.const 0
   call $~lib/rt/itcms/__new
   local.tee $5
   i32.store offset=4
   local.get $5
-  local.get $4
+  local.get $7
   call $~lib/memory/memory.fill
   local.get $1
   local.get $5
@@ -3473,7 +3490,7 @@
   local.get $5
   i32.store offset=4
   local.get $1
-  local.get $4
+  local.get $7
   i32.store offset=8
   local.get $1
   local.get $4
@@ -3486,10 +3503,10 @@
   i32.store
   loop $for-loop|0
    local.get $6
-   local.get $10
+   local.get $11
    i32.lt_s
    if
-    local.get $8
+    local.get $9
     local.get $6
     i32.const 3
     i32.shl
@@ -4007,7 +4024,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4017,6 +4034,7 @@
    i32.const 1
    i32.add
    local.tee $3
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -4036,6 +4054,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -4049,7 +4068,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4271,12 +4290,12 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $10
+  local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $6
-  local.set $7
+  local.tee $11
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -4303,40 +4322,45 @@
   local.get $1
   i32.const 0
   i32.store offset=12
-  local.get $6
+  local.get $4
   i32.const 536870910
   i32.gt_u
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  i32.const 8
+  local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 1
   i32.shl
-  local.tee $8
+  local.tee $7
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $5
   i32.store offset=4
-  local.get $4
-  local.get $8
+  local.get $5
+  local.get $7
   call $~lib/memory/memory.fill
   local.get $1
-  local.get $4
+  local.get $5
   call $~lib/set/Set<i8>#set:buckets
   local.get $1
-  local.get $4
+  local.get $5
   i32.store offset=4
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -4345,12 +4369,12 @@
   local.get $1
   i32.store
   loop $for-loop|0
-   local.get $5
    local.get $6
+   local.get $11
    i32.lt_s
    if
-    local.get $10
-    local.get $5
+    local.get $9
+    local.get $6
     i32.const 3
     i32.shl
     i32.add
@@ -4370,10 +4394,10 @@
      i32.add
      local.set $0
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
@@ -4821,7 +4845,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5039,12 +5063,12 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $10
+  local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $6
-  local.set $7
+  local.tee $11
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -5071,40 +5095,45 @@
   local.get $1
   i32.const 0
   i32.store offset=12
-  local.get $6
+  local.get $4
   i32.const 536870910
   i32.gt_u
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  i32.const 8
+  local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 1
   i32.shl
-  local.tee $8
+  local.tee $7
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $5
   i32.store offset=4
-  local.get $4
-  local.get $8
+  local.get $5
+  local.get $7
   call $~lib/memory/memory.fill
   local.get $1
-  local.get $4
+  local.get $5
   call $~lib/set/Set<i8>#set:buckets
   local.get $1
-  local.get $4
+  local.get $5
   i32.store offset=4
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -5113,12 +5142,12 @@
   local.get $1
   i32.store
   loop $for-loop|0
-   local.get $5
    local.get $6
+   local.get $11
    i32.lt_s
    if
-    local.get $10
-    local.get $5
+    local.get $9
+    local.get $6
     i32.const 3
     i32.shl
     i32.add
@@ -5138,10 +5167,10 @@
      i32.add
      local.set $0
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|0
    end
   end
@@ -5629,7 +5658,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5640,6 +5669,7 @@
    i32.add
    local.tee $3
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -5658,6 +5688,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -5671,7 +5702,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5885,12 +5916,12 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $10
+  local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $6
-  local.set $7
+  local.tee $11
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -5917,40 +5948,45 @@
   local.get $1
   i32.const 0
   i32.store offset=12
-  local.get $6
+  local.get $4
   i32.const 268435455
   i32.gt_u
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  i32.const 8
+  local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
-  local.tee $8
+  local.tee $7
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $5
   i32.store offset=4
-  local.get $4
-  local.get $8
+  local.get $5
+  local.get $7
   call $~lib/memory/memory.fill
   local.get $1
-  local.get $4
+  local.get $5
   call $~lib/set/Set<i8>#set:buckets
   local.get $1
-  local.get $4
+  local.get $5
   i32.store offset=4
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -5959,12 +5995,12 @@
   local.get $1
   i32.store
   loop $for-loop|01
-   local.get $5
    local.get $6
+   local.get $11
    i32.lt_s
    if
-    local.get $10
-    local.get $5
+    local.get $9
+    local.get $6
     i32.const 3
     i32.shl
     i32.add
@@ -5984,10 +6020,10 @@
      i32.add
      local.set $0
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|01
    end
   end
@@ -6436,7 +6472,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6650,12 +6686,12 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $10
+  local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $6
-  local.set $7
+  local.tee $11
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -6682,40 +6718,45 @@
   local.get $1
   i32.const 0
   i32.store offset=12
-  local.get $6
+  local.get $4
   i32.const 268435455
   i32.gt_u
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $7
+  i32.const 8
+  local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
-  local.tee $8
+  local.tee $7
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $5
   i32.store offset=4
-  local.get $4
-  local.get $8
+  local.get $5
+  local.get $7
   call $~lib/memory/memory.fill
   local.get $1
-  local.get $4
+  local.get $5
   call $~lib/set/Set<i8>#set:buckets
   local.get $1
-  local.get $4
+  local.get $5
   i32.store offset=4
   local.get $1
-  local.get $8
+  local.get $7
   i32.store offset=8
   local.get $1
-  local.get $7
+  local.get $4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -6724,12 +6765,12 @@
   local.get $1
   i32.store
   loop $for-loop|01
-   local.get $5
    local.get $6
+   local.get $11
    i32.lt_s
    if
-    local.get $10
-    local.get $5
+    local.get $9
+    local.get $6
     i32.const 3
     i32.shl
     i32.add
@@ -6749,10 +6790,10 @@
      i32.add
      local.set $0
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $for-loop|01
    end
   end
@@ -7250,7 +7291,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7261,6 +7302,7 @@
    i32.add
    local.tee $3
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -7279,6 +7321,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -7292,7 +7335,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7530,12 +7573,12 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $11
+  local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $7
-  local.set $8
+  local.tee $12
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -7562,40 +7605,45 @@
   local.get $3
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $4
   i32.const 134217727
   i32.gt_u
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  i32.const 8
+  local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 3
   i32.shl
-  local.tee $9
+  local.tee $8
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $6
   i32.store offset=4
-  local.get $4
-  local.get $9
+  local.get $6
+  local.get $8
   call $~lib/memory/memory.fill
   local.get $3
-  local.get $4
+  local.get $6
   call $~lib/set/Set<i8>#set:buckets
   local.get $3
-  local.get $4
+  local.get $6
   i32.store offset=4
   local.get $3
-  local.get $9
+  local.get $8
   i32.store offset=8
   local.get $3
-  local.get $8
+  local.get $4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -7604,12 +7652,12 @@
   local.get $3
   i32.store
   loop $for-loop|01
-   local.get $6
    local.get $7
+   local.get $12
    i32.lt_s
    if
-    local.get $11
-    local.get $6
+    local.get $10
+    local.get $7
     i32.const 4
     i32.shl
     i32.add
@@ -7629,10 +7677,10 @@
      i32.add
      local.set $0
     end
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|01
    end
   end
@@ -8082,7 +8130,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8298,12 +8346,12 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $11
+  local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $7
-  local.set $8
+  local.tee $12
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -8330,40 +8378,45 @@
   local.get $3
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $4
   i32.const 134217727
   i32.gt_u
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  i32.const 8
+  local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 3
   i32.shl
-  local.tee $9
+  local.tee $8
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $6
   i32.store offset=4
-  local.get $4
-  local.get $9
+  local.get $6
+  local.get $8
   call $~lib/memory/memory.fill
   local.get $3
-  local.get $4
+  local.get $6
   call $~lib/set/Set<i8>#set:buckets
   local.get $3
-  local.get $4
+  local.get $6
   i32.store offset=4
   local.get $3
-  local.get $9
+  local.get $8
   i32.store offset=8
   local.get $3
-  local.get $8
+  local.get $4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -8372,12 +8425,12 @@
   local.get $3
   i32.store
   loop $for-loop|01
-   local.get $6
    local.get $7
+   local.get $12
    i32.lt_s
    if
-    local.get $11
-    local.get $6
+    local.get $10
+    local.get $7
     i32.const 4
     i32.shl
     i32.add
@@ -8397,10 +8450,10 @@
      i32.add
      local.set $0
     end
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|01
    end
   end
@@ -8882,7 +8935,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9098,12 +9151,12 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $11
+  local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $7
-  local.set $8
+  local.tee $12
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -9130,40 +9183,45 @@
   local.get $3
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $4
   i32.const 268435455
   i32.gt_u
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  i32.const 8
+  local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 2
   i32.shl
-  local.tee $9
+  local.tee $8
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $6
   i32.store offset=4
-  local.get $4
-  local.get $9
+  local.get $6
+  local.get $8
   call $~lib/memory/memory.fill
   local.get $3
-  local.get $4
+  local.get $6
   call $~lib/set/Set<i8>#set:buckets
   local.get $3
-  local.get $4
+  local.get $6
   i32.store offset=4
   local.get $3
-  local.get $9
+  local.get $8
   i32.store offset=8
   local.get $3
-  local.get $8
+  local.get $4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -9172,12 +9230,12 @@
   local.get $3
   i32.store
   loop $for-loop|01
-   local.get $6
    local.get $7
+   local.get $12
    i32.lt_s
    if
-    local.get $11
-    local.get $6
+    local.get $10
+    local.get $7
     i32.const 3
     i32.shl
     i32.add
@@ -9201,7 +9259,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 108
+       i32.const 112
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -9212,6 +9270,7 @@
       i32.add
       local.tee $4
       i32.const 2
+      i32.const 1
       call $~lib/array/ensureSize
       local.get $3
       local.get $4
@@ -9230,10 +9289,10 @@
      i32.add
      local.set $0
     end
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|01
    end
   end
@@ -9729,7 +9788,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9945,12 +10004,12 @@
   i32.store
   local.get $2
   i32.load offset=8
-  local.set $11
+  local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.load offset=16
-  local.tee $7
-  local.set $8
+  local.tee $12
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -9977,40 +10036,45 @@
   local.get $3
   i32.const 0
   i32.store offset=12
-  local.get $7
+  local.get $4
   i32.const 134217727
   i32.gt_u
   if
    i32.const 1456
    i32.const 1616
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.get $8
+  i32.const 8
+  local.get $4
+  local.get $4
+  i32.const 8
+  i32.lt_s
+  select
   i32.const 3
   i32.shl
-  local.tee $9
+  local.tee $8
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $4
+  local.tee $6
   i32.store offset=4
-  local.get $4
-  local.get $9
+  local.get $6
+  local.get $8
   call $~lib/memory/memory.fill
   local.get $3
-  local.get $4
+  local.get $6
   call $~lib/set/Set<i8>#set:buckets
   local.get $3
-  local.get $4
+  local.get $6
   i32.store offset=4
   local.get $3
-  local.get $9
+  local.get $8
   i32.store offset=8
   local.get $3
-  local.get $8
+  local.get $4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -10019,12 +10083,12 @@
   local.get $3
   i32.store
   loop $for-loop|01
-   local.get $6
    local.get $7
+   local.get $12
    i32.lt_s
    if
-    local.get $11
-    local.get $6
+    local.get $10
+    local.get $7
     i32.const 4
     i32.shl
     i32.add
@@ -10048,7 +10112,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 108
+       i32.const 112
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -10059,6 +10123,7 @@
       i32.add
       local.tee $4
       i32.const 3
+      i32.const 1
       call $~lib/array/ensureSize
       local.get $3
       local.get $4
@@ -10077,10 +10142,10 @@
      i32.add
      local.set $0
     end
-    local.get $6
+    local.get $7
     i32.const 1
     i32.add
-    local.set $6
+    local.set $7
     br $for-loop|01
    end
   end

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -2283,7 +2283,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -2295,18 +2295,19 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
     i32.const 32
+    i32.const 8
     local.get $1
+    local.get $1
+    i32.const 8
+    i32.lt_u
+    select
     local.get $2
     i32.shl
-    local.tee $1
     i32.const 1
     i32.sub
     i32.clz
     i32.sub
     i32.shl
-    i32.const 8
-    local.get $1
-    select
     local.tee $7
     local.tee $4
     local.get $6
@@ -2382,7 +2383,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2422,7 +2423,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2702,7 +2703,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3217,7 +3218,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3471,7 +3472,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4032,7 +4033,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4074,7 +4075,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4334,7 +4335,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4851,7 +4852,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5107,7 +5108,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5664,7 +5665,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5706,7 +5707,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5958,7 +5959,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6476,7 +6477,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6728,7 +6729,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -7295,7 +7296,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7337,7 +7338,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7613,7 +7614,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8132,7 +8133,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8386,7 +8387,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8937,7 +8938,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9191,7 +9192,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9261,7 +9262,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 118
+       i32.const 119
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -9789,7 +9790,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10043,7 +10044,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10113,7 +10114,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 118
+       i32.const 119
        i32.const 22
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -3,17 +3,17 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $i32_f64_=>_none (func (param i32 f64)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $f32_=>_i32 (func (param f32) (result i32)))
@@ -2261,16 +2261,14 @@
    end
   end
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2290,30 +2288,53 @@
    end
    local.get $0
    i32.load
-   local.tee $6
-   local.set $3
-   block $__inlined_func$~lib/rt/itcms/__renew
+   local.set $4
+   i32.const 8
+   local.get $1
+   local.get $1
+   i32.const 8
+   i32.lt_u
+   select
+   local.get $2
+   i32.shl
+   local.set $5
+   local.get $3
+   if
+    local.get $1
     i32.const 1
     i32.const 32
-    i32.const 8
-    local.get $1
-    local.get $1
-    i32.const 8
-    i32.lt_u
-    select
-    local.get $2
-    i32.shl
+    local.get $5
     i32.const 1
     i32.sub
     i32.clz
     i32.sub
     i32.shl
-    local.tee $7
-    local.tee $4
-    local.get $6
+    local.tee $1
+    i32.const 1073741820
+    local.get $1
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $5
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 1456
+     i32.const 1616
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $5
+    local.get $4
+    local.tee $1
     i32.const 20
     i32.sub
-    local.tee $2
+    local.tee $3
     i32.load
     i32.const -4
     i32.and
@@ -2321,38 +2342,38 @@
     i32.sub
     i32.le_u
     if
-     local.get $2
-     local.get $4
-     i32.store offset=16
      local.get $3
-     local.set $1
+     local.get $5
+     i32.store offset=16
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $4
-    local.get $2
+    local.get $5
+    local.get $3
     i32.load offset=12
     call $~lib/rt/itcms/__new
-    local.tee $1
-    local.get $3
-    local.get $4
-    local.get $2
-    i32.load offset=16
     local.tee $2
-    local.get $2
-    local.get $4
+    local.get $1
+    local.get $5
+    local.get $3
+    i32.load offset=16
+    local.tee $1
+    local.get $1
+    local.get $5
     i32.gt_u
     select
     call $~lib/memory/memory.copy
+    local.get $2
+    local.set $1
    end
    local.get $1
-   local.get $5
+   local.get $6
    i32.add
-   local.get $7
    local.get $5
+   local.get $6
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
@@ -2366,7 +2387,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $7
+   local.get $5
    i32.store offset=8
   end
  )
@@ -2383,7 +2404,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2394,6 +2415,7 @@
    i32.add
    local.tee $3
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
@@ -2410,6 +2432,7 @@
   local.get $0
   local.get $1
   i32.const 0
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -2423,7 +2446,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2703,7 +2726,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3218,7 +3241,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3472,7 +3495,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4033,7 +4056,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4043,6 +4066,7 @@
    i32.const 1
    i32.add
    local.tee $3
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
@@ -4062,6 +4086,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -4075,7 +4100,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4335,7 +4360,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4852,7 +4877,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5108,7 +5133,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5665,7 +5690,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5676,6 +5701,7 @@
    i32.add
    local.tee $3
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
@@ -5694,6 +5720,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -5707,7 +5734,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5959,7 +5986,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6477,7 +6504,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6729,7 +6756,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -7296,7 +7323,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7307,6 +7334,7 @@
    i32.add
    local.tee $3
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $3
@@ -7325,6 +7353,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -7338,7 +7367,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7614,7 +7643,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8133,7 +8162,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8387,7 +8416,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8938,7 +8967,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9192,7 +9221,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9262,7 +9291,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 119
+       i32.const 124
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -9273,6 +9302,7 @@
       i32.add
       local.tee $4
       i32.const 2
+      i32.const 1
       call $~lib/array/ensureCapacity
       local.get $3
       local.get $4
@@ -9790,7 +9820,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10044,7 +10074,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10114,7 +10144,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 119
+       i32.const 124
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -10125,6 +10155,7 @@
       i32.add
       local.tee $4
       i32.const 3
+      i32.const 1
       call $~lib/array/ensureCapacity
       local.get $3
       local.get $4

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -3,17 +3,17 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $i32_f64_=>_none (func (param i32 f64)))
  (type $i32_i64_=>_i32 (func (param i32 i64) (result i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $f32_=>_i32 (func (param f32) (result i32)))
@@ -2261,7 +2261,8 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2269,7 +2270,7 @@
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2282,24 +2283,33 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.tee $7
-   local.set $4
+   local.tee $6
+   local.set $3
    block $__inlined_func$~lib/rt/itcms/__renew
+    i32.const 1
+    i32.const 32
     local.get $1
     local.get $2
-    local.get $3
-    i32.add
     i32.shl
-    local.tee $3
-    local.tee $5
-    local.get $7
+    local.tee $1
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 8
+    local.get $1
+    select
+    local.tee $7
+    local.tee $4
+    local.get $6
     i32.const 20
     i32.sub
     local.tee $2
@@ -2311,37 +2321,37 @@
     i32.le_u
     if
      local.get $2
-     local.get $5
-     i32.store offset=16
      local.get $4
+     i32.store offset=16
+     local.get $3
      local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $5
+    local.get $4
     local.get $2
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $1
+    local.get $3
     local.get $4
-    local.get $5
     local.get $2
     i32.load offset=16
     local.tee $2
     local.get $2
-    local.get $5
+    local.get $4
     i32.gt_u
     select
     call $~lib/memory/memory.copy
    end
    local.get $1
-   local.get $6
+   local.get $5
    i32.add
-   local.get $3
-   local.get $6
+   local.get $7
+   local.get $5
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $7
+   local.get $6
    i32.ne
    if
     local.get $0
@@ -2355,7 +2365,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $3
+   local.get $7
    i32.store offset=8
   end
  )
@@ -2372,7 +2382,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2383,7 +2393,6 @@
    i32.add
    local.tee $3
    i32.const 0
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -2400,7 +2409,6 @@
   local.get $0
   local.get $1
   i32.const 0
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -2414,7 +2422,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2694,7 +2702,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3209,7 +3217,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3463,7 +3471,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4024,7 +4032,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4034,7 +4042,6 @@
    i32.const 1
    i32.add
    local.tee $3
-   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -4054,7 +4061,6 @@
   local.get $0
   local.get $1
   i32.const 1
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -4068,7 +4074,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4328,7 +4334,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4845,7 +4851,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5101,7 +5107,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5658,7 +5664,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5669,7 +5675,6 @@
    i32.add
    local.tee $3
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -5688,7 +5693,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -5702,7 +5706,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5954,7 +5958,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6472,7 +6476,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6724,7 +6728,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -7291,7 +7295,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7302,7 +7306,6 @@
    i32.add
    local.tee $3
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $3
@@ -7321,7 +7324,6 @@
   local.get $0
   local.get $1
   i32.const 3
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -7335,7 +7337,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7611,7 +7613,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8130,7 +8132,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8384,7 +8386,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8935,7 +8937,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9189,7 +9191,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9259,7 +9261,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 112
+       i32.const 117
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -9270,7 +9272,6 @@
       i32.add
       local.tee $4
       i32.const 2
-      i32.const 1
       call $~lib/array/ensureSize
       local.get $3
       local.get $4
@@ -9788,7 +9789,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10042,7 +10043,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10112,7 +10113,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 112
+       i32.const 117
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -10123,7 +10124,6 @@
       i32.add
       local.tee $4
       i32.const 3
-      i32.const 1
       call $~lib/array/ensureSize
       local.get $3
       local.get $4

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -2268,7 +2268,7 @@
   local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -2286,9 +2286,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $0
-   i32.load
-   local.set $4
    i32.const 8
    local.get $1
    local.get $1
@@ -2297,41 +2294,35 @@
    select
    local.get $2
    i32.shl
+   local.set $1
+   local.get $4
    local.set $5
-   local.get $3
-   if
-    local.get $1
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-    local.tee $1
-    i32.const 1073741820
-    local.get $1
-    i32.const 1073741820
-    i32.lt_u
-    select
-    local.tee $5
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 1456
-     i32.const 1616
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
-   end
+   local.get $0
+   i32.load
+   local.tee $6
+   local.set $4
    block $__inlined_func$~lib/rt/itcms/__renew
-    local.get $5
+    local.get $3
+    if (result i32)
+     i32.const 1
+     i32.const 32
+     local.get $1
+     i32.const 1
+     i32.sub
+     i32.clz
+     i32.sub
+     i32.shl
+     local.tee $1
+     i32.const 1073741820
+     local.get $1
+     i32.const 1073741820
+     i32.lt_u
+     select
+    else
+     local.get $1
+    end
+    local.tee $2
     local.get $4
-    local.tee $1
     i32.const 20
     i32.sub
     local.tee $3
@@ -2343,37 +2334,37 @@
     i32.le_u
     if
      local.get $3
-     local.get $5
+     local.get $2
      i32.store offset=16
+     local.get $4
+     local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $5
+    local.get $2
     local.get $3
     i32.load offset=12
     call $~lib/rt/itcms/__new
-    local.tee $2
-    local.get $1
-    local.get $5
+    local.tee $1
+    local.get $4
+    local.get $2
     local.get $3
     i32.load offset=16
-    local.tee $1
-    local.get $1
-    local.get $5
-    i32.gt_u
+    local.tee $3
+    local.get $2
+    local.get $3
+    i32.lt_u
     select
     call $~lib/memory/memory.copy
-    local.get $2
-    local.set $1
    end
    local.get $1
-   local.get $6
-   i32.add
    local.get $5
-   local.get $6
+   i32.add
+   local.get $2
+   local.get $5
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $4
+   local.get $6
    i32.ne
    if
     local.get $0
@@ -2387,7 +2378,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $2
    i32.store offset=8
   end
  )
@@ -2404,7 +2395,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -2446,7 +2437,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2726,7 +2717,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -3241,7 +3232,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3495,7 +3486,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4056,7 +4047,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4100,7 +4091,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4360,7 +4351,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4877,7 +4868,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5133,7 +5124,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -5690,7 +5681,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5734,7 +5725,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5986,7 +5977,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -6504,7 +6495,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6756,7 +6747,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -7323,7 +7314,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7367,7 +7358,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7643,7 +7634,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8162,7 +8153,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8416,7 +8407,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -8967,7 +8958,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9221,7 +9212,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -9291,7 +9282,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 124
+       i32.const 123
        i32.const 22
        call $~lib/builtins/abort
        unreachable
@@ -9820,7 +9811,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10074,7 +10065,7 @@
   if
    i32.const 1456
    i32.const 1616
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -10144,7 +10135,7 @@
       if
        i32.const 1248
        i32.const 1616
-       i32.const 124
+       i32.const 123
        i32.const 22
        call $~lib/builtins/abort
        unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -4185,7 +4185,7 @@
    if
     i32.const 432
     i32.const 592
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -4206,15 +4206,8 @@
    local.set $6
    local.get $3
    if
-    local.get $6
-    local.set $7
+    local.get $4
     i32.const 1
-    i32.const 32
-    local.get $7
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
     local.tee $7
     i32.const 1073741820
@@ -4223,13 +4216,20 @@
     local.get $8
     i32.lt_u
     select
+    local.tee $8
+    local.get $6
+    local.tee $7
+    local.get $8
+    local.get $7
+    i32.gt_u
+    select
     local.set $6
    end
    local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    local.get $4
    i32.add
    i32.const 0
@@ -4237,18 +4237,18 @@
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
+   local.get $8
    local.get $5
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $8
     i32.store
     local.get $0
-    local.get $7
+    local.get $8
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -4281,7 +4281,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4327,7 +4327,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5263,7 +5263,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5309,7 +5309,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6241,7 +6241,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6287,7 +6287,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7223,7 +7223,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7269,7 +7269,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8193,7 +8193,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8239,7 +8239,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9151,7 +9151,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9197,7 +9197,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10126,7 +10126,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10172,7 +10172,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11102,7 +11102,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11148,7 +11148,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -12062,7 +12062,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -12108,7 +12108,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13039,7 +13039,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13085,7 +13085,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14287,7 +14287,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14515,7 +14515,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14743,7 +14743,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14971,7 +14971,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15199,7 +15199,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15427,7 +15427,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15655,7 +15655,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15883,7 +15883,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16111,7 +16111,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16339,7 +16339,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 72
+   i32.const 64
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -4193,9 +4193,9 @@
    local.get $0
    i32.load
    local.set $5
-   i32.const 8
-   local.tee $6
    local.get $1
+   local.tee $6
+   i32.const 8
    local.tee $7
    local.get $6
    local.get $7
@@ -14292,9 +14292,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -14520,9 +14520,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -14748,9 +14748,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -14976,9 +14976,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -15204,9 +15204,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -15432,9 +15432,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -15660,9 +15660,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -15888,9 +15888,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -16116,9 +16116,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3
@@ -16344,9 +16344,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8
-  local.tee $2
   local.get $1
+  local.tee $2
+  i32.const 8
   local.tee $3
   local.get $2
   local.get $3

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -10,13 +10,13 @@
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $i32_f64_=>_none (func (param i32 f64)))
  (type $none_=>_i32 (func (result i32)))
@@ -4162,16 +4162,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
-  local.get $4
+  local.get $3
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -4184,49 +4184,63 @@
    if
     i32.const 432
     i32.const 592
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $5
+   local.set $4
    local.get $1
    local.get $2
+   i32.shl
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 8
+   else
+    i32.const 1
+    i32.const 32
+    local.get $5
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+   end
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
    local.get $3
    i32.add
-   i32.shl
-   local.set $6
-   local.get $5
-   local.get $6
-   call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.add
    i32.const 0
-   local.get $6
-   local.get $4
+   local.get $5
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.store
     local.get $0
-    local.get $7
+    local.get $6
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.store offset=8
   end
  )
@@ -4254,7 +4268,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4264,7 +4278,6 @@
    i32.const 1
    i32.add
    i32.const 0
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4280,7 +4293,6 @@
  (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -4300,7 +4312,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5236,7 +5248,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5246,7 +5258,6 @@
    i32.const 1
    i32.add
    i32.const 0
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -5262,7 +5273,6 @@
  (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -5282,7 +5292,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6214,7 +6224,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6223,7 +6233,6 @@
    local.get $1
    i32.const 1
    i32.add
-   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -6241,7 +6250,6 @@
   local.get $0
   local.get $1
   i32.const 1
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -6260,7 +6268,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7196,7 +7204,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7205,7 +7213,6 @@
    local.get $1
    i32.const 1
    i32.add
-   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -7223,7 +7230,6 @@
   local.get $0
   local.get $1
   i32.const 1
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -7242,7 +7248,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8166,7 +8172,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8176,7 +8182,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -8193,7 +8198,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -8212,7 +8216,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9124,7 +9128,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9134,7 +9138,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -9151,7 +9154,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -9170,7 +9172,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10099,7 +10101,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10109,7 +10111,6 @@
    i32.const 1
    i32.add
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -10126,7 +10127,6 @@
   local.get $0
   local.get $1
   i32.const 3
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -10145,7 +10145,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11075,7 +11075,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11085,7 +11085,6 @@
    i32.const 1
    i32.add
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -11102,7 +11101,6 @@
   local.get $0
   local.get $1
   i32.const 3
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -11121,7 +11119,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -12035,7 +12033,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -12045,7 +12043,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -12062,7 +12059,6 @@
   local.get $0
   local.get $1
   i32.const 2
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -12081,7 +12077,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13012,7 +13008,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13022,7 +13018,6 @@
    i32.const 1
    i32.add
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -13039,7 +13034,6 @@
   local.get $0
   local.get $1
   i32.const 3
-  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -13058,7 +13052,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14260,7 +14254,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14488,7 +14482,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14716,7 +14710,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14944,7 +14938,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15172,7 +15166,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15400,7 +15394,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15628,7 +15622,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15856,7 +15850,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16084,7 +16078,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16312,7 +16306,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 61
+   i32.const 66
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -4224,19 +4224,6 @@
     i32.lt_u
     select
     local.set $6
-    local.get $1
-    local.get $6
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 432
-     i32.const 592
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
    end
    local.get $5
    local.get $6
@@ -4294,7 +4281,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4340,7 +4327,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5276,7 +5263,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5322,7 +5309,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6254,7 +6241,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6300,7 +6287,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7236,7 +7223,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7282,7 +7269,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8206,7 +8193,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8252,7 +8239,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9164,7 +9151,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9210,7 +9197,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10139,7 +10126,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10185,7 +10172,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11115,7 +11102,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11161,7 +11148,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -12075,7 +12062,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -12121,7 +12108,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13052,7 +13039,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13098,7 +13085,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14300,7 +14287,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14528,7 +14515,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14756,7 +14743,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14984,7 +14971,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15212,7 +15199,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15440,7 +15427,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15668,7 +15655,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15896,7 +15883,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16124,7 +16111,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16352,7 +16339,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 73
+   i32.const 72
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -4162,7 +4162,7 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4268,7 +4268,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4278,7 +4278,7 @@
    i32.const 1
    i32.add
    i32.const 0
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -4294,7 +4294,7 @@
   local.get $0
   local.get $1
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<i8>#set:length_
@@ -4312,7 +4312,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5248,7 +5248,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5258,7 +5258,7 @@
    i32.const 1
    i32.add
    i32.const 0
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -5274,7 +5274,7 @@
   local.get $0
   local.get $1
   i32.const 0
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u8>#set:length_
@@ -5292,7 +5292,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6224,7 +6224,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6234,7 +6234,7 @@
    i32.const 1
    i32.add
    i32.const 1
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -6250,7 +6250,7 @@
   local.get $0
   local.get $1
   i32.const 1
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<i16>#set:length_
@@ -6268,7 +6268,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7204,7 +7204,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7214,7 +7214,7 @@
    i32.const 1
    i32.add
    i32.const 1
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -7230,7 +7230,7 @@
   local.get $0
   local.get $1
   i32.const 1
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u16>#set:length_
@@ -7248,7 +7248,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8172,7 +8172,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8182,7 +8182,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -8198,7 +8198,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#set:length_
@@ -8216,7 +8216,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9128,7 +9128,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9138,7 +9138,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -9154,7 +9154,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u32>#set:length_
@@ -9172,7 +9172,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10101,7 +10101,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10111,7 +10111,7 @@
    i32.const 1
    i32.add
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -10127,7 +10127,7 @@
   local.get $0
   local.get $1
   i32.const 3
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<i64>#set:length_
@@ -10145,7 +10145,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11075,7 +11075,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11085,7 +11085,7 @@
    i32.const 1
    i32.add
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -11101,7 +11101,7 @@
   local.get $0
   local.get $1
   i32.const 3
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<u64>#set:length_
@@ -11119,7 +11119,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -12033,7 +12033,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -12043,7 +12043,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -12059,7 +12059,7 @@
   local.get $0
   local.get $1
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<f32>#set:length_
@@ -12077,7 +12077,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13008,7 +13008,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13018,7 +13018,7 @@
    i32.const 1
    i32.add
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -13034,7 +13034,7 @@
   local.get $0
   local.get $1
   i32.const 3
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
   call $~lib/array/Array<f64>#set:length_
@@ -13052,7 +13052,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14254,7 +14254,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14482,7 +14482,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14710,7 +14710,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14938,7 +14938,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15166,7 +15166,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15394,7 +15394,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15622,7 +15622,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15850,7 +15850,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16078,7 +16078,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16306,7 +16306,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 66
+   i32.const 67
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -4184,7 +4184,7 @@
    if
     i32.const 432
     i32.const 592
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -4192,55 +4192,55 @@
    local.get $0
    i32.load
    local.set $4
+   i32.const 8
+   local.tee $5
    local.get $1
+   local.tee $6
+   local.get $5
+   local.get $6
+   i32.gt_u
+   select
    local.get $2
    i32.shl
-   local.set $5
-   local.get $5
-   i32.const 0
-   i32.eq
-   if (result i32)
-    i32.const 8
-   else
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-   end
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
    local.set $6
+   i32.const 1
+   i32.const 32
    local.get $6
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.set $6
+   local.get $4
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $5
+   local.get $5
    local.get $3
    i32.add
    i32.const 0
-   local.get $5
+   local.get $6
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $6
+   local.get $5
    local.get $4
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $5
     i32.store
     local.get $0
-    local.get $6
+    local.get $5
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $5
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -4268,7 +4268,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4312,7 +4312,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5248,7 +5248,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5292,7 +5292,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6224,7 +6224,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6268,7 +6268,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7204,7 +7204,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7248,7 +7248,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8172,7 +8172,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8216,7 +8216,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9128,7 +9128,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9172,7 +9172,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10101,7 +10101,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10145,7 +10145,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11075,7 +11075,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11119,7 +11119,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -12033,7 +12033,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -12077,7 +12077,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13008,7 +13008,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13052,7 +13052,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14254,7 +14254,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14482,7 +14482,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14710,7 +14710,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14938,7 +14938,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15166,7 +15166,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15394,7 +15394,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15622,7 +15622,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15850,7 +15850,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16078,7 +16078,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16306,7 +16306,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 67
+   i32.const 68
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -10,13 +10,13 @@
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $i32_f64_=>_none (func (param i32 f64)))
  (type $none_=>_i32 (func (result i32)))
@@ -4162,16 +4162,17 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -4191,51 +4192,76 @@
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    i32.const 8
-   local.tee $5
-   local.get $1
    local.tee $6
-   local.get $5
+   local.get $1
+   local.tee $7
    local.get $6
+   local.get $7
    i32.gt_u
    select
    local.get $2
    i32.shl
    local.set $6
-   i32.const 1
-   i32.const 32
-   local.get $6
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.set $6
-   local.get $4
+   local.get $3
+   if
+    local.get $6
+    local.set $7
+    i32.const 1
+    i32.const 32
+    local.get $7
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $7
+    i32.const 1073741820
+    local.tee $8
+    local.get $7
+    local.get $8
+    i32.lt_u
+    select
+    local.set $6
+    local.get $1
+    local.get $6
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 432
+     i32.const 592
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $5
-   local.get $5
-   local.get $3
+   local.set $7
+   local.get $7
+   local.get $4
    i32.add
    i32.const 0
    local.get $6
-   local.get $3
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $7
    local.get $5
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $5
+    local.get $7
     i32.store
     local.get $0
-    local.get $5
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $5
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -4268,7 +4294,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4278,6 +4304,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -4293,6 +4320,7 @@
  (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
@@ -4312,7 +4340,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5248,7 +5276,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5258,6 +5286,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -5273,6 +5302,7 @@
  (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
@@ -5292,7 +5322,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6224,7 +6254,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6233,6 +6263,7 @@
    local.get $1
    i32.const 1
    i32.add
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
@@ -6250,6 +6281,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -6268,7 +6300,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7204,7 +7236,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7213,6 +7245,7 @@
    local.get $1
    i32.const 1
    i32.add
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
@@ -7230,6 +7263,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -7248,7 +7282,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8172,7 +8206,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8182,6 +8216,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -8198,6 +8233,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -8216,7 +8252,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9128,7 +9164,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9138,6 +9174,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -9154,6 +9191,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -9172,7 +9210,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10101,7 +10139,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10111,6 +10149,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -10127,6 +10166,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -10145,7 +10185,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11075,7 +11115,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11085,6 +11125,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -11101,6 +11142,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -11119,7 +11161,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -12033,7 +12075,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -12043,6 +12085,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -12059,6 +12102,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -12077,7 +12121,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13008,7 +13052,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13018,6 +13062,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -13034,6 +13079,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureCapacity
   local.get $0
   local.get $1
@@ -13052,7 +13098,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14254,7 +14300,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14482,7 +14528,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14710,7 +14756,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14938,7 +14984,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15166,7 +15212,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15394,7 +15440,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15622,7 +15668,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15850,7 +15896,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16078,7 +16124,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16306,7 +16352,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 68
+   i32.const 73
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -10,13 +10,13 @@
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_f32_=>_i32 (func (param i32 f32) (result i32)))
  (type $i32_f64_=>_i32 (func (param i32 f64) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i64_=>_i32 (func (param i64) (result i32)))
  (type $i32_i64_i32_=>_i32 (func (param i32 i64 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $i32_f64_=>_none (func (param i32 f64)))
  (type $none_=>_i32 (func (result i32)))
@@ -4162,16 +4162,16 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -4184,47 +4184,49 @@
    if
     i32.const 432
     i32.const 592
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    local.get $1
    local.get $2
-   i32.shl
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
-   local.set $6
-   local.get $6
    local.get $3
    i32.add
-   i32.const 0
+   i32.shl
+   local.set $6
    local.get $5
-   local.get $3
-   i32.sub
-   call $~lib/memory/memory.fill
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $7
+   local.get $7
+   local.get $4
+   i32.add
+   i32.const 0
    local.get $6
    local.get $4
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $7
+   local.get $5
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.store
     local.get $0
-    local.get $6
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -4252,7 +4254,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4262,6 +4264,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4277,6 +4280,7 @@
  (func $~lib/array/Array<i8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -4296,7 +4300,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5232,7 +5236,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5242,6 +5246,7 @@
    i32.const 1
    i32.add
    i32.const 0
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -5257,6 +5262,7 @@
  (func $~lib/array/Array<u8>#set:length (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
+  i32.const 0
   i32.const 0
   call $~lib/array/ensureSize
   local.get $0
@@ -5276,7 +5282,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6208,7 +6214,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6217,6 +6223,7 @@
    local.get $1
    i32.const 1
    i32.add
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -6234,6 +6241,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -6252,7 +6260,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7188,7 +7196,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7197,6 +7205,7 @@
    local.get $1
    i32.const 1
    i32.add
+   i32.const 1
    i32.const 1
    call $~lib/array/ensureSize
    local.get $0
@@ -7214,6 +7223,7 @@
   local.get $0
   local.get $1
   i32.const 1
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -7232,7 +7242,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8156,7 +8166,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8166,6 +8176,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -8182,6 +8193,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -8200,7 +8212,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9112,7 +9124,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9122,6 +9134,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -9138,6 +9151,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -9156,7 +9170,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10085,7 +10099,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10095,6 +10109,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -10111,6 +10126,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -10129,7 +10145,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11059,7 +11075,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11069,6 +11085,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -11085,6 +11102,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -11103,7 +11121,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -12017,7 +12035,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -12027,6 +12045,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -12043,6 +12062,7 @@
   local.get $0
   local.get $1
   i32.const 2
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -12061,7 +12081,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -12992,7 +13012,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13002,6 +13022,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -13018,6 +13039,7 @@
   local.get $0
   local.get $1
   i32.const 3
+  i32.const 0
   call $~lib/array/ensureSize
   local.get $0
   local.get $1
@@ -13036,7 +13058,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14198,6 +14220,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -14236,44 +14260,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 0
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i8>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i8>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i8>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i8>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<i8>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -14417,6 +14448,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -14455,44 +14488,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 0
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u8>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u8>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u8>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u8>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<u8>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -14636,6 +14676,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -14674,44 +14716,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 1
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i16>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i16>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i16>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i16>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<i16>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -14855,6 +14904,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -14893,44 +14944,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 1
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u16>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u16>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u16>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u16>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<u16>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -15074,6 +15132,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -15112,44 +15172,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i32>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i32>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i32>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<i32>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -15293,6 +15360,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -15331,44 +15400,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u32>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u32>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u32>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u32>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<u32>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -15512,6 +15588,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -15550,44 +15628,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 3
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i64>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<i64>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<i64>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<i64>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<i64>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -15731,6 +15816,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -15769,44 +15856,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 3
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u64>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<u64>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<u64>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<u64>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<u64>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -15950,6 +16044,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -15988,44 +16084,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 2
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<f32>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<f32>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<f32>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<f32>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<f32>#values (param $0 i32) (result i32)
   (local $1 i32)
@@ -16169,6 +16272,8 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -16207,44 +16312,51 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 58
+   i32.const 61
    i32.const 60
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 8
+  local.tee $2
   local.get $1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_s
+  select
   i32.const 3
   i32.shl
-  local.set $2
+  local.set $4
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $4
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $5
   i32.store offset=4
-  local.get $3
+  local.get $5
   i32.const 0
-  local.get $2
+  local.get $4
   call $~lib/memory/memory.fill
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<f64>#set:buffer
   local.get $0
-  local.get $3
+  local.get $5
   call $~lib/array/Array<f64>#set:dataStart
   local.get $0
-  local.get $2
+  local.get $4
   call $~lib/array/Array<f64>#set:byteLength
   local.get $0
   local.get $1
   call $~lib/array/Array<f64>#set:length_
   local.get $0
-  local.set $4
+  local.set $6
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $6
  )
  (func $~lib/set/Set<f64>#values (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -68,7 +68,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -1960,7 +1960,7 @@
    if
     i32.const 1584
     i32.const 1536
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -1972,6 +1972,8 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
     local.get $1
+    i32.const 1
+    i32.add
     i32.shl
     local.tee $7
     local.tee $3
@@ -2093,7 +2095,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2114,7 +2116,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2135,7 +2137,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -68,7 +68,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -1946,7 +1946,7 @@
   (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $4
   local.get $1
   i32.shr_u
   i32.const 1
@@ -1960,7 +1960,7 @@
    if
     i32.const 1584
     i32.const 1536
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -1970,20 +1970,22 @@
    local.tee $6
    local.set $2
    block $__inlined_func$~lib/rt/itcms/__renew
+    local.get $4
     i32.const 1
-    i32.const 32
+    i32.shl
+    local.tee $3
+    i32.const 1073741820
+    local.get $3
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $3
     i32.const 8
     local.get $1
     i32.shl
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
     local.tee $1
-    i32.const 1073741820
     local.get $1
-    i32.const 1073741820
+    local.get $3
     i32.lt_u
     select
     local.tee $7
@@ -1991,7 +1993,7 @@
     local.get $6
     i32.const 20
     i32.sub
-    local.tee $4
+    local.tee $5
     i32.load
     i32.const -4
     i32.and
@@ -1999,7 +2001,7 @@
     i32.sub
     i32.le_u
     if
-     local.get $4
+     local.get $5
      local.get $3
      i32.store offset=16
      local.get $2
@@ -2007,13 +2009,13 @@
      br $__inlined_func$~lib/rt/itcms/__renew
     end
     local.get $3
-    local.get $4
+    local.get $5
     i32.load offset=12
     call $~lib/rt/itcms/__new
     local.tee $1
     local.get $2
     local.get $3
-    local.get $4
+    local.get $5
     i32.load offset=16
     local.tee $2
     local.get $2
@@ -2023,10 +2025,10 @@
     call $~lib/memory/memory.copy
    end
    local.get $1
-   local.get $5
+   local.get $4
    i32.add
    local.get $7
-   local.get $5
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
@@ -2106,7 +2108,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2127,7 +2129,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2148,7 +2150,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -68,7 +68,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -1960,7 +1960,7 @@
    if
     i32.const 1584
     i32.const 1536
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -1972,18 +1972,14 @@
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
     i32.const 32
-    i32.const 1
+    i32.const 8
     local.get $1
     i32.shl
-    local.tee $1
     i32.const 1
     i32.sub
     i32.clz
     i32.sub
     i32.shl
-    i32.const 8
-    local.get $1
-    select
     local.tee $7
     local.tee $3
     local.get $6
@@ -2104,7 +2100,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2125,7 +2121,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2146,7 +2142,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -68,7 +68,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -1943,10 +1943,9 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.tee $5
+  local.tee $6
   local.get $1
   i32.shr_u
   i32.const 1
@@ -1967,25 +1966,43 @@
    end
    local.get $0
    i32.load
-   local.tee $6
    local.set $2
+   i32.const 1
+   i32.const 32
+   i32.const 8
+   local.get $1
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.tee $4
+   i32.const 1073741820
+   local.get $4
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $4
+   local.get $1
+   i32.shr_u
+   i32.const 1
+   i32.lt_u
+   if
+    i32.const 1584
+    i32.const 1536
+    i32.const 30
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
    block $__inlined_func$~lib/rt/itcms/__renew
-    i32.const 1
-    i32.const 32
-    i32.const 8
-    local.get $1
-    i32.shl
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-    local.tee $7
-    local.tee $3
-    local.get $6
+    local.get $4
+    local.get $2
+    local.tee $1
     i32.const 20
     i32.sub
-    local.tee $4
+    local.tee $5
     i32.load
     i32.const -4
     i32.and
@@ -1993,38 +2010,38 @@
     i32.sub
     i32.le_u
     if
+     local.get $5
      local.get $4
-     local.get $3
      i32.store offset=16
-     local.get $2
-     local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
-    local.get $3
     local.get $4
+    local.get $5
     i32.load offset=12
     call $~lib/rt/itcms/__new
-    local.tee $1
-    local.get $2
-    local.get $3
+    local.tee $3
+    local.get $1
     local.get $4
+    local.get $5
     i32.load offset=16
-    local.tee $2
-    local.get $2
-    local.get $3
+    local.tee $1
+    local.get $1
+    local.get $4
     i32.gt_u
     select
     call $~lib/memory/memory.copy
+    local.get $3
+    local.set $1
    end
    local.get $1
-   local.get $5
+   local.get $6
    i32.add
-   local.get $7
-   local.get $5
+   local.get $4
+   local.get $6
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $6
+   local.get $2
    i32.ne
    if
     local.get $0
@@ -2088,7 +2105,7 @@
     end
    end
    local.get $0
-   local.get $7
+   local.get $4
    i32.store offset=8
   end
  )
@@ -2100,7 +2117,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2121,7 +2138,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2142,7 +2159,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -68,7 +68,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -1960,7 +1960,7 @@
    if
     i32.const 1584
     i32.const 1536
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -1971,10 +1971,19 @@
    local.set $2
    block $__inlined_func$~lib/rt/itcms/__renew
     i32.const 1
-    local.get $1
+    i32.const 32
     i32.const 1
-    i32.add
+    local.get $1
     i32.shl
+    local.tee $1
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 8
+    local.get $1
+    select
     local.tee $7
     local.tee $3
     local.get $6
@@ -2095,7 +2104,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2116,7 +2125,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2137,7 +2146,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -68,7 +68,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -1943,9 +1943,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.tee $6
+  local.tee $5
   local.get $1
   i32.shr_u
   i32.const 1
@@ -1966,43 +1967,31 @@
    end
    local.get $0
    i32.load
+   local.tee $6
    local.set $2
-   i32.const 1
-   i32.const 32
-   i32.const 8
-   local.get $1
-   i32.shl
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.tee $4
-   i32.const 1073741820
-   local.get $4
-   i32.const 1073741820
-   i32.lt_u
-   select
-   local.tee $4
-   local.get $1
-   i32.shr_u
-   i32.const 1
-   i32.lt_u
-   if
-    i32.const 1584
-    i32.const 1536
-    i32.const 30
-    i32.const 48
-    call $~lib/builtins/abort
-    unreachable
-   end
    block $__inlined_func$~lib/rt/itcms/__renew
-    local.get $4
-    local.get $2
+    i32.const 1
+    i32.const 32
+    i32.const 8
+    local.get $1
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
     local.tee $1
+    i32.const 1073741820
+    local.get $1
+    i32.const 1073741820
+    i32.lt_u
+    select
+    local.tee $7
+    local.tee $3
+    local.get $6
     i32.const 20
     i32.sub
-    local.tee $5
+    local.tee $4
     i32.load
     i32.const -4
     i32.and
@@ -2010,38 +1999,38 @@
     i32.sub
     i32.le_u
     if
-     local.get $5
      local.get $4
+     local.get $3
      i32.store offset=16
+     local.get $2
+     local.set $1
      br $__inlined_func$~lib/rt/itcms/__renew
     end
+    local.get $3
     local.get $4
-    local.get $5
     i32.load offset=12
     call $~lib/rt/itcms/__new
-    local.tee $3
-    local.get $1
-    local.get $4
-    local.get $5
-    i32.load offset=16
     local.tee $1
-    local.get $1
+    local.get $2
+    local.get $3
     local.get $4
+    i32.load offset=16
+    local.tee $2
+    local.get $2
+    local.get $3
     i32.gt_u
     select
     call $~lib/memory/memory.copy
-    local.get $3
-    local.set $1
    end
    local.get $1
-   local.get $6
+   local.get $5
    i32.add
-   local.get $4
-   local.get $6
+   local.get $7
+   local.get $5
    i32.sub
    call $~lib/memory/memory.fill
    local.get $1
-   local.get $2
+   local.get $6
    i32.ne
    if
     local.get $0
@@ -2105,7 +2094,7 @@
     end
    end
    local.get $0
-   local.get $4
+   local.get $7
    i32.store offset=8
   end
  )
@@ -2117,7 +2106,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2138,7 +2127,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2159,7 +2148,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -68,7 +68,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -1937,7 +1937,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2104,7 +2104,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2125,7 +2125,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2146,7 +2146,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2283,7 +2283,7 @@
   if
    i32.const 1088
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    i32.const 1100
    i32.const 1
    i32.store
@@ -2361,7 +2361,7 @@
   if
    i32.const 1184
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    i32.const 1196
    i32.const 1
    i32.store
@@ -2439,7 +2439,7 @@
   if
    i32.const 1264
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    i32.const 1276
    i32.const 1
    i32.store
@@ -2517,7 +2517,7 @@
   if
    i32.const 1360
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    i32.const 1372
    i32.const 1
    i32.store

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -72,7 +72,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3822,19 +3822,6 @@
     i32.lt_u
     select
     local.set $6
-    local.get $1
-    local.get $6
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 560
-     i32.const 512
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
    end
    local.get $5
    local.get $6
@@ -3897,7 +3884,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3933,7 +3920,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3979,7 +3966,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4015,7 +4002,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4061,7 +4048,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4097,7 +4084,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4143,7 +4130,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 124
+    i32.const 123
     i32.const 22
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -72,7 +72,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3760,7 +3760,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3871,7 +3871,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3881,7 +3881,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -3906,7 +3906,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3952,7 +3952,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3962,7 +3962,7 @@
    i32.const 1
    i32.add
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -3987,7 +3987,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4033,7 +4033,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4043,7 +4043,7 @@
    i32.const 1
    i32.add
    i32.const 2
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1
@@ -4068,7 +4068,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4114,7 +4114,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 117
+    i32.const 118
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4124,7 +4124,7 @@
    i32.const 1
    i32.add
    i32.const 3
-   call $~lib/array/ensureSize
+   call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
    i32.const 1

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -72,7 +72,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3782,7 +3782,7 @@
    if
     i32.const 560
     i32.const 512
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -3790,55 +3790,55 @@
    local.get $0
    i32.load
    local.set $4
+   i32.const 8
+   local.tee $5
    local.get $1
+   local.tee $6
+   local.get $5
+   local.get $6
+   i32.gt_u
+   select
    local.get $2
    i32.shl
-   local.set $5
-   local.get $5
-   i32.const 0
-   i32.eq
-   if (result i32)
-    i32.const 8
-   else
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-   end
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
    local.set $6
+   i32.const 1
+   i32.const 32
    local.get $6
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.set $6
+   local.get $4
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $5
+   local.get $5
    local.get $3
    i32.add
    i32.const 0
-   local.get $5
+   local.get $6
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $6
+   local.get $5
    local.get $4
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $5
     i32.store
     local.get $0
-    local.get $6
+    local.get $5
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $5
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -3871,7 +3871,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3906,7 +3906,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3952,7 +3952,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3987,7 +3987,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4033,7 +4033,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4068,7 +4068,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4114,7 +4114,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 118
+    i32.const 119
     i32.const 22
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -3791,9 +3791,9 @@
    local.get $0
    i32.load
    local.set $5
-   i32.const 8
-   local.tee $6
    local.get $1
+   local.tee $6
+   i32.const 8
    local.tee $7
    local.get $6
    local.get $7

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -5,10 +5,10 @@
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
@@ -72,7 +72,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3760,16 +3760,17 @@
    end
   end
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -3789,51 +3790,76 @@
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    i32.const 8
-   local.tee $5
-   local.get $1
    local.tee $6
-   local.get $5
+   local.get $1
+   local.tee $7
    local.get $6
+   local.get $7
    i32.gt_u
    select
    local.get $2
    i32.shl
    local.set $6
-   i32.const 1
-   i32.const 32
-   local.get $6
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.set $6
-   local.get $4
+   local.get $3
+   if
+    local.get $6
+    local.set $7
+    i32.const 1
+    i32.const 32
+    local.get $7
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $7
+    i32.const 1073741820
+    local.tee $8
+    local.get $7
+    local.get $8
+    i32.lt_u
+    select
+    local.set $6
+    local.get $1
+    local.get $6
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 560
+     i32.const 512
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $5
-   local.get $5
-   local.get $3
+   local.set $7
+   local.get $7
+   local.get $4
    i32.add
    i32.const 0
    local.get $6
-   local.get $3
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $7
    local.get $5
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $5
+    local.get $7
     i32.store
     local.get $0
-    local.get $5
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $5
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -3871,7 +3897,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3881,6 +3907,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -3906,7 +3933,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3952,7 +3979,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3962,6 +3989,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -3987,7 +4015,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4033,7 +4061,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4043,6 +4071,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1
@@ -4068,7 +4097,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4114,7 +4143,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 119
+    i32.const 124
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4124,6 +4153,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureCapacity
    local.get $0
    local.get $1

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -72,7 +72,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3783,7 +3783,7 @@
    if
     i32.const 560
     i32.const 512
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -3804,15 +3804,8 @@
    local.set $6
    local.get $3
    if
-    local.get $6
-    local.set $7
+    local.get $4
     i32.const 1
-    i32.const 32
-    local.get $7
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
     local.tee $7
     i32.const 1073741820
@@ -3821,13 +3814,20 @@
     local.get $8
     i32.lt_u
     select
+    local.tee $8
+    local.get $6
+    local.tee $7
+    local.get $8
+    local.get $7
+    i32.gt_u
+    select
     local.set $6
    end
    local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    local.get $4
    i32.add
    i32.const 0
@@ -3835,18 +3835,18 @@
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
+   local.get $8
    local.get $5
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $8
     i32.store
     local.get $0
-    local.get $7
+    local.get $8
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -3884,7 +3884,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3920,7 +3920,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3966,7 +3966,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4002,7 +4002,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4048,7 +4048,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4084,7 +4084,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4130,7 +4130,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 123
+    i32.const 115
     i32.const 22
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -5,10 +5,10 @@
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
@@ -72,7 +72,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3760,16 +3760,16 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
-  local.get $4
+  local.get $3
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -3782,49 +3782,63 @@
    if
     i32.const 560
     i32.const 512
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $5
+   local.set $4
    local.get $1
    local.get $2
+   i32.shl
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 8
+   else
+    i32.const 1
+    i32.const 32
+    local.get $5
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+   end
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
    local.get $3
    i32.add
-   i32.shl
-   local.set $6
-   local.get $5
-   local.get $6
-   call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.add
    i32.const 0
-   local.get $6
-   local.get $4
+   local.get $5
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.store
     local.get $0
-    local.get $7
+    local.get $6
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.store offset=8
   end
  )
@@ -3857,7 +3871,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3867,7 +3881,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -3893,7 +3906,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3939,7 +3952,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3949,7 +3962,6 @@
    i32.const 1
    i32.add
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -3975,7 +3987,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4021,7 +4033,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4031,7 +4043,6 @@
    i32.const 1
    i32.add
    i32.const 2
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4057,7 +4068,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4103,7 +4114,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 112
+    i32.const 117
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4113,7 +4124,6 @@
    i32.const 1
    i32.add
    i32.const 3
-   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -5,10 +5,10 @@
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
@@ -72,7 +72,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3760,16 +3760,16 @@
    end
   end
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -3782,47 +3782,49 @@
    if
     i32.const 560
     i32.const 512
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    local.get $1
    local.get $2
-   i32.shl
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
-   local.set $6
-   local.get $6
    local.get $3
    i32.add
-   i32.const 0
+   i32.shl
+   local.set $6
    local.get $5
-   local.get $3
-   i32.sub
-   call $~lib/memory/memory.fill
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $7
+   local.get $7
+   local.get $4
+   i32.add
+   i32.const 0
    local.get $6
    local.get $4
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $7
+   local.get $5
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.store
     local.get $0
-    local.get $6
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -3855,7 +3857,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3865,6 +3867,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -3890,7 +3893,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3936,7 +3939,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3946,6 +3949,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -3971,7 +3975,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4017,7 +4021,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4027,6 +4031,7 @@
    i32.const 1
    i32.add
    i32.const 2
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1
@@ -4052,7 +4057,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4098,7 +4103,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 108
+    i32.const 112
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4108,6 +4113,7 @@
    i32.const 1
    i32.add
    i32.const 3
+   i32.const 1
    call $~lib/array/ensureSize
    local.get $0
    local.get $1

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -3205,7 +3205,7 @@
     if
      i32.const 1088
      i32.const 1776
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -3205,7 +3205,7 @@
     if
      i32.const 1088
      i32.const 1776
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -3205,7 +3205,7 @@
     if
      i32.const 1088
      i32.const 1776
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -3205,7 +3205,7 @@
     if
      i32.const 1088
      i32.const 1776
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -3205,7 +3205,7 @@
     if
      i32.const 1088
      i32.const 1776
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -3205,7 +3205,7 @@
     if
      i32.const 1088
      i32.const 1776
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -3205,7 +3205,7 @@
     if
      i32.const 1088
      i32.const 1776
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -3826,7 +3826,7 @@
   if
    i32.const 64
    i32.const 752
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -3826,7 +3826,7 @@
   if
    i32.const 64
    i32.const 752
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -3826,7 +3826,7 @@
   if
    i32.const 64
    i32.const 752
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -3826,7 +3826,7 @@
   if
    i32.const 64
    i32.const 752
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -3826,7 +3826,7 @@
   if
    i32.const 64
    i32.const 752
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -3826,7 +3826,7 @@
   if
    i32.const 64
    i32.const 752
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -3826,7 +3826,7 @@
   if
    i32.const 64
    i32.const 752
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5078,11 +5078,11 @@
    local.tee $7
    i32.const 1
    i32.const 32
-   i32.const 8
-   local.get $2
    local.get $2
    i32.const 8
-   i32.lt_u
+   local.get $2
+   i32.const 8
+   i32.gt_u
    select
    i32.const 2
    i32.shl

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5039,29 +5039,19 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  local.get $0
-  i32.load offset=12
-  local.tee $6
-  i32.const 1
-  i32.add
-  local.tee $3
-  local.set $2
-  local.get $3
+  local.get $1
   local.get $0
   i32.load offset=8
-  local.tee $4
+  local.tee $3
   i32.const 2
   i32.shr_u
   i32.gt_u
   if
-   local.get $2
+   local.get $1
    i32.const 268435455
    i32.gt_u
    if
@@ -5072,15 +5062,15 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $4
    local.get $0
    i32.load
-   local.tee $7
+   local.set $4
+   local.get $1
    i32.const 1
    i32.const 32
    i32.const 8
-   local.get $2
-   local.get $2
+   local.get $1
+   local.get $1
    i32.const 8
    i32.lt_u
    select
@@ -5091,36 +5081,68 @@
    i32.clz
    i32.sub
    i32.shl
-   local.tee $5
-   call $~lib/rt/itcms/__renew
+   local.tee $1
+   i32.const 1073741820
+   local.get $1
+   i32.const 1073741820
+   i32.lt_u
+   select
    local.tee $2
-   i32.add
-   local.get $5
+   i32.const 2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 13648
+    i32.const 15248
+    i32.const 30
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $3
    local.get $4
+   local.get $2
+   call $~lib/rt/itcms/__renew
+   local.tee $1
+   i32.add
+   local.get $2
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $2
-   local.get $7
+   local.get $1
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $2
+    local.get $1
     i32.store
     local.get $0
-    local.get $2
+    local.get $1
     i32.store offset=4
     local.get $0
-    local.get $2
+    local.get $1
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $2
    i32.store offset=8
   end
+ )
+ (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  local.get $0
+  i32.load offset=12
+  local.tee $2
+  i32.const 1
+  i32.add
+  local.tee $3
+  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
-  local.get $6
+  local.get $2
   i32.const 2
   i32.shl
   i32.add
@@ -21797,7 +21819,7 @@
   if
    i32.const 1264
    i32.const 15248
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -21817,7 +21839,7 @@
   if
    i32.const 15296
    i32.const 15248
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -21796,7 +21796,7 @@
   if
    i32.const 1264
    i32.const 15248
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -21816,7 +21816,7 @@
   if
    i32.const 15296
    i32.const 15248
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5067,7 +5067,7 @@
    if
     i32.const 13648
     i32.const 15248
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -5076,9 +5076,20 @@
    local.get $0
    i32.load
    local.tee $7
+   i32.const 1
+   i32.const 32
    local.get $2
-   i32.const 3
+   i32.const 2
    i32.shl
+   local.tee $2
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 8
+   local.get $2
+   select
    local.tee $5
    call $~lib/rt/itcms/__renew
    local.tee $2
@@ -21785,7 +21796,7 @@
   if
    i32.const 1264
    i32.const 15248
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -21805,7 +21816,7 @@
   if
    i32.const 15296
    i32.const 15248
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5051,9 +5051,9 @@
   local.tee $6
   i32.const 1
   i32.add
-  local.tee $3
+  local.tee $5
   local.set $2
-  local.get $3
+  local.get $5
   local.get $0
   i32.load offset=8
   local.tee $4
@@ -5067,7 +5067,7 @@
    if
     i32.const 13648
     i32.const 15248
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -5076,8 +5076,16 @@
    local.get $0
    i32.load
    local.tee $7
+   local.get $4
    i32.const 1
-   i32.const 32
+   i32.shl
+   local.tee $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
    local.get $2
    i32.const 8
    local.get $2
@@ -5086,22 +5094,16 @@
    select
    i32.const 2
    i32.shl
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
    local.tee $2
-   i32.const 1073741820
    local.get $2
-   i32.const 1073741820
+   local.get $3
    i32.lt_u
    select
-   local.tee $5
+   local.tee $3
    call $~lib/rt/itcms/__renew
    local.tee $2
    i32.add
-   local.get $5
+   local.get $3
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
@@ -5121,7 +5123,7 @@
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $3
    i32.store offset=8
   end
   local.get $0
@@ -5137,7 +5139,7 @@
   i32.const 1
   call $~lib/rt/itcms/__link
   local.get $0
-  local.get $3
+  local.get $5
   i32.store offset=12
  )
  (func $~lib/util/number/decimalCount32 (param $0 i32) (result i32)
@@ -21803,7 +21805,7 @@
   if
    i32.const 1264
    i32.const 15248
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -21823,7 +21825,7 @@
   if
    i32.const 15296
    i32.const 15248
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5039,19 +5039,29 @@
   call $~lib/memory/memory.copy
   local.get $3
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  local.get $1
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=12
+  local.tee $6
+  i32.const 1
+  i32.add
+  local.tee $3
+  local.set $2
+  local.get $3
   local.get $0
   i32.load offset=8
-  local.tee $3
+  local.tee $4
   i32.const 2
   i32.shr_u
   i32.gt_u
   if
-   local.get $1
+   local.get $2
    i32.const 268435455
    i32.gt_u
    if
@@ -5062,15 +5072,15 @@
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $4
    local.get $0
    i32.load
-   local.set $4
-   local.get $1
+   local.tee $7
    i32.const 1
    i32.const 32
    i32.const 8
-   local.get $1
-   local.get $1
+   local.get $2
+   local.get $2
    i32.const 8
    i32.lt_u
    select
@@ -5081,68 +5091,42 @@
    i32.clz
    i32.sub
    i32.shl
-   local.tee $1
+   local.tee $2
    i32.const 1073741820
-   local.get $1
+   local.get $2
    i32.const 1073741820
    i32.lt_u
    select
-   local.tee $2
-   i32.const 2
-   i32.shr_u
-   i32.gt_u
-   if
-    i32.const 13648
-    i32.const 15248
-    i32.const 30
-    i32.const 48
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $3
-   local.get $4
-   local.get $2
+   local.tee $5
    call $~lib/rt/itcms/__renew
-   local.tee $1
+   local.tee $2
    i32.add
-   local.get $2
-   local.get $3
+   local.get $5
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $1
-   local.get $4
+   local.get $2
+   local.get $7
    i32.ne
    if
     local.get $0
-    local.get $1
+    local.get $2
     i32.store
     local.get $0
-    local.get $1
+    local.get $2
     i32.store offset=4
     local.get $0
-    local.get $1
+    local.get $2
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $2
+   local.get $5
    i32.store offset=8
   end
- )
- (func $~lib/array/Array<~lib/string/String>#push (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $0
-  local.get $0
-  i32.load offset=12
-  local.tee $2
-  i32.const 1
-  i32.add
-  local.tee $3
-  call $~lib/array/ensureCapacity
   local.get $0
   i32.load offset=4
-  local.get $2
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -21819,7 +21803,7 @@
   if
    i32.const 1264
    i32.const 15248
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -21839,7 +21823,7 @@
   if
    i32.const 15296
    i32.const 15248
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5067,7 +5067,7 @@
    if
     i32.const 13648
     i32.const 15248
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -5077,7 +5077,7 @@
    i32.load
    local.tee $7
    local.get $2
-   i32.const 2
+   i32.const 3
    i32.shl
    local.tee $5
    call $~lib/rt/itcms/__renew
@@ -21785,7 +21785,7 @@
   if
    i32.const 1264
    i32.const 15248
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -21805,7 +21805,7 @@
   if
    i32.const 15296
    i32.const 15248
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -5067,7 +5067,7 @@
    if
     i32.const 13648
     i32.const 15248
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -5078,18 +5078,19 @@
    local.tee $7
    i32.const 1
    i32.const 32
+   i32.const 8
    local.get $2
+   local.get $2
+   i32.const 8
+   i32.lt_u
+   select
    i32.const 2
    i32.shl
-   local.tee $2
    i32.const 1
    i32.sub
    i32.clz
    i32.sub
    i32.shl
-   i32.const 8
-   local.get $2
-   select
    local.tee $5
    call $~lib/rt/itcms/__renew
    local.tee $2
@@ -21796,7 +21797,7 @@
   if
    i32.const 1264
    i32.const 15248
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -21816,7 +21817,7 @@
   if
    i32.const 15296
    i32.const 15248
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -7277,7 +7277,7 @@
    if
     i32.const 12624
     i32.const 14224
-    i32.const 23
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -7298,15 +7298,8 @@
    local.set $6
    local.get $3
    if
-    local.get $6
-    local.set $7
+    local.get $4
     i32.const 1
-    i32.const 32
-    local.get $7
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
     i32.shl
     local.tee $7
     i32.const 1073741820
@@ -7315,13 +7308,20 @@
     local.get $8
     i32.lt_u
     select
+    local.tee $8
+    local.get $6
+    local.tee $7
+    local.get $8
+    local.get $7
+    i32.gt_u
+    select
     local.set $6
    end
    local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
+   local.set $8
+   local.get $8
    local.get $4
    i32.add
    i32.const 0
@@ -7329,18 +7329,18 @@
    local.get $4
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
+   local.get $8
    local.get $5
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $8
     i32.store
     local.get $0
-    local.get $7
+    local.get $8
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $8
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -27011,7 +27011,7 @@
   if
    i32.const 240
    i32.const 14224
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -27036,7 +27036,7 @@
   if
    i32.const 14272
    i32.const 14224
-   i32.const 111
+   i32.const 103
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -6,9 +6,9 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
@@ -7254,16 +7254,16 @@
   i32.const 1
   call $~lib/rt/itcms/__link
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $3
   local.get $1
-  local.get $4
+  local.get $3
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -7276,49 +7276,63 @@
    if
     i32.const 12624
     i32.const 14224
-    i32.const 17
+    i32.const 22
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $5
+   local.set $4
    local.get $1
    local.get $2
+   i32.shl
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 8
+   else
+    i32.const 1
+    i32.const 32
+    local.get $5
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+   end
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/itcms/__renew
+   local.set $6
+   local.get $6
    local.get $3
    i32.add
-   i32.shl
-   local.set $6
-   local.get $5
-   local.get $6
-   call $~lib/rt/itcms/__renew
-   local.set $7
-   local.get $7
-   local.get $4
-   i32.add
    i32.const 0
-   local.get $6
-   local.get $4
+   local.get $5
+   local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $7
-   local.get $5
+   local.get $6
+   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $7
+    local.get $6
     i32.store
     local.get $0
-    local.get $7
+    local.get $6
     i32.store offset=4
     local.get $0
-    local.get $7
+    local.get $6
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $6
+   local.get $5
    i32.store offset=8
   end
  )
@@ -7340,7 +7354,6 @@
   local.get $0
   local.get $3
   i32.const 2
-  i32.const 1
   call $~lib/array/ensureSize
   i32.const 1
   drop
@@ -26984,7 +26997,7 @@
   if
    i32.const 240
    i32.const 14224
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -27009,7 +27022,7 @@
   if
    i32.const 14272
    i32.const 14224
-   i32.const 100
+   i32.const 105
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -6,9 +6,9 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
@@ -7254,16 +7254,16 @@
   i32.const 1
   call $~lib/rt/itcms/__link
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -7276,47 +7276,49 @@
    if
     i32.const 12624
     i32.const 14224
-    i32.const 14
+    i32.const 17
     i32.const 48
     call $~lib/builtins/abort
     unreachable
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    local.get $1
    local.get $2
-   i32.shl
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
-   local.set $6
-   local.get $6
    local.get $3
    i32.add
-   i32.const 0
+   i32.shl
+   local.set $6
    local.get $5
-   local.get $3
-   i32.sub
-   call $~lib/memory/memory.fill
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $7
+   local.get $7
+   local.get $4
+   i32.add
+   i32.const 0
    local.get $6
    local.get $4
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $7
+   local.get $5
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $7
     i32.store
     local.get $0
-    local.get $6
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -7338,6 +7340,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureSize
   i32.const 1
   drop
@@ -26981,7 +26984,7 @@
   if
    i32.const 240
    i32.const 14224
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -27006,7 +27009,7 @@
   if
    i32.const 14272
    i32.const 14224
-   i32.const 96
+   i32.const 100
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -6,9 +6,9 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
- (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
@@ -7254,16 +7254,17 @@
   i32.const 1
   call $~lib/rt/itcms/__link
  )
- (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
-  local.get $3
+  local.get $4
   local.get $2
   i32.shr_u
   i32.gt_u
@@ -7283,51 +7284,76 @@
    end
    local.get $0
    i32.load
-   local.set $4
+   local.set $5
    i32.const 8
-   local.tee $5
-   local.get $1
    local.tee $6
-   local.get $5
+   local.get $1
+   local.tee $7
    local.get $6
+   local.get $7
    i32.gt_u
    select
    local.get $2
    i32.shl
    local.set $6
-   i32.const 1
-   i32.const 32
-   local.get $6
-   i32.const 1
-   i32.sub
-   i32.clz
-   i32.sub
-   i32.shl
-   local.set $6
-   local.get $4
+   local.get $3
+   if
+    local.get $6
+    local.set $7
+    i32.const 1
+    i32.const 32
+    local.get $7
+    i32.const 1
+    i32.sub
+    i32.clz
+    i32.sub
+    i32.shl
+    local.tee $7
+    i32.const 1073741820
+    local.tee $8
+    local.get $7
+    local.get $8
+    i32.lt_u
+    select
+    local.set $6
+    local.get $1
+    local.get $6
+    local.get $2
+    i32.shr_u
+    i32.gt_u
+    if
+     i32.const 12624
+     i32.const 14224
+     i32.const 30
+     i32.const 48
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   local.get $5
    local.get $6
    call $~lib/rt/itcms/__renew
-   local.set $5
-   local.get $5
-   local.get $3
+   local.set $7
+   local.get $7
+   local.get $4
    i32.add
    i32.const 0
    local.get $6
-   local.get $3
+   local.get $4
    i32.sub
    call $~lib/memory/memory.fill
+   local.get $7
    local.get $5
-   local.get $4
    i32.ne
    if
     local.get $0
-    local.get $5
+    local.get $7
     i32.store
     local.get $0
-    local.get $5
+    local.get $7
     i32.store offset=4
     local.get $0
-    local.get $5
+    local.get $7
     i32.const 0
     call $~lib/rt/itcms/__link
    end
@@ -7354,6 +7380,7 @@
   local.get $0
   local.get $3
   i32.const 2
+  i32.const 1
   call $~lib/array/ensureCapacity
   i32.const 1
   drop
@@ -26997,7 +27024,7 @@
   if
    i32.const 240
    i32.const 14224
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -27022,7 +27049,7 @@
   if
    i32.const 14272
    i32.const 14224
-   i32.const 107
+   i32.const 112
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -7254,7 +7254,7 @@
   i32.const 1
   call $~lib/rt/itcms/__link
  )
- (func $~lib/array/ensureSize (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureCapacity (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7354,7 +7354,7 @@
   local.get $0
   local.get $3
   i32.const 2
-  call $~lib/array/ensureSize
+  call $~lib/array/ensureCapacity
   i32.const 1
   drop
   local.get $0
@@ -26997,7 +26997,7 @@
   if
    i32.const 240
    i32.const 14224
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -27022,7 +27022,7 @@
   if
    i32.const 14272
    i32.const 14224
-   i32.const 105
+   i32.const 106
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -7316,19 +7316,6 @@
     i32.lt_u
     select
     local.set $6
-    local.get $1
-    local.get $6
-    local.get $2
-    i32.shr_u
-    i32.gt_u
-    if
-     i32.const 12624
-     i32.const 14224
-     i32.const 30
-     i32.const 48
-     call $~lib/builtins/abort
-     unreachable
-    end
    end
    local.get $5
    local.get $6
@@ -27024,7 +27011,7 @@
   if
    i32.const 240
    i32.const 14224
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -27049,7 +27036,7 @@
   if
    i32.const 14272
    i32.const 14224
-   i32.const 112
+   i32.const 111
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -7285,9 +7285,9 @@
    local.get $0
    i32.load
    local.set $5
-   i32.const 8
-   local.tee $6
    local.get $1
+   local.tee $6
+   i32.const 8
    local.tee $7
    local.get $6
    local.get $7

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -7276,7 +7276,7 @@
    if
     i32.const 12624
     i32.const 14224
-    i32.const 22
+    i32.const 23
     i32.const 48
     call $~lib/builtins/abort
     unreachable
@@ -7284,55 +7284,55 @@
    local.get $0
    i32.load
    local.set $4
+   i32.const 8
+   local.tee $5
    local.get $1
+   local.tee $6
+   local.get $5
+   local.get $6
+   i32.gt_u
+   select
    local.get $2
    i32.shl
-   local.set $5
-   local.get $5
-   i32.const 0
-   i32.eq
-   if (result i32)
-    i32.const 8
-   else
-    i32.const 1
-    i32.const 32
-    local.get $5
-    i32.const 1
-    i32.sub
-    i32.clz
-    i32.sub
-    i32.shl
-   end
-   local.set $5
-   local.get $4
-   local.get $5
-   call $~lib/rt/itcms/__renew
    local.set $6
+   i32.const 1
+   i32.const 32
    local.get $6
+   i32.const 1
+   i32.sub
+   i32.clz
+   i32.sub
+   i32.shl
+   local.set $6
+   local.get $4
+   local.get $6
+   call $~lib/rt/itcms/__renew
+   local.set $5
+   local.get $5
    local.get $3
    i32.add
    i32.const 0
-   local.get $5
+   local.get $6
    local.get $3
    i32.sub
    call $~lib/memory/memory.fill
-   local.get $6
+   local.get $5
    local.get $4
    i32.ne
    if
     local.get $0
-    local.get $6
+    local.get $5
     i32.store
     local.get $0
-    local.get $6
+    local.get $5
     i32.store offset=4
     local.get $0
-    local.get $6
+    local.get $5
     i32.const 0
     call $~lib/rt/itcms/__link
    end
    local.get $0
-   local.get $5
+   local.get $6
    i32.store offset=8
   end
  )
@@ -26997,7 +26997,7 @@
   if
    i32.const 240
    i32.const 14224
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -27022,7 +27022,7 @@
   if
    i32.const 14272
    i32.const 14224
-   i32.const 106
+   i32.const 107
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3815,7 +3815,7 @@
     if
      i32.const 1360
      i32.const 1760
-     i32.const 101
+     i32.const 102
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -3924,7 +3924,7 @@
   if
    i32.const 1360
    i32.const 1760
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3815,7 +3815,7 @@
     if
      i32.const 1360
      i32.const 1760
-     i32.const 103
+     i32.const 108
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -3924,7 +3924,7 @@
   if
    i32.const 1360
    i32.const 1760
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3815,7 +3815,7 @@
     if
      i32.const 1360
      i32.const 1760
-     i32.const 102
+     i32.const 103
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -3924,7 +3924,7 @@
   if
    i32.const 1360
    i32.const 1760
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3815,7 +3815,7 @@
     if
      i32.const 1360
      i32.const 1760
-     i32.const 92
+     i32.const 96
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -3924,7 +3924,7 @@
   if
    i32.const 1360
    i32.const 1760
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3815,7 +3815,7 @@
     if
      i32.const 1360
      i32.const 1760
-     i32.const 107
+     i32.const 99
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -3924,7 +3924,7 @@
   if
    i32.const 1360
    i32.const 1760
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3815,7 +3815,7 @@
     if
      i32.const 1360
      i32.const 1760
-     i32.const 108
+     i32.const 107
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -3924,7 +3924,7 @@
   if
    i32.const 1360
    i32.const 1760
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3815,7 +3815,7 @@
     if
      i32.const 1360
      i32.const 1760
-     i32.const 96
+     i32.const 101
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -3924,7 +3924,7 @@
   if
    i32.const 1360
    i32.const 1760
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5454,7 +5454,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5629,7 +5629,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 103
+   i32.const 108
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5454,7 +5454,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5629,7 +5629,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 96
+   i32.const 101
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5454,7 +5454,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5629,7 +5629,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 92
+   i32.const 96
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5454,7 +5454,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5629,7 +5629,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 102
+   i32.const 103
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5454,7 +5454,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5629,7 +5629,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 101
+   i32.const 102
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5454,7 +5454,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5629,7 +5629,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 107
+   i32.const 99
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5454,7 +5454,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5629,7 +5629,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 108
+   i32.const 107
    i32.const 42
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
Fix #1798

- Now internal capacity growing by factor of two.
- Initial capacity changed from `0` to `8` elements

Performance results for sequentially push 1,000,000 items into empty i32 array (`--runtime=incremental`)

|  Browser      |    master<br/> ms    | this PR<br/> ms  |  JavaScript's Array<br/> (baseline), ms  |
| ------------ |----------------:|------------:|------------------------------:|
|  Firefox 88   |   61557             |                  7 |                                              10 |
|  Chrome 90 |   69552            |                  8 |                                            11.4 |

- [x] I've read the contributing guidelines