### PR TITLE
fix: More proper Math.round

### DIFF
--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1437,7 +1437,8 @@ export namespace NativeMath {
   // @ts-ignore: decorator
   @inline
   export function round(x: f64): f64 {
-    return builtin_copysign<f64>(builtin_floor<f64>(x + 0.5), x);
+    let roundUp = builtin_ceil<f64>(x);
+    return select<f64>(roundUp, roundUp - 1.0, roundUp - 0.5 <= x);
   }
 
   // @ts-ignore: decorator
@@ -2732,7 +2733,8 @@ export namespace NativeMathf {
   // @ts-ignore: decorator
   @inline
   export function round(x: f32): f32 {
-    return builtin_copysign<f32>(builtin_floor<f32>(x + 0.5), x);
+    let roundUp = builtin_ceil<f32>(x);
+    return select<f32>(roundUp, roundUp - 1.0, roundUp - 0.5 <= x);
   }
 
   // @ts-ignore: decorator

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -8226,23 +8226,37 @@
   end
  )
  (func $std/math/test_round (param $0 f64) (param $1 f64) (result i32)
+  (local $2 f64)
   local.get $0
+  f64.ceil
+  local.tee $2
+  local.get $2
+  f64.const 1
+  f64.sub
+  local.get $0
+  local.get $2
   f64.const 0.5
-  f64.add
-  f64.floor
-  local.get $0
-  f64.copysign
+  f64.sub
+  f64.ge
+  select
   local.get $1
   f64.const 0
   call $std/math/check<f64>
  )
  (func $std/math/test_roundf (param $0 f32) (param $1 f32) (result i32)
+  (local $2 f32)
   local.get $0
+  f32.ceil
+  local.tee $2
+  local.get $2
+  f32.const 1
+  f32.sub
+  local.get $0
+  local.get $2
   f32.const 0.5
-  f32.add
-  f32.floor
-  local.get $0
-  f32.copysign
+  f32.sub
+  f32.ge
+  select
   local.get $1
   f32.const 0
   call $std/math/check<f32>
@@ -39402,7 +39416,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3058
+   i32.const 3064
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39414,7 +39428,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3059
+   i32.const 3065
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39426,7 +39440,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3060
+   i32.const 3066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39438,7 +39452,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3061
+   i32.const 3067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39450,7 +39464,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3062
+   i32.const 3068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39462,7 +39476,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3063
+   i32.const 3069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39474,7 +39488,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3064
+   i32.const 3070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39486,7 +39500,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3065
+   i32.const 3071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39498,7 +39512,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3066
+   i32.const 3072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39510,85 +39524,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3067
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3070
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3071
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3072
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3074
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3075
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_roundf
   i32.eqz
   if
@@ -39599,8 +39541,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 1
+  f32.const inf
+  f32.const inf
   call $std/math/test_roundf
   i32.eqz
   if
@@ -39611,8 +39553,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0
+  f32.const -inf
+  f32.const -inf
   call $std/math/test_roundf
   i32.eqz
   if
@@ -39623,9 +39565,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const 2
-  call $std/math/test_round
+  f32.const 0
+  f32.const 0
+  call $std/math/test_roundf
   i32.eqz
   if
    i32.const 0
@@ -39635,9 +39577,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.5
-  f64.const -1
-  call $std/math/test_round
+  f32.const -0
+  f32.const -0
+  call $std/math/test_roundf
   i32.eqz
   if
    i32.const 0
@@ -39647,7 +39589,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.0000152587890625
+  f32.const 1
   f32.const 1
   call $std/math/test_roundf
   i32.eqz
@@ -39659,7 +39601,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.0000152587890625
+  f32.const -1
   f32.const -1
   call $std/math/test_roundf
   i32.eqz
@@ -39671,7 +39613,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.9999923706054688
+  f32.const 0.5
   f32.const 1
   call $std/math/test_roundf
   i32.eqz
@@ -39683,6 +39625,78 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0.5
+  f32.const -0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3084
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5
+  f64.const 2
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3085
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.5
+  f64.const -1
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3086
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.0000152587890625
+  f32.const 1
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3087
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.0000152587890625
+  f32.const -1
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3088
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.9999923706054688
+  f32.const 1
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3089
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -0.9999923706054688
   f32.const -1
   call $std/math/test_roundf
@@ -39690,7 +39704,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3084
+   i32.const 3090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39702,7 +39716,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3085
+   i32.const 3091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39714,7 +39728,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3086
+   i32.const 3092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39726,7 +39740,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3097
+   i32.const 3103
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39738,7 +39752,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3098
+   i32.const 3104
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39750,7 +39764,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3099
+   i32.const 3105
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39762,7 +39776,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3100
+   i32.const 3106
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39774,7 +39788,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3101
+   i32.const 3107
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39786,7 +39800,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3102
+   i32.const 3108
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39798,7 +39812,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3103
+   i32.const 3109
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39810,7 +39824,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3104
+   i32.const 3110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39822,7 +39836,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3105
+   i32.const 3111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39834,7 +39848,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3113
+   i32.const 3119
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39846,7 +39860,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3114
+   i32.const 3120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39858,7 +39872,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3115
+   i32.const 3121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39870,7 +39884,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3116
+   i32.const 3122
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39882,7 +39896,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3117
+   i32.const 3123
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39894,7 +39908,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3118
+   i32.const 3124
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39906,7 +39920,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3119
+   i32.const 3125
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39918,7 +39932,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3120
+   i32.const 3126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39930,7 +39944,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3121
+   i32.const 3127
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39945,7 +39959,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3158
+   i32.const 3164
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39960,7 +39974,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3159
+   i32.const 3165
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39975,7 +39989,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3160
+   i32.const 3166
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39990,7 +40004,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3161
+   i32.const 3167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40005,7 +40019,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3162
+   i32.const 3168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40020,7 +40034,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3163
+   i32.const 3169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40035,7 +40049,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3164
+   i32.const 3170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40050,7 +40064,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3165
+   i32.const 3171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40065,7 +40079,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3166
+   i32.const 3172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40080,105 +40094,15 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3167
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3170
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3171
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const 0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3172
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const 0
   f64.const 1
   call $~lib/math/NativeMath.rem
   f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3174
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3175
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.5
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0.5
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40190,6 +40114,96 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const 1
+  call $~lib/math/NativeMath.rem
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3177
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  call $~lib/math/NativeMath.rem
+  f64.const 0.5
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3178
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  call $~lib/math/NativeMath.rem
+  f64.const -0.5
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3179
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  call $~lib/math/NativeMath.rem
+  f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3180
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 1
+  call $~lib/math/NativeMath.rem
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3181
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5
+  f64.const 1
+  call $~lib/math/NativeMath.rem
+  f64.const -0.5
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3182
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1.5
   f64.const 1
   call $~lib/math/NativeMath.rem
@@ -40200,7 +40214,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3177
+   i32.const 3183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40215,7 +40229,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3178
+   i32.const 3184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40230,7 +40244,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3179
+   i32.const 3185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40245,7 +40259,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3180
+   i32.const 3186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40260,105 +40274,15 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3181
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3182
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3183
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3184
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const 0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3185
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const -0.5
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3186
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 1
   call $~lib/math/NativeMath.rem
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40366,6 +40290,96 @@
    i32.const 0
    i32.const 1056
    i32.const 3188
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  call $~lib/math/NativeMath.rem
+  f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3189
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -1
+  call $~lib/math/NativeMath.rem
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3190
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const -1
+  call $~lib/math/NativeMath.rem
+  f64.const 0.5
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3191
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const -1
+  call $~lib/math/NativeMath.rem
+  f64.const -0.5
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3192
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const -1
+  call $~lib/math/NativeMath.rem
+  f64.const 0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3193
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  call $~lib/math/NativeMath.rem
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40380,7 +40394,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3189
+   i32.const 3195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40395,7 +40409,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3190
+   i32.const 3196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40410,7 +40424,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3191
+   i32.const 3197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40425,105 +40439,15 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3192
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3193
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3194
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3195
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3196
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3197
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const inf
-  call $~lib/math/NativeMath.rem
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -inf
+  f64.const inf
+  f64.const -1
   call $~lib/math/NativeMath.rem
-  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40535,8 +40459,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const -1
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40550,8 +40474,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -1
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40565,8 +40489,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40580,10 +40504,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
   f64.const -0
-  f64.const inf
   call $~lib/math/NativeMath.rem
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40595,10 +40519,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -inf
+  f64.const 0
+  f64.const inf
   call $~lib/math/NativeMath.rem
-  f64.const -0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40610,10 +40534,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const -inf
   call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40625,8 +40549,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const 0
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40640,7 +40564,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0
   f64.const 0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -40655,6 +40579,96 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  call $~lib/math/NativeMath.rem
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3208
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const inf
+  call $~lib/math/NativeMath.rem
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3209
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -inf
+  call $~lib/math/NativeMath.rem
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3210
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const nan:0x8000000000000
+  call $~lib/math/NativeMath.rem
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3211
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 0
+  call $~lib/math/NativeMath.rem
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3212
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 0
+  call $~lib/math/NativeMath.rem
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3213
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const 0
   call $~lib/math/NativeMath.rem
@@ -40665,7 +40679,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3208
+   i32.const 3214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40680,7 +40694,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3209
+   i32.const 3215
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40695,7 +40709,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3210
+   i32.const 3216
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40710,103 +40724,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3211
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3212
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3213
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -0
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3214
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 2
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3215
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0.5
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3216
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 2
+  f64.const inf
+  f64.const -0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40821,7 +40745,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
+  f64.const -0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40835,8 +40759,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
   f64.const nan:0x8000000000000
+  f64.const -0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40850,8 +40774,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40865,8 +40789,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40880,7 +40804,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -40895,10 +40819,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
+  f64.const -inf
+  f64.const 2
   call $~lib/math/NativeMath.rem
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40910,10 +40834,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
+  f64.const -inf
+  f64.const -0.5
   call $~lib/math/NativeMath.rem
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40925,8 +40849,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40940,8 +40864,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40956,9 +40880,9 @@
    unreachable
   end
   f64.const 1
-  f64.const -inf
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40971,9 +40895,9 @@
    unreachable
   end
   f64.const -1
-  f64.const -inf
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -40985,10 +40909,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const inf
-  f64.const -inf
   call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -41000,10 +40924,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const -1
+  f64.const inf
   call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -41015,10 +40939,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
+  f64.const inf
+  f64.const inf
   call $~lib/math/NativeMath.rem
-  f64.const -0.25
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -41030,6 +40954,96 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
+  f64.const inf
+  call $~lib/math/NativeMath.rem
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3233
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const -inf
+  call $~lib/math/NativeMath.rem
+  f64.const 1
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3234
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -inf
+  call $~lib/math/NativeMath.rem
+  f64.const -1
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3235
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const -inf
+  call $~lib/math/NativeMath.rem
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3236
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  call $~lib/math/NativeMath.rem
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3237
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const 0.5
+  call $~lib/math/NativeMath.rem
+  f64.const -0.25
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3238
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1.75
   f64.const 0.5
   call $~lib/math/NativeMath.rem
@@ -41040,7 +41054,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3233
+   i32.const 3239
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41055,7 +41069,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3234
+   i32.const 3240
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41070,7 +41084,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3235
+   i32.const 3241
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41085,7 +41099,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3236
+   i32.const 3242
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41100,7 +41114,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3245
+   i32.const 3251
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41115,7 +41129,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3246
+   i32.const 3252
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41130,7 +41144,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3247
+   i32.const 3253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41145,7 +41159,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3248
+   i32.const 3254
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41160,7 +41174,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3249
+   i32.const 3255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41175,7 +41189,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3250
+   i32.const 3256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41190,7 +41204,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3251
+   i32.const 3257
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41205,7 +41219,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3252
+   i32.const 3258
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41220,7 +41234,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3253
+   i32.const 3259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41235,105 +41249,15 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3254
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3257
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3258
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3259
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3260
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const 0
   f32.const 1
   call $~lib/math/NativeMathf.rem
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3261
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3262
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41345,6 +41269,96 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const 1
+  call $~lib/math/NativeMathf.rem
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3264
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  call $~lib/math/NativeMathf.rem
+  f32.const 0.5
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3265
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 1
+  call $~lib/math/NativeMathf.rem
+  f32.const -0.5
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3266
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  call $~lib/math/NativeMathf.rem
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3267
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 1
+  call $~lib/math/NativeMathf.rem
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3268
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const 1
+  call $~lib/math/NativeMathf.rem
+  f32.const -0.5
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3269
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.5
   f32.const 1
   call $~lib/math/NativeMathf.rem
@@ -41355,7 +41369,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3264
+   i32.const 3270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41370,7 +41384,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3265
+   i32.const 3271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41385,7 +41399,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3266
+   i32.const 3272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41400,7 +41414,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3267
+   i32.const 3273
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41415,105 +41429,15 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3268
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3269
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3270
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3271
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3272
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0.5
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3273
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3274
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const 1
   call $~lib/math/NativeMathf.rem
-  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41521,6 +41445,96 @@
    i32.const 0
    i32.const 1056
    i32.const 3275
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -1
+  call $~lib/math/NativeMathf.rem
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3276
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -1
+  call $~lib/math/NativeMathf.rem
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3277
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const -1
+  call $~lib/math/NativeMathf.rem
+  f32.const 0.5
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3278
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const -1
+  call $~lib/math/NativeMathf.rem
+  f32.const -0.5
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3279
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -1
+  call $~lib/math/NativeMathf.rem
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3280
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  call $~lib/math/NativeMathf.rem
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3281
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41535,7 +41549,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3276
+   i32.const 3282
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41550,7 +41564,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3277
+   i32.const 3283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41565,7 +41579,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3278
+   i32.const 3284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41580,105 +41594,15 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3279
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3280
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3281
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3282
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3283
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3284
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const inf
-  call $~lib/math/NativeMathf.rem
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -inf
+  f32.const inf
+  f32.const -1
   call $~lib/math/NativeMathf.rem
-  f32.const 0
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41690,8 +41614,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -1
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -41705,8 +41629,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -1
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -41720,8 +41644,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -41735,10 +41659,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
   f32.const -0
-  f32.const inf
   call $~lib/math/NativeMathf.rem
-  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41750,10 +41674,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -inf
+  f32.const 0
+  f32.const inf
   call $~lib/math/NativeMathf.rem
-  f32.const -0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41765,10 +41689,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -inf
   call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41780,8 +41704,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const 0
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -41795,7 +41719,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const -0
   f32.const 0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -41810,6 +41734,96 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  call $~lib/math/NativeMathf.rem
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3295
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const inf
+  call $~lib/math/NativeMathf.rem
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3296
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -inf
+  call $~lib/math/NativeMathf.rem
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3297
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const nan:0x400000
+  call $~lib/math/NativeMathf.rem
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3298
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 0
+  call $~lib/math/NativeMathf.rem
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3299
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 0
+  call $~lib/math/NativeMathf.rem
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3300
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const inf
   f32.const 0
   call $~lib/math/NativeMathf.rem
@@ -41820,7 +41834,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3295
+   i32.const 3301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41835,7 +41849,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3296
+   i32.const 3302
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41850,7 +41864,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3297
+   i32.const 3303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41865,103 +41879,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3298
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3299
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3300
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -0
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3301
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 2
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3302
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0.5
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3303
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 2
+  f32.const inf
+  f32.const -0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -41976,7 +41900,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const -0.5
+  f32.const -0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -41990,8 +41914,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
   f32.const nan:0x400000
+  f32.const -0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -42005,8 +41929,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -42020,8 +41944,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -42035,7 +41959,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -42050,10 +41974,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
+  f32.const -inf
+  f32.const 2
   call $~lib/math/NativeMathf.rem
-  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42065,10 +41989,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
+  f32.const -inf
+  f32.const -0.5
   call $~lib/math/NativeMathf.rem
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42080,8 +42004,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -42095,8 +42019,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -42111,9 +42035,9 @@
    unreachable
   end
   f32.const 1
-  f32.const -inf
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
-  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42126,9 +42050,9 @@
    unreachable
   end
   f32.const -1
-  f32.const -inf
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42140,10 +42064,10 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const inf
-  f32.const -inf
   call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42155,10 +42079,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -1
+  f32.const inf
   call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42170,10 +42094,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
+  f32.const inf
+  f32.const inf
   call $~lib/math/NativeMathf.rem
-  f32.const -0.25
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42185,6 +42109,96 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
+  f32.const inf
+  call $~lib/math/NativeMathf.rem
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3320
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -inf
+  call $~lib/math/NativeMathf.rem
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3321
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -inf
+  call $~lib/math/NativeMathf.rem
+  f32.const -1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3322
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const -inf
+  call $~lib/math/NativeMathf.rem
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3323
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  call $~lib/math/NativeMathf.rem
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3324
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const 0.5
+  call $~lib/math/NativeMathf.rem
+  f32.const -0.25
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3325
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.75
   f32.const 0.5
   call $~lib/math/NativeMathf.rem
@@ -42195,7 +42209,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3320
+   i32.const 3326
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42210,7 +42224,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3321
+   i32.const 3327
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42225,7 +42239,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3322
+   i32.const 3328
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42240,7 +42254,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3323
+   i32.const 3329
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42253,7 +42267,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3335
+   i32.const 3341
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42266,7 +42280,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3336
+   i32.const 3342
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42279,7 +42293,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3337
+   i32.const 3343
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42292,7 +42306,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3338
+   i32.const 3344
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42305,7 +42319,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3339
+   i32.const 3345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42318,7 +42332,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3340
+   i32.const 3346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42331,7 +42345,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3341
+   i32.const 3347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42344,7 +42358,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3342
+   i32.const 3348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42357,7 +42371,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3343
+   i32.const 3349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42370,7 +42384,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3344
+   i32.const 3350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42383,7 +42397,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3347
+   i32.const 3353
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42396,91 +42410,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3348
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3349
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3350
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5e-324
-  f64.const 5e-324
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3351
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3352
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3353
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3354
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42492,8 +42428,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42505,8 +42441,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42518,8 +42454,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
+  f64.const -5e-324
+  f64.const -5e-324
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42531,6 +42467,84 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3359
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3360
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3361
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3362
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3363
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3364
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4.450147717014406e-308
   f64.const 4.450147717014406e-308
   f64.const 0
@@ -42539,7 +42553,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3359
+   i32.const 3365
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42552,7 +42566,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3360
+   i32.const 3366
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42565,7 +42579,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3361
+   i32.const 3367
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42578,85 +42592,85 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3362
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3363
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3364
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3365
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3366
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3367
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3368
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3369
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3370
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3371
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3372
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3373
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3374
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42669,92 +42683,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3369
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3370
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3371
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3372
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3373
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3374
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3375
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   call $std/math/test_sin
   i32.eqz
   if
@@ -42765,9 +42701,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
-  f64.const 0
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   call $std/math/test_sin
   i32.eqz
   if
@@ -42778,8 +42714,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42791,8 +42727,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42804,8 +42740,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42817,8 +42753,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42830,8 +42766,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42843,8 +42779,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -42856,6 +42792,84 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1e-323
+  f64.const -1e-323
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3384
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3385
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3386
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3387
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3388
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3389
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -42864,7 +42878,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3386
+   i32.const 3392
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42877,7 +42891,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3387
+   i32.const 3393
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42890,7 +42904,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3388
+   i32.const 3394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42903,7 +42917,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3389
+   i32.const 3395
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42916,7 +42930,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3390
+   i32.const 3396
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42929,7 +42943,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3393
+   i32.const 3399
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42942,7 +42956,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3394
+   i32.const 3400
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42954,7 +42968,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3397
+   i32.const 3403
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42966,7 +42980,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3398
+   i32.const 3404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42978,7 +42992,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3400
+   i32.const 3406
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42990,7 +43004,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3401
+   i32.const 3407
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43002,7 +43016,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3404
+   i32.const 3410
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43014,7 +43028,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3405
+   i32.const 3411
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43026,7 +43040,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3406
+   i32.const 3412
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43038,7 +43052,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3407
+   i32.const 3413
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43050,7 +43064,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3409
+   i32.const 3415
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43062,7 +43076,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3410
+   i32.const 3416
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43074,7 +43088,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3412
+   i32.const 3418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43086,7 +43100,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3413
+   i32.const 3419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43098,7 +43112,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3414
+   i32.const 3420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43110,7 +43124,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3415
+   i32.const 3421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43122,7 +43136,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3416
+   i32.const 3422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43134,7 +43148,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3419
+   i32.const 3425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43146,7 +43160,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3420
+   i32.const 3426
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43160,7 +43174,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3429
+   i32.const 3435
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43174,7 +43188,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3430
+   i32.const 3436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43188,7 +43202,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3431
+   i32.const 3437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43202,7 +43216,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3432
+   i32.const 3438
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43216,7 +43230,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3433
+   i32.const 3439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43230,7 +43244,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3434
+   i32.const 3440
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43244,7 +43258,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3435
+   i32.const 3441
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43258,7 +43272,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3436
+   i32.const 3442
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43272,7 +43286,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3437
+   i32.const 3443
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43286,7 +43300,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3438
+   i32.const 3444
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43300,7 +43314,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3441
+   i32.const 3447
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43314,7 +43328,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3442
+   i32.const 3448
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43328,7 +43342,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3443
+   i32.const 3449
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43342,7 +43356,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3444
+   i32.const 3450
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43356,7 +43370,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3445
+   i32.const 3451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43370,7 +43384,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3448
+   i32.const 3454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43384,98 +43398,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3449
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3450
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3451
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  call $~lib/math/NativeMathf.sin
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3452
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  call $~lib/math/NativeMathf.sin
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3453
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3454
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754946310819804e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const 1.1754946310819804e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754943508222875e-38
   call $~lib/math/NativeMathf.sin
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43487,9 +43417,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
+  f32.const -1.1754943508222875e-38
   call $~lib/math/NativeMathf.sin
-  f32.const 2.350988701644575e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43501,6 +43431,90 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.401298464324817e-45
+  call $~lib/math/NativeMathf.sin
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3458
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  call $~lib/math/NativeMathf.sin
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3459
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3460
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3461
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3462
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3463
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   call $~lib/math/NativeMathf.sin
   f32.const 2.3509895424236536e-38
@@ -43510,7 +43524,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3458
+   i32.const 3464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43524,7 +43538,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3459
+   i32.const 3465
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43538,7 +43552,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3460
+   i32.const 3466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43552,7 +43566,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3461
+   i32.const 3467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43566,7 +43580,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3462
+   i32.const 3468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43580,91 +43594,91 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3463
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3464
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3465
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3466
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.350988701644575e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const -2.350988701644575e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3467
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3468
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3469
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.175494490952134e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const -1.175494490952134e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3470
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const -1.1754946310819804e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3471
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509880009953429e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const -2.3509880009953429e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3472
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.350988701644575e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const -2.350988701644575e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3473
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509895424236536e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const -2.3509895424236536e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3474
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -4.70197740328915e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const -4.70197740328915e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3475
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43678,7 +43692,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3470
+   i32.const 3476
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43692,7 +43706,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3471
+   i32.const 3477
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43706,7 +43720,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3472
+   i32.const 3478
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43720,98 +43734,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3473
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  call $~lib/math/NativeMathf.sin
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3474
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.2611686178923354e-44
-  call $~lib/math/NativeMathf.sin
-  f32.const 1.2611686178923354e-44
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3475
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  call $~lib/math/NativeMathf.sin
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3476
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  call $~lib/math/NativeMathf.sin
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3477
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3478
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754942106924411e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const 1.1754942106924411e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   call $~lib/math/NativeMathf.sin
-  f32.const -2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43823,9 +43753,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   call $~lib/math/NativeMathf.sin
-  f32.const -1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43837,9 +43767,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   call $~lib/math/NativeMathf.sin
-  f32.const -2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43851,9 +43781,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   call $~lib/math/NativeMathf.sin
-  f32.const -5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43865,6 +43795,90 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.1754940705625946e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const 1.1754940705625946e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3484
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754942106924411e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3485
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  call $~lib/math/NativeMathf.sin
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3486
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  call $~lib/math/NativeMathf.sin
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3487
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  call $~lib/math/NativeMathf.sin
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3488
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  call $~lib/math/NativeMathf.sin
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3489
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.1754940705625946e-38
   call $~lib/math/NativeMathf.sin
   f32.const -1.1754940705625946e-38
@@ -43874,7 +43888,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3484
+   i32.const 3490
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43888,7 +43902,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3485
+   i32.const 3491
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43902,7 +43916,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3488
+   i32.const 3494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43916,7 +43930,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3489
+   i32.const 3495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43930,7 +43944,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3490
+   i32.const 3496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43944,7 +43958,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3491
+   i32.const 3497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43958,7 +43972,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3492
+   i32.const 3498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43972,7 +43986,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3493
+   i32.const 3499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43986,7 +44000,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3494
+   i32.const 3500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44000,7 +44014,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3495
+   i32.const 3501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44014,7 +44028,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3496
+   i32.const 3502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44028,7 +44042,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3497
+   i32.const 3503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44042,7 +44056,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3498
+   i32.const 3504
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44056,7 +44070,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3499
+   i32.const 3505
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44070,7 +44084,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3500
+   i32.const 3506
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44084,7 +44098,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3501
+   i32.const 3507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44097,7 +44111,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3513
+   i32.const 3519
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44110,7 +44124,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3514
+   i32.const 3520
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44123,7 +44137,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3515
+   i32.const 3521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44136,7 +44150,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3516
+   i32.const 3522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44149,7 +44163,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3517
+   i32.const 3523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44162,7 +44176,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3518
+   i32.const 3524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44175,7 +44189,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3519
+   i32.const 3525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44188,7 +44202,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3520
+   i32.const 3526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44201,7 +44215,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3521
+   i32.const 3527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44214,63 +44228,63 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3522
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3525
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3526
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3527
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3531
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3532
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3533
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3534
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44279,7 +44293,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3529
+   i32.const 3535
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44292,7 +44306,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3538
+   i32.const 3544
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44305,7 +44319,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3539
+   i32.const 3545
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44318,7 +44332,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3540
+   i32.const 3546
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44331,7 +44345,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3541
+   i32.const 3547
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44344,7 +44358,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3542
+   i32.const 3548
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44357,7 +44371,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3543
+   i32.const 3549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44370,7 +44384,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3544
+   i32.const 3550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44383,7 +44397,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3545
+   i32.const 3551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44396,7 +44410,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3546
+   i32.const 3552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44409,63 +44423,63 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3547
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3550
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3551
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3552
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3556
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3557
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3558
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3559
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -44474,7 +44488,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3554
+   i32.const 3560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44487,7 +44501,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3566
+   i32.const 3572
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44500,7 +44514,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3567
+   i32.const 3573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44513,7 +44527,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3568
+   i32.const 3574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44526,7 +44540,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3569
+   i32.const 3575
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44539,7 +44553,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3570
+   i32.const 3576
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44552,7 +44566,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3571
+   i32.const 3577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44565,7 +44579,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3572
+   i32.const 3578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44578,7 +44592,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3573
+   i32.const 3579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44591,7 +44605,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3574
+   i32.const 3580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44604,90 +44618,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3575
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3578
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3579
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3580
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3582
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3583
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_sqrt
@@ -44700,6 +44636,84 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3585
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3586
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3587
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3588
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3589
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3590
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4
   f64.const 2
   f64.const 0
@@ -44708,7 +44722,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3585
+   i32.const 3591
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44721,7 +44735,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3586
+   i32.const 3592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44734,7 +44748,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3587
+   i32.const 3593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44747,7 +44761,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3588
+   i32.const 3594
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44760,7 +44774,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3589
+   i32.const 3595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44773,7 +44787,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3590
+   i32.const 3596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44786,7 +44800,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3591
+   i32.const 3597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44799,7 +44813,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3592
+   i32.const 3598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44812,7 +44826,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3593
+   i32.const 3599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44825,7 +44839,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3594
+   i32.const 3600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44838,7 +44852,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3595
+   i32.const 3601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44851,7 +44865,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3596
+   i32.const 3602
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44864,7 +44878,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3597
+   i32.const 3603
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44877,7 +44891,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3598
+   i32.const 3604
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44890,7 +44904,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3599
+   i32.const 3605
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44903,7 +44917,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3600
+   i32.const 3606
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44916,7 +44930,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3601
+   i32.const 3607
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44929,7 +44943,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3602
+   i32.const 3608
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44942,7 +44956,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3603
+   i32.const 3609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44955,7 +44969,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3604
+   i32.const 3610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44968,7 +44982,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3605
+   i32.const 3611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44981,7 +44995,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3606
+   i32.const 3612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44994,7 +45008,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3607
+   i32.const 3613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45007,7 +45021,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3608
+   i32.const 3614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45020,7 +45034,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3609
+   i32.const 3615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45033,7 +45047,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3610
+   i32.const 3616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45046,7 +45060,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3611
+   i32.const 3617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45059,7 +45073,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3612
+   i32.const 3618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45072,7 +45086,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3613
+   i32.const 3619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45085,7 +45099,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3614
+   i32.const 3620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45098,7 +45112,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3615
+   i32.const 3621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45111,7 +45125,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3616
+   i32.const 3622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45124,7 +45138,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3617
+   i32.const 3623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45137,7 +45151,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3618
+   i32.const 3624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45150,7 +45164,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3619
+   i32.const 3625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45163,7 +45177,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3620
+   i32.const 3626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45176,7 +45190,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3621
+   i32.const 3627
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45189,7 +45203,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3622
+   i32.const 3628
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45202,7 +45216,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3623
+   i32.const 3629
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45215,7 +45229,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3624
+   i32.const 3630
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45228,7 +45242,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3625
+   i32.const 3631
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45241,7 +45255,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3626
+   i32.const 3632
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45254,7 +45268,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3627
+   i32.const 3633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45267,7 +45281,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3628
+   i32.const 3634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45280,7 +45294,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3629
+   i32.const 3635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45293,7 +45307,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3630
+   i32.const 3636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45306,7 +45320,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3631
+   i32.const 3637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45319,7 +45333,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3632
+   i32.const 3638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45332,7 +45346,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3633
+   i32.const 3639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45345,7 +45359,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3634
+   i32.const 3640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45358,7 +45372,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3635
+   i32.const 3641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45371,7 +45385,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3636
+   i32.const 3642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45384,7 +45398,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3637
+   i32.const 3643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45397,7 +45411,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3638
+   i32.const 3644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45410,7 +45424,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3639
+   i32.const 3645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45423,7 +45437,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3640
+   i32.const 3646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45436,7 +45450,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3641
+   i32.const 3647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45449,7 +45463,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3642
+   i32.const 3648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45462,7 +45476,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3643
+   i32.const 3649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45475,7 +45489,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3644
+   i32.const 3650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45488,7 +45502,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3645
+   i32.const 3651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45501,7 +45515,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3646
+   i32.const 3652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45514,7 +45528,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3647
+   i32.const 3653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45527,7 +45541,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3648
+   i32.const 3654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45540,7 +45554,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3649
+   i32.const 3655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45553,7 +45567,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3650
+   i32.const 3656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45566,85 +45580,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3651
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3660
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.084523916244507
-  f32.const 2.084523916244507
-  f32.const 0.3200402557849884
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3661
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3662
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3663
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3.0441842079162598
-  f32.const 3.0441842079162598
-  f32.const 0.05022354796528816
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3664
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.813625156879425
-  f32.const 0.813625156879425
-  f32.const 0.2240506112575531
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3665
+   i32.const 3657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45662,9 +45598,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.7495063543319702
-  f32.const 0.7495063543319702
-  f32.const 0.05895441770553589
+  f32.const 2.084523916244507
+  f32.const 2.084523916244507
+  f32.const 0.3200402557849884
   call $std/math/check<f32>
   i32.eqz
   if
@@ -45675,9 +45611,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.879859209060669
-  f32.const 0.879859209060669
-  f32.const -0.4874873757362366
+  f32.const -nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
@@ -45701,7 +45637,33 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 3.0441842079162598
+  f32.const 3.0441842079162598
+  f32.const 0.05022354796528816
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3670
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.813625156879425
+  f32.const 0.813625156879425
+  f32.const 0.2240506112575531
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3671
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -45714,15 +45676,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.const 0
+  f32.const 0.7495063543319702
+  f32.const 0.7495063543319702
+  f32.const 0.05895441770553589
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 3673
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.879859209060669
+  f32.const 0.879859209060669
+  f32.const -0.4874873757362366
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3674
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45735,51 +45710,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3674
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3676
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3677
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
@@ -45792,6 +45728,84 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3679
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3680
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3681
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3682
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3683
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3684
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2
   f32.const 2
   f32.const 0
@@ -45800,7 +45814,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3679
+   i32.const 3685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45813,7 +45827,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3680
+   i32.const 3686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45826,7 +45840,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3681
+   i32.const 3687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45839,7 +45853,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3682
+   i32.const 3688
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45852,7 +45866,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3683
+   i32.const 3689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45865,7 +45879,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3684
+   i32.const 3690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45878,7 +45892,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3685
+   i32.const 3691
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45891,7 +45905,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3686
+   i32.const 3692
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45904,7 +45918,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3687
+   i32.const 3693
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45917,7 +45931,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3688
+   i32.const 3694
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45930,7 +45944,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3689
+   i32.const 3695
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45943,7 +45957,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3690
+   i32.const 3696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45956,7 +45970,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3691
+   i32.const 3697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45969,7 +45983,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3692
+   i32.const 3698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45982,7 +45996,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3693
+   i32.const 3699
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45995,7 +46009,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3705
+   i32.const 3711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46008,7 +46022,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3706
+   i32.const 3712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46021,7 +46035,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3707
+   i32.const 3713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46034,7 +46048,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3708
+   i32.const 3714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46047,7 +46061,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3709
+   i32.const 3715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46060,7 +46074,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3710
+   i32.const 3716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46073,7 +46087,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3711
+   i32.const 3717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46086,7 +46100,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3712
+   i32.const 3718
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46099,7 +46113,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3713
+   i32.const 3719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46112,7 +46126,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3714
+   i32.const 3720
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46125,7 +46139,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3717
+   i32.const 3723
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46138,85 +46152,85 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3718
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3719
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3720
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5e-324
-  f64.const 5e-324
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3721
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3722
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3723
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3724
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3725
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3726
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5e-324
+  f64.const 5e-324
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3727
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5e-324
+  f64.const -5e-324
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3728
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3729
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46229,7 +46243,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3725
+   i32.const 3731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46242,85 +46256,85 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3726
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3727
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3728
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3729
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3730
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3731
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3732
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3733
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3734
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3735
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3736
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3737
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46333,7 +46347,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3733
+   i32.const 3739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46346,85 +46360,85 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3734
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3735
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3736
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3737
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3738
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3739
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3740
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3741
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3742
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3743
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3744
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3745
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3746
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46437,7 +46451,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3741
+   i32.const 3747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46450,91 +46464,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3742
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3743
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3744
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3745
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3746
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3747
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -46546,8 +46482,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -46559,8 +46495,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -46572,8 +46508,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -46585,8 +46521,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -46598,8 +46534,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -46611,11 +46547,37 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const -1e-323
+  f64.const -1e-323
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3755
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3756
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 1056
@@ -46624,11 +46586,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 1056
@@ -46637,11 +46599,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6875
-  call $~lib/math/NativeMath.tan
-  f64.const 0.6875
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 1056
@@ -46650,11 +46612,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6875
-  call $~lib/math/NativeMath.tan
-  f64.const -0.6875
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 1056
@@ -46663,35 +46625,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.39269908169872414
+  f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3761
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.6743358
-  call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3762
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 3.725290298461914e-09
-  call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const 2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -46702,9 +46638,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const 1.5707963267948966
+  f64.const -2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -46715,9 +46651,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 0.6875
   call $~lib/math/NativeMath.tan
-  f64.const 0.5
+  f64.const 0.6875
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3765
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.6875
+  call $~lib/math/NativeMath.tan
+  f64.const -0.6875
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -46728,9 +46677,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.107148717794091
+  f64.const 0.39269908169872414
   call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
+  f64.const 0.39269908169872414
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -46741,9 +46690,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.497787143782138
+  f64.const 0.6743358
   call $~lib/math/NativeMath.tan
-  f64.const 5.497787143782138
+  f64.const 0.6743358
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -46754,9 +46703,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7.0685834705770345
+  f64.const 3.725290298461914e-09
   call $~lib/math/NativeMath.tan
-  f64.const 7.0685834705770345
+  f64.const 3.725290298461914e-09
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -46767,9 +46716,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647099.3291652855
+  f64.const 1.5707963267948966
   call $~lib/math/NativeMath.tan
-  f64.const 1647099.3291652855
+  f64.const 1.5707963267948966
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -46780,22 +46729,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647097.7583689587
+  f64.const 0.5
   call $~lib/math/NativeMath.tan
-  f64.const 1647097.7583689587
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3771
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1329227995784915872903807e12
-  call $~lib/math/NativeMath.tan
-  f64.const 1329227995784915872903807e12
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -46806,9 +46742,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1329227995784915872903807e12
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  f64.const -1329227995784915872903807e12
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -46819,6 +46755,84 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 5.497787143782138
+  call $~lib/math/NativeMath.tan
+  f64.const 5.497787143782138
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3774
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 7.0685834705770345
+  call $~lib/math/NativeMath.tan
+  f64.const 7.0685834705770345
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3775
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1647099.3291652855
+  call $~lib/math/NativeMath.tan
+  f64.const 1647099.3291652855
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3776
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1647097.7583689587
+  call $~lib/math/NativeMath.tan
+  f64.const 1647097.7583689587
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3777
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1329227995784915872903807e12
+  call $~lib/math/NativeMath.tan
+  f64.const 1329227995784915872903807e12
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3778
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1329227995784915872903807e12
+  call $~lib/math/NativeMath.tan
+  f64.const -1329227995784915872903807e12
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3779
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -46827,7 +46841,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3776
+   i32.const 3782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46840,7 +46854,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3777
+   i32.const 3783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46853,7 +46867,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3778
+   i32.const 3784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46866,7 +46880,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3779
+   i32.const 3785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46879,7 +46893,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3780
+   i32.const 3786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46893,7 +46907,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3789
+   i32.const 3795
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46907,7 +46921,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3790
+   i32.const 3796
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46921,7 +46935,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3791
+   i32.const 3797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46935,7 +46949,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3792
+   i32.const 3798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46949,7 +46963,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3793
+   i32.const 3799
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46963,7 +46977,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3794
+   i32.const 3800
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46977,7 +46991,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3795
+   i32.const 3801
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46991,7 +47005,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3796
+   i32.const 3802
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47005,7 +47019,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3797
+   i32.const 3803
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47019,7 +47033,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3798
+   i32.const 3804
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47033,7 +47047,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3801
+   i32.const 3807
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47047,7 +47061,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3802
+   i32.const 3808
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47061,7 +47075,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3803
+   i32.const 3809
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47075,7 +47089,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3804
+   i32.const 3810
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47089,7 +47103,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3805
+   i32.const 3811
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47103,7 +47117,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3808
+   i32.const 3814
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47117,98 +47131,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3809
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3810
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3811
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  call $~lib/math/NativeMathf.tan
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3812
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  call $~lib/math/NativeMathf.tan
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3813
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3814
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754946310819804e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const 1.1754946310819804e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754943508222875e-38
   call $~lib/math/NativeMathf.tan
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47220,9 +47150,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
+  f32.const -1.1754943508222875e-38
   call $~lib/math/NativeMathf.tan
-  f32.const 2.350988701644575e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47234,6 +47164,90 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.401298464324817e-45
+  call $~lib/math/NativeMathf.tan
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3818
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  call $~lib/math/NativeMathf.tan
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3819
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3820
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3821
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3822
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3823
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   call $~lib/math/NativeMathf.tan
   f32.const 2.3509895424236536e-38
@@ -47243,7 +47257,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3818
+   i32.const 3824
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47257,7 +47271,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3819
+   i32.const 3825
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47271,7 +47285,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3820
+   i32.const 3826
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47285,7 +47299,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3821
+   i32.const 3827
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47299,91 +47313,91 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3822
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3823
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3824
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3825
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.350988701644575e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const 2.350988701644575e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3826
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3827
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3828
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.175494490952134e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const -1.175494490952134e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3829
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const -1.1754946310819804e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3830
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509880009953429e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const -2.3509880009953429e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3831
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3832
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509895424236536e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const -2.3509895424236536e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3833
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -4.70197740328915e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const -4.70197740328915e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47397,7 +47411,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3829
+   i32.const 3835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47411,7 +47425,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3830
+   i32.const 3836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47425,98 +47439,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3831
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  call $~lib/math/NativeMathf.tan
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3832
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.2611686178923354e-44
-  call $~lib/math/NativeMathf.tan
-  f32.const 1.2611686178923354e-44
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3833
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  call $~lib/math/NativeMathf.tan
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3834
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  call $~lib/math/NativeMathf.tan
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3835
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3836
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754942106924411e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const 1.1754942106924411e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   call $~lib/math/NativeMathf.tan
-  f32.const -2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47528,9 +47458,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   call $~lib/math/NativeMathf.tan
-  f32.const -1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47542,9 +47472,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   call $~lib/math/NativeMathf.tan
-  f32.const -2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47556,9 +47486,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   call $~lib/math/NativeMathf.tan
-  f32.const -5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47570,6 +47500,90 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.1754940705625946e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const 1.1754940705625946e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3842
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754942106924411e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3843
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  call $~lib/math/NativeMathf.tan
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3844
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  call $~lib/math/NativeMathf.tan
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3845
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  call $~lib/math/NativeMathf.tan
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3846
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  call $~lib/math/NativeMathf.tan
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3847
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.1754940705625946e-38
   call $~lib/math/NativeMathf.tan
   f32.const -1.1754940705625946e-38
@@ -47579,7 +47593,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3842
+   i32.const 3848
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47593,7 +47607,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3843
+   i32.const 3849
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47606,7 +47620,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3855
+   i32.const 3861
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47619,7 +47633,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3856
+   i32.const 3862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47632,7 +47646,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3857
+   i32.const 3863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47645,7 +47659,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3858
+   i32.const 3864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47658,7 +47672,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3859
+   i32.const 3865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47671,7 +47685,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3860
+   i32.const 3866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47684,7 +47698,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3861
+   i32.const 3867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47697,7 +47711,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3862
+   i32.const 3868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47710,7 +47724,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3863
+   i32.const 3869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47723,7 +47737,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3864
+   i32.const 3870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47736,7 +47750,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3867
+   i32.const 3873
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47749,7 +47763,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3868
+   i32.const 3874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47762,7 +47776,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3869
+   i32.const 3875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47775,7 +47789,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3870
+   i32.const 3876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47788,7 +47802,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3871
+   i32.const 3877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47801,7 +47815,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3880
+   i32.const 3886
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47814,7 +47828,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3881
+   i32.const 3887
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47827,7 +47841,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3882
+   i32.const 3888
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47840,7 +47854,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3883
+   i32.const 3889
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47853,7 +47867,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3884
+   i32.const 3890
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47866,7 +47880,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3885
+   i32.const 3891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47879,7 +47893,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3886
+   i32.const 3892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47892,7 +47906,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3887
+   i32.const 3893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47905,7 +47919,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3888
+   i32.const 3894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47918,7 +47932,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3889
+   i32.const 3895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47931,7 +47945,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3892
+   i32.const 3898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47944,7 +47958,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3893
+   i32.const 3899
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47957,7 +47971,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3894
+   i32.const 3900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47970,7 +47984,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3895
+   i32.const 3901
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47983,7 +47997,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3896
+   i32.const 3902
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47995,7 +48009,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3908
+   i32.const 3914
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48007,7 +48021,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3909
+   i32.const 3915
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48019,7 +48033,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3910
+   i32.const 3916
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48031,7 +48045,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3911
+   i32.const 3917
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48043,7 +48057,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3912
+   i32.const 3918
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48055,7 +48069,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3913
+   i32.const 3919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48067,7 +48081,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3914
+   i32.const 3920
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48079,7 +48093,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3915
+   i32.const 3921
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48091,7 +48105,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3916
+   i32.const 3922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48103,91 +48117,91 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3917
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3920
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3921
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3922
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3924
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3925
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_trunc
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 3926
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3927
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3928
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3929
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3930
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3931
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48199,7 +48213,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3927
+   i32.const 3933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48211,7 +48225,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3928
+   i32.const 3934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48223,7 +48237,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3929
+   i32.const 3935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48235,7 +48249,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3930
+   i32.const 3936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48247,7 +48261,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3931
+   i32.const 3937
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48259,7 +48273,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3932
+   i32.const 3938
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48271,7 +48285,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3933
+   i32.const 3939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48283,91 +48297,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3934
+   i32.const 3940
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8
   f32.const -8
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3943
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4
-  f32.const 4
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3944
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -8
-  f32.const -8
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3945
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -6
-  f32.const -6
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3946
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 9
-  f32.const 9
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3947
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3948
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48379,8 +48315,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const 4
+  f32.const 4
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48392,8 +48328,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -8
+  f32.const -8
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48405,8 +48341,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const -6
+  f32.const -6
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48418,8 +48354,34 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 9
+  f32.const 9
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3953
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3954
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48431,8 +48393,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48444,8 +48406,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48457,8 +48419,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48470,34 +48432,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3959
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3960
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48509,8 +48445,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48522,8 +48458,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48535,8 +48471,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48548,8 +48484,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48561,8 +48497,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48574,8 +48510,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48609,6 +48545,84 @@
    i32.const 0
    i32.const 1056
    i32.const 3969
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3970
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3971
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3972
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3973
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3974
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3975
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48681,7 +48695,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4010
+   i32.const 4016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48694,7 +48708,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4011
+   i32.const 4017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48707,7 +48721,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4012
+   i32.const 4018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48720,7 +48734,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4013
+   i32.const 4019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48733,7 +48747,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4014
+   i32.const 4020
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48746,7 +48760,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4015
+   i32.const 4021
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48759,7 +48773,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4016
+   i32.const 4022
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48772,7 +48786,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4017
+   i32.const 4023
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48785,7 +48799,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4018
+   i32.const 4024
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48798,7 +48812,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4019
+   i32.const 4025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48811,7 +48825,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4020
+   i32.const 4026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48824,84 +48838,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4021
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4025
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  call $~lib/math/NativeMath.clz32
-  f64.const 31
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4026
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 4027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -128
-  call $~lib/math/NativeMath.clz32
   f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4028
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4294967295
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4029
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4294967295.5
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4030
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4294967296
   call $~lib/math/NativeMath.clz32
   f64.const 32
   f64.ne
@@ -48913,7 +48855,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4294967297
+  f64.const 1
   call $~lib/math/NativeMath.clz32
   f64.const 31
   f64.ne
@@ -48925,9 +48867,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -1
   call $~lib/math/NativeMath.clz32
-  f64.const 32
+  f64.const 0
   f64.ne
   if
    i32.const 0
@@ -48937,9 +48879,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -128
   call $~lib/math/NativeMath.clz32
-  f64.const 32
+  f64.const 0
   f64.ne
   if
    i32.const 0
@@ -48949,7 +48891,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 9007199254740991
+  f64.const 4294967295
   call $~lib/math/NativeMath.clz32
   f64.const 0
   f64.ne
@@ -48961,9 +48903,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -9007199254740991
+  f64.const 4294967295.5
   call $~lib/math/NativeMath.clz32
-  f64.const 31
+  f64.const 0
   f64.ne
   if
    i32.const 0
@@ -48973,7 +48915,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
+  f64.const 4294967296
   call $~lib/math/NativeMath.clz32
   f64.const 32
   f64.ne
@@ -48985,9 +48927,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
+  f64.const 4294967297
   call $~lib/math/NativeMath.clz32
-  f64.const 32
+  f64.const 31
   f64.ne
   if
    i32.const 0
@@ -48997,7 +48939,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1797693134862315708145274e284
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.clz32
   f64.const 32
   f64.ne
@@ -49009,7 +48951,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.220446049250313e-16
+  f64.const inf
   call $~lib/math/NativeMath.clz32
   f64.const 32
   f64.ne
@@ -49021,11 +48963,46 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
-  i64.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
+  f64.const 9007199254740991
+  call $~lib/math/NativeMath.clz32
+  f64.const 0
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4041
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -9007199254740991
+  call $~lib/math/NativeMath.clz32
+  f64.const 31
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4042
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1797693134862315708145274e284
+  call $~lib/math/NativeMath.clz32
+  f64.const 32
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4043
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5e-324
+  call $~lib/math/NativeMath.clz32
+  f64.const 32
+  f64.ne
   if
    i32.const 0
    i32.const 1056
@@ -49034,11 +49011,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
-  i64.const 1
-  call $~lib/math/ipow64
-  i64.eqz
-  i32.eqz
+  f64.const -1797693134862315708145274e284
+  call $~lib/math/NativeMath.clz32
+  f64.const 32
+  f64.ne
   if
    i32.const 0
    i32.const 1056
@@ -49047,11 +49023,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
-  i64.const 2
-  call $~lib/math/ipow64
-  i64.eqz
-  i32.eqz
+  f64.const 2.220446049250313e-16
+  call $~lib/math/NativeMath.clz32
+  f64.const 32
+  f64.ne
   if
    i32.const 0
    i32.const 1056
@@ -49061,33 +49036,7 @@
    unreachable
   end
   i64.const 0
-  i64.const 3
-  call $~lib/math/ipow64
-  i64.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4047
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
   i64.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4049
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i64.const 1
   call $~lib/math/ipow64
   i64.const 1
   i64.ne
@@ -49099,6 +49048,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const 0
+  i64.const 1
+  call $~lib/math/ipow64
+  i64.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4051
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i64.const 2
+  call $~lib/math/ipow64
+  i64.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4052
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i64.const 3
+  call $~lib/math/ipow64
+  i64.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4053
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i64.const 0
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4055
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i64.const 1
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4056
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 1
   i64.const 2
   call $~lib/math/ipow64
@@ -49107,7 +49121,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4051
+   i32.const 4057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49120,7 +49134,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4052
+   i32.const 4058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49133,7 +49147,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4054
+   i32.const 4060
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49146,7 +49160,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4055
+   i32.const 4061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49159,7 +49173,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4056
+   i32.const 4062
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49172,7 +49186,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4057
+   i32.const 4063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49185,7 +49199,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4059
+   i32.const 4065
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49198,7 +49212,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4060
+   i32.const 4066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49211,7 +49225,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4061
+   i32.const 4067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49224,7 +49238,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4062
+   i32.const 4068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49237,7 +49251,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4064
+   i32.const 4070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49250,7 +49264,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4065
+   i32.const 4071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49263,7 +49277,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4066
+   i32.const 4072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49276,7 +49290,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4067
+   i32.const 4073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49289,7 +49303,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4069
+   i32.const 4075
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49299,71 +49313,6 @@
   call $~lib/math/ipow64
   i64.const -6289078614652622815
   i64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4070
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 2
-  i64.const 64
-  call $~lib/math/ipow64
-  i64.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4071
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 3
-  i64.const 41
-  call $~lib/math/ipow64
-  i64.const -420491770248316829
-  i64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4072
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 3
-  i64.const 128
-  call $~lib/math/ipow64
-  i64.const -9204772141784466943
-  i64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4073
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i64.const -1
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4075
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 2
-  i64.const -1
-  call $~lib/math/ipow64
-  i64.eqz
-  i32.eqz
   if
    i32.const 0
    i32.const 1056
@@ -49385,6 +49334,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const 3
+  i64.const 41
+  call $~lib/math/ipow64
+  i64.const -420491770248316829
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4078
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 3
+  i64.const 128
+  call $~lib/math/ipow64
+  i64.const -9204772141784466943
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4079
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i64.const -1
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4081
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 2
+  i64.const -1
+  call $~lib/math/ipow64
+  i64.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4082
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 2
+  i64.const 64
+  call $~lib/math/ipow64
+  i64.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4083
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 2
   i64.const 128
   call $~lib/math/ipow64
@@ -49393,7 +49407,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4078
+   i32.const 4084
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49406,7 +49420,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4084
+   i32.const 4090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49419,7 +49433,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4085
+   i32.const 4091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49432,7 +49446,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4086
+   i32.const 4092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49445,7 +49459,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4087
+   i32.const 4093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49458,7 +49472,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4088
+   i32.const 4094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49471,49 +49485,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4089
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  i32.const -2
-  call $~lib/math/ipow32
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4091
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  i32.const -1
-  call $~lib/math/ipow32
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4092
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  i32.const 2
-  call $~lib/math/ipow32
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 4095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 0
   i32.const -2
   call $~lib/math/ipow32
-  i32.const 1
-  i32.ne
   if
    i32.const 0
    i32.const 1056
@@ -49522,6 +49501,41 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  i32.const -1
+  call $~lib/math/ipow32
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4098
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  i32.const 2
+  call $~lib/math/ipow32
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4101
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  i32.const -2
+  call $~lib/math/ipow32
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4103
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   i32.const 1
   i32.const -1
   call $~lib/math/ipow32
@@ -49530,7 +49544,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4098
+   i32.const 4104
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49543,7 +49557,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4101
+   i32.const 4107
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49558,7 +49572,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4103
+   i32.const 4109
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49573,7 +49587,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4104
+   i32.const 4110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49588,7 +49602,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4105
+   i32.const 4111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49601,7 +49615,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4106
+   i32.const 4112
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49616,7 +49630,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4107
+   i32.const 4113
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49629,7 +49643,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4109
+   i32.const 4115
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49642,7 +49656,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4110
+   i32.const 4116
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49655,7 +49669,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4111
+   i32.const 4117
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49668,7 +49682,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4112
+   i32.const 4118
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49681,7 +49695,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4113
+   i32.const 4119
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49694,7 +49708,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4114
+   i32.const 4120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49707,7 +49721,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4115
+   i32.const 4121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49720,7 +49734,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4116
+   i32.const 4122
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49733,7 +49747,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4117
+   i32.const 4123
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49752,7 +49766,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4119
+   i32.const 4125
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49769,7 +49783,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4120
+   i32.const 4126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49782,7 +49796,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4122
+   i32.const 4128
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49795,7 +49809,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4123
+   i32.const 4129
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49808,7 +49822,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4124
+   i32.const 4130
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49821,7 +49835,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4125
+   i32.const 4131
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49834,7 +49848,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4126
+   i32.const 4132
    i32.const 1
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.ts
+++ b/tests/compiler/std/math.ts
@@ -3048,6 +3048,12 @@ assert(test_round(-0.999992370605468750, -1.0, 0.0, INEXACT));
 assert(test_round(7.88860905221011805e-31, 0.0, 0.0, INEXACT));
 assert(test_round(-7.88860905221011805e-31, -0.0, 0.0, INEXACT));
 
+assert(NativeMath.round( 9007199254740990.0) ==  9007199254740990.0); // round(+2 ** 53) == +2 ** 53
+assert(NativeMath.round(-9007199254740990.0) == -9007199254740990.0); // round(-2 ** 53) == -2 ** 53
+assert(NativeMath.round( 9007199254740991.0) ==  9007199254740991.0); // round(+(2 ** 53 - 1)) == +(2 ** 53 - 1)
+assert(NativeMath.round(-9007199254740991.0) == -9007199254740991.0); // round(-(2 ** 53 - 1)) == -(2 ** 53 - 1)
+assert(NativeMath.round(-1.7976931348623157e+308) == -1.7976931348623157e+308);
+
 // Mathf.round /////////////////////////////////////////////////////////////////////////////////////
 
 function test_roundf(value: f32, expected: f32, error: f32, flags: i32): bool {

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -11542,14 +11542,22 @@
  )
  (func $std/math/test_round (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
+  (local $5 f64)
   local.get $0
   local.set $4
   local.get $4
+  f64.ceil
+  local.set $5
+  local.get $5
+  local.get $5
+  f64.const 1
+  f64.sub
+  local.get $5
   f64.const 0.5
-  f64.add
-  f64.floor
+  f64.sub
   local.get $4
-  f64.copysign
+  f64.le
+  select
   local.get $1
   local.get $2
   local.get $3
@@ -11557,14 +11565,22 @@
  )
  (func $std/math/test_roundf (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
+  (local $5 f32)
   local.get $0
   local.set $4
   local.get $4
+  f32.ceil
+  local.set $5
+  local.get $5
+  local.get $5
+  f32.const 1
+  f32.sub
+  local.get $5
   f32.const 0.5
-  f32.add
-  f32.floor
+  f32.sub
   local.get $4
-  f32.copysign
+  f32.le
+  select
   local.get $1
   local.get $2
   local.get $3
@@ -16455,6 +16471,7 @@
   (local $2 i32)
   (local $3 i64)
   (local $4 f32)
+  (local $5 f64)
   global.get $~lib/math/NativeMath.E
   global.get $~lib/math/NativeMath.E
   f64.eq
@@ -47816,6 +47833,96 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 9007199254740990
+  local.set $0
+  local.get $0
+  f64.ceil
+  local.set $5
+  local.get $5
+  local.get $5
+  f64.const 1
+  f64.sub
+  local.get $5
+  f64.const 0.5
+  f64.sub
+  local.get $0
+  f64.le
+  select
+  f64.const 9007199254740990
+  f64.eq
+  drop
+  f64.const -9007199254740990
+  local.set $0
+  local.get $0
+  f64.ceil
+  local.set $5
+  local.get $5
+  local.get $5
+  f64.const 1
+  f64.sub
+  local.get $5
+  f64.const 0.5
+  f64.sub
+  local.get $0
+  f64.le
+  select
+  f64.const -9007199254740990
+  f64.eq
+  drop
+  f64.const 9007199254740991
+  local.set $0
+  local.get $0
+  f64.ceil
+  local.set $5
+  local.get $5
+  local.get $5
+  f64.const 1
+  f64.sub
+  local.get $5
+  f64.const 0.5
+  f64.sub
+  local.get $0
+  f64.le
+  select
+  f64.const 9007199254740991
+  f64.eq
+  drop
+  f64.const -9007199254740991
+  local.set $0
+  local.get $0
+  f64.ceil
+  local.set $5
+  local.get $5
+  local.get $5
+  f64.const 1
+  f64.sub
+  local.get $5
+  f64.const 0.5
+  f64.sub
+  local.get $0
+  f64.le
+  select
+  f64.const -9007199254740991
+  f64.eq
+  drop
+  f64.const -1797693134862315708145274e284
+  local.set $0
+  local.get $0
+  f64.ceil
+  local.set $5
+  local.get $5
+  local.get $5
+  f64.const 1
+  f64.sub
+  local.get $5
+  f64.const 0.5
+  f64.sub
+  local.get $0
+  f64.le
+  select
+  f64.const -1797693134862315708145274e284
+  f64.eq
+  drop
   f32.const -8.066848754882812
   f32.const -8
   f32.const 0
@@ -47825,7 +47932,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3058
+   i32.const 3064
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47839,7 +47946,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3059
+   i32.const 3065
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47853,7 +47960,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3060
+   i32.const 3066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47867,7 +47974,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3061
+   i32.const 3067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47881,7 +47988,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3062
+   i32.const 3068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47895,7 +48002,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3063
+   i32.const 3069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47909,7 +48016,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3064
+   i32.const 3070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47923,7 +48030,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3065
+   i32.const 3071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47937,7 +48044,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3066
+   i32.const 3072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47951,99 +48058,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3067
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3070
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3071
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3072
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3074
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3075
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -48052,6 +48073,92 @@
    i32.const 0
    i32.const 32
    i32.const 3076
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3077
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3078
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3079
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3080
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3081
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3082
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48065,7 +48172,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3077
+   i32.const 3083
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48079,7 +48186,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3078
+   i32.const 3084
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48093,7 +48200,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3079
+   i32.const 3085
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48107,7 +48214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3080
+   i32.const 3086
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48121,7 +48228,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3081
+   i32.const 3087
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48135,7 +48242,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3082
+   i32.const 3088
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48149,7 +48256,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3083
+   i32.const 3089
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48163,7 +48270,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3084
+   i32.const 3090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48177,7 +48284,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3085
+   i32.const 3091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48191,7 +48298,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3086
+   i32.const 3092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48205,7 +48312,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3097
+   i32.const 3103
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48219,7 +48326,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3098
+   i32.const 3104
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48233,7 +48340,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3099
+   i32.const 3105
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48247,7 +48354,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3100
+   i32.const 3106
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48261,7 +48368,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3101
+   i32.const 3107
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48275,7 +48382,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3102
+   i32.const 3108
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48289,7 +48396,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3103
+   i32.const 3109
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48304,7 +48411,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3104
+   i32.const 3110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48318,7 +48425,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3105
+   i32.const 3111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48332,7 +48439,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3113
+   i32.const 3119
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48346,7 +48453,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3114
+   i32.const 3120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48360,7 +48467,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3115
+   i32.const 3121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48374,7 +48481,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3116
+   i32.const 3122
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48388,7 +48495,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3117
+   i32.const 3123
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48402,7 +48509,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3118
+   i32.const 3124
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48416,7 +48523,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3119
+   i32.const 3125
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48431,7 +48538,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3120
+   i32.const 3126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48445,7 +48552,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3121
+   i32.const 3127
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48464,8 +48571,8 @@
   i32.eq
   drop
   f64.const -0
-  local.set $0
-  local.get $0
+  local.set $5
+  local.get $5
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
@@ -48490,8 +48597,8 @@
   i32.eq
   drop
   f64.const -1
-  local.set $0
-  local.get $0
+  local.set $5
+  local.get $5
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
@@ -48517,8 +48624,8 @@
   drop
   f64.const nan:0x8000000000000
   f64.neg
-  local.set $0
-  local.get $0
+  local.set $5
+  local.get $5
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
@@ -48544,8 +48651,8 @@
   drop
   f64.const inf
   f64.neg
-  local.set $0
-  local.get $0
+  local.set $5
+  local.get $5
   i64.reinterpret_f64
   i64.const 63
   i64.shr_u
@@ -48656,7 +48763,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3158
+   i32.const 3164
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48671,7 +48778,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3159
+   i32.const 3165
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48686,7 +48793,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3160
+   i32.const 3166
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48701,7 +48808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3161
+   i32.const 3167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48716,7 +48823,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3162
+   i32.const 3168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48731,7 +48838,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3163
+   i32.const 3169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48746,7 +48853,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3164
+   i32.const 3170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48761,7 +48868,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3165
+   i32.const 3171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48776,7 +48883,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3166
+   i32.const 3172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48791,104 +48898,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3167
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3170
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3171
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3172
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const 0
   f64.const 1
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3174
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3175
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.5
-  f64.const 1
-  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -48901,6 +48918,96 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3177
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3178
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3179
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3180
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3181
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5
+  f64.const 1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3182
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1.5
   f64.const 1
   f64.const 0.5
@@ -48911,7 +49018,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3177
+   i32.const 3183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48926,7 +49033,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3178
+   i32.const 3184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48941,7 +49048,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3179
+   i32.const 3185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48956,7 +49063,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3180
+   i32.const 3186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48972,104 +49079,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3181
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3182
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3183
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3184
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3185
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3186
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49078,6 +49095,96 @@
    i32.const 0
    i32.const 32
    i32.const 3188
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3189
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3190
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const -1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3191
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const -1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3192
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const -1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3193
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49092,7 +49199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3189
+   i32.const 3195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49107,7 +49214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3190
+   i32.const 3196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49122,7 +49229,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3191
+   i32.const 3197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49137,108 +49244,16 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3192
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3193
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3194
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3195
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3196
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3197
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const inf
-  f64.neg
+  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49249,11 +49264,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const -1
   f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49264,11 +49280,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49279,8 +49295,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -49294,11 +49310,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const inf
-  f64.const -0
   f64.const 0
-  i32.const 0
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49309,10 +49325,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const inf
-  f64.neg
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49325,9 +49340,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49340,11 +49356,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const 0
   f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49355,7 +49371,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49370,6 +49386,97 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3208
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const inf
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3209
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const inf
+  f64.neg
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3210
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3211
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3212
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3213
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const 0
   f64.const nan:0x8000000000000
@@ -49380,7 +49487,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3208
+   i32.const 3214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49396,7 +49503,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3209
+   i32.const 3215
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49411,7 +49518,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3210
+   i32.const 3216
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49426,105 +49533,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3211
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3212
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3213
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3214
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 2
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3215
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0.5
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3216
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const 2
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -49540,7 +49555,7 @@
   end
   f64.const inf
   f64.neg
-  f64.const -0.5
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -49554,9 +49569,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
   f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -49570,11 +49584,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49585,11 +49599,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49600,7 +49614,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49615,11 +49629,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
-  f64.const 1
+  f64.neg
+  f64.const 2
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49630,11 +49645,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const inf
-  f64.const -1
+  f64.neg
+  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49646,10 +49662,11 @@
    unreachable
   end
   f64.const inf
-  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49660,12 +49677,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.neg
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49677,9 +49693,8 @@
    unreachable
   end
   f64.const 1
-  f64.const inf
-  f64.neg
-  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49693,9 +49708,8 @@
    unreachable
   end
   f64.const -1
-  f64.const inf
-  f64.neg
-  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49708,12 +49722,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const inf
-  f64.const inf
-  f64.neg
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49724,13 +49737,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49741,11 +49752,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const -0.25
+  f64.const inf
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49756,11 +49767,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.25
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49771,9 +49783,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.25
+  f64.const 1
+  f64.const inf
+  f64.neg
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49786,6 +49799,100 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const inf
+  f64.neg
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3235
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3236
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3237
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const -0.25
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3238
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.25
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3239
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.25
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3240
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1.75
   f64.const -0.5
   f64.const 0.25
@@ -49796,7 +49903,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3235
+   i32.const 3241
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49811,7 +49918,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3236
+   i32.const 3242
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49826,7 +49933,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3245
+   i32.const 3251
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49841,7 +49948,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3246
+   i32.const 3252
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49856,7 +49963,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3247
+   i32.const 3253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49871,7 +49978,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3248
+   i32.const 3254
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49886,7 +49993,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3249
+   i32.const 3255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49901,7 +50008,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3250
+   i32.const 3256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49916,7 +50023,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3251
+   i32.const 3257
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49931,7 +50038,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3252
+   i32.const 3258
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49946,7 +50053,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3253
+   i32.const 3259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49961,104 +50068,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3254
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3257
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3258
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3259
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const 1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3260
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const 0
   f32.const 1
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3261
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3262
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const 1
-  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50071,6 +50088,96 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3264
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3265
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3266
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3267
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3268
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const 1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3269
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.5
   f32.const 1
   f32.const 0.5
@@ -50081,7 +50188,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3264
+   i32.const 3270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50096,7 +50203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3265
+   i32.const 3271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50111,7 +50218,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3266
+   i32.const 3272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50126,7 +50233,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3267
+   i32.const 3273
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50142,104 +50249,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3268
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3269
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3270
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3271
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3272
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3273
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3274
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50248,6 +50265,96 @@
    i32.const 0
    i32.const 32
    i32.const 3275
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3276
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3277
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const -1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3278
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const -1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3279
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3280
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3281
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50262,7 +50369,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3276
+   i32.const 3282
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50277,7 +50384,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3277
+   i32.const 3283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50292,7 +50399,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3278
+   i32.const 3284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50307,108 +50414,16 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3279
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3280
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3281
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3282
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3283
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3284
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const inf
-  f32.neg
+  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50419,11 +50434,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const -1
   f32.const nan:0x400000
-  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50434,11 +50450,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50449,8 +50465,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -50464,11 +50480,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const inf
-  f32.const -0
   f32.const 0
-  i32.const 0
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50479,10 +50495,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const inf
-  f32.neg
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50495,9 +50510,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50510,11 +50526,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const 0
   f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50525,7 +50541,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const -0
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -50540,6 +50556,97 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3295
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const inf
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3296
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const inf
+  f32.neg
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3297
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3298
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 0
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3299
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 0
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3300
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const inf
   f32.const 0
   f32.const nan:0x400000
@@ -50550,7 +50657,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3295
+   i32.const 3301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50566,7 +50673,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3296
+   i32.const 3302
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50581,7 +50688,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3297
+   i32.const 3303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50596,105 +50703,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3298
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3299
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3300
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3301
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 2
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3302
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3303
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const 2
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -50710,7 +50725,7 @@
   end
   f32.const inf
   f32.neg
-  f32.const -0.5
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -50724,9 +50739,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
   f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -50740,11 +50754,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50755,11 +50769,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50770,7 +50784,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -50785,11 +50799,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
-  f32.const 1
+  f32.neg
+  f32.const 2
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50800,11 +50815,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
   f32.const inf
-  f32.const -1
+  f32.neg
+  f32.const -0.5
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50816,10 +50832,11 @@
    unreachable
   end
   f32.const inf
-  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50830,12 +50847,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50847,9 +50863,8 @@
    unreachable
   end
   f32.const 1
-  f32.const inf
-  f32.neg
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50863,9 +50878,8 @@
    unreachable
   end
   f32.const -1
-  f32.const inf
-  f32.neg
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50878,12 +50892,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const inf
-  f32.const inf
-  f32.neg
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50894,13 +50907,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50911,11 +50922,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const -0.25
+  f32.const inf
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50926,11 +50937,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.25
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50941,9 +50953,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const -0.25
+  f32.const 1
+  f32.const inf
+  f32.neg
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50956,6 +50969,100 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
+  f32.const inf
+  f32.neg
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3322
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3323
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3324
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const 0.5
+  f32.const -0.25
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3325
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.25
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3326
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.25
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3327
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.75
   f32.const -0.5
   f32.const 0.25
@@ -50966,7 +51073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3322
+   i32.const 3328
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50981,7 +51088,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3323
+   i32.const 3329
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50995,7 +51102,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3335
+   i32.const 3341
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51009,7 +51116,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3336
+   i32.const 3342
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51023,7 +51130,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3337
+   i32.const 3343
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51037,7 +51144,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3338
+   i32.const 3344
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51051,7 +51158,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3339
+   i32.const 3345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51065,7 +51172,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3340
+   i32.const 3346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51079,7 +51186,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3341
+   i32.const 3347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51093,7 +51200,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3342
+   i32.const 3348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51107,7 +51214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3343
+   i32.const 3349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51121,7 +51228,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3344
+   i32.const 3350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51135,7 +51242,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3347
+   i32.const 3353
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51149,101 +51256,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3348
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3349
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3350
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5e-324
-  f64.const 5e-324
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3351
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3352
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3353
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3354
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51256,8 +51275,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51270,10 +51289,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
   global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
   call $std/math/test_sin
   i32.eqz
   if
@@ -51284,10 +51305,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
+  f64.const -5e-324
+  f64.const -5e-324
   f64.const 0
   global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
   call $std/math/test_sin
   i32.eqz
   if
@@ -51298,6 +51321,90 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3359
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3360
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3361
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3362
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3363
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3364
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4.450147717014406e-308
   f64.const 4.450147717014406e-308
   f64.const 0
@@ -51307,7 +51414,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3359
+   i32.const 3365
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51321,7 +51428,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3360
+   i32.const 3366
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51335,7 +51442,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3361
+   i32.const 3367
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51349,91 +51456,91 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3362
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3363
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3364
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3365
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3366
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3367
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3368
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3369
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3370
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3371
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3372
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3373
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3374
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51447,109 +51554,15 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3369
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3370
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3371
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3372
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3373
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3374
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3375
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
   call $std/math/test_sin
   i32.eqz
   if
@@ -51560,12 +51573,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
-  f64.const 0
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
   call $std/math/test_sin
   i32.eqz
   if
@@ -51576,8 +51587,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51592,8 +51603,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51608,8 +51619,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51624,8 +51635,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51640,8 +51651,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51656,8 +51667,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51672,6 +51683,102 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1e-323
+  f64.const -1e-323
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3384
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3385
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3386
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3387
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3388
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3389
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -51681,7 +51788,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3386
+   i32.const 3392
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51695,7 +51802,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3387
+   i32.const 3393
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51709,7 +51816,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3388
+   i32.const 3394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51724,7 +51831,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3389
+   i32.const 3395
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51738,7 +51845,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3390
+   i32.const 3396
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51756,7 +51863,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3393
+   i32.const 3399
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51778,7 +51885,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3394
+   i32.const 3400
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51791,7 +51898,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3397
+   i32.const 3403
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51804,7 +51911,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3398
+   i32.const 3404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51817,7 +51924,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3400
+   i32.const 3406
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51830,7 +51937,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3401
+   i32.const 3407
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51843,7 +51950,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3404
+   i32.const 3410
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51856,7 +51963,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3405
+   i32.const 3411
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51871,7 +51978,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3406
+   i32.const 3412
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51887,7 +51994,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3407
+   i32.const 3413
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51900,7 +52007,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3409
+   i32.const 3415
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51915,7 +52022,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3410
+   i32.const 3416
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51932,7 +52039,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3412
+   i32.const 3418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51949,7 +52056,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3413
+   i32.const 3419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51966,7 +52073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3414
+   i32.const 3420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51983,7 +52090,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3415
+   i32.const 3421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52000,7 +52107,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3416
+   i32.const 3422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52013,7 +52120,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3419
+   i32.const 3425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52027,7 +52134,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3420
+   i32.const 3426
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52041,7 +52148,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3429
+   i32.const 3435
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52055,7 +52162,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3430
+   i32.const 3436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52069,7 +52176,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3431
+   i32.const 3437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52083,7 +52190,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3432
+   i32.const 3438
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52097,7 +52204,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3433
+   i32.const 3439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52111,7 +52218,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3434
+   i32.const 3440
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52125,7 +52232,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3435
+   i32.const 3441
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52139,7 +52246,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3436
+   i32.const 3442
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52153,7 +52260,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3437
+   i32.const 3443
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52167,7 +52274,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3438
+   i32.const 3444
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52181,7 +52288,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3441
+   i32.const 3447
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52195,7 +52302,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3442
+   i32.const 3448
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52209,7 +52316,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3443
+   i32.const 3449
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52224,7 +52331,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3444
+   i32.const 3450
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52238,7 +52345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3445
+   i32.const 3451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52252,7 +52359,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3448
+   i32.const 3454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52266,101 +52373,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3449
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3450
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3451
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3452
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3453
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3454
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sinf
@@ -52373,8 +52392,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sinf
@@ -52387,6 +52406,94 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3458
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3459
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3460
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3461
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3462
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3463
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   f32.const 2.3509895424236536e-38
   f32.const 0
@@ -52396,7 +52503,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3458
+   i32.const 3464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52410,7 +52517,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3459
+   i32.const 3465
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52424,7 +52531,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3460
+   i32.const 3466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52438,7 +52545,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3461
+   i32.const 3467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52452,7 +52559,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3462
+   i32.const 3468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52466,91 +52573,91 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3463
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3464
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3465
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3466
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.350988701644575e-38
-  f32.const -2.350988701644575e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3467
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3468
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3469
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3470
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3471
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3472
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.350988701644575e-38
+  f32.const -2.350988701644575e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3473
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3474
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3475
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52564,7 +52671,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3470
+   i32.const 3476
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52578,7 +52685,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3471
+   i32.const 3477
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52592,7 +52699,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3472
+   i32.const 3478
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52606,109 +52713,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3473
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3474
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3475
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3476
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3477
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3478
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const 2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52723,8 +52734,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52739,8 +52750,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52755,8 +52766,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52771,8 +52782,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52787,8 +52798,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52803,6 +52814,102 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3486
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3487
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3488
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3489
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3490
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3491
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 255.99993896484375
   f32.const -0.9992055892944336
   f32.const 0
@@ -52812,7 +52919,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3488
+   i32.const 3494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52826,7 +52933,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3489
+   i32.const 3495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52840,7 +52947,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3490
+   i32.const 3496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52854,7 +52961,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3491
+   i32.const 3497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52868,7 +52975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3492
+   i32.const 3498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52882,7 +52989,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3493
+   i32.const 3499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52896,7 +53003,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3494
+   i32.const 3500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52910,7 +53017,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3495
+   i32.const 3501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52924,7 +53031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3496
+   i32.const 3502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52938,7 +53045,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3497
+   i32.const 3503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52952,7 +53059,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3498
+   i32.const 3504
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52966,7 +53073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3499
+   i32.const 3505
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52980,7 +53087,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3500
+   i32.const 3506
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52995,7 +53102,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3501
+   i32.const 3507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53009,7 +53116,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3513
+   i32.const 3519
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53023,7 +53130,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3514
+   i32.const 3520
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53037,7 +53144,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3515
+   i32.const 3521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53051,7 +53158,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3516
+   i32.const 3522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53065,7 +53172,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3517
+   i32.const 3523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53079,7 +53186,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3518
+   i32.const 3524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53093,7 +53200,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3519
+   i32.const 3525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53107,7 +53214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3520
+   i32.const 3526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53121,7 +53228,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3521
+   i32.const 3527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53135,69 +53242,69 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3522
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3525
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3526
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3527
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3531
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3532
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3533
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3534
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -53207,7 +53314,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3529
+   i32.const 3535
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53221,7 +53328,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3538
+   i32.const 3544
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53235,7 +53342,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3539
+   i32.const 3545
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53249,7 +53356,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3540
+   i32.const 3546
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53263,7 +53370,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3541
+   i32.const 3547
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53277,7 +53384,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3542
+   i32.const 3548
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53291,7 +53398,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3543
+   i32.const 3549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53305,7 +53412,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3544
+   i32.const 3550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53319,7 +53426,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3545
+   i32.const 3551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53333,7 +53440,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3546
+   i32.const 3552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53347,69 +53454,69 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3547
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3550
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3551
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3552
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3556
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3557
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3558
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3559
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -53419,7 +53526,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3554
+   i32.const 3560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53433,7 +53540,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3566
+   i32.const 3572
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53447,7 +53554,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3567
+   i32.const 3573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53461,7 +53568,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3568
+   i32.const 3574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53475,7 +53582,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3569
+   i32.const 3575
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53489,7 +53596,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3570
+   i32.const 3576
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53503,7 +53610,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3571
+   i32.const 3577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53517,7 +53624,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3572
+   i32.const 3578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53531,7 +53638,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3573
+   i32.const 3579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53545,7 +53652,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3574
+   i32.const 3580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53559,7 +53666,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3575
+   i32.const 3581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53573,7 +53680,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3578
+   i32.const 3584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53587,7 +53694,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3579
+   i32.const 3585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53602,7 +53709,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3580
+   i32.const 3586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53616,7 +53723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3581
+   i32.const 3587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53630,7 +53737,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3582
+   i32.const 3588
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53644,7 +53751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3583
+   i32.const 3589
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53658,7 +53765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3584
+   i32.const 3590
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53672,7 +53779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3585
+   i32.const 3591
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53686,7 +53793,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3586
+   i32.const 3592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53700,7 +53807,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3587
+   i32.const 3593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53714,7 +53821,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3588
+   i32.const 3594
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53728,7 +53835,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3589
+   i32.const 3595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53742,7 +53849,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3590
+   i32.const 3596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53756,7 +53863,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3591
+   i32.const 3597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53770,7 +53877,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3592
+   i32.const 3598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53784,7 +53891,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3593
+   i32.const 3599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53798,7 +53905,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3594
+   i32.const 3600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53812,7 +53919,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3595
+   i32.const 3601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53826,7 +53933,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3596
+   i32.const 3602
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53840,7 +53947,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3597
+   i32.const 3603
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53854,7 +53961,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3598
+   i32.const 3604
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53868,7 +53975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3599
+   i32.const 3605
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53882,7 +53989,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3600
+   i32.const 3606
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53896,7 +54003,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3601
+   i32.const 3607
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53910,7 +54017,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3602
+   i32.const 3608
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53924,7 +54031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3603
+   i32.const 3609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53938,7 +54045,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3604
+   i32.const 3610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53952,7 +54059,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3605
+   i32.const 3611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53966,7 +54073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3606
+   i32.const 3612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53980,7 +54087,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3607
+   i32.const 3613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53994,7 +54101,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3608
+   i32.const 3614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54008,7 +54115,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3609
+   i32.const 3615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54022,7 +54129,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3610
+   i32.const 3616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54036,7 +54143,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3611
+   i32.const 3617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54050,7 +54157,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3612
+   i32.const 3618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54064,7 +54171,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3613
+   i32.const 3619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54078,7 +54185,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3614
+   i32.const 3620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54092,7 +54199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3615
+   i32.const 3621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54106,7 +54213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3616
+   i32.const 3622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54120,7 +54227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3617
+   i32.const 3623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54134,7 +54241,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3618
+   i32.const 3624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54148,7 +54255,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3619
+   i32.const 3625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54162,7 +54269,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3620
+   i32.const 3626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54176,7 +54283,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3621
+   i32.const 3627
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54190,7 +54297,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3622
+   i32.const 3628
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54204,7 +54311,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3623
+   i32.const 3629
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54218,7 +54325,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3624
+   i32.const 3630
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54232,7 +54339,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3625
+   i32.const 3631
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54246,7 +54353,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3626
+   i32.const 3632
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54260,7 +54367,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3627
+   i32.const 3633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54274,7 +54381,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3628
+   i32.const 3634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54288,7 +54395,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3629
+   i32.const 3635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54302,7 +54409,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3630
+   i32.const 3636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54316,7 +54423,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3631
+   i32.const 3637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54330,7 +54437,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3632
+   i32.const 3638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54344,7 +54451,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3633
+   i32.const 3639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54358,7 +54465,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3634
+   i32.const 3640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54372,7 +54479,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3635
+   i32.const 3641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54386,7 +54493,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3636
+   i32.const 3642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54400,7 +54507,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3637
+   i32.const 3643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54414,7 +54521,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3638
+   i32.const 3644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54428,7 +54535,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3639
+   i32.const 3645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54442,7 +54549,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3640
+   i32.const 3646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54456,7 +54563,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3641
+   i32.const 3647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54470,7 +54577,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3642
+   i32.const 3648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54484,7 +54591,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3643
+   i32.const 3649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54498,7 +54605,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3644
+   i32.const 3650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54512,7 +54619,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3645
+   i32.const 3651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54526,7 +54633,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3646
+   i32.const 3652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54540,7 +54647,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3647
+   i32.const 3653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54554,7 +54661,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3648
+   i32.const 3654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54568,7 +54675,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3649
+   i32.const 3655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54582,7 +54689,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3650
+   i32.const 3656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54596,7 +54703,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3651
+   i32.const 3657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54610,7 +54717,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3660
+   i32.const 3666
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54624,7 +54731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3661
+   i32.const 3667
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54638,7 +54745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3662
+   i32.const 3668
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54652,7 +54759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3663
+   i32.const 3669
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54666,7 +54773,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3664
+   i32.const 3670
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54680,7 +54787,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3665
+   i32.const 3671
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54694,7 +54801,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3666
+   i32.const 3672
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54708,7 +54815,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3667
+   i32.const 3673
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54722,7 +54829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3668
+   i32.const 3674
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54736,7 +54843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3669
+   i32.const 3675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54750,7 +54857,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3672
+   i32.const 3678
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54764,7 +54871,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3673
+   i32.const 3679
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54779,7 +54886,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3674
+   i32.const 3680
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54793,7 +54900,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3675
+   i32.const 3681
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54807,7 +54914,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3676
+   i32.const 3682
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54821,7 +54928,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3677
+   i32.const 3683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54835,7 +54942,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3678
+   i32.const 3684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54849,7 +54956,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3679
+   i32.const 3685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54863,7 +54970,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3680
+   i32.const 3686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54877,7 +54984,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3681
+   i32.const 3687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54891,7 +54998,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3682
+   i32.const 3688
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54905,7 +55012,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3683
+   i32.const 3689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54919,7 +55026,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3684
+   i32.const 3690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54933,7 +55040,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3685
+   i32.const 3691
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54947,7 +55054,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3686
+   i32.const 3692
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54961,7 +55068,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3687
+   i32.const 3693
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54975,7 +55082,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3688
+   i32.const 3694
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54989,7 +55096,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3689
+   i32.const 3695
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55003,7 +55110,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3690
+   i32.const 3696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55017,7 +55124,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3691
+   i32.const 3697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55031,7 +55138,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3692
+   i32.const 3698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55045,7 +55152,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3693
+   i32.const 3699
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55059,7 +55166,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3705
+   i32.const 3711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55073,7 +55180,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3706
+   i32.const 3712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55087,7 +55194,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3707
+   i32.const 3713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55101,7 +55208,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3708
+   i32.const 3714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55115,7 +55222,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3709
+   i32.const 3715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55129,7 +55236,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3710
+   i32.const 3716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55143,7 +55250,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3711
+   i32.const 3717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55157,7 +55264,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3712
+   i32.const 3718
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55171,7 +55278,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3713
+   i32.const 3719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55185,7 +55292,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3714
+   i32.const 3720
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55199,7 +55306,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3717
+   i32.const 3723
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55213,95 +55320,95 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3718
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3719
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3720
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5e-324
-  f64.const 5e-324
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3721
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3722
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3723
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3724
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3725
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3726
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5e-324
+  f64.const 5e-324
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3727
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5e-324
+  f64.const -5e-324
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3728
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3729
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55315,7 +55422,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3725
+   i32.const 3731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55329,91 +55436,91 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3726
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3727
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3728
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3729
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3730
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3731
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3732
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3733
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3734
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3735
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3736
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3737
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55427,7 +55534,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3733
+   i32.const 3739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55441,91 +55548,91 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3734
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3735
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3736
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3737
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3738
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3739
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3740
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3741
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3742
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3743
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3744
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3745
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3746
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55539,7 +55646,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3741
+   i32.const 3747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55553,109 +55660,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3742
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3743
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3744
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3745
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3746
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3747
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55670,8 +55681,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55686,8 +55697,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55702,8 +55713,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55718,8 +55729,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55734,8 +55745,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55750,11 +55761,45 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const -1e-323
+  f64.const -1e-323
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3755
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3756
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
@@ -55764,11 +55809,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
@@ -55778,15 +55825,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 11
-  f64.const 16
-  f64.div
-  call $~lib/math/NativeMath.tan
-  f64.const 11
-  f64.const 16
-  f64.div
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
@@ -55796,15 +55841,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -11
-  f64.const 16
-  f64.div
-  call $~lib/math/NativeMath.tan
-  f64.const -11
-  f64.const 16
-  f64.div
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
@@ -55814,37 +55857,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.39269908169872414
+  f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3761
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.6743358
-  call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3762
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 3.725290298461914e-09
-  call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const 2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55856,13 +55871,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/math/kPI
-  f64.const 2
-  f64.div
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  global.get $std/math/kPI
-  f64.const 2
-  f64.div
+  f64.const -2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55874,9 +55885,31 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 11
+  f64.const 16
+  f64.div
   call $~lib/math/NativeMath.tan
-  f64.const 0.5
+  f64.const 11
+  f64.const 16
+  f64.div
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3765
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -11
+  f64.const 16
+  f64.div
+  call $~lib/math/NativeMath.tan
+  f64.const -11
+  f64.const 16
+  f64.div
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55888,9 +55921,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.107148717794091
+  f64.const 0.39269908169872414
   call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
+  f64.const 0.39269908169872414
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55902,17 +55935,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
+  f64.const 0.6743358
   call $~lib/math/NativeMath.tan
-  f64.const 7
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
+  f64.const 0.6743358
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55924,17 +55949,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 9
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
+  f64.const 3.725290298461914e-09
   call $~lib/math/NativeMath.tan
-  f64.const 9
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
+  f64.const 3.725290298461914e-09
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55946,17 +55963,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1048576
+  global.get $std/math/kPI
   f64.const 2
   f64.div
-  global.get $std/math/kPI
-  f64.mul
   call $~lib/math/NativeMath.tan
-  f64.const 1048576
+  global.get $std/math/kPI
   f64.const 2
   f64.div
-  global.get $std/math/kPI
-  f64.mul
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55968,31 +55981,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1048575
-  f64.const 2
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
+  f64.const 0.5
   call $~lib/math/NativeMath.tan
-  f64.const 1048575
-  f64.const 2
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3771
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $std/math/kTwo120
-  call $~lib/math/NativeMath.tan
-  global.get $std/math/kTwo120
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -56004,11 +55995,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/math/kTwo120
-  f64.neg
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  global.get $std/math/kTwo120
-  f64.neg
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -56020,6 +56009,124 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 7
+  f64.const 4
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
+  call $~lib/math/NativeMath.tan
+  f64.const 7
+  f64.const 4
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3774
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 9
+  f64.const 4
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
+  call $~lib/math/NativeMath.tan
+  f64.const 9
+  f64.const 4
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3775
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1048576
+  f64.const 2
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
+  call $~lib/math/NativeMath.tan
+  f64.const 1048576
+  f64.const 2
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3776
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1048575
+  f64.const 2
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
+  call $~lib/math/NativeMath.tan
+  f64.const 1048575
+  f64.const 2
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3777
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $std/math/kTwo120
+  call $~lib/math/NativeMath.tan
+  global.get $std/math/kTwo120
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3778
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $std/math/kTwo120
+  f64.neg
+  call $~lib/math/NativeMath.tan
+  global.get $std/math/kTwo120
+  f64.neg
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3779
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -56029,7 +56136,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3776
+   i32.const 3782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56043,7 +56150,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3777
+   i32.const 3783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56057,7 +56164,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3778
+   i32.const 3784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56072,7 +56179,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3779
+   i32.const 3785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56086,7 +56193,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3780
+   i32.const 3786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56100,7 +56207,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3789
+   i32.const 3795
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56114,7 +56221,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3790
+   i32.const 3796
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56128,7 +56235,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3791
+   i32.const 3797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56142,7 +56249,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3792
+   i32.const 3798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56156,7 +56263,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3793
+   i32.const 3799
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56170,7 +56277,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3794
+   i32.const 3800
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56184,7 +56291,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3795
+   i32.const 3801
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56198,7 +56305,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3796
+   i32.const 3802
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56212,7 +56319,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3797
+   i32.const 3803
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56226,7 +56333,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3798
+   i32.const 3804
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56240,7 +56347,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3801
+   i32.const 3807
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56254,7 +56361,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3802
+   i32.const 3808
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56268,7 +56375,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3803
+   i32.const 3809
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56283,7 +56390,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3804
+   i32.const 3810
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56297,7 +56404,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3805
+   i32.const 3811
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56311,7 +56418,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3808
+   i32.const 3814
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56325,101 +56432,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3809
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3810
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3811
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3812
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3813
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3814
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tanf
@@ -56432,8 +56451,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tanf
@@ -56446,6 +56465,94 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3818
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3819
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3820
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3821
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3822
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3823
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   f32.const 2.3509895424236536e-38
   f32.const 0
@@ -56455,7 +56562,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3818
+   i32.const 3824
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56469,7 +56576,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3819
+   i32.const 3825
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56483,7 +56590,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3820
+   i32.const 3826
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56497,7 +56604,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3821
+   i32.const 3827
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56511,91 +56618,91 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3822
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3823
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3824
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3825
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3826
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3827
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3828
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3829
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3830
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3831
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3832
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3833
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56609,7 +56716,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3829
+   i32.const 3835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56623,7 +56730,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3830
+   i32.const 3836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56637,109 +56744,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3831
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3832
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3833
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3834
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3835
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3836
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const 2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56754,8 +56765,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56770,8 +56781,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56786,8 +56797,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56802,8 +56813,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56818,8 +56829,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56834,6 +56845,102 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3844
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3845
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3846
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3847
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3848
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3849
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -8.06684839057968
   f64.const -0.999999803096032
   f64.const 0.012793331407010555
@@ -56843,7 +56950,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3855
+   i32.const 3861
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56857,7 +56964,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3856
+   i32.const 3862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56871,7 +56978,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3857
+   i32.const 3863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56885,7 +56992,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3858
+   i32.const 3864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56899,7 +57006,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3859
+   i32.const 3865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56913,7 +57020,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3860
+   i32.const 3866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56927,7 +57034,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3861
+   i32.const 3867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56941,7 +57048,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3862
+   i32.const 3868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56955,7 +57062,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3863
+   i32.const 3869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56969,7 +57076,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3864
+   i32.const 3870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56983,7 +57090,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3867
+   i32.const 3873
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56997,7 +57104,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3868
+   i32.const 3874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57011,7 +57118,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3869
+   i32.const 3875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57026,7 +57133,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3870
+   i32.const 3876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57040,7 +57147,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3871
+   i32.const 3877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57054,7 +57161,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3880
+   i32.const 3886
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57068,7 +57175,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3881
+   i32.const 3887
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57082,7 +57189,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3882
+   i32.const 3888
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57096,7 +57203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3883
+   i32.const 3889
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57110,7 +57217,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3884
+   i32.const 3890
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57124,7 +57231,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3885
+   i32.const 3891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57138,7 +57245,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3886
+   i32.const 3892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57152,7 +57259,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3887
+   i32.const 3893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57166,7 +57273,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3888
+   i32.const 3894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57180,7 +57287,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3889
+   i32.const 3895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57194,7 +57301,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3892
+   i32.const 3898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57208,7 +57315,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3893
+   i32.const 3899
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57222,7 +57329,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3894
+   i32.const 3900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57237,7 +57344,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3895
+   i32.const 3901
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57251,7 +57358,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3896
+   i32.const 3902
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57265,7 +57372,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3908
+   i32.const 3914
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57279,7 +57386,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3909
+   i32.const 3915
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57293,7 +57400,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3910
+   i32.const 3916
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57307,7 +57414,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3911
+   i32.const 3917
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57321,7 +57428,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3912
+   i32.const 3918
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57335,7 +57442,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3913
+   i32.const 3919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57349,7 +57456,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3914
+   i32.const 3920
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57363,7 +57470,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3915
+   i32.const 3921
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57377,7 +57484,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3916
+   i32.const 3922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57391,99 +57498,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3917
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3920
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3921
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3922
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3924
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3925
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -57492,6 +57513,92 @@
    i32.const 0
    i32.const 32
    i32.const 3926
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3927
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3928
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3929
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3930
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3931
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57505,7 +57612,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3927
+   i32.const 3933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57519,7 +57626,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3928
+   i32.const 3934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57533,7 +57640,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3929
+   i32.const 3935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57547,7 +57654,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3930
+   i32.const 3936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57561,7 +57668,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3931
+   i32.const 3937
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57575,7 +57682,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3932
+   i32.const 3938
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57589,7 +57696,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3933
+   i32.const 3939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57603,7 +57710,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3934
+   i32.const 3940
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57617,7 +57724,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3943
+   i32.const 3949
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57631,7 +57738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3944
+   i32.const 3950
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57645,7 +57752,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3945
+   i32.const 3951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57659,7 +57766,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3946
+   i32.const 3952
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57673,7 +57780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3947
+   i32.const 3953
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57687,7 +57794,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3948
+   i32.const 3954
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57701,7 +57808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3949
+   i32.const 3955
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57715,7 +57822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3950
+   i32.const 3956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57729,7 +57836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3951
+   i32.const 3957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57743,99 +57850,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3952
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3955
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3956
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3957
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3959
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3960
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -57844,6 +57865,92 @@
    i32.const 0
    i32.const 32
    i32.const 3961
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3962
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3963
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3964
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3965
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3966
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3967
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57857,7 +57964,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3962
+   i32.const 3968
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57871,7 +57978,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3963
+   i32.const 3969
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57885,7 +57992,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3964
+   i32.const 3970
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57899,7 +58006,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3965
+   i32.const 3971
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57913,7 +58020,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3966
+   i32.const 3972
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57927,7 +58034,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3967
+   i32.const 3973
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57941,7 +58048,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3968
+   i32.const 3974
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57955,7 +58062,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3969
+   i32.const 3975
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58049,7 +58156,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4010
+   i32.const 4016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58063,7 +58170,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4011
+   i32.const 4017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58077,7 +58184,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4012
+   i32.const 4018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58091,7 +58198,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4013
+   i32.const 4019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58105,7 +58212,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4014
+   i32.const 4020
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58119,7 +58226,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4015
+   i32.const 4021
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58133,7 +58240,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4016
+   i32.const 4022
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58147,7 +58254,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4017
+   i32.const 4023
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58161,7 +58268,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4018
+   i32.const 4024
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58175,7 +58282,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4019
+   i32.const 4025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58189,7 +58296,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4020
+   i32.const 4026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58203,90 +58310,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4021
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  call $~lib/math/NativeMath.clz32
-  f64.const 32
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4025
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  call $~lib/math/NativeMath.clz32
-  f64.const 31
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4026
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 4027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -128
-  call $~lib/math/NativeMath.clz32
   f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4028
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4294967295
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4029
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4294967295.5
-  call $~lib/math/NativeMath.clz32
-  f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4030
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4294967296
   call $~lib/math/NativeMath.clz32
   f64.const 32
   f64.eq
@@ -58299,7 +58328,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4294967297
+  f64.const 1
   call $~lib/math/NativeMath.clz32
   f64.const 31
   f64.eq
@@ -58312,6 +58341,84 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  call $~lib/math/NativeMath.clz32
+  f64.const 0
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4033
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -128
+  call $~lib/math/NativeMath.clz32
+  f64.const 0
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4034
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4294967295
+  call $~lib/math/NativeMath.clz32
+  f64.const 0
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4035
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4294967295.5
+  call $~lib/math/NativeMath.clz32
+  f64.const 0
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4036
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4294967296
+  call $~lib/math/NativeMath.clz32
+  f64.const 32
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4037
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4294967297
+  call $~lib/math/NativeMath.clz32
+  f64.const 31
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4038
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.clz32
   f64.const 32
@@ -58320,7 +58427,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4033
+   i32.const 4039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58333,7 +58440,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4034
+   i32.const 4040
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58346,7 +58453,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4035
+   i32.const 4041
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58360,7 +58467,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4036
+   i32.const 4042
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58373,7 +58480,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4037
+   i32.const 4043
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58386,7 +58493,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4038
+   i32.const 4044
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58400,7 +58507,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4039
+   i32.const 4045
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58413,83 +58520,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4040
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i64.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4044
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i64.const 1
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4045
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i64.const 2
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 4046
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
-  i64.const 3
-  call $~lib/math/ipow64
   i64.const 0
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4047
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i64.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4049
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i64.const 1
   call $~lib/math/ipow64
   i64.const 1
   i64.eq
@@ -58502,6 +58539,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const 0
+  i64.const 1
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4051
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i64.const 2
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4052
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i64.const 3
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4053
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i64.const 0
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4055
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i64.const 1
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4056
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 1
   i64.const 2
   call $~lib/math/ipow64
@@ -58511,7 +58618,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4051
+   i32.const 4057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58525,7 +58632,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4052
+   i32.const 4058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58539,7 +58646,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4054
+   i32.const 4060
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58553,7 +58660,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4055
+   i32.const 4061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58567,7 +58674,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4056
+   i32.const 4062
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58581,7 +58688,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4057
+   i32.const 4063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58595,7 +58702,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4059
+   i32.const 4065
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58609,7 +58716,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4060
+   i32.const 4066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58623,7 +58730,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4061
+   i32.const 4067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58637,7 +58744,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4062
+   i32.const 4068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58651,7 +58758,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4064
+   i32.const 4070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58665,7 +58772,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4065
+   i32.const 4071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58679,7 +58786,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4066
+   i32.const 4072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58693,7 +58800,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4067
+   i32.const 4073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58707,7 +58814,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4069
+   i32.const 4075
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58716,76 +58823,6 @@
   i64.const 40
   call $~lib/math/ipow64
   i64.const -6289078614652622815
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4070
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 2
-  i64.const 64
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4071
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 3
-  i64.const 41
-  call $~lib/math/ipow64
-  i64.const -420491770248316829
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4072
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 3
-  i64.const 128
-  call $~lib/math/ipow64
-  i64.const -9204772141784466943
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4073
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i64.const -1
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4075
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 2
-  i64.const -1
-  call $~lib/math/ipow64
-  i64.const 0
   i64.eq
   i32.eqz
   if
@@ -58810,6 +58847,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const 3
+  i64.const 41
+  call $~lib/math/ipow64
+  i64.const -420491770248316829
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4078
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 3
+  i64.const 128
+  call $~lib/math/ipow64
+  i64.const -9204772141784466943
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4079
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i64.const -1
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4081
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 2
+  i64.const -1
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4082
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 2
+  i64.const 64
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4083
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 2
   i64.const 128
   call $~lib/math/ipow64
@@ -58819,7 +58926,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4078
+   i32.const 4084
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58851,7 +58958,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4084
+   i32.const 4090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58865,7 +58972,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4085
+   i32.const 4091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58879,7 +58986,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4086
+   i32.const 4092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58893,7 +59000,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4087
+   i32.const 4093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58907,7 +59014,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4088
+   i32.const 4094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58921,75 +59028,15 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4089
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  i32.const -2
-  call $~lib/math/ipow32
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4091
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  i32.const -1
-  call $~lib/math/ipow32
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4092
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  i32.const 0
-  i32.const 0
-  i32.eq
-  i32.const 0
-  select
-  i32.const 1
-  i32.eq
-  drop
-  i32.const 1
-  i32.const 1
-  i32.const 0
-  i32.eq
-  i32.const 0
-  select
-  i32.const 0
-  i32.eq
-  drop
-  i32.const 0
-  i32.const 2
-  call $~lib/math/ipow32
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 4095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 0
   i32.const -2
   call $~lib/math/ipow32
-  i32.const 1
+  i32.const 0
   i32.eq
   i32.eqz
   if
@@ -59000,10 +59047,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 0
   i32.const -1
   call $~lib/math/ipow32
-  i32.const 1
+  i32.const 0
   i32.eq
   i32.eqz
   if
@@ -59018,6 +59065,66 @@
   i32.const 0
   i32.const 0
   i32.eq
+  i32.const 0
+  select
+  i32.const 1
+  i32.eq
+  drop
+  i32.const 1
+  i32.const 1
+  i32.const 0
+  i32.eq
+  i32.const 0
+  select
+  i32.const 0
+  i32.eq
+  drop
+  i32.const 0
+  i32.const 2
+  call $~lib/math/ipow32
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4101
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  i32.const -2
+  call $~lib/math/ipow32
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4103
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  i32.const -1
+  call $~lib/math/ipow32
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4104
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  i32.const 0
+  i32.const 0
+  i32.eq
   i32.const 1
   select
   i32.const 1
@@ -59041,7 +59148,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4101
+   i32.const 4107
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59059,7 +59166,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4103
+   i32.const 4109
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59077,7 +59184,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4104
+   i32.const 4110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59093,7 +59200,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4105
+   i32.const 4111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59109,7 +59216,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4106
+   i32.const 4112
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59125,7 +59232,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4107
+   i32.const 4113
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59139,7 +59246,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4109
+   i32.const 4115
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59153,7 +59260,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4110
+   i32.const 4116
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59167,7 +59274,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4111
+   i32.const 4117
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59181,7 +59288,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4112
+   i32.const 4118
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59195,7 +59302,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4113
+   i32.const 4119
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59209,7 +59316,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4114
+   i32.const 4120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59223,7 +59330,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4115
+   i32.const 4121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59237,7 +59344,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4116
+   i32.const 4122
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59251,7 +59358,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4117
+   i32.const 4123
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59271,7 +59378,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4119
+   i32.const 4125
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59289,7 +59396,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4120
+   i32.const 4126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59304,7 +59411,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4122
+   i32.const 4128
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59319,7 +59426,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4123
+   i32.const 4129
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59334,7 +59441,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4124
+   i32.const 4130
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59348,7 +59455,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4125
+   i32.const 4131
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59362,7 +59469,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4126
+   i32.const 4132
    i32.const 1
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
Previous implementation  was incorrect for maximum mantissa values.

Edge cases current:
```ts
Math.round(+9007199254740991) -> +9007199254740992
Math.round(-9007199254740991) -> -9007199254740990
```

Edge cases fixed:
```ts
Math.round(+9007199254740991) -> +9007199254740991
Math.round(-9007199254740991) -> -9007199254740991
```

Fix #1856 

- [x] I've read the contributing guidelines