### PR TITLE
fix: Fix negative inputs of Math.acosh

### DIFF
--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -498,7 +498,9 @@ export namespace NativeMath {
 
   export function acosh(x: f64): f64 { // see: musl/src/math/acosh.c
     const s = reinterpret<f64>(0x3FE62E42FEFA39EF);
-    var e = reinterpret<u64>(x) >> 52 & 0x7FF;
+    var u = reinterpret<u64>(x);
+    if (<i64>u < 0x3FF0000000000000) return (x - x) / 0.0;
+    var e = u >> 52 & 0x7FF;
     if (e < 0x3FF + 1) return log1p(x - 1 + builtin_sqrt<f64>((x - 1) * (x - 1) + 2 * (x - 1)));
     if (e < 0x3FF + 26) return log(2 * x - 1 / (x + builtin_sqrt<f64>(x * x - 1)));
     return log(x) + s;

--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -499,6 +499,8 @@ export namespace NativeMath {
   export function acosh(x: f64): f64 { // see: musl/src/math/acosh.c
     const s = reinterpret<f64>(0x3FE62E42FEFA39EF);
     var u = reinterpret<u64>(x);
+    // Prevent propagation for all input values less than 1.0.
+    // Note musl lib didn't fix this yet.
     if (<i64>u < 0x3FF0000000000000) return (x - x) / 0.0;
     var e = u >> 52 & 0x7FF;
     if (e < 0x3FF + 1) return log1p(x - 1 + builtin_sqrt<f64>((x - 1) * (x - 1) + 2 * (x - 1)));

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -4547,7 +4547,7 @@
   if
    i32.const 0
    i32.const 7264
-   i32.const 1417
+   i32.const 1421
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -6650,7 +6650,7 @@
   if
    i32.const 0
    i32.const 6240
-   i32.const 1417
+   i32.const 1421
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -1506,7 +1506,18 @@
   (local $4 i64)
   block $__inlined_func$~lib/math/NativeMath.acosh (result f64)
    local.get $0
+   local.get $0
+   f64.sub
+   f64.const 0
+   f64.div
+   local.get $0
    i64.reinterpret_f64
+   local.tee $4
+   i64.const 4607182418800017408
+   i64.lt_s
+   br_if $__inlined_func$~lib/math/NativeMath.acosh
+   drop
+   local.get $4
    i64.const 52
    i64.shr_u
    i64.const 2047
@@ -8859,7 +8870,7 @@
   if
    i32.const 0
    i32.const 14400
-   i32.const 1417
+   i32.const 1419
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -14962,7 +14973,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -9784.820766473835
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_acosh
@@ -14975,7 +14986,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_acosh
@@ -14988,7 +14999,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_acosh
@@ -15001,6 +15012,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_acosh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 357
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.1060831199926429
   f64.const 0.4566373404384803
   f64.const -0.29381608963012695
@@ -15009,7 +15033,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 372
+   i32.const 373
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15022,7 +15046,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 374
+   i32.const 375
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15035,7 +15059,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 375
+   i32.const 376
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15048,7 +15072,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 384
+   i32.const 385
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15061,7 +15085,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 385
+   i32.const 386
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15074,7 +15098,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 386
+   i32.const 387
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15087,7 +15111,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 387
+   i32.const 388
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15100,7 +15124,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 388
+   i32.const 389
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15113,7 +15137,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 389
+   i32.const 390
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15126,7 +15150,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 390
+   i32.const 391
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15139,7 +15163,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 391
+   i32.const 392
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15152,7 +15176,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 392
+   i32.const 393
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15165,26 +15189,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 393
+   i32.const 394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_acoshf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 396
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   call $std/math/test_acoshf
   i32.eqz
@@ -15192,6 +15203,19 @@
    i32.const 0
    i32.const 1056
    i32.const 397
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_acoshf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 398
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15204,7 +15228,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 398
+   i32.const 399
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15217,25 +15241,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 399
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_acoshf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 400
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_acoshf
@@ -15248,7 +15259,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_acoshf
@@ -15261,7 +15272,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1125899906842624
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_acoshf
@@ -15270,6 +15281,19 @@
    i32.const 0
    i32.const 1056
    i32.const 403
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1125899906842624
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_acoshf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15292,7 +15316,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 415
+   i32.const 416
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15315,7 +15339,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 416
+   i32.const 417
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15338,7 +15362,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 417
+   i32.const 418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15361,7 +15385,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 418
+   i32.const 419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15384,7 +15408,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 419
+   i32.const 420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15407,7 +15431,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 420
+   i32.const 421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15430,7 +15454,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 421
+   i32.const 422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15453,7 +15477,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 422
+   i32.const 423
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15476,7 +15500,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 423
+   i32.const 424
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15499,7 +15523,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 424
+   i32.const 425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15522,7 +15546,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 427
+   i32.const 428
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15545,43 +15569,20 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 428
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  call $~lib/math/NativeMath.asin
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 0
-   call $~lib/bindings/Math/asin
-   f64.const 0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 429
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   call $~lib/math/NativeMath.asin
-  f64.const -0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0
    call $~lib/bindings/Math/asin
-   f64.const -0
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -15592,6 +15593,29 @@
    i32.const 0
    i32.const 1056
    i32.const 430
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  call $~lib/math/NativeMath.asin
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -0
+   call $~lib/bindings/Math/asin
+   f64.const -0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15614,7 +15638,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 431
+   i32.const 432
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15637,7 +15661,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 432
+   i32.const 433
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15660,7 +15684,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 433
+   i32.const 434
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15683,7 +15707,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 434
+   i32.const 435
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15706,7 +15730,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 435
+   i32.const 436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15729,25 +15753,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 436
+   i32.const 437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_asinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 445
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.345239639282227
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_asinf
@@ -15760,7 +15771,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
+  f32.const 4.345239639282227
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_asinf
@@ -15773,7 +15784,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
+  f32.const -8.381433486938477
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_asinf
@@ -15786,7 +15797,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_asinf
@@ -15799,6 +15810,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 9.267057418823242
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 450
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0.6619858741760254
   f32.const 0.7234652042388916
   f32.const -0.1307632476091385
@@ -15807,7 +15831,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 450
+   i32.const 451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15820,7 +15844,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 451
+   i32.const 452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15833,7 +15857,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 452
+   i32.const 453
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15846,7 +15870,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 453
+   i32.const 454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15859,7 +15883,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 454
+   i32.const 455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15872,7 +15896,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 457
+   i32.const 458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15885,26 +15909,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 458
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/test_asinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/test_asinf
   i32.eqz
@@ -15912,6 +15923,19 @@
    i32.const 0
    i32.const 1056
    i32.const 460
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15924,7 +15948,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 461
+   i32.const 462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -15937,25 +15961,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 462
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_asinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 463
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_asinf
@@ -15968,7 +15979,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_asinf
@@ -15981,6 +15992,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 466
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0.5004770159721375
   f32.const 0.5241496562957764
   f32.const -0.29427099227905273
@@ -15989,7 +16013,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 466
+   i32.const 467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16002,7 +16026,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 478
+   i32.const 479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16015,7 +16039,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 479
+   i32.const 480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16028,7 +16052,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 480
+   i32.const 481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16041,7 +16065,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 481
+   i32.const 482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16054,7 +16078,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 482
+   i32.const 483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16067,7 +16091,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 483
+   i32.const 484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16080,7 +16104,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 484
+   i32.const 485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16093,7 +16117,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 485
+   i32.const 486
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16106,7 +16130,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 486
+   i32.const 487
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16119,26 +16143,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 487
+   i32.const 488
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_asinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 490
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
   f64.const 0
   call $std/math/test_asinh
   i32.eqz
@@ -16150,8 +16161,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/test_asinh
   i32.eqz
@@ -16163,6 +16174,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_asinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 493
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -16171,7 +16195,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 493
+   i32.const 494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16184,7 +16208,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 494
+   i32.const 495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16197,7 +16221,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 523
+   i32.const 524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16210,7 +16234,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 524
+   i32.const 525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16223,7 +16247,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 525
+   i32.const 526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16236,7 +16260,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 526
+   i32.const 527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16249,7 +16273,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 527
+   i32.const 528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16262,7 +16286,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 528
+   i32.const 529
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16275,7 +16299,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 529
+   i32.const 530
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16288,7 +16312,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 530
+   i32.const 531
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16301,7 +16325,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 531
+   i32.const 532
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16314,26 +16338,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 532
+   i32.const 533
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_asinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 535
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   call $std/math/test_asinhf
   i32.eqz
@@ -16345,8 +16356,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/test_asinhf
   i32.eqz
@@ -16358,6 +16369,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_asinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 538
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
   f32.const 0
   f32.const 0
@@ -16366,7 +16390,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 538
+   i32.const 539
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16379,7 +16403,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 539
+   i32.const 540
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16402,7 +16426,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 551
+   i32.const 552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16425,7 +16449,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 552
+   i32.const 553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16448,7 +16472,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 553
+   i32.const 554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16471,7 +16495,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 554
+   i32.const 555
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16494,7 +16518,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 555
+   i32.const 556
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16517,7 +16541,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 556
+   i32.const 557
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16540,7 +16564,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 557
+   i32.const 558
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16563,7 +16587,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 558
+   i32.const 559
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16586,7 +16610,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 559
+   i32.const 560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16609,7 +16633,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 560
+   i32.const 561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16623,29 +16647,6 @@
    f64.const 0
    call $~lib/bindings/Math/atan
    f64.const 0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 563
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  call $~lib/math/NativeMath.atan
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -0
-   call $~lib/bindings/Math/atan
-   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -16656,6 +16657,29 @@
    i32.const 0
    i32.const 1056
    i32.const 564
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  call $~lib/math/NativeMath.atan
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -0
+   call $~lib/bindings/Math/atan
+   f64.const -0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16678,7 +16702,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 565
+   i32.const 566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16701,7 +16725,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 566
+   i32.const 567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16724,7 +16748,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 567
+   i32.const 568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16747,7 +16771,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 568
+   i32.const 569
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16770,7 +16794,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 569
+   i32.const 570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16793,7 +16817,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 570
+   i32.const 571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16807,7 +16831,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 579
+   i32.const 580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16821,7 +16845,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 580
+   i32.const 581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16835,7 +16859,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 581
+   i32.const 582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16849,7 +16873,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 582
+   i32.const 583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16863,7 +16887,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 583
+   i32.const 584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16877,7 +16901,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 584
+   i32.const 585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16891,7 +16915,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 585
+   i32.const 586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16905,7 +16929,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 586
+   i32.const 587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16919,7 +16943,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 587
+   i32.const 588
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16933,7 +16957,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 588
+   i32.const 589
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16941,20 +16965,6 @@
   f32.const 0
   call $~lib/math/NativeMathf.atan
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 591
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  call $~lib/math/NativeMathf.atan
-  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -16962,6 +16972,20 @@
    i32.const 0
    i32.const 1056
    i32.const 592
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  call $~lib/math/NativeMathf.atan
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16975,7 +16999,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 593
+   i32.const 594
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -16989,7 +17013,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 594
+   i32.const 595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17003,7 +17027,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 595
+   i32.const 596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17017,7 +17041,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 596
+   i32.const 597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17031,7 +17055,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 597
+   i32.const 598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17044,7 +17068,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 609
+   i32.const 610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17057,7 +17081,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 610
+   i32.const 611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17070,7 +17094,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 611
+   i32.const 612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17083,7 +17107,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 612
+   i32.const 613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17096,7 +17120,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 613
+   i32.const 614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17109,7 +17133,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 614
+   i32.const 615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17122,7 +17146,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 615
+   i32.const 616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17135,7 +17159,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 616
+   i32.const 617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17148,7 +17172,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 617
+   i32.const 618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17161,25 +17185,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 618
+   i32.const 619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 621
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_atanh
@@ -17192,7 +17203,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_atanh
@@ -17205,6 +17216,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 624
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -17213,7 +17237,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 624
+   i32.const 625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17226,7 +17250,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 625
+   i32.const 626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17239,7 +17263,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 626
+   i32.const 627
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17252,7 +17276,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 627
+   i32.const 628
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17265,7 +17289,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 628
+   i32.const 629
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17278,26 +17302,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 629
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.3552527156068805e-20
-  f64.const 1.3552527156068805e-20
-  f64.const 0
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 630
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 9.332636185032189e-302
-  f64.const 9.332636185032189e-302
+  f64.const 1.3552527156068805e-20
+  f64.const 1.3552527156068805e-20
   f64.const 0
   call $std/math/test_atanh
   i32.eqz
@@ -17309,6 +17320,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 9.332636185032189e-302
+  f64.const 9.332636185032189e-302
+  f64.const 0
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 632
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 5.562684646268003e-309
   f64.const 5.562684646268003e-309
   f64.const 0
@@ -17317,7 +17341,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 632
+   i32.const 633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17330,7 +17354,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 633
+   i32.const 634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17343,7 +17367,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 634
+   i32.const 635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17356,7 +17380,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 643
+   i32.const 644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17369,7 +17393,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 644
+   i32.const 645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17382,7 +17406,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 645
+   i32.const 646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17395,7 +17419,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 646
+   i32.const 647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17408,7 +17432,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 647
+   i32.const 648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17421,7 +17445,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 648
+   i32.const 649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17434,7 +17458,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 649
+   i32.const 650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17447,7 +17471,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 650
+   i32.const 651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17460,7 +17484,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 651
+   i32.const 652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17473,25 +17497,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 652
+   i32.const 653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 655
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_atanhf
@@ -17504,7 +17515,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_atanhf
@@ -17517,6 +17528,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 658
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
   f32.const 0
   f32.const 0
@@ -17525,7 +17549,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 658
+   i32.const 659
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17538,7 +17562,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 659
+   i32.const 660
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17551,7 +17575,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 660
+   i32.const 661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17564,7 +17588,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 661
+   i32.const 662
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17577,7 +17601,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 662
+   i32.const 663
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17590,26 +17614,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 663
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.3552527156068805e-20
-  f32.const 1.3552527156068805e-20
-  f32.const 0
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 664
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.888609052210118e-31
-  f32.const 7.888609052210118e-31
+  f32.const 1.3552527156068805e-20
+  f32.const 1.3552527156068805e-20
   f32.const 0
   call $std/math/test_atanhf
   i32.eqz
@@ -17621,6 +17632,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 7.888609052210118e-31
+  f32.const 7.888609052210118e-31
+  f32.const 0
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 666
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.938735877055719e-39
   f32.const 2.938735877055719e-39
   f32.const 0
@@ -17629,7 +17653,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 666
+   i32.const 667
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17642,7 +17666,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 667
+   i32.const 668
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17655,7 +17679,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 668
+   i32.const 669
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17669,7 +17693,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 680
+   i32.const 681
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17683,7 +17707,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 681
+   i32.const 682
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17697,7 +17721,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 682
+   i32.const 683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17711,7 +17735,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 683
+   i32.const 684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17725,7 +17749,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 684
+   i32.const 685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17739,7 +17763,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 685
+   i32.const 686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17753,7 +17777,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 686
+   i32.const 687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17767,7 +17791,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 687
+   i32.const 688
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17781,7 +17805,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 688
+   i32.const 689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17795,7 +17819,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 689
+   i32.const 690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17804,20 +17828,6 @@
   f64.const 0
   f64.const 0
   f64.const 0
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 692
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const 3.141592653589793
-  f64.const -0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17829,7 +17839,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -1
+  f64.const -0
   f64.const 3.141592653589793
   f64.const -0.27576595544815063
   call $std/math/test_atan2
@@ -17843,7 +17853,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
+  f64.const -1
   f64.const 3.141592653589793
   f64.const -0.27576595544815063
   call $std/math/test_atan2
@@ -17857,6 +17867,20 @@
    unreachable
   end
   f64.const 0
+  f64.const -inf
+  f64.const 3.141592653589793
+  f64.const -0.27576595544815063
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 696
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
   f64.const 1
   f64.const 0
   f64.const 0
@@ -17865,7 +17889,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 696
+   i32.const 697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -17879,29 +17903,15 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 697
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
+  f64.const 0
   f64.const -0
-  f64.const -3.141592653589793
-  f64.const 0.27576595544815063
+  f64.const 0
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17913,7 +17923,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -1
+  f64.const -0
   f64.const -3.141592653589793
   f64.const 0.27576595544815063
   call $std/math/test_atan2
@@ -17927,7 +17937,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
+  f64.const -1
   f64.const -3.141592653589793
   f64.const 0.27576595544815063
   call $std/math/test_atan2
@@ -17941,9 +17951,9 @@
    unreachable
   end
   f64.const -0
-  f64.const 1
-  f64.const -0
-  f64.const 0
+  f64.const -inf
+  f64.const -3.141592653589793
+  f64.const 0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17955,7 +17965,7 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
+  f64.const 1
   f64.const -0
   f64.const 0
   call $std/math/test_atan2
@@ -17968,10 +17978,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0
+  f64.const inf
+  f64.const -0
   f64.const 0
-  f64.const -1.5707963267948966
-  f64.const 0.27576595544815063
   call $std/math/test_atan2
   i32.eqz
   if
@@ -17983,7 +17993,7 @@
    unreachable
   end
   f64.const -1
-  f64.const -0
+  f64.const 0
   f64.const -1.5707963267948966
   f64.const 0.27576595544815063
   call $std/math/test_atan2
@@ -17996,6 +18006,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const -0
+  f64.const -1.5707963267948966
+  f64.const 0.27576595544815063
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 706
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 0
   f64.const 1.5707963267948966
@@ -18005,7 +18029,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 706
+   i32.const 707
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18019,7 +18043,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 707
+   i32.const 708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18033,7 +18057,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 708
+   i32.const 709
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18047,7 +18071,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 709
+   i32.const 710
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18061,7 +18085,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 710
+   i32.const 711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18075,7 +18099,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 711
+   i32.const 712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18089,7 +18113,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 712
+   i32.const 713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18103,7 +18127,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 713
+   i32.const 714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18117,7 +18141,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 714
+   i32.const 715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18131,7 +18155,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 715
+   i32.const 716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18145,7 +18169,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 716
+   i32.const 717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18159,7 +18183,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 717
+   i32.const 718
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18173,7 +18197,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 718
+   i32.const 719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18187,7 +18211,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 719
+   i32.const 720
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18201,7 +18225,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 720
+   i32.const 721
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18215,7 +18239,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 721
+   i32.const 722
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18229,7 +18253,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 730
+   i32.const 731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18243,7 +18267,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 731
+   i32.const 732
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18257,7 +18281,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 732
+   i32.const 733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18271,7 +18295,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 733
+   i32.const 734
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18285,7 +18309,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 734
+   i32.const 735
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18299,7 +18323,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 735
+   i32.const 736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18313,7 +18337,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 736
+   i32.const 737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18327,7 +18351,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 737
+   i32.const 738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18341,7 +18365,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 738
+   i32.const 739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18355,7 +18379,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 739
+   i32.const 740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18364,20 +18388,6 @@
   f32.const 0
   f32.const 0
   f32.const 0
-  call $std/math/test_atan2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 742
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const 3.1415927410125732
-  f32.const 0.3666777014732361
   call $std/math/test_atan2f
   i32.eqz
   if
@@ -18389,7 +18399,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -1
+  f32.const -0
   f32.const 3.1415927410125732
   f32.const 0.3666777014732361
   call $std/math/test_atan2f
@@ -18403,7 +18413,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
+  f32.const -1
   f32.const 3.1415927410125732
   f32.const 0.3666777014732361
   call $std/math/test_atan2f
@@ -18417,6 +18427,20 @@
    unreachable
   end
   f32.const 0
+  f32.const -inf
+  f32.const 3.1415927410125732
+  f32.const 0.3666777014732361
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 746
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
   f32.const 1
   f32.const 0
   f32.const 0
@@ -18425,7 +18449,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 746
+   i32.const 747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18439,29 +18463,15 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 747
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 0
-  f32.const -0
-  f32.const 0
-  call $std/math/test_atan2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0
+  f32.const 0
   f32.const -0
-  f32.const -3.1415927410125732
-  f32.const -0.3666777014732361
+  f32.const 0
   call $std/math/test_atan2f
   i32.eqz
   if
@@ -18473,7 +18483,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -1
+  f32.const -0
   f32.const -3.1415927410125732
   f32.const -0.3666777014732361
   call $std/math/test_atan2f
@@ -18487,7 +18497,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
+  f32.const -1
   f32.const -3.1415927410125732
   f32.const -0.3666777014732361
   call $std/math/test_atan2f
@@ -18501,9 +18511,9 @@
    unreachable
   end
   f32.const -0
-  f32.const 1
-  f32.const -0
-  f32.const 0
+  f32.const -inf
+  f32.const -3.1415927410125732
+  f32.const -0.3666777014732361
   call $std/math/test_atan2f
   i32.eqz
   if
@@ -18515,7 +18525,7 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
+  f32.const 1
   f32.const -0
   f32.const 0
   call $std/math/test_atan2f
@@ -18528,10 +18538,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const -0
+  f32.const inf
+  f32.const -0
   f32.const 0
-  f32.const -1.5707963705062866
-  f32.const -0.3666777014732361
   call $std/math/test_atan2f
   i32.eqz
   if
@@ -18543,7 +18553,7 @@
    unreachable
   end
   f32.const -1
-  f32.const -0
+  f32.const 0
   f32.const -1.5707963705062866
   f32.const -0.3666777014732361
   call $std/math/test_atan2f
@@ -18556,6 +18566,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
+  f32.const -0
+  f32.const -1.5707963705062866
+  f32.const -0.3666777014732361
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 756
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 0
   f32.const 1.5707963705062866
@@ -18565,7 +18589,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 756
+   i32.const 757
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18579,7 +18603,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 757
+   i32.const 758
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18593,7 +18617,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 758
+   i32.const 759
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18607,7 +18631,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 759
+   i32.const 760
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18621,7 +18645,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 760
+   i32.const 761
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18635,7 +18659,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 761
+   i32.const 762
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18649,7 +18673,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 762
+   i32.const 763
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18663,7 +18687,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 763
+   i32.const 764
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18677,7 +18701,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 764
+   i32.const 765
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18691,7 +18715,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 765
+   i32.const 766
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18705,7 +18729,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 766
+   i32.const 767
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18719,7 +18743,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 767
+   i32.const 768
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18733,7 +18757,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 768
+   i32.const 769
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18747,7 +18771,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 769
+   i32.const 770
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18760,7 +18784,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 781
+   i32.const 782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18773,7 +18797,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 782
+   i32.const 783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18786,7 +18810,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 783
+   i32.const 784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18799,7 +18823,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 784
+   i32.const 785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18812,7 +18836,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 785
+   i32.const 786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18825,7 +18849,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 786
+   i32.const 787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18838,7 +18862,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 787
+   i32.const 788
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18851,7 +18875,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 788
+   i32.const 789
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18864,7 +18888,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 789
+   i32.const 790
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18877,26 +18901,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 790
+   i32.const 791
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 793
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
   f64.const 0
   call $std/math/test_cbrt
   i32.eqz
@@ -18908,8 +18919,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/test_cbrt
   i32.eqz
@@ -18921,6 +18932,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 796
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -18929,7 +18953,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 796
+   i32.const 797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18942,7 +18966,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 797
+   i32.const 798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18955,7 +18979,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 798
+   i32.const 799
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18968,26 +18992,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 799
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 800
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/test_cbrt
   i32.eqz
@@ -18995,6 +19006,19 @@
    i32.const 0
    i32.const 1056
    i32.const 801
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  f64.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 802
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19007,7 +19031,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 802
+   i32.const 803
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19020,7 +19044,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 811
+   i32.const 812
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19033,7 +19057,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 812
+   i32.const 813
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19046,7 +19070,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 813
+   i32.const 814
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19059,7 +19083,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 814
+   i32.const 815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19072,7 +19096,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 815
+   i32.const 816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19085,7 +19109,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 816
+   i32.const 817
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19098,7 +19122,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 817
+   i32.const 818
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19111,7 +19135,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 818
+   i32.const 819
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19124,7 +19148,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 819
+   i32.const 820
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19137,26 +19161,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 820
+   i32.const 821
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 823
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   call $std/math/test_cbrtf
   i32.eqz
@@ -19168,8 +19179,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/test_cbrtf
   i32.eqz
@@ -19181,6 +19192,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 826
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
   f32.const 0
   f32.const 0
@@ -19189,7 +19213,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 826
+   i32.const 827
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19202,7 +19226,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 827
+   i32.const 828
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19215,7 +19239,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 828
+   i32.const 829
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19228,26 +19252,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 829
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 830
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/test_cbrtf
   i32.eqz
@@ -19255,6 +19266,19 @@
    i32.const 0
    i32.const 1056
    i32.const 831
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19267,7 +19291,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 832
+   i32.const 833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19289,7 +19313,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 844
+   i32.const 845
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19311,7 +19335,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 845
+   i32.const 846
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19333,7 +19357,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 846
+   i32.const 847
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19355,7 +19379,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 847
+   i32.const 848
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19377,7 +19401,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 848
+   i32.const 849
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19399,7 +19423,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 849
+   i32.const 850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19421,7 +19445,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 850
+   i32.const 851
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19443,7 +19467,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 851
+   i32.const 852
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19465,7 +19489,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 852
+   i32.const 853
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19487,7 +19511,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 853
+   i32.const 854
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19500,28 +19524,6 @@
    f64.const nan:0x8000000000000
    call $~lib/bindings/Math/ceil
    f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 856
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const inf
-   call $~lib/bindings/Math/ceil
-   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19536,14 +19538,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -inf
+   f64.const inf
    call $~lib/bindings/Math/ceil
-   f64.const -inf
+   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19558,14 +19560,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -inf
    call $~lib/bindings/Math/ceil
-   f64.const 0
+   f64.const -inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19580,14 +19582,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0
    call $~lib/bindings/Math/ceil
-   f64.const -0
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19602,14 +19604,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 1
+   f64.const -0
    call $~lib/bindings/Math/ceil
-   f64.const 1
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19624,14 +19626,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1
+   f64.const 1
    call $~lib/bindings/Math/ceil
-   f64.const -1
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19646,14 +19648,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0.5
+   f64.const -1
    call $~lib/bindings/Math/ceil
-   f64.const 1
+   f64.const -1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19668,14 +19670,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0.5
+   f64.const 0.5
    call $~lib/bindings/Math/ceil
-   f64.const -0
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19690,14 +19692,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2
-  f64.const 2
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 1.0000152587890625
+   f64.const -0.5
    call $~lib/bindings/Math/ceil
-   f64.const 2
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19712,14 +19714,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 2
+  f64.const 2
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1.0000152587890625
+   f64.const 1.0000152587890625
    call $~lib/bindings/Math/ceil
-   f64.const -1
+   f64.const 2
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19734,14 +19736,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0.9999923706054688
+   f64.const -1.0000152587890625
    call $~lib/bindings/Math/ceil
-   f64.const 1
+   f64.const -1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19756,14 +19758,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0.9999923706054688
+   f64.const 0.9999923706054688
    call $~lib/bindings/Math/ceil
-   f64.const -0
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19778,14 +19780,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 7.888609052210118e-31
+   f64.const -0.9999923706054688
    call $~lib/bindings/Math/ceil
-   f64.const 1
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19800,14 +19802,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -7.888609052210118e-31
+   f64.const 7.888609052210118e-31
    call $~lib/bindings/Math/ceil
-   f64.const -0
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19822,14 +19824,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const nan:0x8000000000000
+   f64.const -7.888609052210118e-31
    call $~lib/bindings/Math/ceil
-   f64.const nan:0x8000000000000
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19844,14 +19846,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const inf
+   f64.const nan:0x8000000000000
    call $~lib/bindings/Math/ceil
-   f64.const inf
+   f64.const nan:0x8000000000000
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19866,14 +19868,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -inf
+   f64.const inf
    call $~lib/bindings/Math/ceil
-   f64.const -inf
+   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19888,14 +19890,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -inf
    call $~lib/bindings/Math/ceil
-   f64.const 0
+   f64.const -inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19910,14 +19912,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0
    call $~lib/bindings/Math/ceil
-   f64.const -0
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19932,14 +19934,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 1
+   f64.const -0
    call $~lib/bindings/Math/ceil
-   f64.const 1
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19954,14 +19956,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1
+   f64.const 1
    call $~lib/bindings/Math/ceil
-   f64.const -1
+   f64.const 1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19976,14 +19978,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0.5
+   f64.const -1
    call $~lib/bindings/Math/ceil
-   f64.const 1
+   f64.const -1
    f64.const 0
    call $std/math/check<f64>
   else
@@ -19998,6 +20000,28 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 0.5
+   call $~lib/bindings/Math/ceil
+   f64.const 1
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 879
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -0
   f64.const -0
   f64.const 0
@@ -20015,7 +20039,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 879
+   i32.const 880
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20037,7 +20061,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 880
+   i32.const 881
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20059,7 +20083,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 881
+   i32.const 882
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20081,7 +20105,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 882
+   i32.const 883
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20103,7 +20127,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 883
+   i32.const 884
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20125,7 +20149,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 884
+   i32.const 885
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20147,41 +20171,19 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 885
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const nan:0x8000000000000
-   call $~lib/bindings/Math/ceil
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 886
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const inf
+   f64.const nan:0x8000000000000
    call $~lib/bindings/Math/ceil
-   f64.const inf
+   f64.const nan:0x8000000000000
    f64.const 0
    call $std/math/check<f64>
   else
@@ -20196,14 +20198,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -inf
+   f64.const inf
    call $~lib/bindings/Math/ceil
-   f64.const -inf
+   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -20218,14 +20220,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -inf
    call $~lib/bindings/Math/ceil
-   f64.const 0
+   f64.const -inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -20240,14 +20242,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0
    call $~lib/bindings/Math/ceil
-   f64.const -0
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -20262,6 +20264,28 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -0
+   call $~lib/bindings/Math/ceil
+   f64.const -0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 891
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -20279,7 +20303,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 891
+   i32.const 892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20301,7 +20325,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 892
+   i32.const 893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20323,7 +20347,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 893
+   i32.const 894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20345,7 +20369,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 894
+   i32.const 895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20367,7 +20391,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 895
+   i32.const 896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20389,7 +20413,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 896
+   i32.const 897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20411,7 +20435,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 897
+   i32.const 898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20433,7 +20457,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 898
+   i32.const 899
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20455,7 +20479,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 899
+   i32.const 900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20477,26 +20501,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 900
+   i32.const 901
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8
   f32.const -8
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 909
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5
-  f32.const 5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20508,8 +20519,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8
-  f32.const -8
+  f32.const 5
+  f32.const 5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20521,8 +20532,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6
-  f32.const -6
+  f32.const -8
+  f32.const -8
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20534,8 +20545,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 10
-  f32.const 10
+  f32.const -6
+  f32.const -6
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20547,8 +20558,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const 10
+  f32.const 10
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20560,8 +20571,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20573,8 +20584,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20599,8 +20610,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20612,21 +20623,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 921
+   i32.const 919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20638,8 +20649,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20651,8 +20662,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20664,8 +20675,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20677,8 +20688,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20690,8 +20701,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20703,8 +20714,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20716,8 +20727,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20729,8 +20740,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20742,8 +20753,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20755,8 +20766,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20768,8 +20779,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20781,8 +20792,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20794,8 +20805,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20807,8 +20818,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20820,8 +20831,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20833,8 +20844,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20846,8 +20857,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20859,8 +20870,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20872,8 +20883,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20885,8 +20896,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20898,8 +20909,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20911,8 +20922,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20924,8 +20935,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20937,8 +20948,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20950,8 +20961,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20963,8 +20974,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20976,8 +20987,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -20989,8 +21000,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21002,8 +21013,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21015,8 +21026,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21028,8 +21039,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21041,8 +21052,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21054,8 +21065,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21067,8 +21078,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21080,8 +21091,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21093,8 +21104,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21106,8 +21117,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21119,8 +21130,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21132,8 +21143,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21145,8 +21156,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21158,8 +21169,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -21171,6 +21182,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 964
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 1
   f32.const 0
@@ -21179,7 +21203,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 964
+   i32.const 965
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21192,7 +21216,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 965
+   i32.const 966
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21215,7 +21239,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 976
+   i32.const 977
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21238,7 +21262,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 977
+   i32.const 978
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21261,7 +21285,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 978
+   i32.const 979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21284,7 +21308,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 979
+   i32.const 980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21307,7 +21331,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 980
+   i32.const 981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21330,7 +21354,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 981
+   i32.const 982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21353,7 +21377,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 982
+   i32.const 983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21376,7 +21400,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 983
+   i32.const 984
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21399,7 +21423,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 984
+   i32.const 985
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21422,7 +21446,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 985
+   i32.const 986
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21445,7 +21469,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 988
+   i32.const 989
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21468,7 +21492,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 989
+   i32.const 990
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21491,7 +21515,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 990
+   i32.const 991
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21514,7 +21538,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 991
+   i32.const 992
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21537,7 +21561,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 992
+   i32.const 993
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21560,7 +21584,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 993
+   i32.const 994
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21583,7 +21607,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 994
+   i32.const 995
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21606,7 +21630,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 995
+   i32.const 996
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21629,7 +21653,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 996
+   i32.const 997
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21652,7 +21676,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 997
+   i32.const 998
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21675,7 +21699,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 998
+   i32.const 999
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21698,7 +21722,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 999
+   i32.const 1000
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21721,7 +21745,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1000
+   i32.const 1001
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21744,7 +21768,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1001
+   i32.const 1002
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21767,7 +21791,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1002
+   i32.const 1003
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21790,7 +21814,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1003
+   i32.const 1004
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21813,7 +21837,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1004
+   i32.const 1005
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21836,7 +21860,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1005
+   i32.const 1006
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21859,7 +21883,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1006
+   i32.const 1007
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21882,7 +21906,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1007
+   i32.const 1008
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21905,7 +21929,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1008
+   i32.const 1009
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21928,7 +21952,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1009
+   i32.const 1010
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21951,7 +21975,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1010
+   i32.const 1011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21974,7 +21998,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1011
+   i32.const 1012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21997,7 +22021,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1012
+   i32.const 1013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22020,7 +22044,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1013
+   i32.const 1014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22043,7 +22067,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1014
+   i32.const 1015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22066,7 +22090,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1015
+   i32.const 1016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22089,7 +22113,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1016
+   i32.const 1017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22112,7 +22136,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1017
+   i32.const 1018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22135,7 +22159,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1018
+   i32.const 1019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22158,7 +22182,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1019
+   i32.const 1020
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22181,7 +22205,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1020
+   i32.const 1021
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22204,7 +22228,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1021
+   i32.const 1022
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22227,7 +22251,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1022
+   i32.const 1023
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22250,7 +22274,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1023
+   i32.const 1024
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22273,7 +22297,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1024
+   i32.const 1025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22296,7 +22320,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1025
+   i32.const 1026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22319,7 +22343,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1026
+   i32.const 1027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22342,7 +22366,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1027
+   i32.const 1028
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22365,7 +22389,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1028
+   i32.const 1029
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22388,7 +22412,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1029
+   i32.const 1030
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22411,7 +22435,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1030
+   i32.const 1031
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22434,7 +22458,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1031
+   i32.const 1032
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22457,7 +22481,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1032
+   i32.const 1033
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22480,7 +22504,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1033
+   i32.const 1034
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22503,7 +22527,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1034
+   i32.const 1035
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22526,7 +22550,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1035
+   i32.const 1036
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22549,7 +22573,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1036
+   i32.const 1037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22572,7 +22596,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1037
+   i32.const 1038
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22595,7 +22619,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1038
+   i32.const 1039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22618,7 +22642,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1039
+   i32.const 1040
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22641,7 +22665,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1040
+   i32.const 1041
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22664,7 +22688,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1041
+   i32.const 1042
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22687,7 +22711,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1042
+   i32.const 1043
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22710,7 +22734,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1043
+   i32.const 1044
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22733,7 +22757,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1044
+   i32.const 1045
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22756,7 +22780,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1045
+   i32.const 1046
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22779,7 +22803,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1046
+   i32.const 1047
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22802,7 +22826,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1047
+   i32.const 1048
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22825,7 +22849,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1048
+   i32.const 1049
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22848,7 +22872,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1049
+   i32.const 1050
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22871,7 +22895,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1050
+   i32.const 1051
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22894,7 +22918,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1051
+   i32.const 1052
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22917,7 +22941,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1052
+   i32.const 1053
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22940,7 +22964,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1053
+   i32.const 1054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22963,7 +22987,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1054
+   i32.const 1055
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22986,7 +23010,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1055
+   i32.const 1056
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23009,7 +23033,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1056
+   i32.const 1057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23032,7 +23056,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1057
+   i32.const 1058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23055,7 +23079,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1058
+   i32.const 1059
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23078,7 +23102,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1059
+   i32.const 1060
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23101,7 +23125,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1060
+   i32.const 1061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23124,7 +23148,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1061
+   i32.const 1062
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23147,7 +23171,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1062
+   i32.const 1063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23170,7 +23194,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1063
+   i32.const 1064
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23193,7 +23217,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1064
+   i32.const 1065
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23216,7 +23240,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1065
+   i32.const 1066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23239,7 +23263,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1068
+   i32.const 1069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23262,7 +23286,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1069
+   i32.const 1070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23285,7 +23309,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1070
+   i32.const 1071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23308,7 +23332,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1071
+   i32.const 1072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23331,7 +23355,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1072
+   i32.const 1073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23354,7 +23378,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1073
+   i32.const 1074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23377,7 +23401,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1074
+   i32.const 1075
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23400,7 +23424,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1075
+   i32.const 1076
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23423,7 +23447,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1076
+   i32.const 1077
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23446,7 +23470,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1077
+   i32.const 1078
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23469,7 +23493,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1078
+   i32.const 1079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23492,7 +23516,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1079
+   i32.const 1080
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23515,7 +23539,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1080
+   i32.const 1081
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23538,7 +23562,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1081
+   i32.const 1082
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23561,7 +23585,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1082
+   i32.const 1083
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23584,7 +23608,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1083
+   i32.const 1084
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23607,7 +23631,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1084
+   i32.const 1085
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23630,7 +23654,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1085
+   i32.const 1086
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23653,7 +23677,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1086
+   i32.const 1087
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23676,7 +23700,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1087
+   i32.const 1088
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23699,7 +23723,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1088
+   i32.const 1089
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23722,7 +23746,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1089
+   i32.const 1090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23745,7 +23769,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1090
+   i32.const 1091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23768,7 +23792,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1091
+   i32.const 1092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23791,7 +23815,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1092
+   i32.const 1093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23814,7 +23838,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1093
+   i32.const 1094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23837,7 +23861,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1094
+   i32.const 1095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23860,7 +23884,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1095
+   i32.const 1096
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23883,7 +23907,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1096
+   i32.const 1097
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23906,7 +23930,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1097
+   i32.const 1098
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23929,7 +23953,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1098
+   i32.const 1099
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23952,7 +23976,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1099
+   i32.const 1100
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23975,7 +23999,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1100
+   i32.const 1101
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23998,7 +24022,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1101
+   i32.const 1102
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24021,7 +24045,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1102
+   i32.const 1103
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24044,7 +24068,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1103
+   i32.const 1104
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24067,7 +24091,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1104
+   i32.const 1105
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24090,7 +24114,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1105
+   i32.const 1106
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24098,19 +24122,6 @@
   f64.const 1.5707963267948966
   call $~lib/math/NativeMath.cos
   f64.const 1.5707963267948966
-  call $~lib/bindings/Math/cos
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1107
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 3.141592653589793
-  call $~lib/math/NativeMath.cos
-  f64.const 3.141592653589793
   call $~lib/bindings/Math/cos
   f64.ne
   if
@@ -24121,6 +24132,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 3.141592653589793
+  call $~lib/math/NativeMath.cos
+  f64.const 3.141592653589793
+  call $~lib/bindings/Math/cos
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1109
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 3141592653589793231804887e66
   call $~lib/math/NativeMath.cos
   f64.const 3141592653589793231804887e66
@@ -24129,7 +24153,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1109
+   i32.const 1110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24141,7 +24165,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1113
+   i32.const 1114
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24153,7 +24177,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1114
+   i32.const 1115
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24165,7 +24189,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1117
+   i32.const 1118
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24177,7 +24201,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1119
+   i32.const 1120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24189,7 +24213,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1120
+   i32.const 1121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24201,7 +24225,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1123
+   i32.const 1124
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24213,7 +24237,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1125
+   i32.const 1126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24225,7 +24249,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1128
+   i32.const 1129
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24237,7 +24261,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1130
+   i32.const 1131
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24249,7 +24273,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1131
+   i32.const 1132
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24261,7 +24285,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1132
+   i32.const 1133
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24273,7 +24297,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1134
+   i32.const 1135
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24285,7 +24309,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1136
+   i32.const 1137
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24297,7 +24321,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1137
+   i32.const 1138
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24309,7 +24333,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1138
+   i32.const 1139
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24321,7 +24345,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1139
+   i32.const 1140
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24333,7 +24357,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1140
+   i32.const 1141
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24345,7 +24369,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1141
+   i32.const 1142
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24359,7 +24383,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1150
+   i32.const 1151
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24373,7 +24397,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1151
+   i32.const 1152
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24387,7 +24411,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1152
+   i32.const 1153
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24401,7 +24425,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1153
+   i32.const 1154
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24415,7 +24439,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1154
+   i32.const 1155
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24429,7 +24453,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1155
+   i32.const 1156
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24443,7 +24467,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1156
+   i32.const 1157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24457,7 +24481,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1157
+   i32.const 1158
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24471,7 +24495,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1158
+   i32.const 1159
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24485,26 +24509,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1159
+   i32.const 1160
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  call $~lib/math/NativeMathf.cos
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1162
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24518,9 +24528,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -0
   call $~lib/math/NativeMathf.cos
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -24532,7 +24542,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.cos
   f32.const nan:0x400000
   f32.const 0
@@ -24546,7 +24556,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   call $~lib/math/NativeMathf.cos
   f32.const nan:0x400000
   f32.const 0
@@ -24560,21 +24570,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.862645149230957e-09
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.cos
-  f32.const 1
-  f32.const 1.4551915228366852e-11
+  f32.const nan:0x400000
+  f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 1169
+   i32.const 1167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.862645149230957e-09
+  f32.const 1.862645149230957e-09
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 1.4551915228366852e-11
@@ -24588,10 +24598,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754943508222875e-38
+  f32.const -1.862645149230957e-09
   call $~lib/math/NativeMathf.cos
   f32.const 1
-  f32.const 0
+  f32.const 1.4551915228366852e-11
   call $std/math/check<f32>
   i32.eqz
   if
@@ -24602,7 +24612,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24616,7 +24626,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
+  f32.const -1.1754943508222875e-38
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24630,7 +24640,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24644,7 +24654,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.802596928649634e-45
+  f32.const -1.401298464324817e-45
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24658,7 +24668,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
+  f32.const 2.802596928649634e-45
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24672,7 +24682,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
+  f32.const 1.2611686178923354e-44
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24686,7 +24696,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
+  f32.const 2.938735877055719e-39
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24700,7 +24710,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
+  f32.const 5.877471754111438e-39
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24714,7 +24724,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
+  f32.const 1.1754940705625946e-38
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24728,7 +24738,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
+  f32.const 1.1754942106924411e-38
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24742,7 +24752,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
+  f32.const 1.175494490952134e-38
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24756,7 +24766,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754946310819804e-38
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24770,7 +24780,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509880009953429e-38
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24784,7 +24794,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509895424236536e-38
+  f32.const 2.350988701644575e-38
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24798,7 +24808,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.70197740328915e-38
+  f32.const 2.3509895424236536e-38
   call $~lib/math/NativeMathf.cos
   f32.const 1
   f32.const 0
@@ -24812,6 +24822,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 4.70197740328915e-38
+  call $~lib/math/NativeMathf.cos
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1187
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 7.450580596923828e-09
   call $~lib/math/NativeMathf.cos
   f32.const 1
@@ -24821,7 +24845,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1187
+   i32.const 1188
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24835,7 +24859,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1188
+   i32.const 1189
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24849,7 +24873,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1189
+   i32.const 1190
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24863,7 +24887,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1190
+   i32.const 1191
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24877,7 +24901,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1191
+   i32.const 1192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24891,7 +24915,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1192
+   i32.const 1193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24905,7 +24929,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1193
+   i32.const 1194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24919,7 +24943,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1194
+   i32.const 1195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24933,7 +24957,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1195
+   i32.const 1196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24947,7 +24971,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1196
+   i32.const 1197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24961,7 +24985,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1197
+   i32.const 1198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24975,7 +24999,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1198
+   i32.const 1199
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24989,7 +25013,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1199
+   i32.const 1200
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25003,7 +25027,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1200
+   i32.const 1201
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25017,7 +25041,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1201
+   i32.const 1202
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25031,7 +25055,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1202
+   i32.const 1203
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25045,7 +25069,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1203
+   i32.const 1204
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25059,7 +25083,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1204
+   i32.const 1205
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25073,7 +25097,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1205
+   i32.const 1206
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25087,7 +25111,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1206
+   i32.const 1207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25101,7 +25125,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1209
+   i32.const 1210
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25115,7 +25139,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1210
+   i32.const 1211
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25129,7 +25153,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1211
+   i32.const 1212
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25143,7 +25167,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1212
+   i32.const 1213
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25157,7 +25181,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1213
+   i32.const 1214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25171,7 +25195,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1214
+   i32.const 1215
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25185,7 +25209,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1215
+   i32.const 1216
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25199,7 +25223,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1216
+   i32.const 1217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25213,7 +25237,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1217
+   i32.const 1218
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25227,7 +25251,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1218
+   i32.const 1219
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25241,7 +25265,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1219
+   i32.const 1220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25255,7 +25279,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1220
+   i32.const 1221
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25269,7 +25293,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1221
+   i32.const 1222
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25283,7 +25307,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1222
+   i32.const 1223
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25296,7 +25320,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1233
+   i32.const 1234
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25309,7 +25333,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1234
+   i32.const 1235
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25322,7 +25346,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1235
+   i32.const 1236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25335,7 +25359,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1236
+   i32.const 1237
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25348,7 +25372,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1237
+   i32.const 1238
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25361,7 +25385,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1238
+   i32.const 1239
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25374,7 +25398,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1239
+   i32.const 1240
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25387,7 +25411,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1240
+   i32.const 1241
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25400,7 +25424,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1241
+   i32.const 1242
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25413,25 +25437,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1242
+   i32.const 1243
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_cosh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1245
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 1
   f64.const 0
   call $std/math/test_cosh
@@ -25444,8 +25455,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const 1
   f64.const 0
   call $std/math/test_cosh
   i32.eqz
@@ -25457,7 +25468,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const inf
   f64.const 0
   call $std/math/test_cosh
@@ -25470,6 +25481,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_cosh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1249
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -25478,7 +25502,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1249
+   i32.const 1250
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25491,7 +25515,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1258
+   i32.const 1259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25504,7 +25528,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1259
+   i32.const 1260
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25517,7 +25541,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1260
+   i32.const 1261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25530,7 +25554,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1261
+   i32.const 1262
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25543,7 +25567,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1262
+   i32.const 1263
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25556,7 +25580,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1263
+   i32.const 1264
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25569,7 +25593,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1264
+   i32.const 1265
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25582,7 +25606,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1265
+   i32.const 1266
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25595,7 +25619,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1266
+   i32.const 1267
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25608,25 +25632,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1267
+   i32.const 1268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_coshf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1270
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const 1
   f32.const 0
   call $std/math/test_coshf
@@ -25639,8 +25650,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const 1
   f32.const 0
   call $std/math/test_coshf
   i32.eqz
@@ -25652,7 +25663,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_coshf
@@ -25665,6 +25676,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_coshf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1274
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -25673,7 +25697,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1274
+   i32.const 1275
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25696,7 +25720,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1286
+   i32.const 1287
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25719,7 +25743,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1287
+   i32.const 1288
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25742,7 +25766,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1288
+   i32.const 1289
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25765,7 +25789,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1289
+   i32.const 1290
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25788,7 +25812,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1290
+   i32.const 1291
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25811,7 +25835,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1291
+   i32.const 1292
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25834,7 +25858,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1292
+   i32.const 1293
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25857,7 +25881,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1293
+   i32.const 1294
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25880,7 +25904,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1294
+   i32.const 1295
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25903,7 +25927,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1295
+   i32.const 1296
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25926,7 +25950,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1298
+   i32.const 1299
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25949,7 +25973,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1299
+   i32.const 1300
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25972,7 +25996,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1300
+   i32.const 1301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25995,7 +26019,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1301
+   i32.const 1302
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26018,7 +26042,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1302
+   i32.const 1303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26041,7 +26065,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1303
+   i32.const 1304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26064,7 +26088,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1304
+   i32.const 1305
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26087,7 +26111,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1305
+   i32.const 1306
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26110,7 +26134,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1306
+   i32.const 1307
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26133,7 +26157,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1307
+   i32.const 1308
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26156,7 +26180,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1308
+   i32.const 1309
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26179,7 +26203,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1311
+   i32.const 1312
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26202,7 +26226,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1312
+   i32.const 1313
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26225,7 +26249,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1314
+   i32.const 1315
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26248,7 +26272,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1321
+   i32.const 1322
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26271,7 +26295,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1322
+   i32.const 1323
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26294,7 +26318,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1329
+   i32.const 1330
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26317,7 +26341,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1336
+   i32.const 1337
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26340,7 +26364,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1343
+   i32.const 1344
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26363,7 +26387,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1350
+   i32.const 1351
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26386,7 +26410,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1357
+   i32.const 1358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26409,7 +26433,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1364
+   i32.const 1365
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26432,7 +26456,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1370
+   i32.const 1371
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26455,7 +26479,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1376
+   i32.const 1377
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26478,7 +26502,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1382
+   i32.const 1383
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26501,7 +26525,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1389
+   i32.const 1390
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26524,7 +26548,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1396
+   i32.const 1397
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26547,7 +26571,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1403
+   i32.const 1404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26570,7 +26594,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1410
+   i32.const 1411
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26593,7 +26617,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1417
+   i32.const 1418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26616,7 +26640,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1424
+   i32.const 1425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26639,7 +26663,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1431
+   i32.const 1432
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26662,7 +26686,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1438
+   i32.const 1439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26676,7 +26700,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1452
+   i32.const 1453
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26690,7 +26714,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1453
+   i32.const 1454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26704,7 +26728,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1454
+   i32.const 1455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26718,7 +26742,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1455
+   i32.const 1456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26732,7 +26756,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1456
+   i32.const 1457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26746,7 +26770,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1457
+   i32.const 1458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26760,7 +26784,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1458
+   i32.const 1459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26774,7 +26798,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1459
+   i32.const 1460
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26788,7 +26812,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1460
+   i32.const 1461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26802,26 +26826,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1461
+   i32.const 1462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  call $~lib/math/NativeMathf.exp
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1464
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   call $~lib/math/NativeMathf.exp
   f32.const 1
   f32.const 0
@@ -26835,6 +26845,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  call $~lib/math/NativeMathf.exp
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1466
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   call $~lib/math/NativeMathf.exp
   f32.const 2.7182817459106445
@@ -26844,7 +26868,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1466
+   i32.const 1467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26858,7 +26882,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1467
+   i32.const 1468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26872,7 +26896,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1468
+   i32.const 1469
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26886,7 +26910,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1469
+   i32.const 1470
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26900,7 +26924,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1470
+   i32.const 1471
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26914,7 +26938,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1471
+   i32.const 1472
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26928,7 +26952,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1472
+   i32.const 1473
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26942,7 +26966,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1473
+   i32.const 1474
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26956,7 +26980,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1474
+   i32.const 1475
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26970,7 +26994,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1475
+   i32.const 1476
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26984,7 +27008,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1476
+   i32.const 1477
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26998,7 +27022,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1477
+   i32.const 1478
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27021,7 +27045,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1489
+   i32.const 1490
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27044,7 +27068,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1490
+   i32.const 1491
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27067,7 +27091,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1491
+   i32.const 1492
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27090,7 +27114,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1492
+   i32.const 1493
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27113,7 +27137,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1493
+   i32.const 1494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27136,7 +27160,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1494
+   i32.const 1495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27159,7 +27183,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1495
+   i32.const 1496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27182,7 +27206,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1496
+   i32.const 1497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27205,7 +27229,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1497
+   i32.const 1498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27228,7 +27252,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1498
+   i32.const 1499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27242,29 +27266,6 @@
    f64.const 0
    call $~lib/bindings/Math/expm1
    f64.const 0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1501
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  call $~lib/math/NativeMath.expm1
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -0
-   call $~lib/bindings/Math/expm1
-   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -27275,6 +27276,29 @@
    i32.const 0
    i32.const 1056
    i32.const 1502
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  call $~lib/math/NativeMath.expm1
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -0
+   call $~lib/bindings/Math/expm1
+   f64.const -0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27297,7 +27321,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1503
+   i32.const 1504
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27320,7 +27344,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1504
+   i32.const 1505
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27343,7 +27367,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1505
+   i32.const 1506
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27366,43 +27390,20 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1506
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  call $~lib/math/NativeMath.expm1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const nan:0x8000000000000
-   call $~lib/bindings/Math/expm1
-   f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 1507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.expm1
-  f64.const 2.225073858507201e-308
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 2.225073858507201e-308
+   f64.const nan:0x8000000000000
    call $~lib/bindings/Math/expm1
-   f64.const 2.225073858507201e-308
+   f64.const nan:0x8000000000000
    f64.const 0
    call $std/math/check<f64>
   else
@@ -27417,6 +27418,29 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 2.225073858507201e-308
+  call $~lib/math/NativeMath.expm1
+  f64.const 2.225073858507201e-308
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 2.225073858507201e-308
+   call $~lib/bindings/Math/expm1
+   f64.const 2.225073858507201e-308
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1509
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -2.225073858507201e-308
   call $~lib/math/NativeMath.expm1
   f64.const -2.225073858507201e-308
@@ -27435,7 +27459,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1509
+   i32.const 1510
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27449,7 +27473,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1518
+   i32.const 1519
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27463,7 +27487,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1519
+   i32.const 1520
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27477,7 +27501,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1520
+   i32.const 1521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27491,7 +27515,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1521
+   i32.const 1522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27505,7 +27529,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1522
+   i32.const 1523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27519,7 +27543,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1523
+   i32.const 1524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27533,7 +27557,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1524
+   i32.const 1525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27547,7 +27571,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1525
+   i32.const 1526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27561,7 +27585,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1526
+   i32.const 1527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27575,7 +27599,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1527
+   i32.const 1528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27583,20 +27607,6 @@
   f32.const 0
   call $~lib/math/NativeMathf.expm1
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1530
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  call $~lib/math/NativeMathf.expm1
-  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -27604,6 +27614,20 @@
    i32.const 0
    i32.const 1056
    i32.const 1531
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  call $~lib/math/NativeMathf.expm1
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1532
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27617,7 +27641,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1532
+   i32.const 1533
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27631,7 +27655,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1533
+   i32.const 1534
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27645,7 +27669,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1534
+   i32.const 1535
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27659,7 +27683,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1535
+   i32.const 1536
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27673,7 +27697,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1536
+   i32.const 1537
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27686,7 +27710,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1548
+   i32.const 1549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27699,7 +27723,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1549
+   i32.const 1550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27712,7 +27736,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1550
+   i32.const 1551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27725,7 +27749,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1551
+   i32.const 1552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27738,7 +27762,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1552
+   i32.const 1553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27751,7 +27775,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1553
+   i32.const 1554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27764,7 +27788,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1554
+   i32.const 1555
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27777,7 +27801,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1555
+   i32.const 1556
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27790,7 +27814,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1556
+   i32.const 1557
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27803,20 +27827,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1557
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_exp2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1560
+   i32.const 1558
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27834,6 +27845,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_exp2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1562
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 2
   f64.const 0
@@ -27842,7 +27866,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1562
+   i32.const 1563
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27855,7 +27879,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1563
+   i32.const 1564
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27868,7 +27892,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1564
+   i32.const 1565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27881,7 +27905,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1565
+   i32.const 1566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27894,7 +27918,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1566
+   i32.const 1567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27907,7 +27931,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1567
+   i32.const 1568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27920,7 +27944,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1568
+   i32.const 1569
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27933,7 +27957,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1569
+   i32.const 1570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27946,7 +27970,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1570
+   i32.const 1571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27959,7 +27983,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1571
+   i32.const 1572
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27972,7 +27996,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1572
+   i32.const 1573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27985,7 +28009,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1573
+   i32.const 1574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27998,7 +28022,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1574
+   i32.const 1575
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28011,7 +28035,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1575
+   i32.const 1576
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28024,7 +28048,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1576
+   i32.const 1577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28037,7 +28061,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1577
+   i32.const 1578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28050,7 +28074,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1578
+   i32.const 1579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28063,7 +28087,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1579
+   i32.const 1580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28076,7 +28100,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1580
+   i32.const 1581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28089,7 +28113,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1581
+   i32.const 1582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28102,7 +28126,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1582
+   i32.const 1583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28115,7 +28139,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1583
+   i32.const 1584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28128,7 +28152,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1584
+   i32.const 1585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28141,7 +28165,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1595
+   i32.const 1596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28154,7 +28178,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1596
+   i32.const 1597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28167,7 +28191,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1597
+   i32.const 1598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28180,7 +28204,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1598
+   i32.const 1599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28193,7 +28217,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1599
+   i32.const 1600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28206,7 +28230,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1600
+   i32.const 1601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28219,7 +28243,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1601
+   i32.const 1602
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28232,7 +28256,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1602
+   i32.const 1603
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28245,7 +28269,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1603
+   i32.const 1604
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28258,7 +28282,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1604
+   i32.const 1605
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28280,7 +28304,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1616
+   i32.const 1617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28302,7 +28326,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1617
+   i32.const 1618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28324,7 +28348,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1618
+   i32.const 1619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28346,7 +28370,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1619
+   i32.const 1620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28368,7 +28392,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1620
+   i32.const 1621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28390,7 +28414,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1621
+   i32.const 1622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28412,7 +28436,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1622
+   i32.const 1623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28434,7 +28458,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1623
+   i32.const 1624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28456,7 +28480,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1624
+   i32.const 1625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28478,7 +28502,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1625
+   i32.const 1626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28491,28 +28515,6 @@
    f64.const nan:0x8000000000000
    call $~lib/bindings/Math/floor
    f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1628
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const inf
-   call $~lib/bindings/Math/floor
-   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -28527,14 +28529,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -inf
+   f64.const inf
    call $~lib/bindings/Math/floor
-   f64.const -inf
+   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -28549,14 +28551,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -inf
    call $~lib/bindings/Math/floor
-   f64.const 0
+   f64.const -inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -28571,14 +28573,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0
    call $~lib/bindings/Math/floor
-   f64.const -0
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -28593,6 +28595,28 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -0
+   call $~lib/bindings/Math/floor
+   f64.const -0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1633
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -28610,7 +28634,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1633
+   i32.const 1634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28632,7 +28656,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1634
+   i32.const 1635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28654,7 +28678,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1635
+   i32.const 1636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28676,7 +28700,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1636
+   i32.const 1637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28698,7 +28722,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1637
+   i32.const 1638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28720,7 +28744,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1638
+   i32.const 1639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28742,7 +28766,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1639
+   i32.const 1640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28764,7 +28788,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1640
+   i32.const 1641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28786,7 +28810,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1641
+   i32.const 1642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28808,26 +28832,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1642
+   i32.const 1643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -9
   f32.const -9
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1651
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4
-  f32.const 4
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28839,8 +28850,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -9
-  f32.const -9
+  f32.const 4
+  f32.const 4
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28852,8 +28863,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7
-  f32.const -7
+  f32.const -9
+  f32.const -9
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28865,8 +28876,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9
-  f32.const 9
+  f32.const -7
+  f32.const -7
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28878,8 +28889,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const 9
+  f32.const 9
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28891,8 +28902,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28904,8 +28915,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28930,8 +28941,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28943,21 +28954,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 1663
+   i32.const 1661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28969,8 +28980,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28982,8 +28993,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -28995,8 +29006,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -29008,8 +29019,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -29021,8 +29032,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -29034,8 +29045,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -29047,8 +29058,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -29060,8 +29071,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -29073,8 +29084,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2
-  f32.const -2
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -29086,8 +29097,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -2
+  f32.const -2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -29099,8 +29110,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -29112,6 +29123,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
+  f32.const -1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1676
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
   f32.const 0
   f32.const 0
@@ -29120,7 +29144,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1676
+   i32.const 1677
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29133,7 +29157,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1677
+   i32.const 1678
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29147,7 +29171,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1691
+   i32.const 1692
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29161,7 +29185,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1692
+   i32.const 1693
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29175,7 +29199,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1693
+   i32.const 1694
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29189,7 +29213,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1694
+   i32.const 1695
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29203,7 +29227,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1695
+   i32.const 1696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29217,7 +29241,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1696
+   i32.const 1697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29231,7 +29255,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1697
+   i32.const 1698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29245,7 +29269,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1698
+   i32.const 1699
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29259,7 +29283,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1699
+   i32.const 1700
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29273,26 +29297,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1700
+   i32.const 1701
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3
-  f64.const 4
-  f64.const 5
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1703
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -3
   f64.const 4
   f64.const 5
   f64.const 0
@@ -29306,8 +29316,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -3
   f64.const 4
-  f64.const 3
   f64.const 5
   f64.const 0
   call $std/math/test_hypot
@@ -29321,7 +29331,7 @@
    unreachable
   end
   f64.const 4
-  f64.const -3
+  f64.const 3
   f64.const 5
   f64.const 0
   call $std/math/test_hypot
@@ -29330,6 +29340,20 @@
    i32.const 0
    i32.const 1056
    i32.const 1706
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4
+  f64.const -3
+  f64.const 5
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1707
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29343,27 +29367,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1707
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 1708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1797693134862315708145274e284
-  f64.const -0
+  f64.const 0
   f64.const 1797693134862315708145274e284
   f64.const 0
   call $std/math/test_hypot
@@ -29376,6 +29386,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1797693134862315708145274e284
+  f64.const -0
+  f64.const 1797693134862315708145274e284
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1710
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 5e-324
   f64.const 0
   f64.const 5e-324
@@ -29385,7 +29409,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1710
+   i32.const 1711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29399,27 +29423,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1711
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const inf
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 1712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
+  f64.const 1
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29432,8 +29442,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const inf
-  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29446,8 +29456,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
   f64.const inf
+  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29460,8 +29470,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29474,8 +29484,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const -inf
+  f64.const 1
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29488,8 +29498,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29502,8 +29512,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
   f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -29517,8 +29527,8 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const inf
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -29530,8 +29540,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_hypot
@@ -29544,6 +29554,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1722
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
@@ -29553,7 +29577,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1722
+   i32.const 1723
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29567,7 +29591,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1723
+   i32.const 1724
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29581,7 +29605,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1732
+   i32.const 1733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29595,7 +29619,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1733
+   i32.const 1734
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29609,7 +29633,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1734
+   i32.const 1735
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29623,7 +29647,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1735
+   i32.const 1736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29637,7 +29661,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1736
+   i32.const 1737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29651,7 +29675,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1737
+   i32.const 1738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29665,7 +29689,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1738
+   i32.const 1739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29679,7 +29703,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1739
+   i32.const 1740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29693,7 +29717,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1740
+   i32.const 1741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29707,26 +29731,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1741
+   i32.const 1742
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3
-  f32.const 4
-  f32.const 5
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1744
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -3
   f32.const 4
   f32.const 5
   f32.const 0
@@ -29740,8 +29750,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -3
   f32.const 4
-  f32.const 3
   f32.const 5
   f32.const 0
   call $std/math/test_hypotf
@@ -29755,7 +29765,7 @@
    unreachable
   end
   f32.const 4
-  f32.const -3
+  f32.const 3
   f32.const 5
   f32.const 0
   call $std/math/test_hypotf
@@ -29764,6 +29774,20 @@
    i32.const 0
    i32.const 1056
    i32.const 1747
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4
+  f32.const -3
+  f32.const 5
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29777,27 +29801,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1748
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 1749
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3402823466385288598117041e14
-  f32.const -0
+  f32.const 0
   f32.const 3402823466385288598117041e14
   f32.const 0
   call $std/math/test_hypotf
@@ -29810,6 +29820,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 3402823466385288598117041e14
+  f32.const -0
+  f32.const 3402823466385288598117041e14
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1751
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.401298464324817e-45
   f32.const 0
   f32.const 1.401298464324817e-45
@@ -29819,7 +29843,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1751
+   i32.const 1752
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29833,27 +29857,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1752
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const inf
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 1753
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
+  f32.const 1
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29866,8 +29876,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const inf
-  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29880,8 +29890,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
   f32.const inf
+  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29894,8 +29904,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29908,8 +29918,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const -inf
+  f32.const 1
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29922,8 +29932,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29936,8 +29946,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
   f32.const -inf
+  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -29951,6 +29961,20 @@
    unreachable
   end
   f32.const nan:0x400000
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1761
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
@@ -29959,7 +29983,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1761
+   i32.const 1762
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29973,7 +29997,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1762
+   i32.const 1763
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29996,7 +30020,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1774
+   i32.const 1775
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30019,7 +30043,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1775
+   i32.const 1776
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30042,7 +30066,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1776
+   i32.const 1777
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30065,7 +30089,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1777
+   i32.const 1778
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30088,7 +30112,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1778
+   i32.const 1779
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30111,7 +30135,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1779
+   i32.const 1780
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30134,7 +30158,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1780
+   i32.const 1781
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30157,7 +30181,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1781
+   i32.const 1782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30180,7 +30204,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1782
+   i32.const 1783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30203,7 +30227,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1783
+   i32.const 1784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30226,7 +30250,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1786
+   i32.const 1787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30249,7 +30273,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1787
+   i32.const 1788
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30272,7 +30296,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1788
+   i32.const 1789
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30295,7 +30319,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1789
+   i32.const 1790
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30318,7 +30342,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1790
+   i32.const 1791
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30341,7 +30365,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1791
+   i32.const 1792
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30364,7 +30388,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1792
+   i32.const 1793
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30387,26 +30411,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1793
+   i32.const 1794
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  call $~lib/math/NativeMathf.log
-  f32.const -inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1802
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   call $~lib/math/NativeMathf.log
   f32.const -inf
   f32.const 0
@@ -30420,6 +30430,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  call $~lib/math/NativeMathf.log
+  f32.const -inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1804
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -7.888609052210118e-31
   call $~lib/math/NativeMathf.log
   f32.const nan:0x400000
@@ -30429,7 +30453,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1804
+   i32.const 1805
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30443,7 +30467,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1805
+   i32.const 1806
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30457,28 +30481,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1806
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  call $~lib/math/NativeMathf.log
-  f32.const inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 1807
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.log
-  f32.const nan:0x400000
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30490,7 +30500,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   call $~lib/math/NativeMathf.log
   f32.const nan:0x400000
   f32.const 0
@@ -30504,21 +30514,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.log
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 1812
+   i32.const 1810
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   call $~lib/math/NativeMathf.log
   f32.const -inf
   f32.const 0
@@ -30532,6 +30542,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  call $~lib/math/NativeMathf.log
+  f32.const -inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1814
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -7.888609052210118e-31
   call $~lib/math/NativeMathf.log
   f32.const nan:0x400000
@@ -30541,7 +30565,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1814
+   i32.const 1815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30555,7 +30579,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1815
+   i32.const 1816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30569,28 +30593,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1816
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  call $~lib/math/NativeMathf.log
-  f32.const inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 1817
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.log
-  f32.const nan:0x400000
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -30602,7 +30612,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   call $~lib/math/NativeMathf.log
   f32.const nan:0x400000
   f32.const 0
@@ -30616,6 +30626,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
+  call $~lib/math/NativeMathf.log
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1820
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -8.06684839057968
   f64.const nan:0x8000000000000
   f64.const 0
@@ -30624,7 +30648,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1831
+   i32.const 1832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30637,7 +30661,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1832
+   i32.const 1833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30650,7 +30674,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1833
+   i32.const 1834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30663,7 +30687,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1834
+   i32.const 1835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30676,7 +30700,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1835
+   i32.const 1836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30689,7 +30713,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1836
+   i32.const 1837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30702,7 +30726,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1837
+   i32.const 1838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30715,7 +30739,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1838
+   i32.const 1839
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30728,7 +30752,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1839
+   i32.const 1840
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30741,25 +30765,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1840
+   i32.const 1841
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1843
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const -inf
   f64.const 0
   call $std/math/test_log10
@@ -30772,6 +30783,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1845
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
@@ -30780,7 +30804,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1845
+   i32.const 1846
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30793,7 +30817,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1846
+   i32.const 1847
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30806,7 +30830,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1847
+   i32.const 1848
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30819,7 +30843,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1848
+   i32.const 1849
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30832,7 +30856,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1849
+   i32.const 1850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30845,7 +30869,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1850
+   i32.const 1851
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30858,7 +30882,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1859
+   i32.const 1860
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30871,7 +30895,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1860
+   i32.const 1861
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30884,7 +30908,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1861
+   i32.const 1862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30897,7 +30921,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1862
+   i32.const 1863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30910,7 +30934,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1863
+   i32.const 1864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30923,7 +30947,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1864
+   i32.const 1865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30936,7 +30960,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1865
+   i32.const 1866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30949,7 +30973,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1866
+   i32.const 1867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30962,7 +30986,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1867
+   i32.const 1868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30975,25 +30999,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1868
+   i32.const 1869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1871
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const -inf
   f32.const 0
   call $std/math/test_log10f
@@ -31006,6 +31017,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1873
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -31014,7 +31038,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1873
+   i32.const 1874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31027,7 +31051,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1874
+   i32.const 1875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31040,7 +31064,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1875
+   i32.const 1876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31053,7 +31077,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1876
+   i32.const 1877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31066,7 +31090,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1877
+   i32.const 1878
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31079,7 +31103,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1878
+   i32.const 1879
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31102,7 +31126,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1890
+   i32.const 1891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31125,7 +31149,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1891
+   i32.const 1892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31148,7 +31172,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1892
+   i32.const 1893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31171,7 +31195,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1893
+   i32.const 1894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31194,7 +31218,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1894
+   i32.const 1895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31217,7 +31241,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1895
+   i32.const 1896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31240,7 +31264,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1896
+   i32.const 1897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31263,7 +31287,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1897
+   i32.const 1898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31286,7 +31310,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1898
+   i32.const 1899
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31309,7 +31333,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1899
+   i32.const 1900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31323,29 +31347,6 @@
    f64.const 0
    call $~lib/bindings/Math/log1p
    f64.const 0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1902
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  call $~lib/math/NativeMath.log1p
-  f64.const -0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -0
-   call $~lib/bindings/Math/log1p
-   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -31356,6 +31357,29 @@
    i32.const 0
    i32.const 1056
    i32.const 1903
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  call $~lib/math/NativeMath.log1p
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -0
+   call $~lib/bindings/Math/log1p
+   f64.const -0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1904
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31378,7 +31402,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1904
+   i32.const 1905
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31401,7 +31425,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1905
+   i32.const 1906
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31424,7 +31448,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1906
+   i32.const 1907
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31447,7 +31471,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1907
+   i32.const 1908
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31470,7 +31494,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1908
+   i32.const 1909
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31493,7 +31517,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1909
+   i32.const 1910
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31507,7 +31531,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1918
+   i32.const 1919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31521,7 +31545,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1919
+   i32.const 1920
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31535,7 +31559,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1920
+   i32.const 1921
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31549,7 +31573,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1921
+   i32.const 1922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31563,7 +31587,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1922
+   i32.const 1923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31577,7 +31601,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1923
+   i32.const 1924
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31591,7 +31615,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1924
+   i32.const 1925
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31605,7 +31629,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1925
+   i32.const 1926
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31619,7 +31643,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1926
+   i32.const 1927
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31633,7 +31657,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1927
+   i32.const 1928
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31641,20 +31665,6 @@
   f32.const 0
   call $~lib/math/NativeMathf.log1p
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1930
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  call $~lib/math/NativeMathf.log1p
-  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -31662,6 +31672,20 @@
    i32.const 0
    i32.const 1056
    i32.const 1931
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  call $~lib/math/NativeMathf.log1p
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31675,7 +31699,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1932
+   i32.const 1933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31689,7 +31713,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1933
+   i32.const 1934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31703,7 +31727,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1934
+   i32.const 1935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31717,7 +31741,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1935
+   i32.const 1936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31731,7 +31755,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1936
+   i32.const 1937
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31745,7 +31769,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1937
+   i32.const 1938
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31759,7 +31783,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1938
+   i32.const 1939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31782,7 +31806,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1950
+   i32.const 1951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31805,7 +31829,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1951
+   i32.const 1952
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31828,7 +31852,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1952
+   i32.const 1953
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31851,7 +31875,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1953
+   i32.const 1954
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31874,7 +31898,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1954
+   i32.const 1955
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31897,7 +31921,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1955
+   i32.const 1956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31920,7 +31944,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1956
+   i32.const 1957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31943,7 +31967,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1957
+   i32.const 1958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31966,7 +31990,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1958
+   i32.const 1959
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31989,7 +32013,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1959
+   i32.const 1960
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32012,7 +32036,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1962
+   i32.const 1963
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32035,7 +32059,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1963
+   i32.const 1964
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32058,7 +32082,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1964
+   i32.const 1965
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32081,7 +32105,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1965
+   i32.const 1966
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32104,7 +32128,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1966
+   i32.const 1967
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32127,7 +32151,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1967
+   i32.const 1968
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32150,7 +32174,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1968
+   i32.const 1969
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32173,7 +32197,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1969
+   i32.const 1970
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32186,7 +32210,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1978
+   i32.const 1979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32199,7 +32223,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1979
+   i32.const 1980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32212,7 +32236,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1980
+   i32.const 1981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32225,7 +32249,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1981
+   i32.const 1982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32238,7 +32262,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1982
+   i32.const 1983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32251,7 +32275,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1983
+   i32.const 1984
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32264,7 +32288,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1984
+   i32.const 1985
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32277,7 +32301,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1985
+   i32.const 1986
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32290,7 +32314,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1986
+   i32.const 1987
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32303,25 +32327,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1987
+   i32.const 1988
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_log2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 1990
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const -inf
   f32.const 0
   call $std/math/test_log2f
@@ -32334,6 +32345,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_log2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 1992
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -32342,7 +32366,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1992
+   i32.const 1993
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32355,7 +32379,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1993
+   i32.const 1994
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32368,7 +32392,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1994
+   i32.const 1995
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32381,7 +32405,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1995
+   i32.const 1996
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32394,7 +32418,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1996
+   i32.const 1997
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32407,7 +32431,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 1997
+   i32.const 1998
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32420,7 +32444,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2009
+   i32.const 2010
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32433,7 +32457,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2010
+   i32.const 2011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32446,7 +32470,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2011
+   i32.const 2012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32459,7 +32483,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2012
+   i32.const 2013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32472,7 +32496,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2013
+   i32.const 2014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32485,7 +32509,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2014
+   i32.const 2015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32498,7 +32522,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2015
+   i32.const 2016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32511,7 +32535,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2016
+   i32.const 2017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32524,7 +32548,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2017
+   i32.const 2018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32537,25 +32561,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2018
+   i32.const 2019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 1
-  f64.const 1
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2021
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -32568,7 +32579,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -32581,7 +32592,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -32594,7 +32605,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0.5
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -32607,7 +32618,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -32620,9 +32631,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 1
-  f64.const inf
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -32633,9 +32644,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const 1
-  f64.const 1
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32646,9 +32657,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -32659,9 +32670,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -32672,9 +32683,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -1
-  f64.const -0
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -32685,9 +32696,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const -1
-  f64.const 0.5
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -32698,9 +32709,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const -1
-  f64.const -0.5
+  f64.const 0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -32711,9 +32722,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0.5
   f64.const -1
-  f64.const 1
+  f64.const -0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -32724,6 +32735,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
+  f64.const -1
+  f64.const 1
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2035
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1
   f64.const -1
   f64.const -1
@@ -32732,7 +32756,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2035
+   i32.const 2036
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32745,7 +32769,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2036
+   i32.const 2037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32758,7 +32782,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2037
+   i32.const 2038
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32766,19 +32790,6 @@
   f64.const nan:0x8000000000000
   f64.const -1
   f64.const nan:0x8000000000000
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2038
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -32790,7 +32801,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const 0
   f64.const 0
   call $std/math/test_max
   i32.eqz
@@ -32803,8 +32814,8 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -32816,8 +32827,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32829,8 +32840,8 @@
    unreachable
   end
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -32841,9 +32852,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -32855,8 +32866,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -32868,8 +32879,8 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -32881,8 +32892,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
-  f64.const -0
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -32894,8 +32905,8 @@
    unreachable
   end
   f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -32906,9 +32917,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 0
-  f64.const 1
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -32919,9 +32930,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const 0
-  f64.const 0
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -32932,6 +32943,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const 0
+  f64.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2051
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const 0
   f64.const inf
@@ -32940,7 +32964,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2051
+   i32.const 2052
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32953,7 +32977,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2052
+   i32.const 2053
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32966,7 +32990,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2053
+   i32.const 2054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32979,7 +33003,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2054
+   i32.const 2055
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32992,7 +33016,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2055
+   i32.const 2056
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33005,7 +33029,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2056
+   i32.const 2057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33013,19 +33037,6 @@
   f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2057
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 2
-  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -33037,7 +33048,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const 2
   f64.const inf
   call $std/math/test_max
   i32.eqz
@@ -33050,8 +33061,8 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -33062,9 +33073,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 2
-  f64.const 2
+  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -33076,8 +33087,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const 2
+  f64.const 2
   call $std/math/test_max
   i32.eqz
   if
@@ -33089,8 +33100,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const -0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -33101,7 +33112,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -33114,7 +33125,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -33127,7 +33138,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -33140,9 +33151,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const inf
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -33153,7 +33164,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
   f64.const inf
   call $std/math/test_max
@@ -33166,7 +33177,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const inf
   f64.const inf
   call $std/math/test_max
@@ -33179,7 +33190,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const inf
   f64.const inf
   call $std/math/test_max
@@ -33192,9 +33203,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const -inf
-  f64.const 1
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -33205,9 +33216,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const -inf
-  f64.const -1
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -33218,9 +33229,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -inf
-  f64.const inf
+  f64.const -1
   call $std/math/test_max
   i32.eqz
   if
@@ -33231,9 +33242,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const -inf
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -33244,9 +33255,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 1.75
+  f64.const -inf
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_max
   i32.eqz
   if
@@ -33257,9 +33268,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
+  f64.const 1.75
   f64.const 0.5
-  f64.const 0.5
+  f64.const 1.75
   call $std/math/test_max
   i32.eqz
   if
@@ -33270,6 +33281,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.5
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2077
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.75
   f64.const -0.5
   f64.const 1.75
@@ -33278,7 +33302,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2077
+   i32.const 2078
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33291,26 +33315,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2078
+   i32.const 2079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 4.535662651062012
   f32.const 4.535662651062012
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2087
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.345239639282227
-  f32.const 4.345239639282227
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33322,8 +33333,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.7636072635650635
-  f32.const -2.7636072635650635
+  f32.const 4.345239639282227
+  f32.const 4.345239639282227
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33335,8 +33346,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.567535400390625
-  f32.const 4.567535400390625
+  f32.const -2.7636072635650635
+  f32.const -2.7636072635650635
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33348,8 +33359,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9.267057418823242
-  f32.const 9.267057418823242
+  f32.const 4.567535400390625
+  f32.const 4.567535400390625
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33361,8 +33372,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6620717644691467
-  f32.const 0.6620717644691467
+  f32.const 9.267057418823242
+  f32.const 9.267057418823242
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33374,8 +33385,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.858890056610107
-  f32.const 7.858890056610107
+  f32.const 0.6620717644691467
+  f32.const 0.6620717644691467
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33387,8 +33398,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.676402568817139
-  f32.const 7.676402568817139
+  f32.const 7.858890056610107
+  f32.const 7.858890056610107
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33400,8 +33411,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.0119025707244873
-  f32.const 2.0119025707244873
+  f32.const 7.676402568817139
+  f32.const 7.676402568817139
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33413,8 +33424,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.03223983198404312
-  f32.const 0.03223983198404312
+  f32.const 2.0119025707244873
+  f32.const 2.0119025707244873
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33426,15 +33437,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const 0.03223983198404312
+  f32.const 0.03223983198404312
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2099
+   i32.const 2097
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33504,8 +33515,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33517,8 +33528,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33530,8 +33541,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33543,8 +33554,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33556,8 +33567,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33569,8 +33580,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 0.5
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33582,8 +33593,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0.5
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33595,8 +33606,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33608,8 +33619,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33621,8 +33632,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33634,8 +33645,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33647,8 +33658,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33660,8 +33671,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33686,8 +33697,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33699,8 +33710,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33712,8 +33723,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33725,8 +33736,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33738,8 +33749,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33751,8 +33762,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33764,8 +33775,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33777,8 +33788,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33790,8 +33801,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33803,8 +33814,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33816,8 +33827,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33829,8 +33840,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33842,8 +33853,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33855,8 +33866,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33868,8 +33879,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33881,8 +33892,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33894,8 +33905,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33907,8 +33918,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33933,8 +33944,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33946,8 +33957,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33959,8 +33970,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0.5
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -33972,8 +33983,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34024,8 +34035,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34076,8 +34087,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34089,8 +34100,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34102,8 +34113,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34115,8 +34126,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34128,8 +34139,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 1.75
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34141,8 +34152,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 0.5
+  f32.const 1.75
+  f32.const 1.75
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -34154,6 +34165,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0.5
+  f32.const 0.5
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2155
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.75
   f32.const 1.75
   f32.const 0
@@ -34162,7 +34186,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2155
+   i32.const 2156
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34175,7 +34199,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2156
+   i32.const 2157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34188,7 +34212,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2168
+   i32.const 2169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34201,7 +34225,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2169
+   i32.const 2170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34214,7 +34238,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2170
+   i32.const 2171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34227,7 +34251,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2171
+   i32.const 2172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34240,7 +34264,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2172
+   i32.const 2173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34253,7 +34277,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2173
+   i32.const 2174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34266,7 +34290,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2174
+   i32.const 2175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34279,7 +34303,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2175
+   i32.const 2176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34292,7 +34316,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2176
+   i32.const 2177
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34305,7 +34329,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2177
+   i32.const 2178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34313,19 +34337,6 @@
   f64.const 0
   f64.const 1
   f64.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2180
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -34336,9 +34347,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const 1
-  f64.const 0.5
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -34349,9 +34360,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const 1
-  f64.const -0.5
+  f64.const 0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -34362,6 +34373,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2184
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 1
@@ -34370,7 +34394,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2184
+   i32.const 2185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34383,7 +34407,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2185
+   i32.const 2186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34396,27 +34420,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2186
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 1
-  f64.const -inf
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34427,9 +34438,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
-  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34440,7 +34451,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34453,7 +34464,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34466,7 +34477,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34479,7 +34490,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0.5
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34492,7 +34503,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34505,7 +34516,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -34518,9 +34529,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -1
-  f64.const -inf
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -34531,9 +34542,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34544,9 +34555,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34558,6 +34569,19 @@
    unreachable
   end
   f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2199
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
   f64.const -0
   f64.const -0
   call $std/math/test_min
@@ -34565,7 +34589,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2199
+   i32.const 2200
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34578,27 +34602,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2200
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -inf
-  f64.const -inf
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2201
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34609,9 +34620,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34623,7 +34634,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   f64.const -0
   call $std/math/test_min
   i32.eqz
@@ -34636,7 +34647,7 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
+  f64.const -0
   f64.const -0
   call $std/math/test_min
   i32.eqz
@@ -34649,6 +34660,19 @@
    unreachable
   end
   f64.const -0
+  f64.const inf
+  f64.const -0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2206
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const -inf
   f64.const -inf
   call $std/math/test_min
@@ -34656,7 +34680,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2206
+   i32.const 2207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34669,7 +34693,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2207
+   i32.const 2208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34682,27 +34706,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2208
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 0
-  f64.const -1
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2209
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
-  f64.const 0
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -34713,9 +34724,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const 0
-  f64.const -inf
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
@@ -34726,9 +34737,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34739,9 +34750,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
-  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34752,9 +34763,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -0
-  f64.const -0
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -34765,9 +34776,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -0
-  f64.const -inf
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -34778,9 +34789,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34791,9 +34802,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34805,6 +34816,19 @@
    unreachable
   end
   f64.const inf
+  f64.const 2
+  f64.const 2
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2218
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.const -0.5
   f64.const -0.5
   call $std/math/test_min
@@ -34812,7 +34836,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2218
+   i32.const 2219
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34825,26 +34849,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2219
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 2
-  f64.const -inf
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
+  f64.const 2
   f64.const -inf
   call $std/math/test_min
   i32.eqz
@@ -34857,8 +34868,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34869,7 +34880,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -34882,7 +34893,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -34895,7 +34906,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -34908,9 +34919,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -34921,9 +34932,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
-  f64.const -1
+  f64.const 1
   call $std/math/test_min
   i32.eqz
   if
@@ -34934,9 +34945,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -34947,9 +34958,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
   f64.const inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   call $std/math/test_min
   i32.eqz
   if
@@ -34960,8 +34971,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const -inf
+  f64.const inf
   f64.const -inf
   call $std/math/test_min
   i32.eqz
@@ -34973,7 +34984,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const -inf
   f64.const -inf
   call $std/math/test_min
@@ -34986,7 +34997,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -inf
   f64.const -inf
   call $std/math/test_min
@@ -34999,7 +35010,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -inf
   f64.const -inf
   call $std/math/test_min
@@ -35012,9 +35023,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.5
+  f64.const -inf
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -35025,6 +35036,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.5
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2235
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1.75
   f64.const 0.5
   f64.const -1.75
@@ -35033,7 +35057,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2235
+   i32.const 2236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35046,7 +35070,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2236
+   i32.const 2237
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35059,26 +35083,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2237
+   i32.const 2238
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.066848754882812
   f32.const -8.066848754882812
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2246
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -8.887990951538086
-  f32.const -8.887990951538086
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35090,8 +35101,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8.381433486938477
-  f32.const -8.381433486938477
+  f32.const -8.887990951538086
+  f32.const -8.887990951538086
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35103,8 +35114,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const -6.531673431396484
+  f32.const -8.381433486938477
+  f32.const -8.381433486938477
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35116,8 +35127,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.811392307281494
-  f32.const 4.811392307281494
+  f32.const -6.531673431396484
+  f32.const -6.531673431396484
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35129,8 +35140,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.450045585632324
-  f32.const -6.450045585632324
+  f32.const 4.811392307281494
+  f32.const 4.811392307281494
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35142,8 +35153,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.052154526114463806
-  f32.const 0.052154526114463806
+  f32.const -6.450045585632324
+  f32.const -6.450045585632324
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35155,8 +35166,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.7920545339584351
-  f32.const -0.7920545339584351
+  f32.const 0.052154526114463806
+  f32.const 0.052154526114463806
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35168,8 +35179,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.6157026886940002
-  f32.const 0.6157026886940002
+  f32.const -0.7920545339584351
+  f32.const -0.7920545339584351
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35181,8 +35192,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5587586760520935
-  f32.const -0.5587586760520935
+  f32.const 0.6157026886940002
+  f32.const 0.6157026886940002
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35194,21 +35205,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0.5587586760520935
+  f32.const -0.5587586760520935
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2258
+   i32.const 2256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35220,8 +35231,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 0.5
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35233,8 +35244,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0.5
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35246,8 +35257,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35259,8 +35270,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35272,8 +35283,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35285,8 +35296,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35298,8 +35309,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35311,8 +35322,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35402,8 +35413,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35415,8 +35426,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35428,8 +35439,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35441,8 +35452,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35454,8 +35465,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35467,8 +35478,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35480,8 +35491,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35493,8 +35504,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35532,8 +35543,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35545,8 +35556,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35558,8 +35569,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35571,8 +35582,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35584,8 +35595,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35597,8 +35608,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35610,8 +35621,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35623,8 +35634,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35636,8 +35647,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35649,8 +35660,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35662,8 +35673,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35675,8 +35686,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35688,8 +35699,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0.5
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35701,8 +35712,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35714,8 +35725,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35740,8 +35751,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35792,8 +35803,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35805,8 +35816,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35818,8 +35829,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35831,8 +35842,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35896,8 +35907,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const 0.5
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35909,8 +35920,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -35922,6 +35933,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.75
+  f32.const -1.75
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2314
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -0.5
   f32.const -0.5
   f32.const 0
@@ -35930,7 +35954,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2314
+   i32.const 2315
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35943,7 +35967,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2315
+   i32.const 2316
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35956,7 +35980,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2329
+   i32.const 2330
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35969,7 +35993,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2330
+   i32.const 2331
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35982,7 +36006,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2331
+   i32.const 2332
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35995,7 +36019,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2332
+   i32.const 2333
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36008,7 +36032,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2333
+   i32.const 2334
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36021,7 +36045,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2334
+   i32.const 2335
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36034,7 +36058,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2335
+   i32.const 2336
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36047,7 +36071,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2336
+   i32.const 2337
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36060,7 +36084,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2337
+   i32.const 2338
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36073,7 +36097,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2338
+   i32.const 2339
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36081,19 +36105,6 @@
   f64.const 0
   f64.const 1
   f64.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2341
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36104,6 +36115,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2343
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0.5
   f64.const 1
   f64.const 0.5
@@ -36112,7 +36136,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2343
+   i32.const 2344
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36125,7 +36149,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2344
+   i32.const 2345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36138,7 +36162,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2345
+   i32.const 2346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36151,7 +36175,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2346
+   i32.const 2347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36164,7 +36188,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2347
+   i32.const 2348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36177,7 +36201,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2348
+   i32.const 2349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36190,7 +36214,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2349
+   i32.const 2350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36203,25 +36227,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2350
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2351
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const 1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36234,7 +36245,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const 1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36247,9 +36258,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36260,9 +36271,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -1
-  f64.const -0
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36273,6 +36284,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -1
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2356
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0.5
   f64.const -1
   f64.const 0.5
@@ -36281,7 +36305,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2356
+   i32.const 2357
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36294,7 +36318,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2357
+   i32.const 2358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36307,7 +36331,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2358
+   i32.const 2359
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36320,7 +36344,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2359
+   i32.const 2360
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36333,7 +36357,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2360
+   i32.const 2361
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36346,7 +36370,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2361
+   i32.const 2362
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36359,7 +36383,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2362
+   i32.const 2363
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36372,25 +36396,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2363
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2364
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36403,7 +36414,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36416,8 +36427,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36430,7 +36441,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36443,8 +36454,8 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.const 0
+  f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36456,7 +36467,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
+  f64.const inf
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -36469,8 +36480,8 @@
    unreachable
   end
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36481,8 +36492,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36495,7 +36506,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36508,8 +36519,8 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
   f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36521,7 +36532,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
+  f64.const inf
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -36534,8 +36545,8 @@
    unreachable
   end
   f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36546,8 +36557,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 0
+  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36559,7 +36570,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36572,7 +36583,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36585,7 +36596,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36598,7 +36609,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36611,8 +36622,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36624,7 +36635,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36637,7 +36648,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36650,7 +36661,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36663,8 +36674,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36677,7 +36688,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36690,7 +36701,7 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36702,8 +36713,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 2
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36716,7 +36727,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36729,7 +36740,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -36741,7 +36752,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36754,7 +36765,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36767,7 +36778,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36780,9 +36791,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36793,9 +36804,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
-  f64.const -1
+  f64.const 1
   call $std/math/test_mod
   i32.eqz
   if
@@ -36806,9 +36817,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -1
   call $std/math/test_mod
   i32.eqz
   if
@@ -36819,7 +36830,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const inf
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36832,9 +36843,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const -inf
-  f64.const 1
+  f64.const inf
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36845,9 +36856,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const -inf
-  f64.const -1
+  f64.const 1
   call $std/math/test_mod
   i32.eqz
   if
@@ -36858,9 +36869,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const -1
   call $std/math/test_mod
   i32.eqz
   if
@@ -36871,7 +36882,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -inf
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -36884,9 +36895,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.25
+  f64.const -inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -36897,6 +36908,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.25
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2404
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1.75
   f64.const 0.5
   f64.const -0.25
@@ -36905,7 +36929,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2404
+   i32.const 2405
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36918,7 +36942,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2405
+   i32.const 2406
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36931,26 +36955,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2406
+   i32.const 2407
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
   f64.const 2.2250738585072014e-308
-  f64.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2409
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -36962,9 +36973,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
   f64.const 2.2250738585072014e-308
-  f64.const -0
+  f64.const -2.2250738585072014e-308
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36976,7 +36987,7 @@
    unreachable
   end
   f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -36988,9 +36999,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
-  f64.const 0
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37002,7 +37013,7 @@
    unreachable
   end
   f64.const 1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -37014,9 +37025,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1797693134862315708145274e284
   f64.const 1797693134862315708145274e284
-  f64.const -0
+  f64.const -1797693134862315708145274e284
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37028,7 +37039,7 @@
    unreachable
   end
   f64.const -1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -37040,21 +37051,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 2.2250738585072014e-308
-  f64.const 0
+  f64.const -1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2419
+   i32.const 2417
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 1797693134862315708145274e284
+  f64.const 2.2250738585072014e-308
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -37067,7 +37078,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -2.2250738585072014e-308
+  f64.const 1797693134862315708145274e284
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -37080,7 +37091,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -1797693134862315708145274e284
+  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -37092,9 +37103,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const 2.2250738585072014e-308
-  f64.const -0
+  f64.const 0
+  f64.const -1797693134862315708145274e284
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37106,7 +37117,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 1797693134862315708145274e284
+  f64.const 2.2250738585072014e-308
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -37119,7 +37130,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -2.2250738585072014e-308
+  f64.const 1797693134862315708145274e284
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -37132,7 +37143,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -1797693134862315708145274e284
+  f64.const -2.2250738585072014e-308
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -37140,6 +37151,19 @@
    i32.const 0
    i32.const 1056
    i32.const 2426
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -1797693134862315708145274e284
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2427
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37152,7 +37176,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2429
+   i32.const 2430
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37165,7 +37189,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2430
+   i32.const 2431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37178,7 +37202,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2432
+   i32.const 2433
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37191,7 +37215,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2433
+   i32.const 2434
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37204,7 +37228,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2435
+   i32.const 2436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37217,7 +37241,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2436
+   i32.const 2437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37230,7 +37254,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2438
+   i32.const 2439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37243,7 +37267,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2439
+   i32.const 2440
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37251,19 +37275,6 @@
   f64.const 8988465674311579538646525e283
   f64.const 1797693134862315708145274e284
   f64.const 8988465674311579538646525e283
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2441
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8988465674311579538646525e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311579538646525e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -37274,22 +37285,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311578540726371e283
-  f64.const -1797693134862315708145274e284
-  f64.const 8988465674311578540726371e283
+  f64.const -8988465674311579538646525e283
+  f64.const 1797693134862315708145274e284
+  f64.const -8988465674311579538646525e283
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2444
+   i32.const 2443
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311578540726371e283
+  f64.const 8988465674311578540726371e283
   f64.const -1797693134862315708145274e284
-  f64.const -8988465674311578540726371e283
+  f64.const 8988465674311578540726371e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -37300,22 +37311,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311577542806216e283
-  f64.const 1797693134862315708145274e284
-  f64.const 8988465674311577542806216e283
+  f64.const -8988465674311578540726371e283
+  f64.const -1797693134862315708145274e284
+  f64.const -8988465674311578540726371e283
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2447
+   i32.const 2446
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311577542806216e283
+  f64.const 8988465674311577542806216e283
   f64.const 1797693134862315708145274e284
-  f64.const -8988465674311577542806216e283
+  f64.const 8988465674311577542806216e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -37326,6 +37337,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -8988465674311577542806216e283
+  f64.const 1797693134862315708145274e284
+  f64.const -8988465674311577542806216e283
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2449
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1797693134862315508561243e284
   f64.const -1797693134862315708145274e284
   f64.const 1797693134862315508561243e284
@@ -37334,7 +37358,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2450
+   i32.const 2451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37347,7 +37371,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2451
+   i32.const 2452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37360,7 +37384,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2453
+   i32.const 2454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37373,7 +37397,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2454
+   i32.const 2455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37386,7 +37410,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2456
+   i32.const 2457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37399,7 +37423,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2457
+   i32.const 2458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37412,7 +37436,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2458
+   i32.const 2459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37425,7 +37449,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2459
+   i32.const 2460
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37438,7 +37462,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2460
+   i32.const 2461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37451,7 +37475,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2461
+   i32.const 2462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37464,7 +37488,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2462
+   i32.const 2463
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37477,7 +37501,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2463
+   i32.const 2464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37490,7 +37514,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2465
+   i32.const 2466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37503,7 +37527,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2466
+   i32.const 2467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37516,26 +37540,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2467
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
-  f64.const 4.4501477170144023e-308
-  f64.const 2.225073858507201e-308
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507201e-308
-  f64.const inf
+  f64.const 4.4501477170144023e-308
   f64.const 2.225073858507201e-308
   call $std/math/test_mod
   i32.eqz
@@ -37548,6 +37559,19 @@
    unreachable
   end
   f64.const 2.225073858507201e-308
+  f64.const inf
+  f64.const 2.225073858507201e-308
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2470
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507201e-308
   f64.const -1.5e-323
   f64.const 0
   call $std/math/test_mod
@@ -37555,7 +37579,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2470
+   i32.const 2471
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37568,7 +37592,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2471
+   i32.const 2472
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37581,7 +37605,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2472
+   i32.const 2473
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37594,7 +37618,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2473
+   i32.const 2474
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37607,7 +37631,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2474
+   i32.const 2475
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37620,26 +37644,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2475
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const 1.5e-323
-  f64.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2476
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072024e-308
-  f64.const -1.5e-323
+  f64.const 1.5e-323
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -37651,6 +37662,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 2.2250738585072024e-308
+  f64.const -1.5e-323
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2478
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 2.225073858507203e-308
   f64.const 1.5e-323
   f64.const 5e-324
@@ -37659,7 +37683,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2478
+   i32.const 2479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37672,7 +37696,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2479
+   i32.const 2480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37685,7 +37709,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2480
+   i32.const 2481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37698,7 +37722,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2481
+   i32.const 2482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37711,7 +37735,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2482
+   i32.const 2483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37724,7 +37748,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2483
+   i32.const 2484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37737,7 +37761,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2484
+   i32.const 2485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37750,7 +37774,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2493
+   i32.const 2494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37763,7 +37787,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2494
+   i32.const 2495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37776,7 +37800,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2495
+   i32.const 2496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37789,7 +37813,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2496
+   i32.const 2497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37802,7 +37826,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2497
+   i32.const 2498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37815,7 +37839,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2498
+   i32.const 2499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37828,7 +37852,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2499
+   i32.const 2500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37841,7 +37865,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2500
+   i32.const 2501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37854,7 +37878,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2501
+   i32.const 2502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37867,7 +37891,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2502
+   i32.const 2503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37875,19 +37899,6 @@
   f32.const 0
   f32.const 1
   f32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2505
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
   call $std/math/test_modf
   i32.eqz
   if
@@ -37898,6 +37909,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2507
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0.5
   f32.const 1
   f32.const 0.5
@@ -37906,7 +37930,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2507
+   i32.const 2508
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37919,7 +37943,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2508
+   i32.const 2509
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37932,7 +37956,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2509
+   i32.const 2510
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37945,7 +37969,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2510
+   i32.const 2511
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37958,7 +37982,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2511
+   i32.const 2512
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37971,7 +37995,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2512
+   i32.const 2513
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37984,7 +38008,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2513
+   i32.const 2514
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37997,25 +38021,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2514
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2515
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const 1
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38028,7 +38039,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const 1
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38041,9 +38052,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -1
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -38054,9 +38065,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -1
-  f32.const -0
+  f32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -38067,6 +38078,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -1
+  f32.const -0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2520
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0.5
   f32.const -1
   f32.const 0.5
@@ -38075,7 +38099,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2520
+   i32.const 2521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38088,7 +38112,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2521
+   i32.const 2522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38101,7 +38125,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2522
+   i32.const 2523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38114,7 +38138,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2523
+   i32.const 2524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38127,7 +38151,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2524
+   i32.const 2525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38140,7 +38164,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2525
+   i32.const 2526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38153,7 +38177,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2526
+   i32.const 2527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38166,25 +38190,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2527
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const -1
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38197,7 +38208,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const -1
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38210,8 +38221,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38224,7 +38235,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38237,8 +38248,8 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.const 0
+  f32.const -0
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -38250,7 +38261,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
+  f32.const inf
   f32.const 0
   call $std/math/test_modf
   i32.eqz
@@ -38263,8 +38274,8 @@
    unreachable
   end
   f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -38275,8 +38286,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 0
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38289,7 +38300,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38302,8 +38313,8 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
   f32.const -0
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -38315,7 +38326,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
+  f32.const inf
   f32.const -0
   call $std/math/test_modf
   i32.eqz
@@ -38328,8 +38339,8 @@
    unreachable
   end
   f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -0
   call $std/math/test_modf
   i32.eqz
   if
@@ -38340,8 +38351,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 0
+  f32.const -0
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38353,7 +38364,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38366,7 +38377,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38379,7 +38390,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38392,7 +38403,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38405,8 +38416,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38418,7 +38429,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38431,7 +38442,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38444,7 +38455,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38457,8 +38468,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38471,7 +38482,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38484,7 +38495,7 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38496,8 +38507,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 2
+  f32.const inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38510,7 +38521,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const -0.5
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38523,7 +38534,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -38535,7 +38546,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38548,7 +38559,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38561,7 +38572,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38574,9 +38585,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -38587,9 +38598,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
-  f32.const -1
+  f32.const 1
   call $std/math/test_modf
   i32.eqz
   if
@@ -38600,9 +38611,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const -1
   call $std/math/test_modf
   i32.eqz
   if
@@ -38613,7 +38624,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const inf
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -38626,6 +38637,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
+  f32.const inf
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2563
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const -inf
   f32.const 1
@@ -38634,7 +38658,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2563
+   i32.const 2564
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38647,7 +38671,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2564
+   i32.const 2565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38660,7 +38684,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2565
+   i32.const 2566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38673,7 +38697,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2566
+   i32.const 2567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38681,19 +38705,6 @@
   f32.const 1.75
   f32.const 0.5
   f32.const 0.25
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2567
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -0.25
   call $std/math/test_modf
   i32.eqz
   if
@@ -38704,6 +38715,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const -0.25
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2569
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.75
   f32.const -0.5
   f32.const 0.25
@@ -38712,7 +38736,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2569
+   i32.const 2570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38725,7 +38749,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2570
+   i32.const 2571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38739,7 +38763,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2582
+   i32.const 2583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38753,7 +38777,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2583
+   i32.const 2584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38767,7 +38791,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2584
+   i32.const 2585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38781,7 +38805,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2585
+   i32.const 2586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38795,7 +38819,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2586
+   i32.const 2587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38809,7 +38833,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2587
+   i32.const 2588
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38823,7 +38847,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2588
+   i32.const 2589
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38837,7 +38861,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2589
+   i32.const 2590
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38851,7 +38875,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2590
+   i32.const 2591
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38865,7 +38889,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2591
+   i32.const 2592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38873,20 +38897,6 @@
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2594
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const inf
-  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -38899,7 +38909,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 3
+  f64.const inf
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -38913,7 +38923,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 2
+  f64.const 3
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -38927,7 +38937,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 1
+  f64.const 2
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -38941,7 +38951,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0.5
+  f64.const 1
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -38955,8 +38965,8 @@
    unreachable
   end
   f64.const 0
+  f64.const 0.5
   f64.const 0
-  f64.const 1
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -38969,7 +38979,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const 0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -38983,8 +38993,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0.5
-  f64.const inf
+  f64.const -0
+  f64.const 1
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -38997,7 +39007,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -1
+  f64.const -0.5
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39011,7 +39021,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -2
+  f64.const -1
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39025,7 +39035,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -3
+  f64.const -2
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39039,7 +39049,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -4
+  f64.const -3
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39053,7 +39063,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
+  f64.const -4
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39066,6 +39076,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const -inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2608
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
@@ -39075,7 +39099,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2608
+   i32.const 2609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39089,7 +39113,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2609
+   i32.const 2610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39103,7 +39127,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2610
+   i32.const 2611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39117,7 +39141,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2611
+   i32.const 2612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39131,7 +39155,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2612
+   i32.const 2613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39145,27 +39169,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2613
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -39179,6 +39189,20 @@
    unreachable
   end
   f64.const -0
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2616
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const -0.5
   f64.const inf
   f64.const 0
@@ -39187,7 +39211,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2616
+   i32.const 2617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39201,7 +39225,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2617
+   i32.const 2618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39215,7 +39239,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2618
+   i32.const 2619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39229,7 +39253,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2619
+   i32.const 2620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39243,7 +39267,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2620
+   i32.const 2621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39257,26 +39281,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2621
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const 1
   f64.const 0
@@ -39290,7 +39300,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const 0
   f64.const 1
   f64.const 0
@@ -39304,7 +39314,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const 0
   f64.const 1
   f64.const 0
@@ -39318,7 +39328,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -39332,7 +39342,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const -1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -39346,8 +39356,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const -0.5
+  f64.const 0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -39360,7 +39370,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const 1
   f64.const 0
@@ -39374,7 +39384,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -0
   f64.const 1
   f64.const 0
@@ -39388,7 +39398,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -inf
   f64.const -0
   f64.const 1
   f64.const 0
@@ -39402,7 +39412,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -39416,7 +39426,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const -1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -39430,9 +39440,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const -0
+  f64.const 1
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39445,7 +39455,7 @@
    unreachable
   end
   f64.const -1
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -39459,7 +39469,7 @@
    unreachable
   end
   f64.const -1
-  f64.const -inf
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -39473,6 +39483,20 @@
    unreachable
   end
   f64.const -1
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2637
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
   f64.const 2
   f64.const 1
   f64.const 0
@@ -39481,7 +39505,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2637
+   i32.const 2638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39495,7 +39519,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2638
+   i32.const 2639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39509,7 +39533,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2639
+   i32.const 2640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39523,27 +39547,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2640
+   i32.const 2641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
   f64.const 0.5
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2641
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -39557,7 +39567,7 @@
    unreachable
   end
   f64.const 1
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -39571,7 +39581,7 @@
    unreachable
   end
   f64.const 1
-  f64.const -inf
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -39585,8 +39595,8 @@
    unreachable
   end
   f64.const 1
-  f64.const 3
-  f64.const 1
+  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39599,7 +39609,7 @@
    unreachable
   end
   f64.const 1
-  f64.const 0.5
+  f64.const 3
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -39613,7 +39623,7 @@
    unreachable
   end
   f64.const 1
-  f64.const -0.5
+  f64.const 0.5
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -39627,7 +39637,7 @@
    unreachable
   end
   f64.const 1
-  f64.const -3
+  f64.const -0.5
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -39640,9 +39650,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 0.5
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const -3
+  f64.const 1
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39655,7 +39665,7 @@
    unreachable
   end
   f64.const -0.5
-  f64.const 1.5
+  f64.const 0.5
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -39669,6 +39679,20 @@
    unreachable
   end
   f64.const -0.5
+  f64.const 1.5
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2651
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
   f64.const 2
   f64.const 0.25
   f64.const 0
@@ -39677,7 +39701,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2651
+   i32.const 2652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39691,28 +39715,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2652
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0.5
-  f64.const -inf
   f64.const inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39725,8 +39735,8 @@
    unreachable
   end
   f64.const -0.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39738,9 +39748,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const inf
-  f64.const 0
+  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39753,6 +39763,20 @@
    unreachable
   end
   f64.const 0.5
+  f64.const inf
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2657
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
   f64.const -inf
   f64.const inf
   f64.const 0
@@ -39761,7 +39785,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2657
+   i32.const 2658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39775,7 +39799,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2658
+   i32.const 2659
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39789,7 +39813,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2659
+   i32.const 2660
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39803,26 +39827,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2660
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const 1.5
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -39837,6 +39847,20 @@
    unreachable
   end
   f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2663
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.const inf
   f64.const inf
   f64.const 0
@@ -39845,7 +39869,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2663
+   i32.const 2664
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39859,27 +39883,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2664
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 3
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2665
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  f64.const 2
+  f64.const 3
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39893,7 +39903,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 1
+  f64.const 2
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39907,7 +39917,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 0.5
+  f64.const 1
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -39921,8 +39931,8 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
-  f64.const 0
+  f64.const 0.5
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39935,7 +39945,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -1
+  f64.const -0.5
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -39949,7 +39959,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -2
+  f64.const -1
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -39962,9 +39972,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -2
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -39977,6 +39987,20 @@
    unreachable
   end
   f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2673
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const inf
   f64.const inf
   f64.const 0
@@ -39985,7 +40009,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2673
+   i32.const 2674
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39999,7 +40023,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2674
+   i32.const 2675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40013,7 +40037,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2675
+   i32.const 2676
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40027,7 +40051,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2676
+   i32.const 2677
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40041,7 +40065,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2677
+   i32.const 2678
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40055,7 +40079,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2678
+   i32.const 2679
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40063,20 +40087,6 @@
   f64.const -inf
   f64.const -0.5
   f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2679
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -1
-  f64.const -0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -40089,6 +40099,20 @@
    unreachable
   end
   f64.const -inf
+  f64.const -1
+  f64.const -0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2681
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const -2
   f64.const 0
   f64.const 0
@@ -40097,7 +40121,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2681
+   i32.const 2682
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40111,7 +40135,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2682
+   i32.const 2683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40125,7 +40149,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2683
+   i32.const 2684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40139,7 +40163,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2684
+   i32.const 2685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40153,25 +40177,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2685
+   i32.const 2686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 0
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2688
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -40185,7 +40196,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
   f64.ne
@@ -40197,7 +40208,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -40210,8 +40221,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const 0
+  f64.const -0
   call $~lib/math/NativeMath.pow
   f64.const 1
   f64.ne
@@ -40223,7 +40234,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -40236,7 +40247,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -40249,7 +40260,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -40262,23 +40273,23 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 1
   call $~lib/math/NativeMath.pow
-  f64.const 0
+  f64.const 1
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 2697
+   i32.const 2696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const 1
   call $~lib/math/NativeMath.pow
-  f64.const -0
+  f64.const 0
   f64.ne
   if
    i32.const 0
@@ -40288,10 +40299,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0
   f64.const 1
   call $~lib/math/NativeMath.pow
-  f64.const -1
+  f64.const -0
   f64.ne
   if
    i32.const 0
@@ -40301,6 +40312,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const 1
+  call $~lib/math/NativeMath.pow
+  f64.const -1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2700
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const 1
   call $~lib/math/NativeMath.pow
@@ -40309,7 +40333,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2700
+   i32.const 2701
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40322,7 +40346,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2701
+   i32.const 2702
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40336,7 +40360,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2702
+   i32.const 2703
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40349,7 +40373,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2704
+   i32.const 2705
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40362,7 +40386,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2705
+   i32.const 2706
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40375,7 +40399,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2706
+   i32.const 2707
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40388,7 +40412,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2707
+   i32.const 2708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40401,7 +40425,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2708
+   i32.const 2709
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40414,7 +40438,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2709
+   i32.const 2710
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40427,7 +40451,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2710
+   i32.const 2711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40441,25 +40465,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2711
+   i32.const 2712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2713
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 2
   call $~lib/math/NativeMath.pow
   f64.const 0
@@ -40472,6 +40483,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const 2
+  call $~lib/math/NativeMath.pow
+  f64.const 0
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2715
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1
   f64.const 2
   call $~lib/math/NativeMath.pow
@@ -40480,7 +40504,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2715
+   i32.const 2716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40493,24 +40517,24 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2716
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
+  f64.const 2
+  call $~lib/math/NativeMath.pow
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2718
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const 2
   call $~lib/math/NativeMath.pow
@@ -40519,7 +40543,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2718
+   i32.const 2719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40532,7 +40556,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2719
+   i32.const 2720
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40546,7 +40570,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2720
+   i32.const 2721
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40559,7 +40583,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2722
+   i32.const 2723
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40572,7 +40596,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2723
+   i32.const 2724
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40586,7 +40610,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2724
+   i32.const 2725
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40599,24 +40623,24 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2725
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2726
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
+  f64.const 0.5
+  call $~lib/math/NativeMath.pow
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2727
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const 0.5
   call $~lib/math/NativeMath.pow
@@ -40625,7 +40649,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2727
+   i32.const 2728
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40638,7 +40662,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2728
+   i32.const 2729
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40652,7 +40676,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2729
+   i32.const 2730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40667,7 +40691,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2738
+   i32.const 2739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40682,7 +40706,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2739
+   i32.const 2740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40697,7 +40721,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2740
+   i32.const 2741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40712,7 +40736,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2741
+   i32.const 2742
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40727,7 +40751,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2742
+   i32.const 2743
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40742,7 +40766,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2743
+   i32.const 2744
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40757,7 +40781,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2744
+   i32.const 2745
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40772,7 +40796,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2745
+   i32.const 2746
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40787,7 +40811,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2746
+   i32.const 2747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40802,7 +40826,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2747
+   i32.const 2748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40811,21 +40835,6 @@
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2750
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40838,7 +40847,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 3
+  f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -40853,7 +40862,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 2
+  f32.const 3
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -40868,7 +40877,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 1
+  f32.const 2
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -40883,7 +40892,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0.5
+  f32.const 1
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -40898,9 +40907,9 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const 0.5
   call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40913,7 +40922,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
+  f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
   f32.const 0
@@ -40928,9 +40937,9 @@
    unreachable
   end
   f32.const 0
-  f32.const -0.5
+  f32.const -0
   call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -40943,7 +40952,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -1
+  f32.const -0.5
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -40958,7 +40967,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -2
+  f32.const -1
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -40973,7 +40982,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -3
+  f32.const -2
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -40988,7 +40997,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -4
+  f32.const -3
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -41003,7 +41012,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
+  f32.const -4
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -41017,6 +41026,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
+  f32.const -inf
+  call $~lib/math/NativeMathf.pow
+  f32.const inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2764
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -0
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
@@ -41027,7 +41051,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2764
+   i32.const 2765
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41042,7 +41066,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2765
+   i32.const 2766
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41057,7 +41081,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2766
+   i32.const 2767
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41072,7 +41096,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2767
+   i32.const 2768
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41087,7 +41111,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2768
+   i32.const 2769
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41102,28 +41126,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2769
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2770
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
   f32.const 0
@@ -41138,6 +41147,21 @@
    unreachable
   end
   f32.const -0
+  f32.const -0
+  call $~lib/math/NativeMathf.pow
+  f32.const 1
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2772
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const -0.5
   call $~lib/math/NativeMathf.pow
   f32.const inf
@@ -41147,7 +41171,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2772
+   i32.const 2773
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41162,7 +41186,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2773
+   i32.const 2774
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41177,7 +41201,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2774
+   i32.const 2775
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41192,7 +41216,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2775
+   i32.const 2776
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41207,7 +41231,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2776
+   i32.const 2777
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41222,27 +41246,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2777
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2778
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41257,7 +41266,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41272,7 +41281,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -inf
   f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41287,7 +41296,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41302,7 +41311,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const -1
   f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41317,8 +41326,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const -0.5
+  f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
   f32.const 0
@@ -41332,7 +41341,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const -0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41347,7 +41356,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const -0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41362,7 +41371,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -inf
   f32.const -0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41377,7 +41386,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const -0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41392,7 +41401,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const -1
   f32.const -0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41407,10 +41416,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const -0.5
+  f32.const -0
   call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41423,7 +41432,7 @@
    unreachable
   end
   f32.const -1
-  f32.const inf
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
   f32.const 0
@@ -41438,7 +41447,7 @@
    unreachable
   end
   f32.const -1
-  f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
   f32.const 0
@@ -41453,6 +41462,21 @@
    unreachable
   end
   f32.const -1
+  f32.const -inf
+  call $~lib/math/NativeMathf.pow
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2793
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
   f32.const 2
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -41462,7 +41486,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2793
+   i32.const 2794
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41477,7 +41501,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2794
+   i32.const 2795
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41492,7 +41516,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2795
+   i32.const 2796
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41507,28 +41531,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2796
+   i32.const 2797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1
   f32.const 0.5
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2797
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
   f32.const 0
@@ -41543,7 +41552,7 @@
    unreachable
   end
   f32.const 1
-  f32.const inf
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
   f32.const 0
@@ -41558,7 +41567,7 @@
    unreachable
   end
   f32.const 1
-  f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
   f32.const 0
@@ -41573,9 +41582,9 @@
    unreachable
   end
   f32.const 1
-  f32.const 3
+  f32.const -inf
   call $~lib/math/NativeMathf.pow
-  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41588,7 +41597,7 @@
    unreachable
   end
   f32.const 1
-  f32.const 0.5
+  f32.const 3
   call $~lib/math/NativeMathf.pow
   f32.const 1
   f32.const 0
@@ -41603,7 +41612,7 @@
    unreachable
   end
   f32.const 1
-  f32.const -0.5
+  f32.const 0.5
   call $~lib/math/NativeMathf.pow
   f32.const 1
   f32.const 0
@@ -41618,7 +41627,7 @@
    unreachable
   end
   f32.const 1
-  f32.const -3
+  f32.const -0.5
   call $~lib/math/NativeMathf.pow
   f32.const 1
   f32.const 0
@@ -41632,10 +41641,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 0.5
+  f32.const 1
+  f32.const -3
   call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41648,7 +41657,7 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 1.5
+  f32.const 0.5
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
   f32.const 0
@@ -41663,6 +41672,21 @@
    unreachable
   end
   f32.const -0.5
+  f32.const 1.5
+  call $~lib/math/NativeMathf.pow
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2807
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
   f32.const 2
   call $~lib/math/NativeMathf.pow
   f32.const 0.25
@@ -41672,7 +41696,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2807
+   i32.const 2808
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41687,30 +41711,15 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2808
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const inf
-  call $~lib/math/NativeMathf.pow
-  f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2809
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.5
-  f32.const -inf
-  call $~lib/math/NativeMathf.pow
   f32.const inf
+  call $~lib/math/NativeMathf.pow
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41723,9 +41732,9 @@
    unreachable
   end
   f32.const -0.5
-  f32.const nan:0x400000
+  f32.const -inf
   call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41737,10 +41746,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const inf
+  f32.const -0.5
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41753,6 +41762,21 @@
    unreachable
   end
   f32.const 0.5
+  f32.const inf
+  call $~lib/math/NativeMathf.pow
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2813
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
   f32.const -inf
   call $~lib/math/NativeMathf.pow
   f32.const inf
@@ -41762,7 +41786,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2813
+   i32.const 2814
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41777,7 +41801,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2814
+   i32.const 2815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41792,7 +41816,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2815
+   i32.const 2816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41807,27 +41831,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2816
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const nan:0x400000
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2817
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const 1.5
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
@@ -41843,6 +41852,21 @@
    unreachable
   end
   f32.const inf
+  f32.const nan:0x400000
+  call $~lib/math/NativeMathf.pow
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2819
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const inf
@@ -41852,7 +41876,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2819
+   i32.const 2820
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41867,28 +41891,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2820
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 3
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2821
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  f32.const 2
+  f32.const 3
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -41903,7 +41912,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 1
+  f32.const 2
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -41918,7 +41927,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 0.5
+  f32.const 1
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -41933,9 +41942,9 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const 0.5
   call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41948,7 +41957,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -1
+  f32.const -0.5
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -41963,7 +41972,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -2
+  f32.const -1
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -41977,10 +41986,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -2
   call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -41993,6 +42002,21 @@
    unreachable
   end
   f32.const -inf
+  f32.const nan:0x400000
+  call $~lib/math/NativeMathf.pow
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2829
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const inf
@@ -42002,7 +42026,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2829
+   i32.const 2830
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42017,7 +42041,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2830
+   i32.const 2831
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42032,7 +42056,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2831
+   i32.const 2832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42047,7 +42071,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2832
+   i32.const 2833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42062,7 +42086,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2833
+   i32.const 2834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42077,7 +42101,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2834
+   i32.const 2835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42092,7 +42116,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2835
+   i32.const 2836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42107,7 +42131,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2836
+   i32.const 2837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42122,28 +42146,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2837
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 2838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
-  f32.const -1
+  f32.const 1
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
   f32.const 0
@@ -42157,6 +42166,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
+  f32.const -1
+  call $~lib/math/NativeMathf.pow
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2840
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -2
   f32.const 1
   call $~lib/math/NativeMathf.pow
@@ -42167,7 +42191,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2840
+   i32.const 2841
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42182,7 +42206,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2841
+   i32.const 2842
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42191,21 +42215,6 @@
   f32.const 1
   call $~lib/math/NativeMathf.pow
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2844
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  call $~lib/math/NativeMathf.pow
-  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42217,10 +42226,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754943508222875e-38
+  f32.const -0
   f32.const 1
   call $~lib/math/NativeMathf.pow
-  f32.const 1.1754943508222875e-38
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42232,10 +42241,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 1
   call $~lib/math/NativeMathf.pow
-  f32.const -1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42247,10 +42256,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
+  f32.const -1.1754943508222875e-38
   f32.const 1
   call $~lib/math/NativeMathf.pow
-  f32.const 3402823466385288598117041e14
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42262,10 +42271,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -3402823466385288598117041e14
+  f32.const 3402823466385288598117041e14
   f32.const 1
   call $~lib/math/NativeMathf.pow
-  f32.const -3402823466385288598117041e14
+  f32.const 3402823466385288598117041e14
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42277,23 +42286,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 3402823466385288598117041e14
+  f32.const -3402823466385288598117041e14
+  f32.const 1
   call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const -3402823466385288598117041e14
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2851
+   i32.const 2850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const 1.1754943508222875e-38
+  f32.const 3402823466385288598117041e14
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -42307,8 +42316,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const 3402823466385288598117041e14
+  f32.const 0
+  f32.const 1.1754943508222875e-38
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -42323,6 +42332,21 @@
    unreachable
   end
   f32.const -0
+  f32.const 3402823466385288598117041e14
+  call $~lib/math/NativeMathf.pow
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2854
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const 17
   call $~lib/math/NativeMathf.pow
   f32.const -0
@@ -42332,7 +42356,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2854
+   i32.const 2855
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42347,7 +42371,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2855
+   i32.const 2856
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42362,7 +42386,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2856
+   i32.const 2857
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42377,7 +42401,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2858
+   i32.const 2859
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42392,7 +42416,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2860
+   i32.const 2861
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42407,7 +42431,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2861
+   i32.const 2862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42422,7 +42446,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2862
+   i32.const 2863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42437,7 +42461,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2863
+   i32.const 2864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42452,7 +42476,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2865
+   i32.const 2866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42467,7 +42491,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2866
+   i32.const 2867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42482,7 +42506,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2867
+   i32.const 2868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42497,7 +42521,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2868
+   i32.const 2869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42512,7 +42536,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2869
+   i32.const 2870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42527,7 +42551,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2870
+   i32.const 2871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42542,7 +42566,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2871
+   i32.const 2872
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42557,7 +42581,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2872
+   i32.const 2873
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42572,7 +42596,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2873
+   i32.const 2874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42587,22 +42611,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2874
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  call $~lib/math/NativeMathf.pow
-  f32.const 1
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2876
+   i32.const 2875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42622,7 +42631,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -42637,7 +42646,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -42652,7 +42661,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
+  f32.const -inf
   f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -42667,7 +42676,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $~lib/math/NativeMathf.pow
   f32.const 1
@@ -42682,17 +42691,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
+  f32.const -1.401298464324817e-45
+  f32.const 0
   call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2883
+   i32.const 2882
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42712,10 +42721,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 1
   call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42727,10 +42736,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const 1
   call $~lib/math/NativeMathf.pow
-  f32.const -inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -42742,22 +42751,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 1
   call $~lib/math/NativeMathf.pow
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2888
+   i32.const 2887
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
@@ -42772,7 +42781,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
@@ -42787,7 +42796,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -inf
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
@@ -42802,7 +42811,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
@@ -42817,7 +42826,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const -1
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
@@ -42832,7 +42841,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
   f32.const nan:0x400000
@@ -42847,22 +42856,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.0000001192092896
-  f32.const inf
+  f32.const 0
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2896
+   i32.const 2895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const 1.0000001192092896
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const inf
@@ -42877,7 +42886,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.0000001192092896
+  f32.const inf
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const inf
@@ -42892,7 +42901,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const -1.0000001192092896
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const inf
@@ -42907,22 +42916,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.0000001192092896
   f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2901
+   i32.const 2900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const 1.0000001192092896
   f32.const -inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
@@ -42937,7 +42946,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.0000001192092896
+  f32.const inf
   f32.const -inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
@@ -42952,7 +42961,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const -1.0000001192092896
   f32.const -inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
@@ -42967,8 +42976,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.9999999403953552
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -42977,12 +42986,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2906
+   i32.const 2905
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
+  f32.const 0.9999999403953552
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
@@ -42997,7 +43006,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const 1.401298464324817e-45
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
@@ -43012,7 +43021,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.9999999403953552
+  f32.const 0
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
@@ -43027,7 +43036,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
+  f32.const -0.9999999403953552
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
@@ -43042,7 +43051,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const -1.401298464324817e-45
   f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
@@ -43057,8 +43066,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 1.401298464324817e-45
+  f32.const -0
+  f32.const inf
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -43067,12 +43076,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2913
+   i32.const 2912
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const 1.401298464324817e-45
   call $~lib/math/NativeMathf.pow
   f32.const 0
@@ -43087,23 +43096,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -3402823466385288598117041e14
+  f32.const -0
+  f32.const 1.401298464324817e-45
   call $~lib/math/NativeMathf.pow
-  f32.const inf
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 2916
+   i32.const 2915
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const -1.401298464324817e-45
+  f32.const -3402823466385288598117041e14
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -43117,8 +43126,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -3402823466385288598117041e14
+  f32.const 0
+  f32.const -1.401298464324817e-45
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -43133,7 +43142,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -2
+  f32.const -3402823466385288598117041e14
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -43148,7 +43157,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -1.401298464324817e-45
+  f32.const -2
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -43163,6 +43172,21 @@
    unreachable
   end
   f32.const -0
+  f32.const -1.401298464324817e-45
+  call $~lib/math/NativeMathf.pow
+  f32.const inf
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2921
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const -1
   call $~lib/math/NativeMathf.pow
   f32.const -inf
@@ -43172,7 +43196,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2921
+   i32.const 2922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43187,7 +43211,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2922
+   i32.const 2923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43202,7 +43226,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2924
+   i32.const 2925
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43217,28 +43241,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2925
+   i32.const 2926
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
   f32.const 3402823466385288598117041e14
-  call $~lib/math/NativeMathf.pow
-  f32.const inf
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 2927
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 1.401298464324817e-45
   call $~lib/math/NativeMathf.pow
   f32.const inf
   f32.const 0
@@ -43253,9 +43262,9 @@
    unreachable
   end
   f32.const -inf
-  f32.const -3402823466385288598117041e14
+  f32.const 1.401298464324817e-45
   call $~lib/math/NativeMathf.pow
-  f32.const 0
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -43268,7 +43277,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const -1.401298464324817e-45
+  f32.const -3402823466385288598117041e14
   call $~lib/math/NativeMathf.pow
   f32.const 0
   f32.const 0
@@ -43283,6 +43292,21 @@
    unreachable
   end
   f32.const -inf
+  f32.const -1.401298464324817e-45
+  call $~lib/math/NativeMathf.pow
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 2931
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const 5
   call $~lib/math/NativeMathf.pow
   f32.const -inf
@@ -43292,7 +43316,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2931
+   i32.const 2932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43307,7 +43331,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2932
+   i32.const 2933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43322,7 +43346,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2933
+   i32.const 2934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43337,7 +43361,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2934
+   i32.const 2935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43352,7 +43376,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2936
+   i32.const 2937
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43367,7 +43391,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2937
+   i32.const 2938
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43382,7 +43406,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2938
+   i32.const 2939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43397,7 +43421,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2940
+   i32.const 2941
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43412,7 +43436,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2941
+   i32.const 2942
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43427,7 +43451,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2943
+   i32.const 2944
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43442,7 +43466,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2944
+   i32.const 2945
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43457,7 +43481,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2945
+   i32.const 2946
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43472,7 +43496,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2946
+   i32.const 2947
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43487,7 +43511,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2947
+   i32.const 2948
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43502,7 +43526,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2948
+   i32.const 2949
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43517,7 +43541,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2949
+   i32.const 2950
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43532,7 +43556,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2950
+   i32.const 2951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43547,7 +43571,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2951
+   i32.const 2952
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43562,7 +43586,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2952
+   i32.const 2953
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43577,7 +43601,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2953
+   i32.const 2954
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43592,7 +43616,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2954
+   i32.const 2955
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43607,7 +43631,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2955
+   i32.const 2956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43622,7 +43646,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2956
+   i32.const 2957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43637,7 +43661,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2957
+   i32.const 2958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43652,7 +43676,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2958
+   i32.const 2959
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43667,7 +43691,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2959
+   i32.const 2960
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43682,7 +43706,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2960
+   i32.const 2961
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43697,7 +43721,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2961
+   i32.const 2962
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43712,7 +43736,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2962
+   i32.const 2963
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43727,7 +43751,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2964
+   i32.const 2965
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43742,7 +43766,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2965
+   i32.const 2966
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43757,7 +43781,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2966
+   i32.const 2967
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43772,7 +43796,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2967
+   i32.const 2968
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43787,7 +43811,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2968
+   i32.const 2969
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43802,7 +43826,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2969
+   i32.const 2970
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43817,7 +43841,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2970
+   i32.const 2971
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43832,7 +43856,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2972
+   i32.const 2973
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43847,7 +43871,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2973
+   i32.const 2974
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43862,7 +43886,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2975
+   i32.const 2976
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43877,7 +43901,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2976
+   i32.const 2977
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43892,7 +43916,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2977
+   i32.const 2978
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43907,7 +43931,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2978
+   i32.const 2979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43922,7 +43946,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2979
+   i32.const 2980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43937,7 +43961,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2980
+   i32.const 2981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43952,7 +43976,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2981
+   i32.const 2982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43967,7 +43991,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2982
+   i32.const 2983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43982,7 +44006,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2983
+   i32.const 2984
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43997,7 +44021,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2984
+   i32.const 2985
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44012,7 +44036,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2985
+   i32.const 2986
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44027,7 +44051,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2987
+   i32.const 2988
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44042,7 +44066,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2988
+   i32.const 2989
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44057,7 +44081,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2989
+   i32.const 2990
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44072,7 +44096,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 2990
+   i32.const 2991
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44135,7 +44159,7 @@
     if
      i32.const 0
      i32.const 1056
-     i32.const 2999
+     i32.const 3000
      i32.const 3
      call $~lib/builtins/abort
      unreachable
@@ -44209,7 +44233,7 @@
     if
      i32.const 0
      i32.const 1056
-     i32.const 3007
+     i32.const 3008
      i32.const 3
      call $~lib/builtins/abort
      unreachable
@@ -44228,7 +44252,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3021
+   i32.const 3022
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44240,7 +44264,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3022
+   i32.const 3023
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44252,7 +44276,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3023
+   i32.const 3024
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44264,7 +44288,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3024
+   i32.const 3025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44276,7 +44300,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3025
+   i32.const 3026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44288,7 +44312,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3026
+   i32.const 3027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44300,7 +44324,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3027
+   i32.const 3028
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44312,7 +44336,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3028
+   i32.const 3029
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44324,7 +44348,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3029
+   i32.const 3030
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44336,25 +44360,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3030
+   i32.const 3031
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3033
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
   call $std/math/test_round
   i32.eqz
   if
@@ -44365,8 +44377,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   call $std/math/test_round
   i32.eqz
   if
@@ -44377,8 +44389,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_round
   i32.eqz
   if
@@ -44389,8 +44401,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   call $std/math/test_round
   i32.eqz
   if
@@ -44401,6 +44413,18 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3038
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   call $std/math/test_round
@@ -44408,7 +44432,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3038
+   i32.const 3039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44420,7 +44444,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3039
+   i32.const 3040
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44432,7 +44456,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3040
+   i32.const 3041
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44444,7 +44468,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3041
+   i32.const 3042
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44456,7 +44480,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3042
+   i32.const 3043
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44468,7 +44492,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3043
+   i32.const 3044
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44480,7 +44504,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3044
+   i32.const 3045
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44492,7 +44516,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3045
+   i32.const 3046
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44504,7 +44528,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3046
+   i32.const 3047
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44516,7 +44540,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3047
+   i32.const 3048
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44528,7 +44552,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3048
+   i32.const 3049
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44540,7 +44564,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3049
+   i32.const 3050
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44552,7 +44576,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3064
+   i32.const 3065
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44564,7 +44588,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3065
+   i32.const 3066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44576,7 +44600,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3066
+   i32.const 3067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44588,7 +44612,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3067
+   i32.const 3068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44600,7 +44624,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3068
+   i32.const 3069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44612,7 +44636,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3069
+   i32.const 3070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44624,7 +44648,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3070
+   i32.const 3071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44636,7 +44660,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3071
+   i32.const 3072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44648,7 +44672,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3072
+   i32.const 3073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44660,25 +44684,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3073
+   i32.const 3074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3076
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   call $std/math/test_roundf
   i32.eqz
   if
@@ -44689,8 +44701,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   call $std/math/test_roundf
   i32.eqz
   if
@@ -44701,8 +44713,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -inf
+  f32.const -inf
   call $std/math/test_roundf
   i32.eqz
   if
@@ -44713,8 +44725,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   call $std/math/test_roundf
   i32.eqz
   if
@@ -44725,6 +44737,18 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3081
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 1
   call $std/math/test_roundf
@@ -44732,7 +44756,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3081
+   i32.const 3082
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44744,7 +44768,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3082
+   i32.const 3083
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44756,7 +44780,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3083
+   i32.const 3084
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44768,7 +44792,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3084
+   i32.const 3085
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44780,7 +44804,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3085
+   i32.const 3086
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44792,7 +44816,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3086
+   i32.const 3087
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44804,7 +44828,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3087
+   i32.const 3088
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44816,7 +44840,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3088
+   i32.const 3089
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44828,7 +44852,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3089
+   i32.const 3090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44840,7 +44864,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3090
+   i32.const 3091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44852,7 +44876,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3091
+   i32.const 3092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44864,25 +44888,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3092
+   i32.const 3093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  call $std/math/test_sign
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3103
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
   call $std/math/test_sign
   i32.eqz
   if
@@ -44893,8 +44905,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -0
   call $std/math/test_sign
   i32.eqz
   if
@@ -44905,7 +44917,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2
+  f64.const 1
   f64.const 1
   call $std/math/test_sign
   i32.eqz
@@ -44917,8 +44929,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 2
+  f64.const 1
   call $std/math/test_sign
   i32.eqz
   if
@@ -44929,7 +44941,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2
+  f64.const -1
   f64.const -1
   call $std/math/test_sign
   i32.eqz
@@ -44941,6 +44953,18 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -2
+  f64.const -1
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3109
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const 1
   call $std/math/test_sign
@@ -44948,7 +44972,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3109
+   i32.const 3110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44960,7 +44984,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3110
+   i32.const 3111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44972,25 +44996,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3111
+   i32.const 3112
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3119
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   call $std/math/test_signf
   i32.eqz
   if
@@ -45001,8 +45013,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   call $std/math/test_signf
   i32.eqz
   if
@@ -45013,7 +45025,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
+  f32.const 1
   f32.const 1
   call $std/math/test_signf
   i32.eqz
@@ -45025,8 +45037,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 2
+  f32.const 1
   call $std/math/test_signf
   i32.eqz
   if
@@ -45037,7 +45049,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2
+  f32.const -1
   f32.const -1
   call $std/math/test_signf
   i32.eqz
@@ -45049,6 +45061,18 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -2
+  f32.const -1
+  call $std/math/test_signf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3125
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const inf
   f32.const 1
   call $std/math/test_signf
@@ -45056,7 +45080,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3125
+   i32.const 3126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45068,7 +45092,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3126
+   i32.const 3127
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45080,7 +45104,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3127
+   i32.const 3128
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45095,7 +45119,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3164
+   i32.const 3165
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45110,7 +45134,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3165
+   i32.const 3166
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45125,7 +45149,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3166
+   i32.const 3167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45140,7 +45164,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3167
+   i32.const 3168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45155,7 +45179,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3168
+   i32.const 3169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45170,7 +45194,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3169
+   i32.const 3170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45185,7 +45209,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3170
+   i32.const 3171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45200,7 +45224,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3171
+   i32.const 3172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45215,7 +45239,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3172
+   i32.const 3173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45230,7 +45254,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3173
+   i32.const 3174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45239,21 +45263,6 @@
   f64.const 1
   call $~lib/math/NativeMath.rem
   f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3176
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -45265,10 +45274,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const 1
   call $~lib/math/NativeMath.rem
-  f64.const 0.5
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -45280,6 +45289,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0.5
+  f64.const 1
+  call $~lib/math/NativeMath.rem
+  f64.const 0.5
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3179
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -0.5
   f64.const 1
   call $~lib/math/NativeMath.rem
@@ -45290,7 +45314,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3179
+   i32.const 3180
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45305,7 +45329,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3180
+   i32.const 3181
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45320,7 +45344,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3181
+   i32.const 3182
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45335,7 +45359,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3182
+   i32.const 3183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45350,7 +45374,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3183
+   i32.const 3184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45365,7 +45389,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3184
+   i32.const 3185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45380,27 +45404,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3185
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const 1
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45415,7 +45424,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const 1
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45430,10 +45439,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 1
   call $~lib/math/NativeMath.rem
-  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -45445,10 +45454,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -1
   call $~lib/math/NativeMath.rem
-  f64.const -0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -45460,6 +45469,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -1
+  call $~lib/math/NativeMath.rem
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3191
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0.5
   f64.const -1
   call $~lib/math/NativeMath.rem
@@ -45470,7 +45494,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3191
+   i32.const 3192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45485,7 +45509,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3192
+   i32.const 3193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45500,7 +45524,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3193
+   i32.const 3194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45515,7 +45539,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3194
+   i32.const 3195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45530,7 +45554,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3195
+   i32.const 3196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45545,7 +45569,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3196
+   i32.const 3197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45560,7 +45584,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3197
+   i32.const 3198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45575,27 +45599,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3198
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/check<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3199
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -1
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45610,7 +45619,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const -1
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45625,8 +45634,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -1
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45641,7 +45650,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const 0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45656,9 +45665,9 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
+  f64.const -0
   call $~lib/math/NativeMath.rem
-  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -45671,7 +45680,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
+  f64.const inf
   call $~lib/math/NativeMath.rem
   f64.const 0
   f64.const 0
@@ -45686,9 +45695,9 @@
    unreachable
   end
   f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -inf
   call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -45700,8 +45709,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45716,7 +45725,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45731,9 +45740,9 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
-  call $~lib/math/NativeMath.rem
   f64.const -0
+  call $~lib/math/NativeMath.rem
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -45746,7 +45755,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
+  f64.const inf
   call $~lib/math/NativeMath.rem
   f64.const -0
   f64.const 0
@@ -45761,9 +45770,9 @@
    unreachable
   end
   f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const -inf
   call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -45775,8 +45784,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 0
+  f64.const -0
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45790,7 +45799,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const 0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45805,7 +45814,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45820,7 +45829,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const 0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45835,7 +45844,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const 0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45850,8 +45859,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45865,7 +45874,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45880,7 +45889,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45895,7 +45904,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const -0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -45910,8 +45919,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const -0
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45926,7 +45935,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const 2
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45941,7 +45950,7 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45955,8 +45964,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 2
+  f64.const inf
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45971,7 +45980,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
+  f64.const 2
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45986,7 +45995,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
   f64.const 0
@@ -46000,7 +46009,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -inf
   f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -46015,7 +46024,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -46030,7 +46039,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -46045,10 +46054,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
+  f64.const -1
+  f64.const nan:0x8000000000000
   call $~lib/math/NativeMath.rem
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -46060,10 +46069,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
   call $~lib/math/NativeMath.rem
-  f64.const -1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -46075,10 +46084,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const inf
   call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -46090,7 +46099,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const inf
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -46105,10 +46114,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const -inf
+  f64.const inf
   call $~lib/math/NativeMath.rem
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -46120,10 +46129,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const -inf
   call $~lib/math/NativeMath.rem
-  f64.const -1
+  f64.const 1
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -46135,10 +46144,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -inf
   call $~lib/math/NativeMath.rem
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -46150,7 +46159,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const inf
   f64.const -inf
   call $~lib/math/NativeMath.rem
   f64.const nan:0x8000000000000
@@ -46165,10 +46174,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
+  f64.const -inf
+  f64.const -inf
   call $~lib/math/NativeMath.rem
-  f64.const -0.25
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/check<f64>
   i32.eqz
@@ -46180,6 +46189,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1.75
+  f64.const 0.5
+  call $~lib/math/NativeMath.rem
+  f64.const -0.25
+  f64.const 0
+  call $std/math/check<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3239
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1.75
   f64.const 0.5
   call $~lib/math/NativeMath.rem
@@ -46190,7 +46214,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3239
+   i32.const 3240
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46205,7 +46229,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3240
+   i32.const 3241
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46220,7 +46244,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3241
+   i32.const 3242
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46235,7 +46259,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3242
+   i32.const 3243
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46250,7 +46274,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3251
+   i32.const 3252
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46265,7 +46289,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3252
+   i32.const 3253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46280,7 +46304,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3253
+   i32.const 3254
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46295,7 +46319,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3254
+   i32.const 3255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46310,7 +46334,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3255
+   i32.const 3256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46325,7 +46349,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3256
+   i32.const 3257
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46340,7 +46364,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3257
+   i32.const 3258
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46355,7 +46379,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3258
+   i32.const 3259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46370,7 +46394,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3259
+   i32.const 3260
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46385,7 +46409,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3260
+   i32.const 3261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46394,21 +46418,6 @@
   f32.const 1
   call $~lib/math/NativeMathf.rem
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3263
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -46420,10 +46429,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0
   f32.const 1
   call $~lib/math/NativeMathf.rem
-  f32.const 0.5
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -46435,6 +46444,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0.5
+  f32.const 1
+  call $~lib/math/NativeMathf.rem
+  f32.const 0.5
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3266
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -0.5
   f32.const 1
   call $~lib/math/NativeMathf.rem
@@ -46445,7 +46469,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3266
+   i32.const 3267
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46460,7 +46484,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3267
+   i32.const 3268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46475,7 +46499,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3268
+   i32.const 3269
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46490,7 +46514,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3269
+   i32.const 3270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46505,7 +46529,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3270
+   i32.const 3271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46520,7 +46544,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3271
+   i32.const 3272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46535,27 +46559,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3272
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3273
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const 1
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -46570,7 +46579,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const 1
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -46585,10 +46594,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const 1
   call $~lib/math/NativeMathf.rem
-  f32.const 0
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -46600,10 +46609,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -1
   call $~lib/math/NativeMathf.rem
-  f32.const -0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -46615,6 +46624,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -1
+  call $~lib/math/NativeMathf.rem
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3278
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0.5
   f32.const -1
   call $~lib/math/NativeMathf.rem
@@ -46625,7 +46649,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3278
+   i32.const 3279
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46640,7 +46664,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3279
+   i32.const 3280
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46655,7 +46679,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3280
+   i32.const 3281
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46670,7 +46694,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3281
+   i32.const 3282
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46685,7 +46709,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3282
+   i32.const 3283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46700,7 +46724,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3283
+   i32.const 3284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46715,7 +46739,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3284
+   i32.const 3285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46730,27 +46754,12 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3285
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3286
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const -1
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -46765,7 +46774,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const -1
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -46780,8 +46789,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -1
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -46796,7 +46805,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
+  f32.const 0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -46811,9 +46820,9 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
+  f32.const -0
   call $~lib/math/NativeMathf.rem
-  f32.const 0
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -46826,7 +46835,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.rem
   f32.const 0
   f32.const 0
@@ -46841,9 +46850,9 @@
    unreachable
   end
   f32.const 0
-  f32.const nan:0x400000
+  f32.const -inf
   call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -46855,8 +46864,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 0
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -46871,7 +46880,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const 0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -46886,9 +46895,9 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
-  call $~lib/math/NativeMathf.rem
   f32.const -0
+  call $~lib/math/NativeMathf.rem
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -46901,7 +46910,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.rem
   f32.const -0
   f32.const 0
@@ -46916,9 +46925,9 @@
    unreachable
   end
   f32.const -0
-  f32.const nan:0x400000
+  f32.const -inf
   call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -46930,8 +46939,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 0
+  f32.const -0
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -46945,7 +46954,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const 0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -46960,7 +46969,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -46975,7 +46984,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const 0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -46990,7 +46999,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const 0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -47005,8 +47014,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const 0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -47020,7 +47029,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const -0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -47035,7 +47044,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const -0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -47050,7 +47059,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const -0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -47065,8 +47074,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const -0
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -47081,7 +47090,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const 2
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -47096,7 +47105,7 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const -0.5
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -47110,8 +47119,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 2
+  f32.const inf
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -47126,7 +47135,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const -0.5
+  f32.const 2
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -47141,7 +47150,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const nan:0x400000
+  f32.const -0.5
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
   f32.const 0
@@ -47155,7 +47164,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -47170,7 +47179,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -47185,7 +47194,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -47200,10 +47209,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
+  f32.const -1
+  f32.const nan:0x400000
   call $~lib/math/NativeMathf.rem
-  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47215,10 +47224,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
   call $~lib/math/NativeMathf.rem
-  f32.const -1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47230,10 +47239,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const inf
   call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47245,7 +47254,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const inf
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -47260,10 +47269,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.rem
-  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47275,10 +47284,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const -inf
   call $~lib/math/NativeMathf.rem
-  f32.const -1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47290,10 +47299,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const -inf
   call $~lib/math/NativeMathf.rem
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47305,7 +47314,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   f32.const -inf
   call $~lib/math/NativeMathf.rem
   f32.const nan:0x400000
@@ -47320,10 +47329,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
+  f32.const -inf
+  f32.const -inf
   call $~lib/math/NativeMathf.rem
-  f32.const -0.25
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -47335,6 +47344,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.75
+  f32.const 0.5
+  call $~lib/math/NativeMathf.rem
+  f32.const -0.25
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3326
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.75
   f32.const 0.5
   call $~lib/math/NativeMathf.rem
@@ -47345,7 +47369,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3326
+   i32.const 3327
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47360,7 +47384,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3327
+   i32.const 3328
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47375,7 +47399,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3328
+   i32.const 3329
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47390,7 +47414,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3329
+   i32.const 3330
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47413,7 +47437,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3341
+   i32.const 3342
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47436,7 +47460,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3342
+   i32.const 3343
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47459,7 +47483,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3343
+   i32.const 3344
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47482,7 +47506,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3344
+   i32.const 3345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47505,7 +47529,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3345
+   i32.const 3346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47528,7 +47552,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3346
+   i32.const 3347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47551,7 +47575,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3347
+   i32.const 3348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47574,7 +47598,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3348
+   i32.const 3349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47597,7 +47621,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3349
+   i32.const 3350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47620,7 +47644,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3350
+   i32.const 3351
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47643,7 +47667,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3353
+   i32.const 3354
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47666,43 +47690,20 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3354
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  call $~lib/math/NativeMath.sin
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 2.2250738585072014e-308
-   call $~lib/bindings/Math/sin
-   f64.const 2.2250738585072014e-308
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3355
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   call $~lib/math/NativeMath.sin
-  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -2.2250738585072014e-308
+   f64.const 2.2250738585072014e-308
    call $~lib/bindings/Math/sin
-   f64.const -2.2250738585072014e-308
+   f64.const 2.2250738585072014e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -47717,15 +47718,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
+  f64.const -2.2250738585072014e-308
   call $~lib/math/NativeMath.sin
-  f64.const 5e-324
+  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 5e-324
+   f64.const -2.2250738585072014e-308
    call $~lib/bindings/Math/sin
-   f64.const 5e-324
+   f64.const -2.2250738585072014e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -47740,15 +47741,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
+  f64.const 5e-324
   call $~lib/math/NativeMath.sin
-  f64.const -5e-324
+  f64.const 5e-324
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -5e-324
+   f64.const 5e-324
    call $~lib/bindings/Math/sin
-   f64.const -5e-324
+   f64.const 5e-324
    f64.const 0
    call $std/math/check<f64>
   else
@@ -47763,15 +47764,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -5e-324
   call $~lib/math/NativeMath.sin
-  f64.const 0
+  f64.const -5e-324
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -5e-324
    call $~lib/bindings/Math/sin
-   f64.const 0
+   f64.const -5e-324
    f64.const 0
    call $std/math/check<f64>
   else
@@ -47786,15 +47787,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   call $~lib/math/NativeMath.sin
-  f64.const -0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0
    call $~lib/bindings/Math/sin
-   f64.const -0
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -47809,15 +47810,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507202e-308
+  f64.const -0
   call $~lib/math/NativeMath.sin
-  f64.const 2.225073858507202e-308
+  f64.const -0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 2.225073858507202e-308
+   f64.const -0
    call $~lib/bindings/Math/sin
-   f64.const 2.225073858507202e-308
+   f64.const -0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -47832,15 +47833,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
+  f64.const 2.225073858507202e-308
   call $~lib/math/NativeMath.sin
-  f64.const 2.2250738585072024e-308
+  f64.const 2.225073858507202e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 2.2250738585072024e-308
+   f64.const 2.225073858507202e-308
    call $~lib/bindings/Math/sin
-   f64.const 2.2250738585072024e-308
+   f64.const 2.225073858507202e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -47855,15 +47856,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
+  f64.const 2.2250738585072024e-308
   call $~lib/math/NativeMath.sin
-  f64.const 4.4501477170144003e-308
+  f64.const 2.2250738585072024e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 4.4501477170144003e-308
+   f64.const 2.2250738585072024e-308
    call $~lib/bindings/Math/sin
-   f64.const 4.4501477170144003e-308
+   f64.const 2.2250738585072024e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -47878,15 +47879,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
+  f64.const 4.4501477170144003e-308
   call $~lib/math/NativeMath.sin
-  f64.const 4.450147717014403e-308
+  f64.const 4.4501477170144003e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 4.450147717014403e-308
+   f64.const 4.4501477170144003e-308
    call $~lib/bindings/Math/sin
-   f64.const 4.450147717014403e-308
+   f64.const 4.4501477170144003e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -47901,6 +47902,29 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 4.450147717014403e-308
+  call $~lib/math/NativeMath.sin
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 4.450147717014403e-308
+   call $~lib/bindings/Math/sin
+   f64.const 4.450147717014403e-308
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3365
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4.450147717014406e-308
   call $~lib/math/NativeMath.sin
   f64.const 4.450147717014406e-308
@@ -47919,7 +47943,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3365
+   i32.const 3366
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47942,7 +47966,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3366
+   i32.const 3367
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47965,7 +47989,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3367
+   i32.const 3368
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47988,43 +48012,20 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3368
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  call $~lib/math/NativeMath.sin
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -2.225073858507202e-308
-   call $~lib/bindings/Math/sin
-   f64.const -2.225073858507202e-308
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3369
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072024e-308
+  f64.const -2.225073858507202e-308
   call $~lib/math/NativeMath.sin
-  f64.const -2.2250738585072024e-308
+  f64.const -2.225073858507202e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -2.2250738585072024e-308
+   f64.const -2.225073858507202e-308
    call $~lib/bindings/Math/sin
-   f64.const -2.2250738585072024e-308
+   f64.const -2.225073858507202e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48039,15 +48040,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4501477170144003e-308
+  f64.const -2.2250738585072024e-308
   call $~lib/math/NativeMath.sin
-  f64.const -4.4501477170144003e-308
+  f64.const -2.2250738585072024e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -4.4501477170144003e-308
+   f64.const -2.2250738585072024e-308
    call $~lib/bindings/Math/sin
-   f64.const -4.4501477170144003e-308
+   f64.const -2.2250738585072024e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48062,15 +48063,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014403e-308
+  f64.const -4.4501477170144003e-308
   call $~lib/math/NativeMath.sin
-  f64.const -4.450147717014403e-308
+  f64.const -4.4501477170144003e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -4.450147717014403e-308
+   f64.const -4.4501477170144003e-308
    call $~lib/bindings/Math/sin
-   f64.const -4.450147717014403e-308
+   f64.const -4.4501477170144003e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48085,15 +48086,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014403e-308
   call $~lib/math/NativeMath.sin
-  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014403e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -4.450147717014406e-308
+   f64.const -4.450147717014403e-308
    call $~lib/bindings/Math/sin
-   f64.const -4.450147717014406e-308
+   f64.const -4.450147717014403e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48108,6 +48109,29 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -4.450147717014406e-308
+  call $~lib/math/NativeMath.sin
+  f64.const -4.450147717014406e-308
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -4.450147717014406e-308
+   call $~lib/bindings/Math/sin
+   f64.const -4.450147717014406e-308
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3374
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -8.900295434028806e-308
   call $~lib/math/NativeMath.sin
   f64.const -8.900295434028806e-308
@@ -48126,7 +48150,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3374
+   i32.const 3375
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48141,29 +48165,6 @@
    call $~lib/bindings/Math/sin
    f64.const -1.1175870895385742e-08
    f64.const -0.140625
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3375
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  call $~lib/math/NativeMath.sin
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -1.4901161193847656e-08
-   call $~lib/bindings/Math/sin
-   f64.const -1.4901161193847656e-08
-   f64.const -0.1666666716337204
    call $std/math/check<f64>
   else
    i32.const 0
@@ -48200,16 +48201,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1e-323
+  f64.const -1.4901161193847656e-08
   call $~lib/math/NativeMath.sin
-  f64.const 1e-323
-  f64.const 0
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   call $std/math/check<f64>
   if (result i32)
-   f64.const 1e-323
+   f64.const -1.4901161193847656e-08
    call $~lib/bindings/Math/sin
-   f64.const 1e-323
-   f64.const 0
+   f64.const -1.4901161193847656e-08
+   f64.const -0.1666666716337204
    call $std/math/check<f64>
   else
    i32.const 0
@@ -48223,15 +48224,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
+  f64.const 1e-323
   call $~lib/math/NativeMath.sin
-  f64.const 4.4e-323
+  f64.const 1e-323
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 4.4e-323
+   f64.const 1e-323
    call $~lib/bindings/Math/sin
-   f64.const 4.4e-323
+   f64.const 1e-323
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48246,15 +48247,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
+  f64.const 4.4e-323
   call $~lib/math/NativeMath.sin
-  f64.const 5.562684646268003e-309
+  f64.const 4.4e-323
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 5.562684646268003e-309
+   f64.const 4.4e-323
    call $~lib/bindings/Math/sin
-   f64.const 5.562684646268003e-309
+   f64.const 4.4e-323
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48269,15 +48270,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
+  f64.const 5.562684646268003e-309
   call $~lib/math/NativeMath.sin
-  f64.const 1.1125369292536007e-308
+  f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 1.1125369292536007e-308
+   f64.const 5.562684646268003e-309
    call $~lib/bindings/Math/sin
-   f64.const 1.1125369292536007e-308
+   f64.const 5.562684646268003e-309
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48292,15 +48293,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
+  f64.const 1.1125369292536007e-308
   call $~lib/math/NativeMath.sin
-  f64.const 2.2250738585072004e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 2.2250738585072004e-308
+   f64.const 1.1125369292536007e-308
    call $~lib/bindings/Math/sin
-   f64.const 2.2250738585072004e-308
+   f64.const 1.1125369292536007e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48315,15 +48316,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
+  f64.const 2.2250738585072004e-308
   call $~lib/math/NativeMath.sin
-  f64.const 2.225073858507201e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 2.225073858507201e-308
+   f64.const 2.2250738585072004e-308
    call $~lib/bindings/Math/sin
-   f64.const 2.225073858507201e-308
+   f64.const 2.2250738585072004e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48338,15 +48339,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
+  f64.const 2.225073858507201e-308
   call $~lib/math/NativeMath.sin
-  f64.const -1e-323
+  f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1e-323
+   f64.const 2.225073858507201e-308
    call $~lib/bindings/Math/sin
-   f64.const -1e-323
+   f64.const 2.225073858507201e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48361,15 +48362,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
+  f64.const -1e-323
   call $~lib/math/NativeMath.sin
-  f64.const -4.4e-323
+  f64.const -1e-323
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -4.4e-323
+   f64.const -1e-323
    call $~lib/bindings/Math/sin
-   f64.const -4.4e-323
+   f64.const -1e-323
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48384,15 +48385,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
+  f64.const -4.4e-323
   call $~lib/math/NativeMath.sin
-  f64.const -5.562684646268003e-309
+  f64.const -4.4e-323
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -5.562684646268003e-309
+   f64.const -4.4e-323
    call $~lib/bindings/Math/sin
-   f64.const -5.562684646268003e-309
+   f64.const -4.4e-323
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48407,15 +48408,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
+  f64.const -5.562684646268003e-309
   call $~lib/math/NativeMath.sin
-  f64.const -1.1125369292536007e-308
+  f64.const -5.562684646268003e-309
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1.1125369292536007e-308
+   f64.const -5.562684646268003e-309
    call $~lib/bindings/Math/sin
-   f64.const -1.1125369292536007e-308
+   f64.const -5.562684646268003e-309
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48430,15 +48431,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
+  f64.const -1.1125369292536007e-308
   call $~lib/math/NativeMath.sin
-  f64.const -2.2250738585072004e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -2.2250738585072004e-308
+   f64.const -1.1125369292536007e-308
    call $~lib/bindings/Math/sin
-   f64.const -2.2250738585072004e-308
+   f64.const -1.1125369292536007e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48453,15 +48454,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
+  f64.const -2.2250738585072004e-308
   call $~lib/math/NativeMath.sin
-  f64.const -2.225073858507201e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -2.225073858507201e-308
+   f64.const -2.2250738585072004e-308
    call $~lib/bindings/Math/sin
-   f64.const -2.225073858507201e-308
+   f64.const -2.2250738585072004e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -48476,6 +48477,29 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -2.225073858507201e-308
+  call $~lib/math/NativeMath.sin
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -2.225073858507201e-308
+   call $~lib/bindings/Math/sin
+   f64.const -2.225073858507201e-308
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3390
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   call $~lib/math/NativeMath.sin
   f64.const 0
@@ -48494,7 +48518,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3392
+   i32.const 3393
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48517,7 +48541,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3393
+   i32.const 3394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48540,7 +48564,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3394
+   i32.const 3395
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48563,7 +48587,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3395
+   i32.const 3396
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48586,7 +48610,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3396
+   i32.const 3397
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48594,19 +48618,6 @@
   f64.const 1.5707963267948966
   call $~lib/math/NativeMath.sin
   f64.const 1.5707963267948966
-  call $~lib/bindings/Math/sin
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3399
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 3.141592653589793
-  call $~lib/math/NativeMath.sin
-  f64.const 3.141592653589793
   call $~lib/bindings/Math/sin
   f64.ne
   if
@@ -48617,6 +48628,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 3.141592653589793
+  call $~lib/math/NativeMath.sin
+  f64.const 3.141592653589793
+  call $~lib/bindings/Math/sin
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3401
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.sin
   f64.const 2.3283064365386963e-10
@@ -48624,7 +48648,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3403
+   i32.const 3404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48636,7 +48660,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3404
+   i32.const 3405
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48648,7 +48672,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3406
+   i32.const 3407
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48660,7 +48684,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3407
+   i32.const 3408
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48672,7 +48696,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3410
+   i32.const 3411
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48684,7 +48708,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3411
+   i32.const 3412
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48696,7 +48720,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3412
+   i32.const 3413
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48708,7 +48732,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3413
+   i32.const 3414
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48720,7 +48744,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3415
+   i32.const 3416
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48732,7 +48756,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3416
+   i32.const 3417
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48744,7 +48768,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3418
+   i32.const 3419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48756,7 +48780,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3419
+   i32.const 3420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48768,7 +48792,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3420
+   i32.const 3421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48780,7 +48804,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3421
+   i32.const 3422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48792,7 +48816,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3422
+   i32.const 3423
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48804,7 +48828,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3425
+   i32.const 3426
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48816,7 +48840,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3426
+   i32.const 3427
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48830,7 +48854,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3435
+   i32.const 3436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48844,7 +48868,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3436
+   i32.const 3437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48858,7 +48882,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3437
+   i32.const 3438
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48872,7 +48896,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3438
+   i32.const 3439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48886,7 +48910,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3439
+   i32.const 3440
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48900,7 +48924,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3440
+   i32.const 3441
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48914,7 +48938,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3441
+   i32.const 3442
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48928,7 +48952,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3442
+   i32.const 3443
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48942,7 +48966,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3443
+   i32.const 3444
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48956,7 +48980,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3444
+   i32.const 3445
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48964,20 +48988,6 @@
   f32.const 0
   call $~lib/math/NativeMathf.sin
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3447
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  call $~lib/math/NativeMathf.sin
-  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -48989,9 +48999,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -0
   call $~lib/math/NativeMathf.sin
-  f32.const nan:0x400000
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49003,7 +49013,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.sin
   f32.const nan:0x400000
   f32.const 0
@@ -49017,7 +49027,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   call $~lib/math/NativeMathf.sin
   f32.const nan:0x400000
   f32.const 0
@@ -49031,6 +49041,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
+  call $~lib/math/NativeMathf.sin
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3452
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.862645149230957e-09
   call $~lib/math/NativeMathf.sin
   f32.const 1.862645149230957e-09
@@ -49040,7 +49064,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3454
+   i32.const 3455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49054,28 +49078,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3455
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   call $~lib/math/NativeMathf.sin
-  f32.const -1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49087,9 +49097,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
+  f32.const -1.1754943508222875e-38
   call $~lib/math/NativeMathf.sin
-  f32.const 1.401298464324817e-45
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49101,9 +49111,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   call $~lib/math/NativeMathf.sin
-  f32.const -1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49115,9 +49125,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
+  f32.const -1.401298464324817e-45
   call $~lib/math/NativeMathf.sin
-  f32.const 1.175494490952134e-38
+  f32.const -1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49129,9 +49139,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
+  f32.const 1.175494490952134e-38
   call $~lib/math/NativeMathf.sin
-  f32.const 1.1754946310819804e-38
+  f32.const 1.175494490952134e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49143,9 +49153,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754946310819804e-38
   call $~lib/math/NativeMathf.sin
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754946310819804e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49157,9 +49167,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509880009953429e-38
   call $~lib/math/NativeMathf.sin
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509880009953429e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49171,6 +49181,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 2.350988701644575e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3464
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   call $~lib/math/NativeMathf.sin
   f32.const 2.3509895424236536e-38
@@ -49180,7 +49204,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3464
+   i32.const 3465
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49194,7 +49218,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3465
+   i32.const 3466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49208,7 +49232,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3466
+   i32.const 3467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49222,7 +49246,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3467
+   i32.const 3468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49236,7 +49260,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3468
+   i32.const 3469
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49250,28 +49274,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3469
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  call $~lib/math/NativeMathf.sin
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3470
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754946310819804e-38
+  f32.const -1.175494490952134e-38
   call $~lib/math/NativeMathf.sin
-  f32.const -1.1754946310819804e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49283,9 +49293,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509880009953429e-38
+  f32.const -1.1754946310819804e-38
   call $~lib/math/NativeMathf.sin
-  f32.const -2.3509880009953429e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49297,9 +49307,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.350988701644575e-38
+  f32.const -2.3509880009953429e-38
   call $~lib/math/NativeMathf.sin
-  f32.const -2.350988701644575e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49311,6 +49321,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -2.350988701644575e-38
+  call $~lib/math/NativeMathf.sin
+  f32.const -2.350988701644575e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3474
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -2.3509895424236536e-38
   call $~lib/math/NativeMathf.sin
   f32.const -2.3509895424236536e-38
@@ -49320,7 +49344,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3474
+   i32.const 3475
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49334,7 +49358,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3475
+   i32.const 3476
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49348,7 +49372,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3476
+   i32.const 3477
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49362,7 +49386,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3477
+   i32.const 3478
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49376,7 +49400,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3478
+   i32.const 3479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49390,28 +49414,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3479
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  call $~lib/math/NativeMathf.sin
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
+  f32.const 2.802596928649634e-45
   call $~lib/math/NativeMathf.sin
-  f32.const 1.2611686178923354e-44
+  f32.const 2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49423,9 +49433,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
+  f32.const 1.2611686178923354e-44
   call $~lib/math/NativeMathf.sin
-  f32.const 2.938735877055719e-39
+  f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49437,9 +49447,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
+  f32.const 2.938735877055719e-39
   call $~lib/math/NativeMathf.sin
-  f32.const 5.877471754111438e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49451,9 +49461,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
+  f32.const 5.877471754111438e-39
   call $~lib/math/NativeMathf.sin
-  f32.const 1.1754940705625946e-38
+  f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49465,9 +49475,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
+  f32.const 1.1754940705625946e-38
   call $~lib/math/NativeMathf.sin
-  f32.const 1.1754942106924411e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49479,9 +49489,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
+  f32.const 1.1754942106924411e-38
   call $~lib/math/NativeMathf.sin
-  f32.const -2.802596928649634e-45
+  f32.const 1.1754942106924411e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49493,9 +49503,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
+  f32.const -2.802596928649634e-45
   call $~lib/math/NativeMathf.sin
-  f32.const -1.2611686178923354e-44
+  f32.const -2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49507,9 +49517,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
+  f32.const -1.2611686178923354e-44
   call $~lib/math/NativeMathf.sin
-  f32.const -2.938735877055719e-39
+  f32.const -1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49521,9 +49531,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
+  f32.const -2.938735877055719e-39
   call $~lib/math/NativeMathf.sin
-  f32.const -5.877471754111438e-39
+  f32.const -2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -49535,6 +49545,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -5.877471754111438e-39
+  call $~lib/math/NativeMathf.sin
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3490
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.1754940705625946e-38
   call $~lib/math/NativeMathf.sin
   f32.const -1.1754940705625946e-38
@@ -49544,7 +49568,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3490
+   i32.const 3491
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49558,7 +49582,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3491
+   i32.const 3492
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49572,7 +49596,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3494
+   i32.const 3495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49586,7 +49610,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3495
+   i32.const 3496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49600,7 +49624,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3496
+   i32.const 3497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49614,7 +49638,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3497
+   i32.const 3498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49628,7 +49652,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3498
+   i32.const 3499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49642,7 +49666,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3499
+   i32.const 3500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49656,7 +49680,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3500
+   i32.const 3501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49670,7 +49694,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3501
+   i32.const 3502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49684,7 +49708,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3502
+   i32.const 3503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49698,7 +49722,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3503
+   i32.const 3504
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49712,7 +49736,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3504
+   i32.const 3505
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49726,7 +49750,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3505
+   i32.const 3506
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49740,7 +49764,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3506
+   i32.const 3507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49754,7 +49778,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3507
+   i32.const 3508
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49767,7 +49791,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3519
+   i32.const 3520
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49780,7 +49804,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3520
+   i32.const 3521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49793,7 +49817,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3521
+   i32.const 3522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49806,7 +49830,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3522
+   i32.const 3523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49819,7 +49843,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3523
+   i32.const 3524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49832,7 +49856,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3524
+   i32.const 3525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49845,7 +49869,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3525
+   i32.const 3526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49858,7 +49882,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3526
+   i32.const 3527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49871,7 +49895,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3527
+   i32.const 3528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49884,26 +49908,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3528
+   i32.const 3529
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  f64.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3531
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
   f64.const 0
   call $std/math/test_sinh
   i32.eqz
@@ -49915,8 +49926,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_sinh
   i32.eqz
@@ -49928,6 +49939,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3534
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -inf
   f64.const -inf
   f64.const 0
@@ -49936,7 +49960,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3534
+   i32.const 3535
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49949,7 +49973,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3535
+   i32.const 3536
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49962,7 +49986,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3544
+   i32.const 3545
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49975,7 +49999,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3545
+   i32.const 3546
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49988,7 +50012,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3546
+   i32.const 3547
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50001,7 +50025,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3547
+   i32.const 3548
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50014,7 +50038,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3548
+   i32.const 3549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50027,7 +50051,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3549
+   i32.const 3550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50040,7 +50064,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3550
+   i32.const 3551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50053,7 +50077,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3551
+   i32.const 3552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50066,7 +50090,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3552
+   i32.const 3553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50079,26 +50103,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3553
+   i32.const 3554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3556
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   call $std/math/test_sinhf
   i32.eqz
@@ -50110,8 +50121,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/test_sinhf
   i32.eqz
@@ -50123,6 +50134,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3559
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -inf
   f32.const -inf
   f32.const 0
@@ -50131,7 +50155,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3559
+   i32.const 3560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50144,7 +50168,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3560
+   i32.const 3561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50166,7 +50190,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3572
+   i32.const 3573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50188,7 +50212,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3573
+   i32.const 3574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50210,7 +50234,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3574
+   i32.const 3575
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50232,7 +50256,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3575
+   i32.const 3576
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50254,7 +50278,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3576
+   i32.const 3577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50276,7 +50300,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3577
+   i32.const 3578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50298,7 +50322,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3578
+   i32.const 3579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50320,7 +50344,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3579
+   i32.const 3580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50342,7 +50366,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3580
+   i32.const 3581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50364,7 +50388,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3581
+   i32.const 3582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50377,28 +50401,6 @@
    f64.const nan:0x8000000000000
    call $~lib/bindings/Math/sqrt
    f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3584
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const inf
-   call $~lib/bindings/Math/sqrt
-   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -50409,6 +50411,28 @@
    i32.const 0
    i32.const 1056
    i32.const 3585
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const inf
+   call $~lib/bindings/Math/sqrt
+   f64.const inf
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50430,41 +50454,19 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3586
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 0
-   call $~lib/bindings/Math/sqrt
-   f64.const 0
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0
    call $~lib/bindings/Math/sqrt
-   f64.const -0
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -50479,6 +50481,28 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -0
+   call $~lib/bindings/Math/sqrt
+   f64.const -0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3589
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -50496,7 +50520,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3589
+   i32.const 3590
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50518,7 +50542,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3590
+   i32.const 3591
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50540,7 +50564,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3591
+   i32.const 3592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50562,7 +50586,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3592
+   i32.const 3593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50584,7 +50608,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3593
+   i32.const 3594
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50606,7 +50630,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3594
+   i32.const 3595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50628,7 +50652,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3595
+   i32.const 3596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50650,7 +50674,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3596
+   i32.const 3597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50672,7 +50696,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3597
+   i32.const 3598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50694,7 +50718,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3598
+   i32.const 3599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50716,7 +50740,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3599
+   i32.const 3600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50738,7 +50762,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3600
+   i32.const 3601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50760,7 +50784,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3601
+   i32.const 3602
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50782,7 +50806,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3602
+   i32.const 3603
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50804,7 +50828,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3603
+   i32.const 3604
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50826,7 +50850,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3604
+   i32.const 3605
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50848,7 +50872,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3605
+   i32.const 3606
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50870,7 +50894,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3606
+   i32.const 3607
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50892,7 +50916,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3607
+   i32.const 3608
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50914,7 +50938,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3608
+   i32.const 3609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50936,7 +50960,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3609
+   i32.const 3610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50958,7 +50982,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3610
+   i32.const 3611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50980,7 +51004,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3611
+   i32.const 3612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51002,7 +51026,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3612
+   i32.const 3613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51024,7 +51048,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3613
+   i32.const 3614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51046,7 +51070,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3614
+   i32.const 3615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51068,7 +51092,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3615
+   i32.const 3616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51090,7 +51114,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3616
+   i32.const 3617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51112,7 +51136,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3617
+   i32.const 3618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51134,7 +51158,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3618
+   i32.const 3619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51156,7 +51180,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3619
+   i32.const 3620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51178,7 +51202,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3620
+   i32.const 3621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51200,7 +51224,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3621
+   i32.const 3622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51222,7 +51246,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3622
+   i32.const 3623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51244,7 +51268,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3623
+   i32.const 3624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51266,7 +51290,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3624
+   i32.const 3625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51288,7 +51312,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3625
+   i32.const 3626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51310,7 +51334,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3626
+   i32.const 3627
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51332,7 +51356,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3627
+   i32.const 3628
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51354,7 +51378,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3628
+   i32.const 3629
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51376,7 +51400,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3629
+   i32.const 3630
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51398,7 +51422,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3630
+   i32.const 3631
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51420,7 +51444,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3631
+   i32.const 3632
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51442,7 +51466,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3632
+   i32.const 3633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51464,7 +51488,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3633
+   i32.const 3634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51486,7 +51510,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3634
+   i32.const 3635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51508,7 +51532,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3635
+   i32.const 3636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51530,7 +51554,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3636
+   i32.const 3637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51552,7 +51576,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3637
+   i32.const 3638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51574,7 +51598,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3638
+   i32.const 3639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51596,7 +51620,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3639
+   i32.const 3640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51618,7 +51642,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3640
+   i32.const 3641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51640,7 +51664,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3641
+   i32.const 3642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51662,7 +51686,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3642
+   i32.const 3643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51684,7 +51708,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3643
+   i32.const 3644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51706,7 +51730,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3644
+   i32.const 3645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51728,7 +51752,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3645
+   i32.const 3646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51750,7 +51774,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3646
+   i32.const 3647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51772,7 +51796,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3647
+   i32.const 3648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51794,7 +51818,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3648
+   i32.const 3649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51816,7 +51840,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3649
+   i32.const 3650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51838,7 +51862,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3650
+   i32.const 3651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51860,7 +51884,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3651
+   i32.const 3652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51882,7 +51906,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3652
+   i32.const 3653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51904,7 +51928,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3653
+   i32.const 3654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51926,7 +51950,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3654
+   i32.const 3655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51948,7 +51972,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3655
+   i32.const 3656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51970,7 +51994,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3656
+   i32.const 3657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51992,7 +52016,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3657
+   i32.const 3658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52000,19 +52024,6 @@
   f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3666
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.084523916244507
-  f32.const 2.084523916244507
-  f32.const 0.3200402557849884
   call $std/math/check<f32>
   i32.eqz
   if
@@ -52023,9 +52034,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const 2.084523916244507
+  f32.const 2.084523916244507
+  f32.const 0.3200402557849884
   call $std/math/check<f32>
   i32.eqz
   if
@@ -52049,6 +52060,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3670
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 3.0441842079162598
   f32.const 3.0441842079162598
   f32.const 0.05022354796528816
@@ -52057,7 +52081,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3670
+   i32.const 3671
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52070,7 +52094,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3671
+   i32.const 3672
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52083,7 +52107,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3672
+   i32.const 3673
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52096,7 +52120,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3673
+   i32.const 3674
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52109,7 +52133,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3674
+   i32.const 3675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52122,26 +52146,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3675
+   i32.const 3676
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3678
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -52153,8 +52164,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -52166,8 +52177,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -52179,6 +52190,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3682
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -0
   f32.const -0
   f32.const 0
@@ -52187,7 +52211,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3682
+   i32.const 3683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52200,7 +52224,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3683
+   i32.const 3684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52213,26 +52237,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3684
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2
-  f32.const 2
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.293955920339377e-23
-  f32.const 5.293955920339377e-23
+  f32.const 2
+  f32.const 2
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -52240,6 +52251,19 @@
    i32.const 0
    i32.const 1056
    i32.const 3686
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 5.293955920339377e-23
+  f32.const 5.293955920339377e-23
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52252,7 +52276,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3687
+   i32.const 3688
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52265,7 +52289,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3688
+   i32.const 3689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52278,7 +52302,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3689
+   i32.const 3690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52291,7 +52315,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3690
+   i32.const 3691
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52299,19 +52323,6 @@
   f32.const -nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3691
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.9999999403953552
-  f32.const 0.9999999403953552
-  f32.const 2.980232594040899e-08
   call $std/math/check<f32>
   i32.eqz
   if
@@ -52324,13 +52335,26 @@
   end
   f32.const 0.9999999403953552
   f32.const 0.9999999403953552
-  f32.const -0.5
+  f32.const 2.980232594040899e-08
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
    i32.const 3693
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.9999999403953552
+  f32.const 0.9999999403953552
+  f32.const -0.5
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3694
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52343,7 +52367,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3694
+   i32.const 3695
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52356,7 +52380,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3695
+   i32.const 3696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52369,7 +52393,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3696
+   i32.const 3697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52382,7 +52406,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3697
+   i32.const 3698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52395,7 +52419,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3698
+   i32.const 3699
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52408,7 +52432,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3699
+   i32.const 3700
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52431,7 +52455,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3711
+   i32.const 3712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52454,7 +52478,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3712
+   i32.const 3713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52477,7 +52501,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3713
+   i32.const 3714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52500,7 +52524,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3714
+   i32.const 3715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52523,7 +52547,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3715
+   i32.const 3716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52546,7 +52570,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3716
+   i32.const 3717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52569,7 +52593,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3717
+   i32.const 3718
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52592,7 +52616,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3718
+   i32.const 3719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52615,7 +52639,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3719
+   i32.const 3720
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52638,7 +52662,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3720
+   i32.const 3721
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52661,7 +52685,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3723
+   i32.const 3724
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52684,43 +52708,20 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3724
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  call $~lib/math/NativeMath.tan
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 2.2250738585072014e-308
-   call $~lib/bindings/Math/tan
-   f64.const 2.2250738585072014e-308
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3725
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   call $~lib/math/NativeMath.tan
-  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -2.2250738585072014e-308
+   f64.const 2.2250738585072014e-308
    call $~lib/bindings/Math/tan
-   f64.const -2.2250738585072014e-308
+   f64.const 2.2250738585072014e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -52735,15 +52736,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
+  f64.const -2.2250738585072014e-308
   call $~lib/math/NativeMath.tan
-  f64.const 5e-324
+  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 5e-324
+   f64.const -2.2250738585072014e-308
    call $~lib/bindings/Math/tan
-   f64.const 5e-324
+   f64.const -2.2250738585072014e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -52758,15 +52759,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
+  f64.const 5e-324
   call $~lib/math/NativeMath.tan
-  f64.const -5e-324
+  f64.const 5e-324
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -5e-324
+   f64.const 5e-324
    call $~lib/bindings/Math/tan
-   f64.const -5e-324
+   f64.const 5e-324
    f64.const 0
    call $std/math/check<f64>
   else
@@ -52781,6 +52782,29 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -5e-324
+  call $~lib/math/NativeMath.tan
+  f64.const -5e-324
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -5e-324
+   call $~lib/bindings/Math/tan
+   f64.const -5e-324
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3729
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   call $~lib/math/NativeMath.tan
   f64.const 0
@@ -52799,7 +52823,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3729
+   i32.const 3730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52822,7 +52846,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3730
+   i32.const 3731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52845,7 +52869,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3731
+   i32.const 3732
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52868,43 +52892,20 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3732
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507202e-308
-  call $~lib/math/NativeMath.tan
-  f64.const 2.225073858507202e-308
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 2.225073858507202e-308
-   call $~lib/bindings/Math/tan
-   f64.const 2.225073858507202e-308
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
+  f64.const 2.225073858507202e-308
   call $~lib/math/NativeMath.tan
-  f64.const 2.2250738585072024e-308
+  f64.const 2.225073858507202e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 2.2250738585072024e-308
+   f64.const 2.225073858507202e-308
    call $~lib/bindings/Math/tan
-   f64.const 2.2250738585072024e-308
+   f64.const 2.225073858507202e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -52919,15 +52920,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
+  f64.const 2.2250738585072024e-308
   call $~lib/math/NativeMath.tan
-  f64.const 4.4501477170144003e-308
+  f64.const 2.2250738585072024e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 4.4501477170144003e-308
+   f64.const 2.2250738585072024e-308
    call $~lib/bindings/Math/tan
-   f64.const 4.4501477170144003e-308
+   f64.const 2.2250738585072024e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -52942,15 +52943,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
+  f64.const 4.4501477170144003e-308
   call $~lib/math/NativeMath.tan
-  f64.const 4.450147717014403e-308
+  f64.const 4.4501477170144003e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 4.450147717014403e-308
+   f64.const 4.4501477170144003e-308
    call $~lib/bindings/Math/tan
-   f64.const 4.450147717014403e-308
+   f64.const 4.4501477170144003e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -52965,6 +52966,29 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 4.450147717014403e-308
+  call $~lib/math/NativeMath.tan
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const 4.450147717014403e-308
+   call $~lib/bindings/Math/tan
+   f64.const 4.450147717014403e-308
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3737
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4.450147717014406e-308
   call $~lib/math/NativeMath.tan
   f64.const 4.450147717014406e-308
@@ -52983,7 +53007,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3737
+   i32.const 3738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53006,7 +53030,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3738
+   i32.const 3739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53029,7 +53053,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3739
+   i32.const 3740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53052,43 +53076,20 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3740
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  call $~lib/math/NativeMath.tan
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const -2.225073858507202e-308
-   call $~lib/bindings/Math/tan
-   f64.const -2.225073858507202e-308
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072024e-308
+  f64.const -2.225073858507202e-308
   call $~lib/math/NativeMath.tan
-  f64.const -2.2250738585072024e-308
+  f64.const -2.225073858507202e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -2.2250738585072024e-308
+   f64.const -2.225073858507202e-308
    call $~lib/bindings/Math/tan
-   f64.const -2.2250738585072024e-308
+   f64.const -2.225073858507202e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53103,15 +53104,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4501477170144003e-308
+  f64.const -2.2250738585072024e-308
   call $~lib/math/NativeMath.tan
-  f64.const -4.4501477170144003e-308
+  f64.const -2.2250738585072024e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -4.4501477170144003e-308
+   f64.const -2.2250738585072024e-308
    call $~lib/bindings/Math/tan
-   f64.const -4.4501477170144003e-308
+   f64.const -2.2250738585072024e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53126,15 +53127,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014403e-308
+  f64.const -4.4501477170144003e-308
   call $~lib/math/NativeMath.tan
-  f64.const -4.450147717014403e-308
+  f64.const -4.4501477170144003e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -4.450147717014403e-308
+   f64.const -4.4501477170144003e-308
    call $~lib/bindings/Math/tan
-   f64.const -4.450147717014403e-308
+   f64.const -4.4501477170144003e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53149,6 +53150,29 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -4.450147717014403e-308
+  call $~lib/math/NativeMath.tan
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -4.450147717014403e-308
+   call $~lib/bindings/Math/tan
+   f64.const -4.450147717014403e-308
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3745
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -4.450147717014406e-308
   call $~lib/math/NativeMath.tan
   f64.const -4.450147717014406e-308
@@ -53167,7 +53191,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3745
+   i32.const 3746
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53190,7 +53214,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3746
+   i32.const 3747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53213,7 +53237,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3747
+   i32.const 3748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53236,43 +53260,20 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3748
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  call $~lib/math/NativeMath.tan
-  f64.const 1e-323
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const 1e-323
-   call $~lib/bindings/Math/tan
-   f64.const 1e-323
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3749
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
+  f64.const 1e-323
   call $~lib/math/NativeMath.tan
-  f64.const 4.4e-323
+  f64.const 1e-323
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 4.4e-323
+   f64.const 1e-323
    call $~lib/bindings/Math/tan
-   f64.const 4.4e-323
+   f64.const 1e-323
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53287,15 +53288,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
+  f64.const 4.4e-323
   call $~lib/math/NativeMath.tan
-  f64.const 5.562684646268003e-309
+  f64.const 4.4e-323
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 5.562684646268003e-309
+   f64.const 4.4e-323
    call $~lib/bindings/Math/tan
-   f64.const 5.562684646268003e-309
+   f64.const 4.4e-323
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53310,15 +53311,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
+  f64.const 5.562684646268003e-309
   call $~lib/math/NativeMath.tan
-  f64.const 1.1125369292536007e-308
+  f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 1.1125369292536007e-308
+   f64.const 5.562684646268003e-309
    call $~lib/bindings/Math/tan
-   f64.const 1.1125369292536007e-308
+   f64.const 5.562684646268003e-309
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53333,15 +53334,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
+  f64.const 1.1125369292536007e-308
   call $~lib/math/NativeMath.tan
-  f64.const 2.2250738585072004e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 2.2250738585072004e-308
+   f64.const 1.1125369292536007e-308
    call $~lib/bindings/Math/tan
-   f64.const 2.2250738585072004e-308
+   f64.const 1.1125369292536007e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53356,15 +53357,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
+  f64.const 2.2250738585072004e-308
   call $~lib/math/NativeMath.tan
-  f64.const 2.225073858507201e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 2.225073858507201e-308
+   f64.const 2.2250738585072004e-308
    call $~lib/bindings/Math/tan
-   f64.const 2.225073858507201e-308
+   f64.const 2.2250738585072004e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53379,15 +53380,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
+  f64.const 2.225073858507201e-308
   call $~lib/math/NativeMath.tan
-  f64.const -1e-323
+  f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1e-323
+   f64.const 2.225073858507201e-308
    call $~lib/bindings/Math/tan
-   f64.const -1e-323
+   f64.const 2.225073858507201e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53402,15 +53403,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
+  f64.const -1e-323
   call $~lib/math/NativeMath.tan
-  f64.const -4.4e-323
+  f64.const -1e-323
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -4.4e-323
+   f64.const -1e-323
    call $~lib/bindings/Math/tan
-   f64.const -4.4e-323
+   f64.const -1e-323
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53425,15 +53426,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
+  f64.const -4.4e-323
   call $~lib/math/NativeMath.tan
-  f64.const -5.562684646268003e-309
+  f64.const -4.4e-323
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -5.562684646268003e-309
+   f64.const -4.4e-323
    call $~lib/bindings/Math/tan
-   f64.const -5.562684646268003e-309
+   f64.const -4.4e-323
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53448,15 +53449,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
+  f64.const -5.562684646268003e-309
   call $~lib/math/NativeMath.tan
-  f64.const -1.1125369292536007e-308
+  f64.const -5.562684646268003e-309
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -1.1125369292536007e-308
+   f64.const -5.562684646268003e-309
    call $~lib/bindings/Math/tan
-   f64.const -1.1125369292536007e-308
+   f64.const -5.562684646268003e-309
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53471,15 +53472,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
+  f64.const -1.1125369292536007e-308
   call $~lib/math/NativeMath.tan
-  f64.const -2.2250738585072004e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -2.2250738585072004e-308
+   f64.const -1.1125369292536007e-308
    call $~lib/bindings/Math/tan
-   f64.const -2.2250738585072004e-308
+   f64.const -1.1125369292536007e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53494,15 +53495,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
+  f64.const -2.2250738585072004e-308
   call $~lib/math/NativeMath.tan
-  f64.const -2.225073858507201e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -2.225073858507201e-308
+   f64.const -2.2250738585072004e-308
    call $~lib/bindings/Math/tan
-   f64.const -2.225073858507201e-308
+   f64.const -2.2250738585072004e-308
    f64.const 0
    call $std/math/check<f64>
   else
@@ -53517,22 +53518,32 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
+  f64.const -2.225073858507201e-308
   call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -2.225073858507201e-308
+   call $~lib/bindings/Math/tan
+   f64.const -2.225073858507201e-308
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 3763
+   i32.const 3761
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
+  f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
+  f64.const 2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53543,9 +53554,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6875
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const 0.6875
+  f64.const -2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53556,9 +53567,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6875
+  f64.const 0.6875
   call $~lib/math/NativeMath.tan
-  f64.const -0.6875
+  f64.const 0.6875
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53569,9 +53580,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.39269908169872414
+  f64.const -0.6875
   call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
+  f64.const -0.6875
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53582,9 +53593,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6743358
+  f64.const 0.39269908169872414
   call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
+  f64.const 0.39269908169872414
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53595,9 +53606,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
+  f64.const 0.6743358
   call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const 0.6743358
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53608,9 +53619,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const 3.725290298461914e-09
   call $~lib/math/NativeMath.tan
-  f64.const 1.5707963267948966
+  f64.const 3.725290298461914e-09
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53621,22 +53632,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 1.5707963267948966
   call $~lib/math/NativeMath.tan
-  f64.const 0.5
+  f64.const 1.5707963267948966
   call $~lib/bindings/Math/tan
   f64.ne
   if
    i32.const 0
    i32.const 1056
-   i32.const 3772
+   i32.const 3771
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.107148717794091
+  f64.const 0.5
   call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53647,9 +53658,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.497787143782138
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  f64.const 5.497787143782138
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53660,9 +53671,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7.0685834705770345
+  f64.const 5.497787143782138
   call $~lib/math/NativeMath.tan
-  f64.const 7.0685834705770345
+  f64.const 5.497787143782138
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53673,9 +53684,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647099.3291652855
+  f64.const 7.0685834705770345
   call $~lib/math/NativeMath.tan
-  f64.const 1647099.3291652855
+  f64.const 7.0685834705770345
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53686,9 +53697,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647097.7583689587
+  f64.const 1647099.3291652855
   call $~lib/math/NativeMath.tan
-  f64.const 1647097.7583689587
+  f64.const 1647099.3291652855
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53699,9 +53710,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1329227995784915872903807e12
+  f64.const 1647097.7583689587
   call $~lib/math/NativeMath.tan
-  f64.const 1329227995784915872903807e12
+  f64.const 1647097.7583689587
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53712,9 +53723,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1329227995784915872903807e12
+  f64.const 1329227995784915872903807e12
   call $~lib/math/NativeMath.tan
-  f64.const -1329227995784915872903807e12
+  f64.const 1329227995784915872903807e12
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -53725,6 +53736,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1329227995784915872903807e12
+  call $~lib/math/NativeMath.tan
+  f64.const -1329227995784915872903807e12
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3780
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   call $~lib/math/NativeMath.tan
   f64.const 0
@@ -53743,7 +53767,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3782
+   i32.const 3783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53766,7 +53790,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3783
+   i32.const 3784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53789,7 +53813,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3784
+   i32.const 3785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53812,7 +53836,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3785
+   i32.const 3786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53835,7 +53859,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3786
+   i32.const 3787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53849,7 +53873,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3795
+   i32.const 3796
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53863,7 +53887,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3796
+   i32.const 3797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53877,7 +53901,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3797
+   i32.const 3798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53891,7 +53915,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3798
+   i32.const 3799
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53905,7 +53929,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3799
+   i32.const 3800
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53919,7 +53943,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3800
+   i32.const 3801
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53933,7 +53957,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3801
+   i32.const 3802
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53947,7 +53971,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3802
+   i32.const 3803
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53961,7 +53985,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3803
+   i32.const 3804
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53975,7 +53999,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3804
+   i32.const 3805
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53983,20 +54007,6 @@
   f32.const 0
   call $~lib/math/NativeMathf.tan
   f32.const 0
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3807
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  call $~lib/math/NativeMathf.tan
-  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54008,9 +54018,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -0
   call $~lib/math/NativeMathf.tan
-  f32.const nan:0x400000
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54022,7 +54032,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const inf
   call $~lib/math/NativeMathf.tan
   f32.const nan:0x400000
   f32.const 0
@@ -54036,7 +54046,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -inf
   call $~lib/math/NativeMathf.tan
   f32.const nan:0x400000
   f32.const 0
@@ -54050,6 +54060,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
+  call $~lib/math/NativeMathf.tan
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3812
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.862645149230957e-09
   call $~lib/math/NativeMathf.tan
   f32.const 1.862645149230957e-09
@@ -54059,7 +54083,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3814
+   i32.const 3815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54073,28 +54097,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3815
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   call $~lib/math/NativeMathf.tan
-  f32.const -1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54106,9 +54116,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
+  f32.const -1.1754943508222875e-38
   call $~lib/math/NativeMathf.tan
-  f32.const 1.401298464324817e-45
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54120,9 +54130,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   call $~lib/math/NativeMathf.tan
-  f32.const -1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54134,9 +54144,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
+  f32.const -1.401298464324817e-45
   call $~lib/math/NativeMathf.tan
-  f32.const 1.175494490952134e-38
+  f32.const -1.401298464324817e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54148,9 +54158,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
+  f32.const 1.175494490952134e-38
   call $~lib/math/NativeMathf.tan
-  f32.const 1.1754946310819804e-38
+  f32.const 1.175494490952134e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54162,9 +54172,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754946310819804e-38
   call $~lib/math/NativeMathf.tan
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754946310819804e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54176,9 +54186,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509880009953429e-38
   call $~lib/math/NativeMathf.tan
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509880009953429e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54190,6 +54200,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 2.350988701644575e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3824
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   call $~lib/math/NativeMathf.tan
   f32.const 2.3509895424236536e-38
@@ -54199,7 +54223,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3824
+   i32.const 3825
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54213,7 +54237,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3825
+   i32.const 3826
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54227,7 +54251,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3826
+   i32.const 3827
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54241,7 +54265,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3827
+   i32.const 3828
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54255,28 +54279,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3828
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  call $~lib/math/NativeMathf.tan
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3829
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754946310819804e-38
+  f32.const -1.175494490952134e-38
   call $~lib/math/NativeMathf.tan
-  f32.const -1.1754946310819804e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54288,9 +54298,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509880009953429e-38
+  f32.const -1.1754946310819804e-38
   call $~lib/math/NativeMathf.tan
-  f32.const -2.3509880009953429e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54302,9 +54312,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
+  f32.const -2.3509880009953429e-38
   call $~lib/math/NativeMathf.tan
-  f32.const 2.350988701644575e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54316,6 +54326,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 2.350988701644575e-38
+  call $~lib/math/NativeMathf.tan
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3833
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -2.3509895424236536e-38
   call $~lib/math/NativeMathf.tan
   f32.const -2.3509895424236536e-38
@@ -54325,7 +54349,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3833
+   i32.const 3834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54339,7 +54363,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3834
+   i32.const 3835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54353,7 +54377,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3835
+   i32.const 3836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54367,7 +54391,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3836
+   i32.const 3837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54381,28 +54405,14 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3837
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  call $~lib/math/NativeMathf.tan
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 3838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
+  f32.const 2.802596928649634e-45
   call $~lib/math/NativeMathf.tan
-  f32.const 1.2611686178923354e-44
+  f32.const 2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54414,9 +54424,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
+  f32.const 1.2611686178923354e-44
   call $~lib/math/NativeMathf.tan
-  f32.const 2.938735877055719e-39
+  f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54428,9 +54438,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
+  f32.const 2.938735877055719e-39
   call $~lib/math/NativeMathf.tan
-  f32.const 5.877471754111438e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54442,9 +54452,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
+  f32.const 5.877471754111438e-39
   call $~lib/math/NativeMathf.tan
-  f32.const 1.1754940705625946e-38
+  f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54456,9 +54466,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
+  f32.const 1.1754940705625946e-38
   call $~lib/math/NativeMathf.tan
-  f32.const 1.1754942106924411e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54470,9 +54480,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
+  f32.const 1.1754942106924411e-38
   call $~lib/math/NativeMathf.tan
-  f32.const -2.802596928649634e-45
+  f32.const 1.1754942106924411e-38
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54484,9 +54494,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
+  f32.const -2.802596928649634e-45
   call $~lib/math/NativeMathf.tan
-  f32.const -1.2611686178923354e-44
+  f32.const -2.802596928649634e-45
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54498,9 +54508,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
+  f32.const -1.2611686178923354e-44
   call $~lib/math/NativeMathf.tan
-  f32.const -2.938735877055719e-39
+  f32.const -1.2611686178923354e-44
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54512,9 +54522,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
+  f32.const -2.938735877055719e-39
   call $~lib/math/NativeMathf.tan
-  f32.const -5.877471754111438e-39
+  f32.const -2.938735877055719e-39
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -54526,6 +54536,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -5.877471754111438e-39
+  call $~lib/math/NativeMathf.tan
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3848
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.1754940705625946e-38
   call $~lib/math/NativeMathf.tan
   f32.const -1.1754940705625946e-38
@@ -54535,7 +54559,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3848
+   i32.const 3849
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54549,7 +54573,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3849
+   i32.const 3850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54562,7 +54586,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3861
+   i32.const 3862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54575,7 +54599,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3862
+   i32.const 3863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54588,7 +54612,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3863
+   i32.const 3864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54601,7 +54625,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3864
+   i32.const 3865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54614,7 +54638,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3865
+   i32.const 3866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54627,7 +54651,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3866
+   i32.const 3867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54640,7 +54664,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3867
+   i32.const 3868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54653,7 +54677,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3868
+   i32.const 3869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54666,7 +54690,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3869
+   i32.const 3870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54679,26 +54703,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3870
+   i32.const 3871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  f64.const 0
-  call $std/math/test_tanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3873
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
   f64.const 0
   call $std/math/test_tanh
   i32.eqz
@@ -54706,6 +54717,19 @@
    i32.const 0
    i32.const 1056
    i32.const 3874
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_tanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54718,7 +54742,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3875
+   i32.const 3876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54731,7 +54755,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3876
+   i32.const 3877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54744,7 +54768,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3877
+   i32.const 3878
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54757,7 +54781,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3886
+   i32.const 3887
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54770,7 +54794,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3887
+   i32.const 3888
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54783,7 +54807,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3888
+   i32.const 3889
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54796,7 +54820,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3889
+   i32.const 3890
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54809,7 +54833,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3890
+   i32.const 3891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54822,7 +54846,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3891
+   i32.const 3892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54835,7 +54859,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3892
+   i32.const 3893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54848,7 +54872,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3893
+   i32.const 3894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54861,7 +54885,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3894
+   i32.const 3895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54874,26 +54898,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3895
+   i32.const 3896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  call $std/math/test_tanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3898
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   call $std/math/test_tanhf
   i32.eqz
@@ -54901,6 +54912,19 @@
    i32.const 0
    i32.const 1056
    i32.const 3899
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/test_tanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54913,7 +54937,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3900
+   i32.const 3901
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54926,7 +54950,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3901
+   i32.const 3902
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54939,7 +54963,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3902
+   i32.const 3903
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54961,7 +54985,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3914
+   i32.const 3915
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54983,7 +55007,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3915
+   i32.const 3916
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55005,7 +55029,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3916
+   i32.const 3917
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55027,7 +55051,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3917
+   i32.const 3918
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55049,7 +55073,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3918
+   i32.const 3919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55071,7 +55095,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3919
+   i32.const 3920
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55093,7 +55117,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3920
+   i32.const 3921
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55115,7 +55139,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3921
+   i32.const 3922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55137,7 +55161,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3922
+   i32.const 3923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55159,7 +55183,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3923
+   i32.const 3924
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55172,28 +55196,6 @@
    f64.const nan:0x8000000000000
    call $~lib/bindings/Math/trunc
    f64.const nan:0x8000000000000
-   f64.const 0
-   call $std/math/check<f64>
-  else
-   i32.const 0
-  end
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3926
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/check<f64>
-  if (result i32)
-   f64.const inf
-   call $~lib/bindings/Math/trunc
-   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -55208,14 +55210,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -inf
+   f64.const inf
    call $~lib/bindings/Math/trunc
-   f64.const -inf
+   f64.const inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -55230,14 +55232,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const 0
+   f64.const -inf
    call $~lib/bindings/Math/trunc
-   f64.const 0
+   f64.const -inf
    f64.const 0
    call $std/math/check<f64>
   else
@@ -55252,14 +55254,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   f64.const -0
+   f64.const 0
    call $~lib/bindings/Math/trunc
-   f64.const -0
+   f64.const 0
    f64.const 0
    call $std/math/check<f64>
   else
@@ -55274,6 +55276,28 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/check<f64>
+  if (result i32)
+   f64.const -0
+   call $~lib/bindings/Math/trunc
+   f64.const -0
+   f64.const 0
+   call $std/math/check<f64>
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3931
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -55291,7 +55315,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3931
+   i32.const 3932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55313,7 +55337,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3932
+   i32.const 3933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55335,7 +55359,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3933
+   i32.const 3934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55357,7 +55381,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3934
+   i32.const 3935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55379,7 +55403,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3935
+   i32.const 3936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55401,7 +55425,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3936
+   i32.const 3937
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55423,7 +55447,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3937
+   i32.const 3938
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55445,7 +55469,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3938
+   i32.const 3939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55467,7 +55491,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3939
+   i32.const 3940
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55489,26 +55513,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3940
+   i32.const 3941
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8
   f32.const -8
-  f32.const 0
-  call $std/math/check<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 3949
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4
-  f32.const 4
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55520,8 +55531,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -8
-  f32.const -8
+  f32.const 4
+  f32.const 4
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55533,8 +55544,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6
-  f32.const -6
+  f32.const -8
+  f32.const -8
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55546,8 +55557,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 9
-  f32.const 9
+  f32.const -6
+  f32.const -6
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55559,8 +55570,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const 9
+  f32.const 9
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55572,8 +55583,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55585,8 +55596,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55611,8 +55622,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55624,21 +55635,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 3961
+   i32.const 3959
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55650,8 +55661,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55663,8 +55674,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55676,8 +55687,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55689,8 +55700,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55702,8 +55713,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55715,8 +55726,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55728,8 +55739,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55741,8 +55752,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55754,8 +55765,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55767,8 +55778,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55780,8 +55791,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/check<f32>
   i32.eqz
@@ -55793,6 +55804,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/check<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 3974
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
   f32.const 0
   f32.const 0
@@ -55801,7 +55825,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3974
+   i32.const 3975
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55814,7 +55838,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 3975
+   i32.const 3976
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55887,7 +55911,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4016
+   i32.const 4017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55900,7 +55924,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4017
+   i32.const 4018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55913,7 +55937,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4018
+   i32.const 4019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55926,7 +55950,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4019
+   i32.const 4020
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55939,26 +55963,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4020
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.e+60
-  f64.const 1.e+60
-  call $~lib/math/NativeMath.imul
-  f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 4021
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+60
-  f64.const -1.e+60
+  f64.const 1.e+60
   call $~lib/math/NativeMath.imul
   f64.const 0
   f64.ne
@@ -55970,7 +55981,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.e+60
+  f64.const 1.e+60
   f64.const -1.e+60
   call $~lib/math/NativeMath.imul
   f64.const 0
@@ -55983,6 +55994,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1.e+60
+  f64.const -1.e+60
+  call $~lib/math/NativeMath.imul
+  f64.const 0
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4024
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.e+24
   f64.const 100
   call $~lib/math/NativeMath.imul
@@ -55991,7 +56015,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4024
+   i32.const 4025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56004,7 +56028,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4025
+   i32.const 4026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56017,7 +56041,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4026
+   i32.const 4027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56030,7 +56054,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4027
+   i32.const 4028
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56043,26 +56067,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4050
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i64.const 1
-  call $~lib/math/ipow64
-  i64.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 4051
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
-  i64.const 2
+  i64.const 1
   call $~lib/math/ipow64
   i64.eqz
   i32.eqz
@@ -56075,7 +56086,7 @@
    unreachable
   end
   i64.const 0
-  i64.const 3
+  i64.const 2
   call $~lib/math/ipow64
   i64.eqz
   i32.eqz
@@ -56087,21 +56098,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 1
   i64.const 0
+  i64.const 3
   call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
+  i64.eqz
+  i32.eqz
   if
    i32.const 0
    i32.const 1056
-   i32.const 4055
+   i32.const 4054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
-  i64.const 1
+  i64.const 0
   call $~lib/math/ipow64
   i64.const 1
   i64.ne
@@ -56114,7 +56125,7 @@
    unreachable
   end
   i64.const 1
-  i64.const 2
+  i64.const 1
   call $~lib/math/ipow64
   i64.const 1
   i64.ne
@@ -56127,7 +56138,7 @@
    unreachable
   end
   i64.const 1
-  i64.const 3
+  i64.const 2
   call $~lib/math/ipow64
   i64.const 1
   i64.ne
@@ -56135,6 +56146,19 @@
    i32.const 0
    i32.const 1056
    i32.const 4058
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i64.const 3
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4059
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56147,7 +56171,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4060
+   i32.const 4061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56160,7 +56184,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4061
+   i32.const 4062
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56173,7 +56197,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4062
+   i32.const 4063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56186,7 +56210,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4063
+   i32.const 4064
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56199,7 +56223,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4065
+   i32.const 4066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56212,7 +56236,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4066
+   i32.const 4067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56225,7 +56249,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4067
+   i32.const 4068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56238,7 +56262,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4068
+   i32.const 4069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56251,7 +56275,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4070
+   i32.const 4071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56264,7 +56288,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4071
+   i32.const 4072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56277,7 +56301,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4072
+   i32.const 4073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56290,7 +56314,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4073
+   i32.const 4074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56303,7 +56327,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4075
+   i32.const 4076
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56316,7 +56340,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4076
+   i32.const 4077
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56329,7 +56353,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4077
+   i32.const 4078
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56342,7 +56366,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4078
+   i32.const 4079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56355,7 +56379,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4079
+   i32.const 4080
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56368,7 +56392,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4081
+   i32.const 4082
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56381,7 +56405,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4082
+   i32.const 4083
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56394,7 +56418,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4083
+   i32.const 4084
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56407,7 +56431,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4084
+   i32.const 4085
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56420,7 +56444,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4090
+   i32.const 4091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56433,7 +56457,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4091
+   i32.const 4092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56446,7 +56470,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4092
+   i32.const 4093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56459,7 +56483,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4093
+   i32.const 4094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56472,7 +56496,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4094
+   i32.const 4095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56485,24 +56509,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4095
+   i32.const 4096
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 0
   i32.const -2
-  call $~lib/math/ipow32
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4097
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  i32.const -1
   call $~lib/math/ipow32
   if
    i32.const 0
@@ -56513,31 +56526,29 @@
    unreachable
   end
   i32.const 0
+  i32.const -1
+  call $~lib/math/ipow32
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4099
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
   i32.const 2
   call $~lib/math/ipow32
   if
    i32.const 0
    i32.const 1056
-   i32.const 4101
+   i32.const 4102
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1
   i32.const -2
-  call $~lib/math/ipow32
-  i32.const 1
-  i32.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4103
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  i32.const -1
   call $~lib/math/ipow32
   i32.const 1
   i32.ne
@@ -56550,6 +56561,19 @@
    unreachable
   end
   i32.const 1
+  i32.const -1
+  call $~lib/math/ipow32
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4105
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
   i32.const 2
   call $~lib/math/ipow32
   i32.const 1
@@ -56557,7 +56581,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4107
+   i32.const 4108
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56571,7 +56595,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4109
+   i32.const 4110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56585,7 +56609,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4110
+   i32.const 4111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56600,7 +56624,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4111
+   i32.const 4112
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56613,7 +56637,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4112
+   i32.const 4113
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56628,7 +56652,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4113
+   i32.const 4114
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56641,7 +56665,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4115
+   i32.const 4116
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56654,7 +56678,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4116
+   i32.const 4117
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56667,7 +56691,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4117
+   i32.const 4118
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56680,7 +56704,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4118
+   i32.const 4119
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56693,7 +56717,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4119
+   i32.const 4120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56706,7 +56730,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4120
+   i32.const 4121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56715,19 +56739,6 @@
   i64.const 8
   call $~lib/math/ipow64
   i64.const -15762478437236735
-  i64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4121
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 61731
-  i64.const 4
-  call $~lib/math/ipow64
-  i64.const -3925184889716469295
   i64.ne
   if
    i32.const 0
@@ -56750,6 +56761,19 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const 61731
+  i64.const 4
+  call $~lib/math/ipow64
+  i64.const -3925184889716469295
+  i64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4124
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 57055
   i64.const 3
   call $~lib/math/ipow64
@@ -56764,7 +56788,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4125
+   i32.const 4126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56781,7 +56805,7 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4126
+   i32.const 4127
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56790,24 +56814,24 @@
   f64.const 0.5
   call $~lib/math/NativeMath.pow
   f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
-   i32.const 4128
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0
   f64.ne
   if
    i32.const 0
    i32.const 1056
    i32.const 4129
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0.5
+  call $~lib/math/NativeMath.pow
+  f64.const 0
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4130
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56820,26 +56844,13 @@
   if
    i32.const 0
    i32.const 1056
-   i32.const 4130
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 1056
    i32.const 4131
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const 0
+  f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
   f64.ne
@@ -56847,6 +56858,19 @@
    i32.const 0
    i32.const 1056
    i32.const 4132
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  call $~lib/math/NativeMath.pow
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 1056
+   i32.const 4133
    i32.const 1
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -8870,7 +8870,7 @@
   if
    i32.const 0
    i32.const 14400
-   i32.const 1419
+   i32.const 1421
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.ts
+++ b/tests/compiler/std/math.ts
@@ -351,6 +351,7 @@ assert(test_acosh(NaN, NaN, 0.0, 0));
 assert(test_acosh(Infinity, Infinity, 0.0, 0));
 assert(test_acosh(1.0, 0.0, 0.0, 0));
 assert(test_acosh(0.99999237060546875, NaN, 0.0, INVALID));
+assert(test_acosh(-9784.8207664738350, NaN, 0.0, INVALID));
 assert(test_acosh(0.0, NaN, 0.0, INVALID));
 assert(test_acosh(-0.0, NaN, 0.0, INVALID));
 assert(test_acosh(-Infinity, NaN, 0.0, INVALID));

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -1618,14 +1618,28 @@
  )
  (func $~lib/math/NativeMath.acosh (param $0 f64) (result f64)
   (local $1 i64)
+  (local $2 i64)
   local.get $0
   i64.reinterpret_f64
+  local.set $1
+  local.get $1
+  i64.const 4607182418800017408
+  i64.lt_s
+  if
+   local.get $0
+   local.get $0
+   f64.sub
+   f64.const 0
+   f64.div
+   return
+  end
+  local.get $1
   i64.const 52
   i64.shr_u
   i64.const 2047
   i64.and
-  local.set $1
-  local.get $1
+  local.set $2
+  local.get $2
   i64.const 1023
   i64.const 1
   i64.add
@@ -1652,7 +1666,7 @@
    call $~lib/math/NativeMath.log1p
    return
   end
-  local.get $1
+  local.get $2
   i64.const 1023
   i64.const 26
   i64.add
@@ -11428,7 +11442,7 @@
   if
    i32.const 0
    i32.const 13376
-   i32.const 1417
+   i32.const 1419
    i32.const 5
    call $~lib/builtins/abort
    unreachable
@@ -18828,7 +18842,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -9784.820766473835
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -18842,7 +18856,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -18852,6 +18866,20 @@
    i32.const 0
    i32.const 32
    i32.const 355
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_acosh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 356
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18866,7 +18894,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 356
+   i32.const 357
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18880,7 +18908,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 372
+   i32.const 373
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18894,7 +18922,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 374
+   i32.const 375
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18908,7 +18936,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 375
+   i32.const 376
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18922,7 +18950,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 384
+   i32.const 385
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18936,7 +18964,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 385
+   i32.const 386
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18950,7 +18978,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 386
+   i32.const 387
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18964,7 +18992,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 387
+   i32.const 388
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18978,7 +19006,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 388
+   i32.const 389
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -18992,7 +19020,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 389
+   i32.const 390
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19006,7 +19034,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 390
+   i32.const 391
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19020,7 +19048,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 391
+   i32.const 392
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19034,7 +19062,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 392
+   i32.const 393
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19048,27 +19076,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 393
+   i32.const 394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_acoshf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 396
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_acoshf
@@ -19077,6 +19091,20 @@
    i32.const 0
    i32.const 32
    i32.const 397
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_acoshf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 398
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19090,7 +19118,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 398
+   i32.const 399
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19104,7 +19132,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 399
+   i32.const 400
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19118,7 +19146,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 400
+   i32.const 401
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19132,7 +19160,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 401
+   i32.const 402
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19147,7 +19175,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 402
+   i32.const 403
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19161,7 +19189,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 403
+   i32.const 404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19175,7 +19203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 415
+   i32.const 416
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19189,7 +19217,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 416
+   i32.const 417
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19203,7 +19231,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 417
+   i32.const 418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19217,7 +19245,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 418
+   i32.const 419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19231,7 +19259,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 419
+   i32.const 420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19245,7 +19273,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 420
+   i32.const 421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19259,7 +19287,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 421
+   i32.const 422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19273,7 +19301,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 422
+   i32.const 423
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19287,7 +19315,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 423
+   i32.const 424
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19301,7 +19329,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 424
+   i32.const 425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19315,7 +19343,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 427
+   i32.const 428
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19329,27 +19357,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 428
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_asin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 429
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_asin
@@ -19358,6 +19372,20 @@
    i32.const 0
    i32.const 32
    i32.const 430
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_asin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19371,26 +19399,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 431
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.0000000000000002
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_asin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 432
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1.0000000000000002
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -19405,7 +19419,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -19419,6 +19432,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_asin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 435
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -19428,7 +19456,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 435
+   i32.const 436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19442,7 +19470,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 436
+   i32.const 437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19456,7 +19484,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 445
+   i32.const 446
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19470,7 +19498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 446
+   i32.const 447
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19484,7 +19512,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 447
+   i32.const 448
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19498,7 +19526,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 448
+   i32.const 449
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19512,7 +19540,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 449
+   i32.const 450
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19526,7 +19554,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 450
+   i32.const 451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19540,7 +19568,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 451
+   i32.const 452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19554,7 +19582,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 452
+   i32.const 453
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19568,7 +19596,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 453
+   i32.const 454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19582,7 +19610,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 454
+   i32.const 455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19596,7 +19624,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 457
+   i32.const 458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19610,27 +19638,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 458
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_asinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_asinf
@@ -19639,6 +19653,20 @@
    i32.const 0
    i32.const 32
    i32.const 460
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19652,26 +19680,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 461
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.0000001192092896
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_asinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1.0000001192092896
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -19686,7 +19700,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -19700,6 +19713,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_asinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 465
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -19709,7 +19737,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 465
+   i32.const 466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19723,7 +19751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 466
+   i32.const 467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19737,7 +19765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 478
+   i32.const 479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19751,7 +19779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 479
+   i32.const 480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19765,7 +19793,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 480
+   i32.const 481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19779,7 +19807,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 481
+   i32.const 482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19793,7 +19821,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 482
+   i32.const 483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19807,7 +19835,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 483
+   i32.const 484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19821,7 +19849,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 484
+   i32.const 485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19835,7 +19863,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 485
+   i32.const 486
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19849,7 +19877,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 486
+   i32.const 487
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19863,27 +19891,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 487
+   i32.const 488
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_asinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 490
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_asinh
@@ -19897,9 +19911,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_asinh
@@ -19912,6 +19924,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_asinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 493
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -19921,7 +19949,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 493
+   i32.const 494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19935,7 +19963,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 494
+   i32.const 495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19949,7 +19977,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 523
+   i32.const 524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19963,7 +19991,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 524
+   i32.const 525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19977,7 +20005,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 525
+   i32.const 526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -19991,7 +20019,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 526
+   i32.const 527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20005,7 +20033,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 527
+   i32.const 528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20019,7 +20047,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 528
+   i32.const 529
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20033,7 +20061,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 529
+   i32.const 530
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20047,7 +20075,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 530
+   i32.const 531
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20061,7 +20089,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 531
+   i32.const 532
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20075,27 +20103,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 532
+   i32.const 533
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_asinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 535
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_asinhf
@@ -20109,9 +20123,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_asinhf
@@ -20124,6 +20136,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_asinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 538
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
   f32.const 0
   f32.const 0
@@ -20133,7 +20161,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 538
+   i32.const 539
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20147,7 +20175,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 539
+   i32.const 540
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20161,7 +20189,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 551
+   i32.const 552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20175,7 +20203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 552
+   i32.const 553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20189,7 +20217,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 553
+   i32.const 554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20203,7 +20231,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 554
+   i32.const 555
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20217,7 +20245,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 555
+   i32.const 556
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20231,7 +20259,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 556
+   i32.const 557
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20245,7 +20273,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 557
+   i32.const 558
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20259,7 +20287,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 558
+   i32.const 559
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20273,7 +20301,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 559
+   i32.const 560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20287,27 +20315,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 560
+   i32.const 561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_atan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 563
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_atan
@@ -20316,6 +20330,20 @@
    i32.const 0
    i32.const 32
    i32.const 564
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_atan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20329,7 +20357,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 565
+   i32.const 566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20343,7 +20371,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 566
+   i32.const 567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20357,7 +20385,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 567
+   i32.const 568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20372,7 +20400,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 568
+   i32.const 569
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20386,7 +20414,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20400,7 +20428,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 570
+   i32.const 571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20414,7 +20442,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 579
+   i32.const 580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20428,7 +20456,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 580
+   i32.const 581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20442,7 +20470,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 581
+   i32.const 582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20456,7 +20484,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 582
+   i32.const 583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20470,7 +20498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 583
+   i32.const 584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20484,7 +20512,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 584
+   i32.const 585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20498,7 +20526,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 585
+   i32.const 586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20512,7 +20540,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 586
+   i32.const 587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20526,7 +20554,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 587
+   i32.const 588
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20540,27 +20568,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 588
+   i32.const 589
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_atanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 591
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_atanf
@@ -20569,6 +20583,20 @@
    i32.const 0
    i32.const 32
    i32.const 592
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_atanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20582,7 +20610,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 594
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20596,7 +20624,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 594
+   i32.const 595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20610,7 +20638,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 595
+   i32.const 596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20625,7 +20653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 596
+   i32.const 597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20639,7 +20667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 597
+   i32.const 598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20653,7 +20681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 609
+   i32.const 610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20667,7 +20695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 610
+   i32.const 611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20681,7 +20709,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 611
+   i32.const 612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20695,7 +20723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 612
+   i32.const 613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20709,7 +20737,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 613
+   i32.const 614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20723,7 +20751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 614
+   i32.const 615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20737,7 +20765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 615
+   i32.const 616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20751,7 +20779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 616
+   i32.const 617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20765,7 +20793,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 617
+   i32.const 618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20779,7 +20807,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 618
+   i32.const 619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20793,7 +20821,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 621
+   i32.const 622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20807,7 +20835,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 622
+   i32.const 623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20822,27 +20850,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 623
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_atanh
@@ -20851,6 +20865,20 @@
    i32.const 0
    i32.const 32
    i32.const 625
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20864,7 +20892,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 626
+   i32.const 627
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20879,7 +20907,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 627
+   i32.const 628
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20893,7 +20921,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 628
+   i32.const 629
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20907,27 +20935,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 629
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.3552527156068805e-20
-  f64.const 1.3552527156068805e-20
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_atanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 630
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 9.332636185032189e-302
-  f64.const 9.332636185032189e-302
+  f64.const 1.3552527156068805e-20
+  f64.const 1.3552527156068805e-20
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_atanh
@@ -20940,12 +20954,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const 9.332636185032189e-302
+  f64.const 9.332636185032189e-302
   f64.const 0
   global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
   call $std/math/test_atanh
   i32.eqz
   if
@@ -20956,8 +20968,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -20972,6 +20984,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_atanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 634
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 8988465674311579538646525e283
   f64.const nan:0x8000000000000
   f64.const 0
@@ -20981,7 +21009,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 634
+   i32.const 635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -20995,7 +21023,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 643
+   i32.const 644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21009,7 +21037,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 644
+   i32.const 645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21023,7 +21051,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 645
+   i32.const 646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21037,7 +21065,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 646
+   i32.const 647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21051,7 +21079,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 647
+   i32.const 648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21065,7 +21093,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 648
+   i32.const 649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21079,7 +21107,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 649
+   i32.const 650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21093,7 +21121,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 650
+   i32.const 651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21107,7 +21135,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 651
+   i32.const 652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21121,7 +21149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 652
+   i32.const 653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21135,7 +21163,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 655
+   i32.const 656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21149,7 +21177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 656
+   i32.const 657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21164,27 +21192,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 657
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_atanhf
@@ -21193,6 +21207,20 @@
    i32.const 0
    i32.const 32
    i32.const 659
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 660
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21206,7 +21234,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 660
+   i32.const 661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21221,7 +21249,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 661
+   i32.const 662
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21235,7 +21263,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 662
+   i32.const 663
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21249,27 +21277,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 663
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.3552527156068805e-20
-  f32.const 1.3552527156068805e-20
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_atanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 664
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 7.888609052210118e-31
-  f32.const 7.888609052210118e-31
+  f32.const 1.3552527156068805e-20
+  f32.const 1.3552527156068805e-20
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_atanhf
@@ -21282,12 +21296,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const 7.888609052210118e-31
+  f32.const 7.888609052210118e-31
   f32.const 0
   global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
   call $std/math/test_atanhf
   i32.eqz
   if
@@ -21298,8 +21310,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -21314,6 +21326,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_atanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 668
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1701411834604692317316873e14
   f32.const nan:0x400000
   f32.const 0
@@ -21323,7 +21351,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 668
+   i32.const 669
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21338,7 +21366,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 680
+   i32.const 681
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21353,7 +21381,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 681
+   i32.const 682
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21368,7 +21396,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 682
+   i32.const 683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21383,7 +21411,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 683
+   i32.const 684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21398,7 +21426,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 684
+   i32.const 685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21413,7 +21441,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 685
+   i32.const 686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21428,7 +21456,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 686
+   i32.const 687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21443,7 +21471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 687
+   i32.const 688
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21458,7 +21486,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 688
+   i32.const 689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21473,7 +21501,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 689
+   i32.const 690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21488,28 +21516,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 692
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const 3.141592653589793
-  f64.const -0.27576595544815063
-  global.get $std/math/INEXACT
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 693
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const -1
+  f64.const -0
   f64.const 3.141592653589793
   f64.const -0.27576595544815063
   global.get $std/math/INEXACT
@@ -21524,8 +21537,7 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.neg
+  f64.const -1
   f64.const 3.141592653589793
   f64.const -0.27576595544815063
   global.get $std/math/INEXACT
@@ -21540,6 +21552,22 @@
    unreachable
   end
   f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const 3.141592653589793
+  f64.const -0.27576595544815063
+  global.get $std/math/INEXACT
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 696
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
   f64.const 1
   f64.const 0
   f64.const 0
@@ -21549,7 +21577,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 696
+   i32.const 697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21564,7 +21592,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 697
+   i32.const 698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21579,28 +21607,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 698
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const -3.141592653589793
-  f64.const 0.27576595544815063
-  global.get $std/math/INEXACT
-  call $std/math/test_atan2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 699
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  f64.const -1
+  f64.const -0
   f64.const -3.141592653589793
   f64.const 0.27576595544815063
   global.get $std/math/INEXACT
@@ -21615,8 +21628,7 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
-  f64.neg
+  f64.const -1
   f64.const -3.141592653589793
   f64.const 0.27576595544815063
   global.get $std/math/INEXACT
@@ -21631,10 +21643,11 @@
    unreachable
   end
   f64.const -0
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
+  f64.const inf
+  f64.neg
+  f64.const -3.141592653589793
+  f64.const 0.27576595544815063
+  global.get $std/math/INEXACT
   call $std/math/test_atan2
   i32.eqz
   if
@@ -21646,7 +21659,7 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
+  f64.const 1
   f64.const -0
   f64.const 0
   i32.const 0
@@ -21660,11 +21673,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0
+  f64.const inf
+  f64.const -0
   f64.const 0
-  f64.const -1.5707963267948966
-  f64.const 0.27576595544815063
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_atan2
   i32.eqz
   if
@@ -21676,7 +21689,7 @@
    unreachable
   end
   f64.const -1
-  f64.const -0
+  f64.const 0
   f64.const -1.5707963267948966
   f64.const 0.27576595544815063
   global.get $std/math/INEXACT
@@ -21690,6 +21703,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const -0
+  f64.const -1.5707963267948966
+  f64.const 0.27576595544815063
+  global.get $std/math/INEXACT
+  call $std/math/test_atan2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 706
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 0
   f64.const 1.5707963267948966
@@ -21700,7 +21728,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 706
+   i32.const 707
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21715,7 +21743,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 707
+   i32.const 708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21730,7 +21758,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 708
+   i32.const 709
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21745,7 +21773,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 709
+   i32.const 710
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21761,7 +21789,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 710
+   i32.const 711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21777,7 +21805,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 711
+   i32.const 712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21792,7 +21820,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 712
+   i32.const 713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21808,7 +21836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 713
+   i32.const 714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21823,7 +21851,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 714
+   i32.const 715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21839,7 +21867,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 715
+   i32.const 716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21855,7 +21883,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 716
+   i32.const 717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21872,7 +21900,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 717
+   i32.const 718
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21889,7 +21917,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 718
+   i32.const 719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21906,7 +21934,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 719
+   i32.const 720
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21923,7 +21951,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 720
+   i32.const 721
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21938,7 +21966,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 721
+   i32.const 722
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21953,7 +21981,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 730
+   i32.const 731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21968,7 +21996,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 731
+   i32.const 732
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21983,7 +22011,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 732
+   i32.const 733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -21998,7 +22026,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 733
+   i32.const 734
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22013,7 +22041,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 734
+   i32.const 735
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22028,7 +22056,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 735
+   i32.const 736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22043,7 +22071,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 736
+   i32.const 737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22058,7 +22086,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 737
+   i32.const 738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22073,7 +22101,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 738
+   i32.const 739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22088,7 +22116,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 739
+   i32.const 740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22103,28 +22131,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 742
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const 3.1415927410125732
-  f32.const 0.3666777014732361
-  global.get $std/math/INEXACT
-  call $std/math/test_atan2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 743
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const -1
+  f32.const -0
   f32.const 3.1415927410125732
   f32.const 0.3666777014732361
   global.get $std/math/INEXACT
@@ -22139,8 +22152,7 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.neg
+  f32.const -1
   f32.const 3.1415927410125732
   f32.const 0.3666777014732361
   global.get $std/math/INEXACT
@@ -22155,6 +22167,22 @@
    unreachable
   end
   f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const 3.1415927410125732
+  f32.const 0.3666777014732361
+  global.get $std/math/INEXACT
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 746
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
   f32.const 1
   f32.const 0
   f32.const 0
@@ -22164,7 +22192,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 746
+   i32.const 747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22179,7 +22207,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 747
+   i32.const 748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22194,28 +22222,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 748
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const -3.1415927410125732
-  f32.const -0.3666777014732361
-  global.get $std/math/INEXACT
-  call $std/math/test_atan2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 749
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0
-  f32.const -1
+  f32.const -0
   f32.const -3.1415927410125732
   f32.const -0.3666777014732361
   global.get $std/math/INEXACT
@@ -22230,8 +22243,7 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
-  f32.neg
+  f32.const -1
   f32.const -3.1415927410125732
   f32.const -0.3666777014732361
   global.get $std/math/INEXACT
@@ -22246,10 +22258,11 @@
    unreachable
   end
   f32.const -0
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
+  f32.const inf
+  f32.neg
+  f32.const -3.1415927410125732
+  f32.const -0.3666777014732361
+  global.get $std/math/INEXACT
   call $std/math/test_atan2f
   i32.eqz
   if
@@ -22261,7 +22274,7 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
+  f32.const 1
   f32.const -0
   f32.const 0
   i32.const 0
@@ -22275,11 +22288,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const -0
+  f32.const inf
+  f32.const -0
   f32.const 0
-  f32.const -1.5707963705062866
-  f32.const -0.3666777014732361
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_atan2f
   i32.eqz
   if
@@ -22291,7 +22304,7 @@
    unreachable
   end
   f32.const -1
-  f32.const -0
+  f32.const 0
   f32.const -1.5707963705062866
   f32.const -0.3666777014732361
   global.get $std/math/INEXACT
@@ -22305,6 +22318,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
+  f32.const -0
+  f32.const -1.5707963705062866
+  f32.const -0.3666777014732361
+  global.get $std/math/INEXACT
+  call $std/math/test_atan2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 756
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 0
   f32.const 1.5707963705062866
@@ -22315,7 +22343,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 756
+   i32.const 757
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22330,7 +22358,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 757
+   i32.const 758
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22345,7 +22373,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 758
+   i32.const 759
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22360,7 +22388,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 759
+   i32.const 760
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22376,7 +22404,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 760
+   i32.const 761
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22392,7 +22420,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 761
+   i32.const 762
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22407,7 +22435,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 762
+   i32.const 763
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22423,7 +22451,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 763
+   i32.const 764
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22438,7 +22466,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 764
+   i32.const 765
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22454,7 +22482,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 765
+   i32.const 766
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22470,7 +22498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 766
+   i32.const 767
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22487,7 +22515,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 767
+   i32.const 768
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22504,7 +22532,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 768
+   i32.const 769
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22521,7 +22549,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 769
+   i32.const 770
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22535,7 +22563,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 781
+   i32.const 782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22549,7 +22577,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 782
+   i32.const 783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22563,7 +22591,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 783
+   i32.const 784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22577,7 +22605,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 784
+   i32.const 785
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22591,7 +22619,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 785
+   i32.const 786
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22605,7 +22633,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 786
+   i32.const 787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22619,7 +22647,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 787
+   i32.const 788
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22633,7 +22661,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 788
+   i32.const 789
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22647,7 +22675,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 789
+   i32.const 790
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22661,27 +22689,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 790
+   i32.const 791
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 793
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_cbrt
@@ -22695,9 +22709,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_cbrt
@@ -22710,6 +22722,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const 0
+  i32.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 796
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -22719,7 +22747,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 796
+   i32.const 797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22733,7 +22761,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 797
+   i32.const 798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22747,7 +22775,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 798
+   i32.const 799
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22761,27 +22789,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 799
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_cbrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 800
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_cbrt
@@ -22790,6 +22804,20 @@
    i32.const 0
    i32.const 32
    i32.const 801
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_cbrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 802
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22803,7 +22831,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 802
+   i32.const 803
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22817,7 +22845,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 811
+   i32.const 812
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22831,7 +22859,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 812
+   i32.const 813
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22845,7 +22873,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 813
+   i32.const 814
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22859,7 +22887,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 814
+   i32.const 815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22873,7 +22901,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 815
+   i32.const 816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22887,7 +22915,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 816
+   i32.const 817
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22901,7 +22929,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 817
+   i32.const 818
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22915,7 +22943,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 818
+   i32.const 819
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22929,7 +22957,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 819
+   i32.const 820
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -22943,27 +22971,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 820
+   i32.const 821
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 823
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_cbrtf
@@ -22977,9 +22991,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_cbrtf
@@ -22992,6 +23004,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const 0
+  i32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 826
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
   f32.const 0
   f32.const 0
@@ -23001,7 +23029,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 826
+   i32.const 827
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23015,7 +23043,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 827
+   i32.const 828
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23029,7 +23057,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 828
+   i32.const 829
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23043,27 +23071,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 829
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_cbrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 830
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_cbrtf
@@ -23072,6 +23086,20 @@
    i32.const 0
    i32.const 32
    i32.const 831
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_cbrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23085,7 +23113,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 832
+   i32.const 833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23099,7 +23127,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 844
+   i32.const 845
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23113,7 +23141,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 845
+   i32.const 846
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23127,7 +23155,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 846
+   i32.const 847
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23141,7 +23169,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 847
+   i32.const 848
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23155,7 +23183,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 848
+   i32.const 849
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23169,7 +23197,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 849
+   i32.const 850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23183,26 +23211,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 850
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5617597462207241
-  f64.const 1
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 851
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.7741522965913037
+  f64.const 0.5617597462207241
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -23216,8 +23230,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6787637026394024
-  f64.const -0
+  f64.const 0.7741522965913037
+  f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_ceil
@@ -23230,22 +23244,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.6787637026394024
+  f64.const -0
   f64.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
   call $std/math/test_ceil
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 856
+   i32.const 854
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23259,9 +23273,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23274,8 +23286,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23288,8 +23302,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23302,6 +23316,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 861
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -23311,7 +23339,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 861
+   i32.const 862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23325,7 +23353,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 862
+   i32.const 863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23339,7 +23367,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 863
+   i32.const 864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23353,7 +23381,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 864
+   i32.const 865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23367,7 +23395,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 865
+   i32.const 866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23381,7 +23409,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 866
+   i32.const 867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23395,7 +23423,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 867
+   i32.const 868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23409,7 +23437,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 868
+   i32.const 869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23423,7 +23451,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 869
+   i32.const 870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23437,27 +23465,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 870
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23471,9 +23485,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23486,8 +23498,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23500,8 +23514,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23514,6 +23528,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 876
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -23523,7 +23551,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 876
+   i32.const 877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23537,7 +23565,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 877
+   i32.const 878
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23551,7 +23579,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 878
+   i32.const 879
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23565,7 +23593,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 879
+   i32.const 880
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23579,7 +23607,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 880
+   i32.const 881
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23593,7 +23621,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 881
+   i32.const 882
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23607,7 +23635,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 882
+   i32.const 883
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23621,7 +23649,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 883
+   i32.const 884
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23635,7 +23663,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 884
+   i32.const 885
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23649,27 +23677,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 885
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_ceil
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 886
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23683,9 +23697,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23698,8 +23710,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23712,8 +23726,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_ceil
@@ -23726,6 +23740,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_ceil
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 891
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -23735,7 +23763,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 891
+   i32.const 892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23749,7 +23777,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 892
+   i32.const 893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23763,7 +23791,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 893
+   i32.const 894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23777,7 +23805,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 894
+   i32.const 895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23791,7 +23819,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 895
+   i32.const 896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23805,7 +23833,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 896
+   i32.const 897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23819,7 +23847,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 897
+   i32.const 898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23833,7 +23861,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 898
+   i32.const 899
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23847,7 +23875,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 899
+   i32.const 900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23861,7 +23889,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 900
+   i32.const 901
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23875,7 +23903,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 909
+   i32.const 910
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23889,7 +23917,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 910
+   i32.const 911
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23903,7 +23931,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 911
+   i32.const 912
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23917,7 +23945,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 912
+   i32.const 913
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23931,7 +23959,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 913
+   i32.const 914
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23945,7 +23973,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 914
+   i32.const 915
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23959,7 +23987,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 915
+   i32.const 916
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23973,7 +24001,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 916
+   i32.const 917
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -23987,7 +24015,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 917
+   i32.const 918
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24001,27 +24029,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 918
+   i32.const 919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 921
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24035,9 +24049,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24050,8 +24062,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24064,8 +24078,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24078,6 +24092,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 926
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 1
   f32.const 0
@@ -24087,7 +24115,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 926
+   i32.const 927
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24101,7 +24129,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 927
+   i32.const 928
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24115,7 +24143,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 928
+   i32.const 929
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24129,7 +24157,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 929
+   i32.const 930
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24143,7 +24171,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 930
+   i32.const 931
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24157,7 +24185,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 931
+   i32.const 932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24171,7 +24199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 932
+   i32.const 933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24185,7 +24213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 933
+   i32.const 934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24199,7 +24227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 934
+   i32.const 935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24213,27 +24241,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 935
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24247,9 +24261,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24262,8 +24274,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24276,8 +24290,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24290,6 +24304,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 941
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 1
   f32.const 0
@@ -24299,7 +24327,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 941
+   i32.const 942
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24313,7 +24341,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 942
+   i32.const 943
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24327,7 +24355,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 943
+   i32.const 944
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24341,7 +24369,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 944
+   i32.const 945
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24355,7 +24383,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 945
+   i32.const 946
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24369,7 +24397,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 946
+   i32.const 947
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24383,7 +24411,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 947
+   i32.const 948
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24397,7 +24425,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 948
+   i32.const 949
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24411,7 +24439,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 949
+   i32.const 950
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24425,27 +24453,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 950
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_ceilf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24459,9 +24473,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24474,8 +24486,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24488,8 +24502,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_ceilf
@@ -24502,6 +24516,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_ceilf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 956
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 1
   f32.const 0
@@ -24511,7 +24539,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 956
+   i32.const 957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24525,7 +24553,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 957
+   i32.const 958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24539,7 +24567,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 958
+   i32.const 959
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24553,7 +24581,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 959
+   i32.const 960
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24567,7 +24595,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 960
+   i32.const 961
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24581,7 +24609,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 961
+   i32.const 962
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24595,7 +24623,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 962
+   i32.const 963
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24609,7 +24637,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 963
+   i32.const 964
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24623,7 +24651,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 964
+   i32.const 965
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24637,7 +24665,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 965
+   i32.const 966
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24651,7 +24679,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 976
+   i32.const 977
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24665,7 +24693,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 977
+   i32.const 978
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24679,7 +24707,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 978
+   i32.const 979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24693,7 +24721,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 979
+   i32.const 980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24707,7 +24735,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 980
+   i32.const 981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24721,7 +24749,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 981
+   i32.const 982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24735,7 +24763,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 982
+   i32.const 983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24749,7 +24777,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 983
+   i32.const 984
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24763,7 +24791,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 984
+   i32.const 985
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24777,26 +24805,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 985
+   i32.const 986
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_cos
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 988
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -24810,6 +24824,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_cos
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 990
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
@@ -24819,7 +24847,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 990
+   i32.const 991
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24834,7 +24862,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 991
+   i32.const 992
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24848,7 +24876,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 992
+   i32.const 993
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24862,7 +24890,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 993
+   i32.const 994
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24876,7 +24904,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 994
+   i32.const 995
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24890,7 +24918,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 995
+   i32.const 996
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24904,7 +24932,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 996
+   i32.const 997
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24918,7 +24946,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 997
+   i32.const 998
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24932,7 +24960,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 998
+   i32.const 999
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24946,7 +24974,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 999
+   i32.const 1000
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24960,7 +24988,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1000
+   i32.const 1001
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24974,7 +25002,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1001
+   i32.const 1002
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -24988,7 +25016,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1002
+   i32.const 1003
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25002,7 +25030,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1003
+   i32.const 1004
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25016,26 +25044,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1004
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5e-324
-  f64.const 1
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_cos
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 1005
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
+  f64.const 5e-324
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -25049,6 +25063,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -5e-324
+  f64.const 1
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_cos
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1007
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -3.14
   f64.const -0.9999987317275395
   f64.const 0.3855516016483307
@@ -25058,7 +25086,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1007
+   i32.const 1008
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25072,7 +25100,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1008
+   i32.const 1009
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25086,7 +25114,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1009
+   i32.const 1010
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25100,7 +25128,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1010
+   i32.const 1011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25114,7 +25142,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1011
+   i32.const 1012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25128,7 +25156,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1012
+   i32.const 1013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25142,7 +25170,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1013
+   i32.const 1014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25156,7 +25184,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1014
+   i32.const 1015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25170,7 +25198,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1015
+   i32.const 1016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25184,7 +25212,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1016
+   i32.const 1017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25198,7 +25226,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1017
+   i32.const 1018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25212,7 +25240,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1018
+   i32.const 1019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25226,7 +25254,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1019
+   i32.const 1020
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25240,7 +25268,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1020
+   i32.const 1021
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25254,7 +25282,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1021
+   i32.const 1022
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25268,7 +25296,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1022
+   i32.const 1023
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25282,7 +25310,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1023
+   i32.const 1024
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25296,7 +25324,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1024
+   i32.const 1025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25310,7 +25338,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1025
+   i32.const 1026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25324,7 +25352,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1026
+   i32.const 1027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25338,7 +25366,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1027
+   i32.const 1028
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25352,7 +25380,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1028
+   i32.const 1029
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25366,7 +25394,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1029
+   i32.const 1030
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25380,7 +25408,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1030
+   i32.const 1031
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25394,7 +25422,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1031
+   i32.const 1032
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25408,7 +25436,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1032
+   i32.const 1033
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25422,7 +25450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1033
+   i32.const 1034
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25436,7 +25464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1034
+   i32.const 1035
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25450,7 +25478,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1035
+   i32.const 1036
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25464,7 +25492,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1036
+   i32.const 1037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25478,7 +25506,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1037
+   i32.const 1038
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25492,7 +25520,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1038
+   i32.const 1039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25506,7 +25534,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1039
+   i32.const 1040
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25520,7 +25548,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1040
+   i32.const 1041
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25534,7 +25562,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1041
+   i32.const 1042
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25548,7 +25576,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1042
+   i32.const 1043
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25562,7 +25590,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1043
+   i32.const 1044
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25576,7 +25604,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1044
+   i32.const 1045
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25590,7 +25618,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1045
+   i32.const 1046
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25604,7 +25632,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1046
+   i32.const 1047
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25618,7 +25646,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1047
+   i32.const 1048
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25632,7 +25660,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1048
+   i32.const 1049
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25646,7 +25674,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1049
+   i32.const 1050
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25660,7 +25688,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1050
+   i32.const 1051
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25674,7 +25702,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1051
+   i32.const 1052
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25688,7 +25716,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1052
+   i32.const 1053
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25702,7 +25730,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1053
+   i32.const 1054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25716,7 +25744,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1054
+   i32.const 1055
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25730,7 +25758,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1055
+   i32.const 1056
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25744,7 +25772,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1056
+   i32.const 1057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25758,7 +25786,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1057
+   i32.const 1058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25772,7 +25800,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1058
+   i32.const 1059
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25786,7 +25814,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1059
+   i32.const 1060
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25800,7 +25828,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1060
+   i32.const 1061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25814,7 +25842,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1061
+   i32.const 1062
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25828,7 +25856,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1062
+   i32.const 1063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25842,7 +25870,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1063
+   i32.const 1064
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25856,7 +25884,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1064
+   i32.const 1065
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25870,7 +25898,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1065
+   i32.const 1066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25884,7 +25912,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1068
+   i32.const 1069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25898,7 +25926,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1069
+   i32.const 1070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25912,7 +25940,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1070
+   i32.const 1071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25926,7 +25954,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1071
+   i32.const 1072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25940,7 +25968,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1072
+   i32.const 1073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -25954,26 +25982,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1073
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_cos
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 1074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -25987,10 +26001,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1e-323
+  f64.const -0
   f64.const 1
   f64.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_cos
   i32.eqz
   if
@@ -26001,7 +26015,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
+  f64.const 1e-323
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26015,7 +26029,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
+  f64.const 4.4e-323
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26029,7 +26043,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
+  f64.const 5.562684646268003e-309
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26043,7 +26057,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
+  f64.const 1.1125369292536007e-308
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26057,7 +26071,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
+  f64.const 2.2250738585072004e-308
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26071,7 +26085,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507201e-308
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26085,7 +26099,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
+  f64.const 2.225073858507202e-308
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26099,7 +26113,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
+  f64.const 2.2250738585072024e-308
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26113,7 +26127,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
+  f64.const 4.4501477170144003e-308
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26127,7 +26141,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014403e-308
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26141,7 +26155,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8.900295434028806e-308
+  f64.const 4.450147717014406e-308
   f64.const 1
   f64.const 0
   global.get $std/math/INEXACT
@@ -26155,6 +26169,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 8.900295434028806e-308
+  f64.const 1
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_cos
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1088
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 7.450580596923828e-09
   f64.const 1
   f64.const 0.125
@@ -26164,7 +26192,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1088
+   i32.const 1089
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26178,7 +26206,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1089
+   i32.const 1090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26192,7 +26220,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1090
+   i32.const 1091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26206,7 +26234,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1091
+   i32.const 1092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26220,7 +26248,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1092
+   i32.const 1093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26234,7 +26262,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1093
+   i32.const 1094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26248,7 +26276,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1094
+   i32.const 1095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26262,7 +26290,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1095
+   i32.const 1096
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26276,7 +26304,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1096
+   i32.const 1097
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26290,7 +26318,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1097
+   i32.const 1098
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26304,7 +26332,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1098
+   i32.const 1099
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26318,7 +26346,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1099
+   i32.const 1100
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26332,7 +26360,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1100
+   i32.const 1101
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26346,7 +26374,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1101
+   i32.const 1102
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26360,7 +26388,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1102
+   i32.const 1103
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26374,7 +26402,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1103
+   i32.const 1104
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26388,7 +26416,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1104
+   i32.const 1105
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26402,7 +26430,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1105
+   i32.const 1106
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26412,28 +26440,6 @@
   f64.div
   call $~lib/math/NativeMath.cos
   global.get $std/math/kPI
-  f64.const 2
-  f64.div
-  call $~lib/bindings/Math/cos
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1107
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2
-  global.get $std/math/kPI
-  f64.mul
-  f64.const 2
-  f64.div
-  call $~lib/math/NativeMath.cos
-  f64.const 2
-  global.get $std/math/kPI
-  f64.mul
   f64.const 2
   f64.div
   call $~lib/bindings/Math/cos
@@ -26447,6 +26453,28 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 2
+  global.get $std/math/kPI
+  f64.mul
+  f64.const 2
+  f64.div
+  call $~lib/math/NativeMath.cos
+  f64.const 2
+  global.get $std/math/kPI
+  f64.mul
+  f64.const 2
+  f64.div
+  call $~lib/bindings/Math/cos
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1109
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.e+90
   global.get $std/math/kPI
   f64.mul
@@ -26460,7 +26488,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1109
+   i32.const 1110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26473,7 +26501,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1113
+   i32.const 1114
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26486,7 +26514,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1114
+   i32.const 1115
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26499,7 +26527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1117
+   i32.const 1118
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26512,7 +26540,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1119
+   i32.const 1120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26525,7 +26553,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1120
+   i32.const 1121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26538,7 +26566,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1123
+   i32.const 1124
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26551,7 +26579,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1125
+   i32.const 1126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26564,7 +26592,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1128
+   i32.const 1129
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26577,7 +26605,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1130
+   i32.const 1131
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26590,7 +26618,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1131
+   i32.const 1132
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26603,7 +26631,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1132
+   i32.const 1133
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26616,7 +26644,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1134
+   i32.const 1135
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26633,7 +26661,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1136
+   i32.const 1137
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26650,7 +26678,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1137
+   i32.const 1138
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26667,7 +26695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1138
+   i32.const 1139
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26684,7 +26712,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1139
+   i32.const 1140
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26697,7 +26725,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1140
+   i32.const 1141
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26714,7 +26742,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1141
+   i32.const 1142
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26728,7 +26756,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1150
+   i32.const 1151
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26742,7 +26770,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1151
+   i32.const 1152
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26756,7 +26784,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1152
+   i32.const 1153
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26770,7 +26798,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1153
+   i32.const 1154
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26784,7 +26812,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1154
+   i32.const 1155
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26798,7 +26826,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1155
+   i32.const 1156
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26812,7 +26840,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1156
+   i32.const 1157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26826,7 +26854,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1157
+   i32.const 1158
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26840,7 +26868,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1158
+   i32.const 1159
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26854,26 +26882,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1159
+   i32.const 1160
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_cosf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1162
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -26887,10 +26901,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const 1
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_cosf
   i32.eqz
   if
@@ -26902,7 +26916,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -26916,6 +26929,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_cosf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1166
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -26925,7 +26953,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1166
+   i32.const 1167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26939,7 +26967,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1169
+   i32.const 1170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26953,7 +26981,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1170
+   i32.const 1171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26967,7 +26995,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1171
+   i32.const 1172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26981,7 +27009,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1172
+   i32.const 1173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -26995,7 +27023,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1173
+   i32.const 1174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27009,7 +27037,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1174
+   i32.const 1175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27023,7 +27051,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1175
+   i32.const 1176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27037,7 +27065,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1176
+   i32.const 1177
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27051,7 +27079,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1177
+   i32.const 1178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27065,7 +27093,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1178
+   i32.const 1179
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27079,7 +27107,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1179
+   i32.const 1180
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27093,7 +27121,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1180
+   i32.const 1181
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27107,7 +27135,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1181
+   i32.const 1182
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27121,7 +27149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1182
+   i32.const 1183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27135,7 +27163,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1183
+   i32.const 1184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27149,7 +27177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1184
+   i32.const 1185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27163,7 +27191,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1185
+   i32.const 1186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27177,7 +27205,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1186
+   i32.const 1187
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27191,7 +27219,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1187
+   i32.const 1188
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27205,7 +27233,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1188
+   i32.const 1189
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27219,7 +27247,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1189
+   i32.const 1190
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27233,7 +27261,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1190
+   i32.const 1191
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27247,7 +27275,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1191
+   i32.const 1192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27261,7 +27289,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1192
+   i32.const 1193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27275,7 +27303,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1193
+   i32.const 1194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27289,7 +27317,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1194
+   i32.const 1195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27303,7 +27331,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1195
+   i32.const 1196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27317,7 +27345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1196
+   i32.const 1197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27331,7 +27359,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1197
+   i32.const 1198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27345,7 +27373,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1198
+   i32.const 1199
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27359,7 +27387,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1199
+   i32.const 1200
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27373,7 +27401,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1200
+   i32.const 1201
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27387,7 +27415,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1201
+   i32.const 1202
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27401,7 +27429,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1202
+   i32.const 1203
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27415,7 +27443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1203
+   i32.const 1204
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27429,7 +27457,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1204
+   i32.const 1205
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27443,7 +27471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1205
+   i32.const 1206
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27457,7 +27485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1206
+   i32.const 1207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27471,7 +27499,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1209
+   i32.const 1210
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27485,7 +27513,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1210
+   i32.const 1211
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27499,7 +27527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1211
+   i32.const 1212
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27513,7 +27541,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1212
+   i32.const 1213
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27527,7 +27555,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1213
+   i32.const 1214
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27541,7 +27569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1214
+   i32.const 1215
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27555,7 +27583,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1215
+   i32.const 1216
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27569,7 +27597,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1216
+   i32.const 1217
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27583,7 +27611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1217
+   i32.const 1218
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27597,7 +27625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1218
+   i32.const 1219
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27611,7 +27639,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1219
+   i32.const 1220
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27625,7 +27653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1220
+   i32.const 1221
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27639,7 +27667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1221
+   i32.const 1222
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27654,7 +27682,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1222
+   i32.const 1223
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27668,7 +27696,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1233
+   i32.const 1234
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27682,7 +27710,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1234
+   i32.const 1235
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27696,7 +27724,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1235
+   i32.const 1236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27710,7 +27738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1236
+   i32.const 1237
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27724,7 +27752,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1237
+   i32.const 1238
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27738,7 +27766,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1238
+   i32.const 1239
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27752,7 +27780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1239
+   i32.const 1240
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27766,7 +27794,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1240
+   i32.const 1241
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27780,7 +27808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1241
+   i32.const 1242
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27794,26 +27822,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1242
+   i32.const 1243
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_cosh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1245
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -27827,6 +27841,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_cosh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1247
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const inf
   f64.const 0
@@ -27836,7 +27864,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1247
+   i32.const 1248
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27851,7 +27879,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1248
+   i32.const 1249
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27865,7 +27893,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1249
+   i32.const 1250
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27879,7 +27907,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1258
+   i32.const 1259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27893,7 +27921,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1259
+   i32.const 1260
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27907,7 +27935,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1260
+   i32.const 1261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27921,7 +27949,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1261
+   i32.const 1262
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27935,7 +27963,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1262
+   i32.const 1263
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27949,7 +27977,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1263
+   i32.const 1264
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27963,7 +27991,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1264
+   i32.const 1265
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27977,7 +28005,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1265
+   i32.const 1266
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -27991,7 +28019,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1266
+   i32.const 1267
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28005,26 +28033,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1267
+   i32.const 1268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_coshf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1270
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -28038,6 +28052,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_coshf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1272
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const inf
   f32.const inf
   f32.const 0
@@ -28047,7 +28075,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1272
+   i32.const 1273
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28062,7 +28090,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1273
+   i32.const 1274
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28076,7 +28104,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1274
+   i32.const 1275
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28090,7 +28118,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1286
+   i32.const 1287
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28104,7 +28132,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1287
+   i32.const 1288
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28118,7 +28146,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1288
+   i32.const 1289
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28132,7 +28160,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1289
+   i32.const 1290
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28146,7 +28174,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1290
+   i32.const 1291
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28160,7 +28188,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1291
+   i32.const 1292
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28174,7 +28202,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1292
+   i32.const 1293
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28188,7 +28216,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1293
+   i32.const 1294
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28202,7 +28230,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1294
+   i32.const 1295
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28216,26 +28244,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1295
+   i32.const 1296
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_exp
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1298
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -28249,6 +28263,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_exp
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1300
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 2.718281828459045
   f64.const -0.3255307376384735
@@ -28258,7 +28286,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1300
+   i32.const 1301
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28272,7 +28300,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1301
+   i32.const 1302
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28286,7 +28314,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1302
+   i32.const 1303
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28301,7 +28329,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1303
+   i32.const 1304
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28315,7 +28343,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1304
+   i32.const 1305
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28329,7 +28357,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1305
+   i32.const 1306
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28343,7 +28371,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1306
+   i32.const 1307
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28357,7 +28385,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1307
+   i32.const 1308
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28371,7 +28399,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1308
+   i32.const 1309
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28385,7 +28413,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1311
+   i32.const 1312
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28400,7 +28428,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1312
+   i32.const 1313
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28417,7 +28445,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1314
+   i32.const 1315
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28434,7 +28462,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1321
+   i32.const 1322
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28452,7 +28480,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1322
+   i32.const 1323
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28470,7 +28498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1329
+   i32.const 1330
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28487,7 +28515,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1336
+   i32.const 1337
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28506,7 +28534,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1343
+   i32.const 1344
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28523,7 +28551,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1350
+   i32.const 1351
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28540,7 +28568,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1357
+   i32.const 1358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28557,7 +28585,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1364
+   i32.const 1365
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28574,7 +28602,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1370
+   i32.const 1371
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28591,7 +28619,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1376
+   i32.const 1377
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28608,7 +28636,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1382
+   i32.const 1383
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28625,7 +28653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1389
+   i32.const 1390
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28642,7 +28670,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1396
+   i32.const 1397
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28659,7 +28687,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1403
+   i32.const 1404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28676,7 +28704,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1410
+   i32.const 1411
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28693,7 +28721,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1417
+   i32.const 1418
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28710,7 +28738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1424
+   i32.const 1425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28727,7 +28755,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1431
+   i32.const 1432
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28744,7 +28772,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1438
+   i32.const 1439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28758,7 +28786,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1452
+   i32.const 1453
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28772,7 +28800,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1453
+   i32.const 1454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28786,7 +28814,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1454
+   i32.const 1455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28800,7 +28828,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1455
+   i32.const 1456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28814,7 +28842,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1456
+   i32.const 1457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28828,7 +28856,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1457
+   i32.const 1458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28842,7 +28870,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1458
+   i32.const 1459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28856,7 +28884,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1459
+   i32.const 1460
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28870,7 +28898,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1460
+   i32.const 1461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28884,26 +28912,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1461
+   i32.const 1462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_expf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1464
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -28917,6 +28931,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_expf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1466
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 2.7182817459106445
   f32.const -0.3462330996990204
@@ -28926,7 +28954,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1466
+   i32.const 1467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28940,7 +28968,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1467
+   i32.const 1468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28954,7 +28982,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1468
+   i32.const 1469
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28969,7 +28997,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1469
+   i32.const 1470
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28983,7 +29011,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1470
+   i32.const 1471
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -28997,7 +29025,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1471
+   i32.const 1472
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29013,7 +29041,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1472
+   i32.const 1473
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29029,7 +29057,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1473
+   i32.const 1474
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29045,7 +29073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1474
+   i32.const 1475
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29059,7 +29087,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1475
+   i32.const 1476
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29073,7 +29101,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1476
+   i32.const 1477
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29087,7 +29115,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1477
+   i32.const 1478
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29101,7 +29129,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1489
+   i32.const 1490
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29115,7 +29143,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1490
+   i32.const 1491
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29129,7 +29157,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1491
+   i32.const 1492
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29143,7 +29171,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1492
+   i32.const 1493
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29157,7 +29185,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1493
+   i32.const 1494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29171,7 +29199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1494
+   i32.const 1495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29185,7 +29213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1495
+   i32.const 1496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29199,7 +29227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1496
+   i32.const 1497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29213,7 +29241,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1497
+   i32.const 1498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29227,27 +29255,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1498
+   i32.const 1499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_expm1
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1501
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_expm1
@@ -29256,6 +29270,20 @@
    i32.const 0
    i32.const 32
    i32.const 1502
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_expm1
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29269,7 +29297,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1503
+   i32.const 1504
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29283,7 +29311,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1504
+   i32.const 1505
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29297,7 +29325,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1505
+   i32.const 1506
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29312,7 +29340,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1506
+   i32.const 1507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29326,29 +29354,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1507
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_expm1
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 1508
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -29363,6 +29375,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_expm1
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1510
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -8.066848754882812
   f32.const -0.9996862411499023
   f32.const -0.19532723724842072
@@ -29372,7 +29400,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1518
+   i32.const 1519
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29386,7 +29414,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1519
+   i32.const 1520
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29400,7 +29428,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1520
+   i32.const 1521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29414,7 +29442,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1521
+   i32.const 1522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29428,7 +29456,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1522
+   i32.const 1523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29442,7 +29470,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1523
+   i32.const 1524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29456,7 +29484,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1524
+   i32.const 1525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29470,7 +29498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1525
+   i32.const 1526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29484,7 +29512,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1526
+   i32.const 1527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29498,27 +29526,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1527
+   i32.const 1528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_expm1f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1530
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_expm1f
@@ -29527,6 +29541,20 @@
    i32.const 0
    i32.const 32
    i32.const 1531
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_expm1f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1532
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29540,7 +29568,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1532
+   i32.const 1533
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29554,7 +29582,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1533
+   i32.const 1534
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29568,7 +29596,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1534
+   i32.const 1535
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29583,7 +29611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1535
+   i32.const 1536
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29597,7 +29625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1536
+   i32.const 1537
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29614,7 +29642,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1548
+   i32.const 1549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29631,7 +29659,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1549
+   i32.const 1550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29648,7 +29676,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1550
+   i32.const 1551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29665,7 +29693,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1551
+   i32.const 1552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29682,7 +29710,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1552
+   i32.const 1553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29699,7 +29727,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1553
+   i32.const 1554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29716,7 +29744,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1554
+   i32.const 1555
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29733,7 +29761,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1555
+   i32.const 1556
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29750,7 +29778,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1556
+   i32.const 1557
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29767,22 +29795,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1557
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  i64.const 4607182418800017408
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_exp2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1560
+   i32.const 1558
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29802,6 +29815,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  i64.const 4607182418800017408
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_exp2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1562
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   i64.const 4611686018427387904
   f64.reinterpret_i64
@@ -29812,7 +29840,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1562
+   i32.const 1563
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29827,7 +29855,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1563
+   i32.const 1564
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29841,7 +29869,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1564
+   i32.const 1565
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29856,7 +29884,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1565
+   i32.const 1566
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29870,7 +29898,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1566
+   i32.const 1567
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29887,7 +29915,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1567
+   i32.const 1568
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29904,7 +29932,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1568
+   i32.const 1569
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29920,7 +29948,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1569
+   i32.const 1570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29939,7 +29967,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1570
+   i32.const 1571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29955,7 +29983,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1571
+   i32.const 1572
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29972,7 +30000,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1572
+   i32.const 1573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -29989,7 +30017,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1573
+   i32.const 1574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30006,7 +30034,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1574
+   i32.const 1575
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30023,7 +30051,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1575
+   i32.const 1576
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30042,7 +30070,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1576
+   i32.const 1577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30058,7 +30086,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1577
+   i32.const 1578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30077,7 +30105,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1578
+   i32.const 1579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30093,7 +30121,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1579
+   i32.const 1580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30109,7 +30137,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1580
+   i32.const 1581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30125,7 +30153,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1581
+   i32.const 1582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30144,7 +30172,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1582
+   i32.const 1583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30162,7 +30190,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1583
+   i32.const 1584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30179,7 +30207,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1584
+   i32.const 1585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30199,7 +30227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1595
+   i32.const 1596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30219,7 +30247,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1596
+   i32.const 1597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30239,7 +30267,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1597
+   i32.const 1598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30259,7 +30287,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1598
+   i32.const 1599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30279,7 +30307,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1599
+   i32.const 1600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30299,7 +30327,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1600
+   i32.const 1601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30319,7 +30347,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1601
+   i32.const 1602
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30339,7 +30367,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1602
+   i32.const 1603
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30359,7 +30387,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1603
+   i32.const 1604
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30379,7 +30407,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1604
+   i32.const 1605
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30393,7 +30421,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1616
+   i32.const 1617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30407,7 +30435,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1617
+   i32.const 1618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30421,7 +30449,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1618
+   i32.const 1619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30435,7 +30463,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1619
+   i32.const 1620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30449,7 +30477,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1620
+   i32.const 1621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30463,7 +30491,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1621
+   i32.const 1622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30477,7 +30505,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1622
+   i32.const 1623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30491,7 +30519,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1623
+   i32.const 1624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30505,7 +30533,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1624
+   i32.const 1625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30519,27 +30547,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1625
+   i32.const 1626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_floor
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1628
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_floor
@@ -30553,9 +30567,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_floor
@@ -30568,8 +30580,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_floor
@@ -30582,8 +30596,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_floor
@@ -30596,6 +30610,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_floor
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1633
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -30605,7 +30633,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1633
+   i32.const 1634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30619,7 +30647,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1634
+   i32.const 1635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30633,7 +30661,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1635
+   i32.const 1636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30647,7 +30675,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1636
+   i32.const 1637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30661,7 +30689,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1637
+   i32.const 1638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30675,7 +30703,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1638
+   i32.const 1639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30689,7 +30717,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1639
+   i32.const 1640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30703,7 +30731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1640
+   i32.const 1641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30717,7 +30745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1641
+   i32.const 1642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30731,7 +30759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1642
+   i32.const 1643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30745,7 +30773,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1651
+   i32.const 1652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30759,7 +30787,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1652
+   i32.const 1653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30773,7 +30801,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1653
+   i32.const 1654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30787,7 +30815,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1654
+   i32.const 1655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30801,7 +30829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1655
+   i32.const 1656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30815,7 +30843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1656
+   i32.const 1657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30829,7 +30857,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1657
+   i32.const 1658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30843,7 +30871,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1658
+   i32.const 1659
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30857,7 +30885,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1659
+   i32.const 1660
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30871,27 +30899,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1660
+   i32.const 1661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_floorf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1663
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_floorf
@@ -30905,9 +30919,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_floorf
@@ -30920,8 +30932,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_floorf
@@ -30934,8 +30948,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_floorf
@@ -30948,6 +30962,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_floorf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1668
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 1
   f32.const 0
@@ -30957,7 +30985,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1668
+   i32.const 1669
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30971,7 +30999,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1669
+   i32.const 1670
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30985,7 +31013,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1670
+   i32.const 1671
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -30999,7 +31027,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1671
+   i32.const 1672
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31013,7 +31041,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1672
+   i32.const 1673
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31027,7 +31055,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1673
+   i32.const 1674
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31041,7 +31069,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1674
+   i32.const 1675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31055,7 +31083,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1675
+   i32.const 1676
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31069,7 +31097,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1676
+   i32.const 1677
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31083,7 +31111,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1677
+   i32.const 1678
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31098,7 +31126,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1691
+   i32.const 1692
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31113,7 +31141,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1692
+   i32.const 1693
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31128,7 +31156,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1693
+   i32.const 1694
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31143,7 +31171,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1694
+   i32.const 1695
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31158,7 +31186,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1695
+   i32.const 1696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31173,7 +31201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1696
+   i32.const 1697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31188,7 +31216,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1697
+   i32.const 1698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31203,7 +31231,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1698
+   i32.const 1699
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31218,7 +31246,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1699
+   i32.const 1700
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31233,27 +31261,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1700
+   i32.const 1701
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3
-  f64.const 4
-  f64.const 5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1703
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -3
   f64.const 4
   f64.const 5
   f64.const 0
@@ -31268,8 +31281,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -3
   f64.const 4
-  f64.const 3
   f64.const 5
   f64.const 0
   i32.const 0
@@ -31284,7 +31297,7 @@
    unreachable
   end
   f64.const 4
-  f64.const -3
+  f64.const 3
   f64.const 5
   f64.const 0
   i32.const 0
@@ -31294,6 +31307,21 @@
    i32.const 0
    i32.const 32
    i32.const 1706
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4
+  f64.const -3
+  f64.const 5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1707
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31308,28 +31336,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1707
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 1708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1797693134862315708145274e284
-  f64.const -0
+  f64.const 0
   f64.const 1797693134862315708145274e284
   f64.const 0
   i32.const 0
@@ -31343,6 +31356,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1797693134862315708145274e284
+  f64.const -0
+  f64.const 1797693134862315708145274e284
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1710
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 5e-324
   f64.const 0
   f64.const 5e-324
@@ -31353,7 +31381,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1710
+   i32.const 1711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31368,28 +31396,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1711
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 1712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
+  f64.const 1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31403,8 +31416,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const inf
-  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31418,8 +31431,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
   f64.const inf
+  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31433,9 +31446,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const inf
-  f64.neg
-  f64.const 1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31449,9 +31461,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
   f64.neg
+  f64.const 1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31465,9 +31477,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const inf
   f64.neg
-  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31481,9 +31493,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
   f64.const inf
   f64.neg
+  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   i32.const 0
@@ -31498,8 +31510,9 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -31512,8 +31525,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -31527,6 +31540,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1722
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
@@ -31537,7 +31565,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1722
+   i32.const 1723
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31552,7 +31580,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1723
+   i32.const 1724
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31567,7 +31595,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1732
+   i32.const 1733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31582,7 +31610,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1733
+   i32.const 1734
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31597,7 +31625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1734
+   i32.const 1735
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31612,7 +31640,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1735
+   i32.const 1736
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31627,7 +31655,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1736
+   i32.const 1737
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31642,7 +31670,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1737
+   i32.const 1738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31657,7 +31685,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1738
+   i32.const 1739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31672,7 +31700,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1739
+   i32.const 1740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31687,7 +31715,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1740
+   i32.const 1741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31702,27 +31730,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1741
+   i32.const 1742
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3
-  f32.const 4
-  f32.const 5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1744
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -3
   f32.const 4
   f32.const 5
   f32.const 0
@@ -31737,8 +31750,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -3
   f32.const 4
-  f32.const 3
   f32.const 5
   f32.const 0
   i32.const 0
@@ -31753,7 +31766,7 @@
    unreachable
   end
   f32.const 4
-  f32.const -3
+  f32.const 3
   f32.const 5
   f32.const 0
   i32.const 0
@@ -31763,6 +31776,21 @@
    i32.const 0
    i32.const 32
    i32.const 1747
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4
+  f32.const -3
+  f32.const 5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31777,28 +31805,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1748
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 1749
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3402823466385288598117041e14
-  f32.const -0
+  f32.const 0
   f32.const 3402823466385288598117041e14
   f32.const 0
   i32.const 0
@@ -31812,6 +31825,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 3402823466385288598117041e14
+  f32.const -0
+  f32.const 3402823466385288598117041e14
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1751
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.401298464324817e-45
   f32.const 0
   f32.const 1.401298464324817e-45
@@ -31822,7 +31850,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1751
+   i32.const 1752
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -31837,28 +31865,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1752
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 1753
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
+  f32.const 1
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31872,8 +31885,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const inf
-  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31887,8 +31900,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
   f32.const inf
+  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31902,9 +31915,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const inf
-  f32.neg
-  f32.const 1
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31918,9 +31930,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
   f32.neg
+  f32.const 1
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31934,9 +31946,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const inf
   f32.neg
-  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31950,9 +31962,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
   f32.const inf
   f32.neg
+  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   i32.const 0
@@ -31967,8 +31979,9 @@
    unreachable
   end
   f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -31981,8 +31994,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const nan:0x400000
+  f32.const 1
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -31996,6 +32009,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1763
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -8.06684839057968
   f64.const nan:0x8000000000000
   f64.const 0
@@ -32005,7 +32033,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1774
+   i32.const 1775
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32019,7 +32047,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1775
+   i32.const 1776
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32033,7 +32061,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1776
+   i32.const 1777
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32047,7 +32075,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1777
+   i32.const 1778
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32061,7 +32089,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1778
+   i32.const 1779
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32075,7 +32103,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1779
+   i32.const 1780
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32089,7 +32117,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1780
+   i32.const 1781
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32103,7 +32131,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1781
+   i32.const 1782
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32117,7 +32145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1782
+   i32.const 1783
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32131,27 +32159,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1783
+   i32.const 1784
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.neg
-  f64.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1786
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const inf
   f64.neg
   f64.const 0
@@ -32166,6 +32179,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const inf
+  f64.neg
+  f64.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1788
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
@@ -32175,7 +32203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1788
+   i32.const 1789
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32189,7 +32217,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1789
+   i32.const 1790
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32203,7 +32231,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1790
+   i32.const 1791
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32217,7 +32245,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1791
+   i32.const 1792
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32232,7 +32260,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1792
+   i32.const 1793
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32246,27 +32274,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1793
+   i32.const 1794
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.neg
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1802
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const inf
   f32.neg
   f32.const 0
@@ -32281,6 +32294,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const inf
+  f32.neg
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1804
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -32290,7 +32318,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1804
+   i32.const 1805
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32304,7 +32332,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1805
+   i32.const 1806
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32318,7 +32346,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1806
+   i32.const 1807
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32332,7 +32360,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1807
+   i32.const 1808
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32347,7 +32375,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1808
+   i32.const 1809
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32361,27 +32389,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1809
+   i32.const 1810
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.neg
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1812
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const inf
   f32.neg
   f32.const 0
@@ -32396,6 +32409,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const inf
+  f32.neg
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1814
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -32405,7 +32433,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1814
+   i32.const 1815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32419,7 +32447,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1815
+   i32.const 1816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32433,7 +32461,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1816
+   i32.const 1817
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32447,7 +32475,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1817
+   i32.const 1818
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32462,7 +32490,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1818
+   i32.const 1819
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32476,7 +32504,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1819
+   i32.const 1820
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32490,7 +32518,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1831
+   i32.const 1832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32504,7 +32532,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1832
+   i32.const 1833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32518,7 +32546,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1833
+   i32.const 1834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32532,7 +32560,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1834
+   i32.const 1835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32546,7 +32574,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1835
+   i32.const 1836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32560,7 +32588,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1836
+   i32.const 1837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32574,7 +32602,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1837
+   i32.const 1838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32588,7 +32616,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1838
+   i32.const 1839
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32602,7 +32630,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1839
+   i32.const 1840
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32616,27 +32644,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1840
+   i32.const 1841
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.neg
-  f64.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1843
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const inf
   f64.neg
   f64.const 0
@@ -32651,6 +32664,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const inf
+  f64.neg
+  f64.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1845
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
@@ -32660,7 +32688,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1845
+   i32.const 1846
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32674,7 +32702,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1846
+   i32.const 1847
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32688,7 +32716,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1847
+   i32.const 1848
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32702,7 +32730,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1848
+   i32.const 1849
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32717,7 +32745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1849
+   i32.const 1850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32731,7 +32759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1850
+   i32.const 1851
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32745,7 +32773,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1859
+   i32.const 1860
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32759,7 +32787,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1860
+   i32.const 1861
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32773,7 +32801,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1861
+   i32.const 1862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32787,7 +32815,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1862
+   i32.const 1863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32801,7 +32829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1863
+   i32.const 1864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32815,7 +32843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1864
+   i32.const 1865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32829,7 +32857,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1865
+   i32.const 1866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32843,7 +32871,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1866
+   i32.const 1867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32857,7 +32885,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1867
+   i32.const 1868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32871,27 +32899,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1868
+   i32.const 1869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.neg
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1871
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const inf
   f32.neg
   f32.const 0
@@ -32906,6 +32919,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const inf
+  f32.neg
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1873
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -32915,7 +32943,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1873
+   i32.const 1874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32929,7 +32957,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1874
+   i32.const 1875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32943,7 +32971,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1875
+   i32.const 1876
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32957,7 +32985,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1876
+   i32.const 1877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32972,7 +33000,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1877
+   i32.const 1878
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -32986,7 +33014,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1878
+   i32.const 1879
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33000,7 +33028,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1890
+   i32.const 1891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33014,7 +33042,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1891
+   i32.const 1892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33028,7 +33056,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1892
+   i32.const 1893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33042,7 +33070,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1893
+   i32.const 1894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33056,7 +33084,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1894
+   i32.const 1895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33070,7 +33098,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1895
+   i32.const 1896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33084,7 +33112,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1896
+   i32.const 1897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33098,7 +33126,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1897
+   i32.const 1898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33112,7 +33140,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1898
+   i32.const 1899
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33126,27 +33154,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1899
+   i32.const 1900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_log1p
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1902
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_log1p
@@ -33155,6 +33169,20 @@
    i32.const 0
    i32.const 32
    i32.const 1903
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_log1p
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1904
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33168,7 +33196,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1904
+   i32.const 1905
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33182,7 +33210,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1905
+   i32.const 1906
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33197,7 +33225,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1906
+   i32.const 1907
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33211,7 +33239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1907
+   i32.const 1908
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33226,7 +33254,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1908
+   i32.const 1909
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33240,7 +33268,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1909
+   i32.const 1910
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33254,7 +33282,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1918
+   i32.const 1919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33268,7 +33296,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1919
+   i32.const 1920
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33282,7 +33310,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1920
+   i32.const 1921
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33296,7 +33324,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1921
+   i32.const 1922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33310,7 +33338,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1922
+   i32.const 1923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33324,7 +33352,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1923
+   i32.const 1924
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33338,7 +33366,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1924
+   i32.const 1925
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33352,7 +33380,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1925
+   i32.const 1926
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33366,7 +33394,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1926
+   i32.const 1927
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33380,27 +33408,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1927
+   i32.const 1928
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_log1pf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1930
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_log1pf
@@ -33409,6 +33423,20 @@
    i32.const 0
    i32.const 32
    i32.const 1931
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_log1pf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33422,7 +33450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1932
+   i32.const 1933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33436,7 +33464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1933
+   i32.const 1934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33451,7 +33479,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1934
+   i32.const 1935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33465,7 +33493,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1935
+   i32.const 1936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33480,7 +33508,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1936
+   i32.const 1937
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33494,7 +33522,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1937
+   i32.const 1938
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33510,7 +33538,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1938
+   i32.const 1939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33524,7 +33552,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1950
+   i32.const 1951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33538,7 +33566,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1951
+   i32.const 1952
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33552,7 +33580,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1952
+   i32.const 1953
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33566,7 +33594,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1953
+   i32.const 1954
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33580,7 +33608,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1954
+   i32.const 1955
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33594,7 +33622,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1955
+   i32.const 1956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33608,7 +33636,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1956
+   i32.const 1957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33622,7 +33650,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1957
+   i32.const 1958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33636,7 +33664,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1958
+   i32.const 1959
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33650,27 +33678,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1959
+   i32.const 1960
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.neg
-  f64.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_log2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1962
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const inf
   f64.neg
   f64.const 0
@@ -33685,6 +33698,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const inf
+  f64.neg
+  f64.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_log2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1964
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
@@ -33694,7 +33722,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1964
+   i32.const 1965
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33708,7 +33736,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1965
+   i32.const 1966
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33722,7 +33750,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1966
+   i32.const 1967
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33736,7 +33764,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1967
+   i32.const 1968
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33751,7 +33779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1968
+   i32.const 1969
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33765,7 +33793,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1969
+   i32.const 1970
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33779,7 +33807,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1978
+   i32.const 1979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33793,7 +33821,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1979
+   i32.const 1980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33807,7 +33835,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1980
+   i32.const 1981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33821,7 +33849,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1981
+   i32.const 1982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33835,7 +33863,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1982
+   i32.const 1983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33849,7 +33877,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1983
+   i32.const 1984
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33863,7 +33891,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1984
+   i32.const 1985
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33877,7 +33905,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1985
+   i32.const 1986
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33891,7 +33919,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1986
+   i32.const 1987
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33905,27 +33933,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1987
+   i32.const 1988
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.neg
-  f32.const 0
-  global.get $std/math/DIVBYZERO
-  call $std/math/test_log2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 1990
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const inf
   f32.neg
   f32.const 0
@@ -33940,6 +33953,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const inf
+  f32.neg
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_log2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 1992
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -33949,7 +33977,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1992
+   i32.const 1993
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33963,7 +33991,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1993
+   i32.const 1994
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33977,7 +34005,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1994
+   i32.const 1995
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -33991,7 +34019,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1995
+   i32.const 1996
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34006,7 +34034,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1996
+   i32.const 1997
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34020,7 +34048,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1997
+   i32.const 1998
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34035,7 +34063,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2009
+   i32.const 2010
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34050,7 +34078,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2010
+   i32.const 2011
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34065,7 +34093,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2011
+   i32.const 2012
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34080,7 +34108,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2012
+   i32.const 2013
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34095,7 +34123,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2013
+   i32.const 2014
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34110,7 +34138,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2014
+   i32.const 2015
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34125,7 +34153,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2015
+   i32.const 2016
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34140,7 +34168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2016
+   i32.const 2017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34155,7 +34183,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2017
+   i32.const 2018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34170,27 +34198,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2018
+   i32.const 2019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2021
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 1
   f64.const 1
   f64.const 0
@@ -34205,7 +34218,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const 1
   f64.const 1
   f64.const 0
@@ -34220,7 +34233,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const 1
   f64.const 1
   f64.const 0
@@ -34235,7 +34248,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0.5
   f64.const 1
   f64.const 1
   f64.const 0
@@ -34250,7 +34263,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const 1
   f64.const 1
   f64.const 0
@@ -34265,9 +34278,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 1
-  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34281,9 +34294,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const 1
-  f64.const 1
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34296,9 +34308,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34311,9 +34324,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34326,9 +34339,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -1
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34341,9 +34354,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const -1
-  f64.const 0.5
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34356,9 +34369,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const -1
-  f64.const -0.5
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34371,9 +34384,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0.5
   f64.const -1
-  f64.const 1
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34386,9 +34399,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -1
-  f64.const -1
-  f64.const -1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34401,9 +34414,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
   f64.const -1
-  f64.const inf
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34417,9 +34430,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const -1
-  f64.const -1
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34432,9 +34444,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34447,9 +34460,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34463,7 +34476,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const 0
   f64.const 0
   f64.const 0
   i32.const 0
@@ -34478,8 +34491,8 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34494,8 +34507,7 @@
   end
   f64.const 0
   f64.const inf
-  f64.neg
-  f64.const 0
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34509,8 +34521,9 @@
    unreachable
   end
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34523,9 +34536,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34539,8 +34552,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34554,8 +34567,8 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34570,8 +34583,7 @@
   end
   f64.const -0
   f64.const inf
-  f64.neg
-  f64.const -0
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34585,8 +34597,9 @@
    unreachable
   end
   f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34599,9 +34612,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 0
-  f64.const 1
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34614,9 +34627,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const 0
-  f64.const 0
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34629,9 +34642,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
-  f64.const inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34645,6 +34658,21 @@
    unreachable
   end
   f64.const inf
+  f64.const 0
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2052
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.neg
   f64.const 0
   f64.const 0
@@ -34655,7 +34683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2052
+   i32.const 2053
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34670,7 +34698,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2053
+   i32.const 2054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34685,7 +34713,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2054
+   i32.const 2055
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34700,7 +34728,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2055
+   i32.const 2056
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34716,7 +34744,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2056
+   i32.const 2057
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34731,28 +34759,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2057
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 2
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2058
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const 2
   f64.const inf
   f64.const 0
   i32.const 0
@@ -34767,8 +34780,8 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34782,9 +34795,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const 2
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34799,6 +34811,22 @@
   end
   f64.const inf
   f64.neg
+  f64.const 2
+  f64.const 2
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2062
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
   f64.const -0.5
   f64.const -0.5
   f64.const 0
@@ -34808,7 +34836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2062
+   i32.const 2063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -34824,27 +34852,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2063
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2064
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -34859,7 +34872,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -34874,9 +34887,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const inf
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34889,7 +34902,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
   f64.const inf
   f64.const 0
@@ -34904,7 +34917,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const inf
   f64.const inf
   f64.const 0
@@ -34920,7 +34933,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
   f64.const inf
   f64.const 0
@@ -34935,10 +34947,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
   f64.neg
-  f64.const 1
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34951,10 +34963,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
   f64.neg
-  f64.const -1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34967,10 +34979,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const inf
   f64.neg
-  f64.const inf
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -34984,11 +34996,9 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
   f64.neg
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -35001,9 +35011,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 1.75
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -35016,9 +35029,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
+  f64.const 1.75
   f64.const 0.5
-  f64.const 0.5
+  f64.const 1.75
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -35031,6 +35044,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2077
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.75
   f64.const -0.5
   f64.const 1.75
@@ -35041,7 +35069,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2077
+   i32.const 2078
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35056,7 +35084,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2078
+   i32.const 2079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35071,7 +35099,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2087
+   i32.const 2088
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35086,7 +35114,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2088
+   i32.const 2089
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35101,7 +35129,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2089
+   i32.const 2090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35116,7 +35144,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2090
+   i32.const 2091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35131,7 +35159,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2091
+   i32.const 2092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35146,7 +35174,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2092
+   i32.const 2093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35161,7 +35189,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2093
+   i32.const 2094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35176,7 +35204,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2094
+   i32.const 2095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35191,7 +35219,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2095
+   i32.const 2096
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35206,27 +35234,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2096
+   i32.const 2097
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2099
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const 1
   f32.const 1
   f32.const 0
@@ -35241,7 +35254,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0
   f32.const 1
   f32.const 1
   f32.const 0
@@ -35256,7 +35269,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 0.5
   f32.const 1
   f32.const 1
   f32.const 0
@@ -35271,7 +35284,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0.5
   f32.const 1
   f32.const 1
   f32.const 0
@@ -35286,7 +35299,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const 1
   f32.const 1
   f32.const 0
@@ -35301,9 +35314,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 1
-  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35317,9 +35330,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 1
-  f32.const 1
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35332,9 +35344,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 1
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35347,9 +35360,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -1
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35362,9 +35375,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -1
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35377,9 +35390,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0
   f32.const -1
-  f32.const 0.5
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35392,9 +35405,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 0.5
   f32.const -1
-  f32.const -0.5
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35407,9 +35420,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0.5
   f32.const -1
-  f32.const 1
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35422,9 +35435,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -1
-  f32.const -1
-  f32.const -1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35437,9 +35450,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
   f32.const -1
-  f32.const inf
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35453,9 +35466,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const -1
-  f32.const -1
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35468,9 +35480,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const -1
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35483,9 +35496,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35499,7 +35512,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
+  f32.const 0
   f32.const 0
   f32.const 0
   i32.const 0
@@ -35514,8 +35527,8 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35530,8 +35543,7 @@
   end
   f32.const 0
   f32.const inf
-  f32.neg
-  f32.const 0
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35545,8 +35557,9 @@
    unreachable
   end
   f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35559,9 +35572,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35575,8 +35588,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35590,8 +35603,8 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35606,8 +35619,7 @@
   end
   f32.const -0
   f32.const inf
-  f32.neg
-  f32.const -0
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35621,8 +35633,9 @@
    unreachable
   end
   f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35635,9 +35648,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 0
-  f32.const 1
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35650,9 +35663,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const 0
-  f32.const 0
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35665,9 +35678,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 0
-  f32.const inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35681,6 +35694,21 @@
    unreachable
   end
   f32.const inf
+  f32.const 0
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2130
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.neg
   f32.const 0
   f32.const 0
@@ -35691,7 +35719,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2130
+   i32.const 2131
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35706,7 +35734,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2131
+   i32.const 2132
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35721,7 +35749,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2132
+   i32.const 2133
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35736,7 +35764,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2133
+   i32.const 2134
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35752,7 +35780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2134
+   i32.const 2135
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35767,28 +35795,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2135
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 2
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2136
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const 2
   f32.const inf
   f32.const 0
   i32.const 0
@@ -35803,8 +35816,8 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0.5
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35818,9 +35831,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const 2
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35835,6 +35847,22 @@
   end
   f32.const inf
   f32.neg
+  f32.const 2
+  f32.const 2
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2140
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
   f32.const -0.5
   f32.const -0.5
   f32.const 0
@@ -35844,7 +35872,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2140
+   i32.const 2141
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -35860,27 +35888,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2141
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2142
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -35895,7 +35908,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -35910,9 +35923,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const inf
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35925,7 +35938,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
   f32.const inf
   f32.const 0
@@ -35940,7 +35953,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const inf
   f32.const inf
   f32.const 0
@@ -35956,7 +35969,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
   f32.const inf
   f32.const 0
@@ -35971,10 +35983,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
   f32.neg
-  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -35987,10 +35999,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
   f32.neg
-  f32.const -1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -36003,10 +36015,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const inf
   f32.neg
-  f32.const inf
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -36020,11 +36032,9 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
   f32.neg
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -36037,9 +36047,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 1.75
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -36052,9 +36065,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
+  f32.const 1.75
   f32.const 0.5
-  f32.const 0.5
+  f32.const 1.75
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -36067,6 +36080,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2155
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.75
   f32.const -0.5
   f32.const 1.75
@@ -36077,7 +36105,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2155
+   i32.const 2156
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36092,7 +36120,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2156
+   i32.const 2157
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36107,7 +36135,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2168
+   i32.const 2169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36122,7 +36150,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2169
+   i32.const 2170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36137,7 +36165,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2170
+   i32.const 2171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36152,7 +36180,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2171
+   i32.const 2172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36167,7 +36195,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2172
+   i32.const 2173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36182,7 +36210,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2173
+   i32.const 2174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36197,7 +36225,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2174
+   i32.const 2175
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36212,7 +36240,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2175
+   i32.const 2176
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36227,7 +36255,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2176
+   i32.const 2177
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36242,7 +36270,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2177
+   i32.const 2178
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36250,21 +36278,6 @@
   f64.const 0
   f64.const 1
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2180
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36277,9 +36290,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const 1
-  f64.const 0.5
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36292,9 +36305,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const 1
-  f64.const -0.5
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36307,9 +36320,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0.5
   f64.const 1
-  f64.const 1
-  f64.const 1
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36322,9 +36335,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const 1
-  f64.const -1
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36337,9 +36350,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 1
-  f64.const 1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36353,10 +36366,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const 1
-  f64.const inf
-  f64.neg
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36369,9 +36380,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36384,9 +36397,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
-  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36399,7 +36412,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36414,7 +36427,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36429,7 +36442,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0.5
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36444,7 +36457,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0.5
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36459,7 +36472,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36474,7 +36487,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -1
   f64.const -1
   f64.const 0
@@ -36490,10 +36503,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const -1
-  f64.const inf
-  f64.neg
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36506,9 +36517,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36521,9 +36534,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36537,8 +36550,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36552,8 +36565,8 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36568,9 +36581,7 @@
   end
   f64.const 0
   f64.const inf
-  f64.neg
-  f64.const inf
-  f64.neg
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36584,8 +36595,10 @@
    unreachable
   end
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36598,9 +36611,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36614,7 +36627,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   f64.const -0
   f64.const 0
   i32.const 0
@@ -36629,7 +36642,7 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
+  f64.const -0
   f64.const -0
   f64.const 0
   i32.const 0
@@ -36645,6 +36658,21 @@
   end
   f64.const -0
   f64.const inf
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2206
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const inf
   f64.neg
   f64.const inf
   f64.neg
@@ -36655,7 +36683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2206
+   i32.const 2207
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36670,7 +36698,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2207
+   i32.const 2208
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -36685,29 +36713,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2208
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 0
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2209
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
-  f64.const 0
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36721,10 +36734,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const 0
-  f64.const inf
-  f64.neg
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36737,9 +36748,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36752,9 +36765,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
-  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36767,9 +36780,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -0
-  f64.const -0
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36783,10 +36796,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const -0
-  f64.const inf
-  f64.neg
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36799,9 +36810,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36814,9 +36827,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36830,8 +36843,8 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const 2
+  f64.const 2
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36845,8 +36858,8 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36860,10 +36873,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const 2
-  f64.const inf
-  f64.neg
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36878,7 +36889,7 @@
   end
   f64.const inf
   f64.neg
-  f64.const -0.5
+  f64.const 2
   f64.const inf
   f64.neg
   f64.const 0
@@ -36895,8 +36906,9 @@
   end
   f64.const inf
   f64.neg
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36909,7 +36921,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -36924,7 +36937,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -36939,7 +36952,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -36954,9 +36967,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36969,9 +36982,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
-  f64.const -1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -36984,9 +36997,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -37000,10 +37013,8 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -37016,9 +37027,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
   f64.neg
+  f64.const inf
   f64.const inf
   f64.neg
   f64.const 0
@@ -37033,7 +37044,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
   f64.neg
   f64.const inf
@@ -37050,7 +37061,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const inf
   f64.neg
   f64.const inf
@@ -37068,7 +37079,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
   f64.neg
   f64.const inf
@@ -37085,9 +37095,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.5
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -37100,6 +37113,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2235
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1.75
   f64.const 0.5
   f64.const -1.75
@@ -37110,7 +37138,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2235
+   i32.const 2236
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37125,7 +37153,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2236
+   i32.const 2237
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37140,7 +37168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2237
+   i32.const 2238
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37155,7 +37183,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2246
+   i32.const 2247
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37170,7 +37198,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2247
+   i32.const 2248
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37185,7 +37213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2248
+   i32.const 2249
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37200,7 +37228,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2249
+   i32.const 2250
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37215,7 +37243,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2250
+   i32.const 2251
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37230,7 +37258,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2251
+   i32.const 2252
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37245,7 +37273,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2252
+   i32.const 2253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37260,7 +37288,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2253
+   i32.const 2254
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37275,7 +37303,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2254
+   i32.const 2255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37290,7 +37318,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2255
+   i32.const 2256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37298,21 +37326,6 @@
   f32.const 0
   f32.const 1
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2258
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37325,9 +37338,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0
   f32.const 1
-  f32.const 0.5
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37340,9 +37353,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 0.5
   f32.const 1
-  f32.const -0.5
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37355,9 +37368,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0.5
   f32.const 1
-  f32.const 1
-  f32.const 1
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37370,9 +37383,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
   f32.const 1
-  f32.const -1
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37385,9 +37398,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 1
-  f32.const 1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37401,10 +37414,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 1
-  f32.const inf
-  f32.neg
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37417,9 +37428,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 1
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37432,9 +37445,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37447,7 +37460,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37462,7 +37475,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37477,7 +37490,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 0.5
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37492,7 +37505,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0.5
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37507,7 +37520,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37522,7 +37535,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const -1
   f32.const -1
   f32.const 0
@@ -37538,10 +37551,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const -1
-  f32.const inf
-  f32.neg
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37554,9 +37565,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const -1
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37569,9 +37582,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37585,8 +37598,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37600,8 +37613,8 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37616,9 +37629,7 @@
   end
   f32.const 0
   f32.const inf
-  f32.neg
-  f32.const inf
-  f32.neg
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37632,8 +37643,10 @@
    unreachable
   end
   f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37646,9 +37659,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 0
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37662,7 +37675,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const 0
   f32.const -0
   f32.const 0
   i32.const 0
@@ -37677,7 +37690,7 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
+  f32.const -0
   f32.const -0
   f32.const 0
   i32.const 0
@@ -37693,6 +37706,21 @@
   end
   f32.const -0
   f32.const inf
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2284
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const inf
   f32.neg
   f32.const inf
   f32.neg
@@ -37703,7 +37731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2284
+   i32.const 2285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37718,7 +37746,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2285
+   i32.const 2286
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -37733,29 +37761,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2286
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 0
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2287
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 0
-  f32.const 0
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37769,10 +37782,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 0
-  f32.const inf
-  f32.neg
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37785,9 +37796,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 0
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37800,9 +37813,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37815,9 +37828,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const -0
-  f32.const -0
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37831,10 +37844,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const -0
-  f32.const inf
-  f32.neg
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37847,9 +37858,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const -0
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37862,9 +37875,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37878,8 +37891,8 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
-  f32.const -0.5
+  f32.const 2
+  f32.const 2
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37893,8 +37906,8 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37908,10 +37921,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const 2
-  f32.const inf
-  f32.neg
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37926,7 +37937,7 @@
   end
   f32.const inf
   f32.neg
-  f32.const -0.5
+  f32.const 2
   f32.const inf
   f32.neg
   f32.const 0
@@ -37943,8 +37954,9 @@
   end
   f32.const inf
   f32.neg
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0.5
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -37957,7 +37969,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -37972,7 +37985,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -37987,7 +38000,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -38002,9 +38015,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -38017,9 +38030,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
-  f32.const -1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -38032,9 +38045,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const inf
-  f32.const inf
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -38048,10 +38061,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -38064,9 +38075,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
   f32.neg
+  f32.const inf
   f32.const inf
   f32.neg
   f32.const 0
@@ -38081,7 +38092,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
   f32.neg
   f32.const inf
@@ -38098,7 +38109,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const inf
   f32.neg
   f32.const inf
@@ -38116,7 +38127,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
   f32.neg
   f32.const inf
@@ -38133,9 +38143,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 0.5
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -38148,6 +38161,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2313
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.75
   f32.const 0.5
   f32.const -1.75
@@ -38158,7 +38186,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2313
+   i32.const 2314
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38173,7 +38201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2314
+   i32.const 2315
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38188,7 +38216,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2315
+   i32.const 2316
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38203,7 +38231,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2329
+   i32.const 2330
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38218,7 +38246,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2330
+   i32.const 2331
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38233,7 +38261,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2331
+   i32.const 2332
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38248,7 +38276,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2332
+   i32.const 2333
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38263,7 +38291,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2333
+   i32.const 2334
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38278,7 +38306,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2334
+   i32.const 2335
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38293,7 +38321,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2335
+   i32.const 2336
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38308,7 +38336,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2336
+   i32.const 2337
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38323,7 +38351,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2337
+   i32.const 2338
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38338,7 +38366,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2338
+   i32.const 2339
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38346,21 +38374,6 @@
   f64.const 0
   f64.const 1
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2341
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38373,9 +38386,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const 1
-  f64.const 0.5
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38388,6 +38401,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2344
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -0.5
   f64.const 1
   f64.const -0.5
@@ -38398,7 +38426,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2344
+   i32.const 2345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38413,7 +38441,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2345
+   i32.const 2346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38428,7 +38456,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2346
+   i32.const 2347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38443,7 +38471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2347
+   i32.const 2348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38458,7 +38486,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2348
+   i32.const 2349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38473,7 +38501,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2349
+   i32.const 2350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38488,28 +38516,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2350
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2351
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38524,11 +38536,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38539,9 +38552,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38554,9 +38567,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -1
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38569,6 +38582,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2356
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0.5
   f64.const -1
   f64.const 0.5
@@ -38579,7 +38607,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2356
+   i32.const 2357
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38594,7 +38622,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2357
+   i32.const 2358
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38609,7 +38637,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2358
+   i32.const 2359
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38624,7 +38652,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2359
+   i32.const 2360
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38639,7 +38667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2360
+   i32.const 2361
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38654,7 +38682,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2361
+   i32.const 2362
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38669,7 +38697,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2362
+   i32.const 2363
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38684,28 +38712,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2363
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2364
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38720,11 +38732,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38735,11 +38748,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38751,7 +38764,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -38766,10 +38779,10 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
+  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38782,7 +38795,6 @@
   end
   f64.const 0
   f64.const inf
-  f64.neg
   f64.const 0
   f64.const 0
   i32.const 0
@@ -38797,8 +38809,9 @@
    unreachable
   end
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38811,11 +38824,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
   f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38827,7 +38840,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -38842,6 +38855,21 @@
    unreachable
   end
   f64.const -0
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2374
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const inf
   f64.const -0
   f64.const 0
@@ -38851,7 +38879,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2374
+   i32.const 2375
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38867,7 +38895,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2375
+   i32.const 2376
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38882,7 +38910,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2376
+   i32.const 2377
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -38897,27 +38925,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2377
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2378
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38933,7 +38946,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38948,11 +38960,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -38963,11 +38976,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -38978,7 +38991,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -38994,7 +39007,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -39009,11 +39021,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -39024,11 +39037,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -39040,7 +39053,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -39055,10 +39068,10 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -39070,11 +39083,10 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const 2
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -39087,7 +39099,7 @@
   end
   f64.const inf
   f64.neg
-  f64.const -0.5
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -39103,10 +39115,10 @@
   end
   f64.const inf
   f64.neg
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -39117,7 +39129,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -39132,7 +39145,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -39147,7 +39160,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -39162,9 +39175,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39177,9 +39190,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
-  f64.const -1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39192,11 +39205,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -39208,7 +39221,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
@@ -39223,12 +39235,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
   f64.neg
-  f64.const 1
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -39239,10 +39251,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
   f64.neg
-  f64.const -1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39255,12 +39267,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const inf
   f64.neg
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -39272,7 +39284,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
   f64.neg
   f64.const nan:0x8000000000000
@@ -39288,11 +39299,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.25
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_mod
   i32.eqz
   if
@@ -39303,9 +39316,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
+  f64.const 1.75
   f64.const 0.5
-  f64.const -0.25
+  f64.const 0.25
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39318,6 +39331,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const -0.25
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2405
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.75
   f64.const -0.5
   f64.const 0.25
@@ -39328,7 +39356,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2405
+   i32.const 2406
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39343,7 +39371,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2406
+   i32.const 2407
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39351,23 +39379,6 @@
   i64.const 4503599627370496
   f64.reinterpret_i64
   i64.const 4503599627370496
-  f64.reinterpret_i64
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2409
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 4503599627370496
-  f64.reinterpret_i64
-  i64.const -9218868437227405312
   f64.reinterpret_i64
   f64.const 0
   f64.const 0
@@ -39382,11 +39393,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -9218868437227405312
-  f64.reinterpret_i64
   i64.const 4503599627370496
   f64.reinterpret_i64
-  f64.const -0
+  i64.const -9218868437227405312
+  f64.reinterpret_i64
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39401,7 +39412,7 @@
   end
   i64.const -9218868437227405312
   f64.reinterpret_i64
-  i64.const -9218868437227405312
+  i64.const 4503599627370496
   f64.reinterpret_i64
   f64.const -0
   f64.const 0
@@ -39416,11 +39427,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 9218868437227405311
+  i64.const -9218868437227405312
   f64.reinterpret_i64
-  i64.const 9218868437227405311
+  i64.const -9218868437227405312
   f64.reinterpret_i64
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39435,7 +39446,7 @@
   end
   i64.const 9218868437227405311
   f64.reinterpret_i64
-  i64.const -4503599627370497
+  i64.const 9218868437227405311
   f64.reinterpret_i64
   f64.const 0
   f64.const 0
@@ -39450,11 +39461,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -4503599627370497
-  f64.reinterpret_i64
   i64.const 9218868437227405311
   f64.reinterpret_i64
-  f64.const -0
+  i64.const -4503599627370497
+  f64.reinterpret_i64
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39469,7 +39480,7 @@
   end
   i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const -4503599627370497
+  i64.const 9218868437227405311
   f64.reinterpret_i64
   f64.const -0
   f64.const 0
@@ -39484,11 +39495,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const 4503599627370496
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -39496,14 +39507,14 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2419
+   i32.const 2417
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   f64.reinterpret_i64
-  i64.const 9218868437227405311
+  i64.const 4503599627370496
   f64.reinterpret_i64
   f64.const 0
   f64.const 0
@@ -39520,7 +39531,7 @@
   end
   i64.const 0
   f64.reinterpret_i64
-  i64.const -9218868437227405312
+  i64.const 9218868437227405311
   f64.reinterpret_i64
   f64.const 0
   f64.const 0
@@ -39537,7 +39548,7 @@
   end
   i64.const 0
   f64.reinterpret_i64
-  i64.const -4503599627370497
+  i64.const -9218868437227405312
   f64.reinterpret_i64
   f64.const 0
   f64.const 0
@@ -39548,6 +39559,23 @@
    i32.const 0
    i32.const 32
    i32.const 2422
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  f64.reinterpret_i64
+  i64.const -4503599627370497
+  f64.reinterpret_i64
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2423
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39564,7 +39592,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2423
+   i32.const 2424
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39581,7 +39609,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2424
+   i32.const 2425
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39598,7 +39626,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2425
+   i32.const 2426
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39615,7 +39643,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2426
+   i32.const 2427
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39633,7 +39661,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2429
+   i32.const 2430
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39651,7 +39679,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2430
+   i32.const 2431
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39669,7 +39697,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2432
+   i32.const 2433
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39687,7 +39715,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2433
+   i32.const 2434
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39705,7 +39733,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2435
+   i32.const 2436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39723,7 +39751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2436
+   i32.const 2437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39741,7 +39769,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2438
+   i32.const 2439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39759,7 +39787,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2439
+   i32.const 2440
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39769,24 +39797,6 @@
   i64.const 9218868437227405311
   f64.reinterpret_i64
   i64.const 9214364837600034816
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2441
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const -9007199254740992
-  f64.reinterpret_i64
-  i64.const 9218868437227405311
-  f64.reinterpret_i64
-  i64.const -9007199254740992
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39800,11 +39810,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 9214364837600034815
+  i64.const -9007199254740992
   f64.reinterpret_i64
-  i64.const -4503599627370497
+  i64.const 9218868437227405311
   f64.reinterpret_i64
-  i64.const 9214364837600034815
+  i64.const -9007199254740992
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39813,16 +39823,16 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2444
+   i32.const 2443
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -9007199254740993
+  i64.const 9214364837600034815
   f64.reinterpret_i64
   i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const -9007199254740993
+  i64.const 9214364837600034815
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39836,11 +39846,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 9214364837600034814
+  i64.const -9007199254740993
   f64.reinterpret_i64
-  i64.const 9218868437227405311
+  i64.const -4503599627370497
   f64.reinterpret_i64
-  i64.const 9214364837600034814
+  i64.const -9007199254740993
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39849,16 +39859,16 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2447
+   i32.const 2446
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -9007199254740994
+  i64.const 9214364837600034814
   f64.reinterpret_i64
   i64.const 9218868437227405311
   f64.reinterpret_i64
-  i64.const -9007199254740994
+  i64.const 9214364837600034814
   f64.reinterpret_i64
   f64.const 0
   i32.const 0
@@ -39872,6 +39882,24 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const -9007199254740994
+  f64.reinterpret_i64
+  i64.const 9218868437227405311
+  f64.reinterpret_i64
+  i64.const -9007199254740994
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2449
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 9218868437227405310
   f64.reinterpret_i64
   i64.const -4503599627370497
@@ -39885,7 +39913,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2450
+   i32.const 2451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39903,7 +39931,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2451
+   i32.const 2452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39921,7 +39949,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2453
+   i32.const 2454
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39939,7 +39967,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2454
+   i32.const 2455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39955,7 +39983,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2456
+   i32.const 2457
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39971,7 +39999,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2457
+   i32.const 2458
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -39987,7 +40015,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2458
+   i32.const 2459
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40003,7 +40031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2459
+   i32.const 2460
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40019,7 +40047,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2460
+   i32.const 2461
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40035,7 +40063,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2461
+   i32.const 2462
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40051,7 +40079,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2462
+   i32.const 2463
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40067,7 +40095,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2463
+   i32.const 2464
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40085,7 +40113,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2465
+   i32.const 2466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40103,7 +40131,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2466
+   i32.const 2467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40121,24 +40149,6 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2467
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 4503599627370495
-  f64.reinterpret_i64
-  i64.const 9007199254740991
-  f64.reinterpret_i64
-  i64.const 4503599627370495
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2468
    i32.const 1
    call $~lib/builtins/abort
@@ -40146,7 +40156,7 @@
   end
   i64.const 4503599627370495
   f64.reinterpret_i64
-  i64.const 9218868437227405312
+  i64.const 9007199254740991
   f64.reinterpret_i64
   i64.const 4503599627370495
   f64.reinterpret_i64
@@ -40164,6 +40174,24 @@
   end
   i64.const 4503599627370495
   f64.reinterpret_i64
+  i64.const 9218868437227405312
+  f64.reinterpret_i64
+  i64.const 4503599627370495
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2470
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 4503599627370495
+  f64.reinterpret_i64
   i64.const -9223372036854775805
   f64.reinterpret_i64
   i64.const 0
@@ -40175,7 +40203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2470
+   i32.const 2471
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40193,7 +40221,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2471
+   i32.const 2472
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40211,7 +40239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2472
+   i32.const 2473
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40229,7 +40257,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2473
+   i32.const 2474
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40247,7 +40275,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2474
+   i32.const 2475
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40265,24 +40293,6 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2475
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 4503599627370498
-  f64.reinterpret_i64
-  i64.const 3
-  f64.reinterpret_i64
-  i64.const 0
-  f64.reinterpret_i64
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2476
    i32.const 1
    call $~lib/builtins/abort
@@ -40290,7 +40300,7 @@
   end
   i64.const 4503599627370498
   f64.reinterpret_i64
-  i64.const -9223372036854775805
+  i64.const 3
   f64.reinterpret_i64
   i64.const 0
   f64.reinterpret_i64
@@ -40306,6 +40316,24 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const 4503599627370498
+  f64.reinterpret_i64
+  i64.const -9223372036854775805
+  f64.reinterpret_i64
+  i64.const 0
+  f64.reinterpret_i64
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2478
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 4503599627370499
   f64.reinterpret_i64
   i64.const 3
@@ -40319,7 +40347,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2478
+   i32.const 2479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40337,7 +40365,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2479
+   i32.const 2480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40355,7 +40383,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2480
+   i32.const 2481
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40373,7 +40401,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2481
+   i32.const 2482
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40391,7 +40419,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2482
+   i32.const 2483
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40409,7 +40437,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2483
+   i32.const 2484
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40427,7 +40455,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2484
+   i32.const 2485
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40442,7 +40470,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2493
+   i32.const 2494
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40457,7 +40485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2494
+   i32.const 2495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40472,7 +40500,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2495
+   i32.const 2496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40487,7 +40515,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2496
+   i32.const 2497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40502,7 +40530,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2497
+   i32.const 2498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40517,7 +40545,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2498
+   i32.const 2499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40532,7 +40560,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2499
+   i32.const 2500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40547,7 +40575,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2500
+   i32.const 2501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40562,7 +40590,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2501
+   i32.const 2502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40577,7 +40605,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2502
+   i32.const 2503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40585,21 +40613,6 @@
   f32.const 0
   f32.const 1
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2505
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40612,9 +40625,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0
   f32.const 1
-  f32.const 0.5
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40627,6 +40640,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2508
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -0.5
   f32.const 1
   f32.const -0.5
@@ -40637,7 +40665,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2508
+   i32.const 2509
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40652,7 +40680,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2509
+   i32.const 2510
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40667,7 +40695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2510
+   i32.const 2511
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40682,7 +40710,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2511
+   i32.const 2512
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40697,7 +40725,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2512
+   i32.const 2513
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40712,7 +40740,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2513
+   i32.const 2514
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40727,28 +40755,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2514
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2515
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
@@ -40763,11 +40775,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -40778,9 +40791,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -1
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40793,9 +40806,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -1
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -40808,6 +40821,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2520
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0.5
   f32.const -1
   f32.const 0.5
@@ -40818,7 +40846,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2520
+   i32.const 2521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40833,7 +40861,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2521
+   i32.const 2522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40848,7 +40876,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2522
+   i32.const 2523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40863,7 +40891,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2523
+   i32.const 2524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40878,7 +40906,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2524
+   i32.const 2525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40893,7 +40921,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2525
+   i32.const 2526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40908,7 +40936,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2526
+   i32.const 2527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -40923,28 +40951,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2527
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const -1
   f32.const nan:0x400000
   f32.const 0
@@ -40959,11 +40971,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const -1
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -40974,11 +40987,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -40990,7 +41003,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -41005,10 +41018,10 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
+  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -41021,7 +41034,6 @@
   end
   f32.const 0
   f32.const inf
-  f32.neg
   f32.const 0
   f32.const 0
   i32.const 0
@@ -41036,8 +41048,9 @@
    unreachable
   end
   f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -41050,11 +41063,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 0
   f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41066,7 +41079,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -41081,6 +41094,21 @@
    unreachable
   end
   f32.const -0
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2538
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const inf
   f32.const -0
   f32.const 0
@@ -41090,7 +41118,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2538
+   i32.const 2539
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41106,7 +41134,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2539
+   i32.const 2540
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41121,7 +41149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2540
+   i32.const 2541
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41136,27 +41164,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2541
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2542
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -41172,7 +41185,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -41187,11 +41199,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -41202,11 +41215,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41217,7 +41230,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -41233,7 +41246,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -41248,11 +41260,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -41263,11 +41276,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41279,7 +41292,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -41294,10 +41307,10 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -41309,11 +41322,10 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const 2
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41326,7 +41338,7 @@
   end
   f32.const inf
   f32.neg
-  f32.const -0.5
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -41342,10 +41354,10 @@
   end
   f32.const inf
   f32.neg
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -41356,7 +41368,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -41371,7 +41384,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -41386,7 +41399,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -41401,9 +41414,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -41416,9 +41429,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
-  f32.const -1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -41431,11 +41444,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41447,7 +41460,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
   f32.const nan:0x400000
   f32.const 0
@@ -41462,12 +41474,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
   f32.neg
-  f32.const 1
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -41478,10 +41490,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
   f32.neg
-  f32.const -1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -41494,12 +41506,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const inf
   f32.neg
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -41511,7 +41523,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
   f32.neg
   f32.const nan:0x400000
@@ -41527,11 +41538,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 0.25
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_modf
   i32.eqz
   if
@@ -41542,9 +41555,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
+  f32.const 1.75
   f32.const 0.5
-  f32.const -0.25
+  f32.const 0.25
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -41557,6 +41570,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const -0.25
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2569
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.75
   f32.const -0.5
   f32.const 0.25
@@ -41567,7 +41595,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2569
+   i32.const 2570
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41582,7 +41610,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2570
+   i32.const 2571
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41597,7 +41625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2582
+   i32.const 2583
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41612,7 +41640,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2583
+   i32.const 2584
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41627,7 +41655,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2584
+   i32.const 2585
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41642,7 +41670,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2585
+   i32.const 2586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41657,7 +41685,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2586
+   i32.const 2587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41672,7 +41700,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2587
+   i32.const 2588
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41687,7 +41715,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2588
+   i32.const 2589
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41702,7 +41730,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2589
+   i32.const 2590
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41717,7 +41745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2590
+   i32.const 2591
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41732,7 +41760,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2591
+   i32.const 2592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41740,21 +41768,6 @@
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2594
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const inf
-  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -41768,7 +41781,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 3
+  f64.const inf
   f64.const 0
   f64.const 0
   i32.const 0
@@ -41783,7 +41796,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 2
+  f64.const 3
   f64.const 0
   f64.const 0
   i32.const 0
@@ -41798,7 +41811,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 1
+  f64.const 2
   f64.const 0
   f64.const 0
   i32.const 0
@@ -41813,7 +41826,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0.5
+  f64.const 1
   f64.const 0
   f64.const 0
   i32.const 0
@@ -41828,8 +41841,8 @@
    unreachable
   end
   f64.const 0
+  f64.const 0.5
   f64.const 0
-  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -41843,7 +41856,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const 0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -41858,10 +41871,10 @@
    unreachable
   end
   f64.const 0
-  f64.const -0.5
-  f64.const inf
+  f64.const -0
+  f64.const 1
   f64.const 0
-  global.get $std/math/DIVBYZERO
+  i32.const 0
   call $std/math/test_pow
   i32.eqz
   if
@@ -41873,7 +41886,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -1
+  f64.const -0.5
   f64.const inf
   f64.const 0
   global.get $std/math/DIVBYZERO
@@ -41888,7 +41901,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -2
+  f64.const -1
   f64.const inf
   f64.const 0
   global.get $std/math/DIVBYZERO
@@ -41903,7 +41916,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -3
+  f64.const -2
   f64.const inf
   f64.const 0
   global.get $std/math/DIVBYZERO
@@ -41918,7 +41931,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -4
+  f64.const -3
   f64.const inf
   f64.const 0
   global.get $std/math/DIVBYZERO
@@ -41928,6 +41941,21 @@
    i32.const 0
    i32.const 32
    i32.const 2606
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -4
+  f64.const inf
+  f64.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2607
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41943,7 +41971,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2607
+   i32.const 2608
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41958,7 +41986,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2608
+   i32.const 2609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41973,7 +42001,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2609
+   i32.const 2610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -41988,7 +42016,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2610
+   i32.const 2611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42003,7 +42031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2611
+   i32.const 2612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42018,7 +42046,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2612
+   i32.const 2613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42033,28 +42061,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2613
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -42069,6 +42082,21 @@
    unreachable
   end
   f64.const -0
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2616
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const -0.5
   f64.const inf
   f64.const 0
@@ -42078,7 +42106,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2616
+   i32.const 2617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42094,7 +42122,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2617
+   i32.const 2618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42109,7 +42137,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2618
+   i32.const 2619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42125,7 +42153,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2619
+   i32.const 2620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42140,7 +42168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2620
+   i32.const 2621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42156,27 +42184,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2621
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const 1
   f64.const 0
@@ -42192,7 +42205,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const 0
   f64.const 1
   f64.const 0
@@ -42207,7 +42219,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
+  f64.neg
   f64.const 0
   f64.const 1
   f64.const 0
@@ -42222,7 +42235,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -42237,7 +42250,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const -1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -42252,8 +42265,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const -0.5
+  f64.const 0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -42267,7 +42280,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const 1
   f64.const 0
@@ -42283,7 +42296,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const -0
   f64.const 1
   f64.const 0
@@ -42298,7 +42310,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
+  f64.neg
   f64.const -0
   f64.const 1
   f64.const 0
@@ -42313,7 +42326,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -42328,7 +42341,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const -1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -42343,9 +42356,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const -0
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42359,7 +42372,7 @@
    unreachable
   end
   f64.const -1
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -42375,7 +42388,6 @@
   end
   f64.const -1
   f64.const inf
-  f64.neg
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -42390,6 +42402,22 @@
    unreachable
   end
   f64.const -1
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2637
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
   f64.const 2
   f64.const 1
   f64.const 0
@@ -42399,7 +42427,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2637
+   i32.const 2638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42414,7 +42442,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2638
+   i32.const 2639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42429,7 +42457,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2639
+   i32.const 2640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42444,7 +42472,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2640
+   i32.const 2641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42459,28 +42487,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2641
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -42496,7 +42509,6 @@
   end
   f64.const 1
   f64.const inf
-  f64.neg
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -42511,8 +42523,9 @@
    unreachable
   end
   f64.const 1
-  f64.const 3
-  f64.const 1
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42526,7 +42539,7 @@
    unreachable
   end
   f64.const 1
-  f64.const 0.5
+  f64.const 3
   f64.const 1
   f64.const 0
   i32.const 0
@@ -42541,7 +42554,7 @@
    unreachable
   end
   f64.const 1
-  f64.const -0.5
+  f64.const 0.5
   f64.const 1
   f64.const 0
   i32.const 0
@@ -42556,7 +42569,7 @@
    unreachable
   end
   f64.const 1
-  f64.const -3
+  f64.const -0.5
   f64.const 1
   f64.const 0
   i32.const 0
@@ -42570,11 +42583,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 0.5
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const -3
+  f64.const 1
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_pow
   i32.eqz
   if
@@ -42586,7 +42599,7 @@
    unreachable
   end
   f64.const -0.5
-  f64.const 1.5
+  f64.const 0.5
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -42601,6 +42614,21 @@
    unreachable
   end
   f64.const -0.5
+  f64.const 1.5
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2651
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
   f64.const 2
   f64.const 0.25
   f64.const 0
@@ -42610,7 +42638,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2651
+   i32.const 2652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42625,7 +42653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2652
+   i32.const 2653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42640,7 +42668,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2653
+   i32.const 2654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42656,7 +42684,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2654
+   i32.const 2655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42664,21 +42692,6 @@
   f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2655
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const inf
-  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42693,6 +42706,21 @@
   end
   f64.const 0.5
   f64.const inf
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2657
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const inf
   f64.neg
   f64.const inf
   f64.const 0
@@ -42702,7 +42730,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2657
+   i32.const 2658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42717,7 +42745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2658
+   i32.const 2659
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42732,7 +42760,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2659
+   i32.const 2660
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42748,27 +42776,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2660
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2661
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const 1.5
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -42784,8 +42797,8 @@
    unreachable
   end
   f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42800,6 +42813,21 @@
   end
   f64.const inf
   f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2664
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
   f64.neg
   f64.const 0
   f64.const 0
@@ -42809,7 +42837,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2664
+   i32.const 2665
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42824,7 +42852,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2665
+   i32.const 2666
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42839,7 +42867,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2666
+   i32.const 2667
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42854,7 +42882,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2667
+   i32.const 2668
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42869,7 +42897,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2668
+   i32.const 2669
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42884,7 +42912,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2669
+   i32.const 2670
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42899,7 +42927,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2670
+   i32.const 2671
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42914,22 +42942,6 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2671
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2672
    i32.const 1
    call $~lib/builtins/abort
@@ -42937,8 +42949,8 @@
   end
   f64.const inf
   f64.neg
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -42954,6 +42966,22 @@
   f64.const inf
   f64.neg
   f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2674
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
+  f64.const inf
   f64.neg
   f64.const 0
   f64.const 0
@@ -42963,7 +42991,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2674
+   i32.const 2675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42980,7 +43008,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2675
+   i32.const 2676
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -42989,23 +43017,6 @@
   f64.neg
   f64.const 2
   f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2676
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.neg
-  f64.const 1
-  f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -43020,8 +43031,9 @@
   end
   f64.const inf
   f64.neg
-  f64.const 0.5
+  f64.const 1
   f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -43036,8 +43048,8 @@
   end
   f64.const inf
   f64.neg
-  f64.const -0.5
-  f64.const 0
+  f64.const 0.5
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -43052,8 +43064,8 @@
   end
   f64.const inf
   f64.neg
-  f64.const -1
-  f64.const -0
+  f64.const -0.5
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -43068,6 +43080,22 @@
   end
   f64.const inf
   f64.neg
+  f64.const -1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2681
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.neg
   f64.const -2
   f64.const 0
   f64.const 0
@@ -43077,7 +43105,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2681
+   i32.const 2682
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43092,7 +43120,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2682
+   i32.const 2683
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43107,7 +43135,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2683
+   i32.const 2684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43122,7 +43150,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2684
+   i32.const 2685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43137,26 +43165,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2685
+   i32.const 2686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 0
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2688
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -43171,7 +43185,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
   f64.eq
@@ -43184,7 +43198,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -43198,8 +43212,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const 0
+  f64.const -0
   call $~lib/math/NativeMath.pow
   f64.const 1
   f64.eq
@@ -43212,7 +43226,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -43227,7 +43241,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -43241,7 +43254,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
@@ -43255,24 +43269,24 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 1
   call $~lib/math/NativeMath.pow
-  f64.const 0
+  f64.const 1
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 2697
+   i32.const 2696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const 1
   call $~lib/math/NativeMath.pow
-  f64.const -0
+  f64.const 0
   f64.eq
   i32.eqz
   if
@@ -43283,10 +43297,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0
   f64.const 1
   call $~lib/math/NativeMath.pow
-  f64.const -1
+  f64.const -0
   f64.eq
   i32.eqz
   if
@@ -43297,10 +43311,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 1
   call $~lib/math/NativeMath.pow
-  f64.const inf
+  f64.const -1
   f64.eq
   i32.eqz
   if
@@ -43312,6 +43326,20 @@
    unreachable
   end
   f64.const inf
+  f64.const 1
+  call $~lib/math/NativeMath.pow
+  f64.const inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2701
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.neg
   f64.const 1
   call $~lib/math/NativeMath.pow
@@ -43322,7 +43350,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2701
+   i32.const 2702
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43337,7 +43365,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2702
+   i32.const 2703
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43351,7 +43379,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2704
+   i32.const 2705
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43366,7 +43394,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2705
+   i32.const 2706
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43380,7 +43408,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2706
+   i32.const 2707
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43394,7 +43422,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2707
+   i32.const 2708
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43408,7 +43436,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2708
+   i32.const 2709
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43422,7 +43450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2709
+   i32.const 2710
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43437,7 +43465,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2710
+   i32.const 2711
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43452,26 +43480,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2711
+   i32.const 2712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2713
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const 2
   call $~lib/math/NativeMath.pow
   f64.const 0
@@ -43485,6 +43499,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const 2
+  call $~lib/math/NativeMath.pow
+  f64.const 0
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2715
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1
   f64.const 2
   call $~lib/math/NativeMath.pow
@@ -43494,7 +43522,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2715
+   i32.const 2716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43508,35 +43536,35 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2716
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 2
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const 1
   f64.const 2
   call $~lib/math/NativeMath.pow
-  f64.const inf
+  f64.const 1
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 2718
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 2
+  call $~lib/math/NativeMath.pow
+  f64.const inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43551,7 +43579,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2719
+   i32.const 2720
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43566,7 +43594,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2720
+   i32.const 2721
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43580,7 +43608,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2722
+   i32.const 2723
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43594,7 +43622,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2723
+   i32.const 2724
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43609,7 +43637,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2724
+   i32.const 2725
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43623,35 +43651,35 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2725
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2726
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const 1
   f64.const 0.5
   call $~lib/math/NativeMath.pow
-  f64.const inf
+  f64.const 1
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 2727
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 0.5
+  call $~lib/math/NativeMath.pow
+  f64.const inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2728
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43666,7 +43694,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2728
+   i32.const 2729
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43681,7 +43709,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2729
+   i32.const 2730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43696,7 +43724,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2738
+   i32.const 2739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43711,7 +43739,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2739
+   i32.const 2740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43726,7 +43754,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2740
+   i32.const 2741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43741,7 +43769,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2741
+   i32.const 2742
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43756,7 +43784,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2742
+   i32.const 2743
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43771,7 +43799,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2743
+   i32.const 2744
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43786,7 +43814,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2744
+   i32.const 2745
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43801,7 +43829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2745
+   i32.const 2746
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43816,7 +43844,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2746
+   i32.const 2747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43831,7 +43859,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2747
+   i32.const 2748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -43839,21 +43867,6 @@
   f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2750
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const inf
-  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -43867,7 +43880,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 3
+  f32.const inf
   f32.const 0
   f32.const 0
   i32.const 0
@@ -43882,7 +43895,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 2
+  f32.const 3
   f32.const 0
   f32.const 0
   i32.const 0
@@ -43897,7 +43910,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 1
+  f32.const 2
   f32.const 0
   f32.const 0
   i32.const 0
@@ -43912,7 +43925,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0.5
+  f32.const 1
   f32.const 0
   f32.const 0
   i32.const 0
@@ -43927,8 +43940,8 @@
    unreachable
   end
   f32.const 0
+  f32.const 0.5
   f32.const 0
-  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -43942,7 +43955,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
+  f32.const 0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -43957,10 +43970,10 @@
    unreachable
   end
   f32.const 0
-  f32.const -0.5
-  f32.const inf
+  f32.const -0
+  f32.const 1
   f32.const 0
-  global.get $std/math/DIVBYZERO
+  i32.const 0
   call $std/math/test_powf
   i32.eqz
   if
@@ -43972,7 +43985,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -1
+  f32.const -0.5
   f32.const inf
   f32.const 0
   global.get $std/math/DIVBYZERO
@@ -43987,7 +44000,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -2
+  f32.const -1
   f32.const inf
   f32.const 0
   global.get $std/math/DIVBYZERO
@@ -44002,7 +44015,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -3
+  f32.const -2
   f32.const inf
   f32.const 0
   global.get $std/math/DIVBYZERO
@@ -44017,7 +44030,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -4
+  f32.const -3
   f32.const inf
   f32.const 0
   global.get $std/math/DIVBYZERO
@@ -44027,6 +44040,21 @@
    i32.const 0
    i32.const 32
    i32.const 2762
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -4
+  f32.const inf
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2763
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44042,7 +44070,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2763
+   i32.const 2764
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44057,7 +44085,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2764
+   i32.const 2765
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44072,7 +44100,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2765
+   i32.const 2766
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44087,7 +44115,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2766
+   i32.const 2767
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44102,7 +44130,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2767
+   i32.const 2768
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44117,7 +44145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2768
+   i32.const 2769
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44132,28 +44160,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2769
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2770
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const 0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -44168,6 +44181,21 @@
    unreachable
   end
   f32.const -0
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2772
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const -0.5
   f32.const inf
   f32.const 0
@@ -44177,7 +44205,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2772
+   i32.const 2773
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44193,7 +44221,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2773
+   i32.const 2774
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44208,7 +44236,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2774
+   i32.const 2775
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44224,7 +44252,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2775
+   i32.const 2776
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44239,7 +44267,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2776
+   i32.const 2777
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44255,27 +44283,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2777
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2778
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   f32.const 1
   f32.const 0
@@ -44291,7 +44304,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 0
   f32.const 1
   f32.const 0
@@ -44306,7 +44318,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const 0
   f32.const 1
   f32.const 0
@@ -44321,7 +44334,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const 0
   f32.const 1
   f32.const 0
@@ -44336,7 +44349,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const -1
   f32.const 0
   f32.const 1
   f32.const 0
@@ -44351,8 +44364,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const -0.5
+  f32.const 0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -44366,7 +44379,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const -0
   f32.const 1
   f32.const 0
@@ -44382,7 +44395,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const -0
   f32.const 1
   f32.const 0
@@ -44397,7 +44409,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const -0
   f32.const 1
   f32.const 0
@@ -44412,7 +44425,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const -0
   f32.const 1
   f32.const 0
@@ -44427,7 +44440,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const -1
   f32.const -0
   f32.const 1
   f32.const 0
@@ -44442,9 +44455,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0.5
+  f32.const -0
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44458,7 +44471,7 @@
    unreachable
   end
   f32.const -1
-  f32.const inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -44474,7 +44487,6 @@
   end
   f32.const -1
   f32.const inf
-  f32.neg
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -44489,6 +44501,22 @@
    unreachable
   end
   f32.const -1
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2793
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
   f32.const 2
   f32.const 1
   f32.const 0
@@ -44498,7 +44526,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2793
+   i32.const 2794
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44513,7 +44541,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2794
+   i32.const 2795
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44528,7 +44556,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2795
+   i32.const 2796
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44543,7 +44571,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2796
+   i32.const 2797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44558,28 +44586,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2797
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1
-  f32.const inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -44595,7 +44608,6 @@
   end
   f32.const 1
   f32.const inf
-  f32.neg
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -44610,8 +44622,9 @@
    unreachable
   end
   f32.const 1
-  f32.const 3
-  f32.const 1
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44625,7 +44638,7 @@
    unreachable
   end
   f32.const 1
-  f32.const 0.5
+  f32.const 3
   f32.const 1
   f32.const 0
   i32.const 0
@@ -44640,7 +44653,7 @@
    unreachable
   end
   f32.const 1
-  f32.const -0.5
+  f32.const 0.5
   f32.const 1
   f32.const 0
   i32.const 0
@@ -44655,7 +44668,7 @@
    unreachable
   end
   f32.const 1
-  f32.const -3
+  f32.const -0.5
   f32.const 1
   f32.const 0
   i32.const 0
@@ -44669,11 +44682,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 0.5
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const -3
+  f32.const 1
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_powf
   i32.eqz
   if
@@ -44685,7 +44698,7 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 1.5
+  f32.const 0.5
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -44700,6 +44713,21 @@
    unreachable
   end
   f32.const -0.5
+  f32.const 1.5
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2807
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
   f32.const 2
   f32.const 0.25
   f32.const 0
@@ -44709,7 +44737,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2807
+   i32.const 2808
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44724,7 +44752,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2808
+   i32.const 2809
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44739,7 +44767,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2809
+   i32.const 2810
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44755,7 +44783,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2810
+   i32.const 2811
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44763,21 +44791,6 @@
   f32.const -0.5
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2811
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const inf
-  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44792,6 +44805,21 @@
   end
   f32.const 0.5
   f32.const inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2813
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const inf
   f32.neg
   f32.const inf
   f32.const 0
@@ -44801,7 +44829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2813
+   i32.const 2814
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44816,7 +44844,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2814
+   i32.const 2815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44831,7 +44859,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2815
+   i32.const 2816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44847,27 +44875,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2816
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2817
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const 1.5
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -44883,8 +44896,8 @@
    unreachable
   end
   f32.const inf
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -44899,6 +44912,21 @@
   end
   f32.const inf
   f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2820
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
   f32.neg
   f32.const 0
   f32.const 0
@@ -44908,7 +44936,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2820
+   i32.const 2821
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44923,7 +44951,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2821
+   i32.const 2822
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44938,7 +44966,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2822
+   i32.const 2823
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44953,7 +44981,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2823
+   i32.const 2824
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44968,7 +44996,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2824
+   i32.const 2825
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44983,7 +45011,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2825
+   i32.const 2826
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -44998,7 +45026,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2826
+   i32.const 2827
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45013,22 +45041,6 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2827
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 2828
    i32.const 1
    call $~lib/builtins/abort
@@ -45036,8 +45048,8 @@
   end
   f32.const inf
   f32.neg
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45053,6 +45065,22 @@
   f32.const inf
   f32.neg
   f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2830
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const inf
   f32.neg
   f32.const 0
   f32.const 0
@@ -45062,7 +45090,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2830
+   i32.const 2831
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45079,7 +45107,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2831
+   i32.const 2832
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45095,7 +45123,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2832
+   i32.const 2833
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45112,7 +45140,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2833
+   i32.const 2834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45128,7 +45156,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2834
+   i32.const 2835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45137,22 +45165,6 @@
   f32.neg
   f32.const -0.5
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2835
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.neg
-  f32.const -1
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45167,6 +45179,22 @@
   end
   f32.const inf
   f32.neg
+  f32.const -1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2837
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
   f32.const -2
   f32.const 0
   f32.const 0
@@ -45176,7 +45204,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2837
+   i32.const 2838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45191,7 +45219,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2838
+   i32.const 2839
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45206,7 +45234,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2839
+   i32.const 2840
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45221,7 +45249,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2840
+   i32.const 2841
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45236,7 +45264,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2841
+   i32.const 2842
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45244,21 +45272,6 @@
   f32.const 0
   f32.const 1
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2844
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45271,11 +45284,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 8388608
-  f32.reinterpret_i32
+  f32.const -0
   f32.const 1
-  i32.const 8388608
-  f32.reinterpret_i32
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45288,10 +45299,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const -2139095040
+  i32.const 8388608
   f32.reinterpret_i32
   f32.const 1
-  i32.const -2139095040
+  i32.const 8388608
   f32.reinterpret_i32
   f32.const 0
   i32.const 0
@@ -45305,10 +45316,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 2139095039
+  i32.const -2139095040
   f32.reinterpret_i32
   f32.const 1
-  i32.const 2139095039
+  i32.const -2139095040
   f32.reinterpret_i32
   f32.const 0
   i32.const 0
@@ -45322,10 +45333,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const -8388609
+  i32.const 2139095039
   f32.reinterpret_i32
   f32.const 1
-  i32.const -8388609
+  i32.const 2139095039
   f32.reinterpret_i32
   f32.const 0
   i32.const 0
@@ -45339,10 +45350,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  i32.const 2139095039
+  i32.const -8388609
   f32.reinterpret_i32
-  f32.const 0
+  f32.const 1
+  i32.const -8388609
+  f32.reinterpret_i32
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45350,13 +45362,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2851
+   i32.const 2850
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  i32.const 8388608
+  i32.const 2139095039
   f32.reinterpret_i32
   f32.const 0
   f32.const 0
@@ -45371,8 +45383,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  i32.const 2139095039
+  f32.const 0
+  i32.const 8388608
   f32.reinterpret_i32
   f32.const 0
   f32.const 0
@@ -45388,6 +45400,22 @@
    unreachable
   end
   f32.const -0
+  i32.const 2139095039
+  f32.reinterpret_i32
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2854
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   i32.const 1099431936
   f32.reinterpret_i32
   f32.const -0
@@ -45398,7 +45426,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2854
+   i32.const 2855
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45413,7 +45441,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2855
+   i32.const 2856
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45429,7 +45457,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2856
+   i32.const 2857
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45448,7 +45476,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2858
+   i32.const 2859
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45466,7 +45494,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2860
+   i32.const 2861
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45484,7 +45512,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2861
+   i32.const 2862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45502,7 +45530,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2862
+   i32.const 2863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45520,7 +45548,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2863
+   i32.const 2864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45539,7 +45567,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2865
+   i32.const 2866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45558,7 +45586,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2866
+   i32.const 2867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45577,7 +45605,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2867
+   i32.const 2868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45596,7 +45624,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2868
+   i32.const 2869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45615,7 +45643,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2869
+   i32.const 2870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45634,7 +45662,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2870
+   i32.const 2871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45653,7 +45681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2871
+   i32.const 2872
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45672,7 +45700,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2872
+   i32.const 2873
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45691,7 +45719,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2873
+   i32.const 2874
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45710,22 +45738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2874
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2876
+   i32.const 2875
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45745,7 +45758,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   f32.const 1
   f32.const 0
@@ -45761,7 +45774,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 0
   f32.const 1
   f32.const 0
@@ -45772,6 +45784,22 @@
    i32.const 0
    i32.const 32
    i32.const 2879
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.neg
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2880
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45787,7 +45815,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2880
+   i32.const 2881
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45803,22 +45831,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2881
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2883
+   i32.const 2882
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45838,9 +45851,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 1
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45854,10 +45867,8 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 1
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45870,9 +45881,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
+  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -45880,12 +45893,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2888
+   i32.const 2887
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45901,7 +45914,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45916,7 +45928,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
+  f32.neg
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45931,7 +45944,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45946,7 +45959,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45961,7 +45974,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45972,6 +45985,21 @@
    i32.const 0
    i32.const 32
    i32.const 2894
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -45987,7 +46015,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2896
+   i32.const 2897
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46002,7 +46030,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2897
+   i32.const 2898
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46018,7 +46046,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2898
+   i32.const 2899
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46034,29 +46062,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2899
+   i32.const 2900
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1065353217
   f32.reinterpret_i32
-  f32.const inf
-  f32.neg
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2901
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
   f32.const inf
   f32.neg
   f32.const 0
@@ -46072,8 +46084,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const -1082130431
-  f32.reinterpret_i32
+  f32.const inf
   f32.const inf
   f32.neg
   f32.const 0
@@ -46089,8 +46100,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.neg
+  i32.const -1082130431
+  f32.reinterpret_i32
   f32.const inf
   f32.neg
   f32.const 0
@@ -46106,9 +46117,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1065353215
-  f32.reinterpret_i32
   f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   f32.const 0
   i32.const 0
@@ -46117,12 +46129,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2906
+   i32.const 2905
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 1065353215
   f32.reinterpret_i32
   f32.const inf
   f32.const 0
@@ -46138,7 +46150,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  i32.const 1
+  f32.reinterpret_i32
   f32.const inf
   f32.const 0
   f32.const 0
@@ -46149,6 +46162,21 @@
    i32.const 0
    i32.const 32
    i32.const 2908
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2909
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46164,7 +46192,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2909
+   i32.const 2910
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46180,7 +46208,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2910
+   i32.const 2911
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46195,28 +46223,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2911
+   i32.const 2912
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  i32.const 1
-  f32.reinterpret_i32
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2913
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   i32.const 1
   f32.reinterpret_i32
   f32.const 0
@@ -46232,24 +46244,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  i32.const -8388609
+  f32.const -0
+  i32.const 1
   f32.reinterpret_i32
-  f32.const inf
   f32.const 0
-  global.get $std/math/DIVBYZERO
+  f32.const 0
+  i32.const 0
   call $std/math/test_powf
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 2916
+   i32.const 2915
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  i32.const -2147483647
+  i32.const -8388609
   f32.reinterpret_i32
   f32.const inf
   f32.const 0
@@ -46264,8 +46276,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  i32.const -8388609
+  f32.const 0
+  i32.const -2147483647
   f32.reinterpret_i32
   f32.const inf
   f32.const 0
@@ -46281,7 +46293,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -2
+  i32.const -8388609
+  f32.reinterpret_i32
   f32.const inf
   f32.const 0
   global.get $std/math/DIVBYZERO
@@ -46291,6 +46304,21 @@
    i32.const 0
    i32.const 32
    i32.const 2919
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -2
+  f32.const inf
+  f32.const 0
+  global.get $std/math/DIVBYZERO
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2920
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46306,7 +46334,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2920
+   i32.const 2921
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46322,7 +46350,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2921
+   i32.const 2922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46339,7 +46367,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2922
+   i32.const 2923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46355,7 +46383,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2924
+   i32.const 2925
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46371,7 +46399,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2925
+   i32.const 2926
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46388,7 +46416,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2927
+   i32.const 2928
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46405,7 +46433,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2928
+   i32.const 2929
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46422,7 +46450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2929
+   i32.const 2930
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46439,7 +46467,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2930
+   i32.const 2931
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46457,7 +46485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2931
+   i32.const 2932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46474,7 +46502,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2932
+   i32.const 2933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46491,7 +46519,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2933
+   i32.const 2934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46508,7 +46536,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2934
+   i32.const 2935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46525,7 +46553,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2936
+   i32.const 2937
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46541,7 +46569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2937
+   i32.const 2938
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46558,7 +46586,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2938
+   i32.const 2939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46578,7 +46606,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2940
+   i32.const 2941
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46594,7 +46622,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2941
+   i32.const 2942
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46611,7 +46639,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2943
+   i32.const 2944
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46628,7 +46656,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2944
+   i32.const 2945
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46645,7 +46673,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2945
+   i32.const 2946
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46662,7 +46690,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2946
+   i32.const 2947
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46679,7 +46707,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2947
+   i32.const 2948
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46696,7 +46724,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2948
+   i32.const 2949
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46713,7 +46741,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2949
+   i32.const 2950
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46730,7 +46758,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2950
+   i32.const 2951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46747,7 +46775,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2951
+   i32.const 2952
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46764,7 +46792,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2952
+   i32.const 2953
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46781,7 +46809,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2953
+   i32.const 2954
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46798,7 +46826,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2954
+   i32.const 2955
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46815,7 +46843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2955
+   i32.const 2956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46832,7 +46860,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2956
+   i32.const 2957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46849,7 +46877,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2957
+   i32.const 2958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46866,7 +46894,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2958
+   i32.const 2959
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46883,7 +46911,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2959
+   i32.const 2960
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46900,7 +46928,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2960
+   i32.const 2961
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46915,7 +46943,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2961
+   i32.const 2962
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46930,7 +46958,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2962
+   i32.const 2963
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46947,7 +46975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2964
+   i32.const 2965
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46964,7 +46992,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2965
+   i32.const 2966
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46980,7 +47008,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2966
+   i32.const 2967
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -46997,7 +47025,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2967
+   i32.const 2968
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47014,7 +47042,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2968
+   i32.const 2969
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47031,7 +47059,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2969
+   i32.const 2970
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47048,7 +47076,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2970
+   i32.const 2971
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47064,7 +47092,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2972
+   i32.const 2973
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47081,7 +47109,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2973
+   i32.const 2974
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47100,7 +47128,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2975
+   i32.const 2976
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47119,7 +47147,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2976
+   i32.const 2977
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47138,7 +47166,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2977
+   i32.const 2978
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47156,7 +47184,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2978
+   i32.const 2979
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47175,7 +47203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2979
+   i32.const 2980
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47194,7 +47222,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2980
+   i32.const 2981
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47213,7 +47241,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2981
+   i32.const 2982
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47232,7 +47260,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2982
+   i32.const 2983
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47250,7 +47278,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2983
+   i32.const 2984
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47270,7 +47298,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2984
+   i32.const 2985
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47289,7 +47317,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2985
+   i32.const 2986
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47308,7 +47336,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2987
+   i32.const 2988
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47326,7 +47354,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2988
+   i32.const 2989
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47346,7 +47374,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2989
+   i32.const 2990
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47365,7 +47393,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2990
+   i32.const 2991
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47399,7 +47427,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 2999
+     i32.const 3000
      i32.const 3
      call $~lib/builtins/abort
      unreachable
@@ -47442,7 +47470,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 3007
+     i32.const 3008
      i32.const 3
      call $~lib/builtins/abort
      unreachable
@@ -47463,7 +47491,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3021
+   i32.const 3022
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47477,7 +47505,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3022
+   i32.const 3023
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47491,7 +47519,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3023
+   i32.const 3024
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47505,7 +47533,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3024
+   i32.const 3025
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47519,7 +47547,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3025
+   i32.const 3026
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47533,7 +47561,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3026
+   i32.const 3027
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47547,7 +47575,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3027
+   i32.const 3028
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47561,7 +47589,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3028
+   i32.const 3029
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47575,7 +47603,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3029
+   i32.const 3030
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47589,27 +47617,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3030
+   i32.const 3031
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3033
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -47623,9 +47637,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -47638,8 +47650,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -47652,8 +47666,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -47666,6 +47680,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3038
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -47675,7 +47703,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3038
+   i32.const 3039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47689,7 +47717,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3039
+   i32.const 3040
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47703,7 +47731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3040
+   i32.const 3041
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47717,7 +47745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3041
+   i32.const 3042
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47731,7 +47759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3042
+   i32.const 3043
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47745,7 +47773,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3043
+   i32.const 3044
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47759,7 +47787,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3044
+   i32.const 3045
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47773,7 +47801,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3045
+   i32.const 3046
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47787,7 +47815,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3046
+   i32.const 3047
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47801,7 +47829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3047
+   i32.const 3048
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47815,7 +47843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3048
+   i32.const 3049
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47829,7 +47857,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3049
+   i32.const 3050
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47933,7 +47961,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3064
+   i32.const 3065
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47947,7 +47975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3065
+   i32.const 3066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47961,7 +47989,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3066
+   i32.const 3067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47975,7 +48003,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3067
+   i32.const 3068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -47989,7 +48017,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3068
+   i32.const 3069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48003,7 +48031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3069
+   i32.const 3070
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48017,7 +48045,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3070
+   i32.const 3071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48031,7 +48059,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3071
+   i32.const 3072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48045,7 +48073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3072
+   i32.const 3073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48059,27 +48087,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3073
+   i32.const 3074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3076
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -48093,9 +48107,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -48108,8 +48120,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -48122,8 +48136,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -48136,6 +48150,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3081
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 1
   f32.const 0
@@ -48145,7 +48173,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3081
+   i32.const 3082
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48159,7 +48187,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3082
+   i32.const 3083
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48173,7 +48201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3083
+   i32.const 3084
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48187,7 +48215,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3084
+   i32.const 3085
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48201,7 +48229,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3085
+   i32.const 3086
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48215,7 +48243,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3086
+   i32.const 3087
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48229,7 +48257,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3087
+   i32.const 3088
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48243,7 +48271,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3088
+   i32.const 3089
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48257,7 +48285,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3089
+   i32.const 3090
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48271,7 +48299,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3090
+   i32.const 3091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48285,7 +48313,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3091
+   i32.const 3092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48299,27 +48327,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3092
+   i32.const 3093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sign
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3103
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_sign
@@ -48332,8 +48346,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_sign
@@ -48346,7 +48360,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2
+  f64.const 1
   f64.const 1
   f64.const 0
   i32.const 0
@@ -48360,8 +48374,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -1
+  f64.const 2
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_sign
@@ -48374,7 +48388,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2
+  f64.const -1
   f64.const -1
   f64.const 0
   i32.const 0
@@ -48388,6 +48402,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -2
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3109
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const 1
   f64.const 0
@@ -48397,7 +48425,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3109
+   i32.const 3110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48412,7 +48440,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3110
+   i32.const 3111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48426,27 +48454,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3111
+   i32.const 3112
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3119
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_signf
@@ -48459,8 +48473,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_signf
@@ -48473,7 +48487,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
+  f32.const 1
   f32.const 1
   f32.const 0
   i32.const 0
@@ -48487,8 +48501,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -1
+  f32.const 2
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_signf
@@ -48501,7 +48515,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2
+  f32.const -1
   f32.const -1
   f32.const 0
   i32.const 0
@@ -48515,6 +48529,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -2
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_signf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3125
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const inf
   f32.const 1
   f32.const 0
@@ -48524,7 +48552,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3125
+   i32.const 3126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48539,7 +48567,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3126
+   i32.const 3127
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48553,7 +48581,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3127
+   i32.const 3128
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48764,7 +48792,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3164
+   i32.const 3165
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48779,7 +48807,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3165
+   i32.const 3166
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48794,7 +48822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3166
+   i32.const 3167
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48809,7 +48837,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3167
+   i32.const 3168
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48824,7 +48852,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3168
+   i32.const 3169
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48839,7 +48867,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3169
+   i32.const 3170
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48854,7 +48882,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3170
+   i32.const 3171
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48869,7 +48897,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3171
+   i32.const 3172
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48884,7 +48912,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3172
+   i32.const 3173
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48899,7 +48927,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3173
+   i32.const 3174
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48907,21 +48935,6 @@
   f64.const 0
   f64.const 1
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3176
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -48934,9 +48947,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0
   f64.const 1
-  f64.const 0.5
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -48949,6 +48962,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3179
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -0.5
   f64.const 1
   f64.const -0.5
@@ -48959,7 +48987,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3179
+   i32.const 3180
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48974,7 +49002,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3180
+   i32.const 3181
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -48989,7 +49017,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3181
+   i32.const 3182
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49004,7 +49032,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3182
+   i32.const 3183
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49019,7 +49047,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3183
+   i32.const 3184
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49034,7 +49062,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3184
+   i32.const 3185
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49049,28 +49077,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3185
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3186
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49085,11 +49097,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49100,9 +49113,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49115,9 +49128,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -1
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49130,6 +49143,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3191
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0.5
   f64.const -1
   f64.const 0.5
@@ -49140,7 +49168,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3191
+   i32.const 3192
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49155,7 +49183,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3192
+   i32.const 3193
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49170,7 +49198,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3193
+   i32.const 3194
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49185,7 +49213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3194
+   i32.const 3195
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49200,7 +49228,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3195
+   i32.const 3196
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49215,7 +49243,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3196
+   i32.const 3197
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49230,7 +49258,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3197
+   i32.const 3198
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49245,28 +49273,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3198
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3199
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49281,11 +49293,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49296,11 +49309,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49312,7 +49325,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -49327,10 +49340,10 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
+  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49343,7 +49356,6 @@
   end
   f64.const 0
   f64.const inf
-  f64.neg
   f64.const 0
   f64.const 0
   i32.const 0
@@ -49358,8 +49370,9 @@
    unreachable
   end
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49372,11 +49385,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
   f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49388,7 +49401,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -49403,6 +49416,21 @@
    unreachable
   end
   f64.const -0
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3209
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const inf
   f64.const -0
   f64.const 0
@@ -49412,7 +49440,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3209
+   i32.const 3210
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49428,7 +49456,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3210
+   i32.const 3211
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49443,7 +49471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3211
+   i32.const 3212
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49458,27 +49486,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3212
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3213
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49494,7 +49507,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49509,11 +49521,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49524,11 +49537,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49539,7 +49552,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49555,7 +49568,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49570,11 +49582,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49585,11 +49598,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49601,7 +49614,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -49616,10 +49629,10 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49631,11 +49644,10 @@
    unreachable
   end
   f64.const inf
-  f64.neg
-  f64.const 2
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49648,7 +49660,7 @@
   end
   f64.const inf
   f64.neg
-  f64.const -0.5
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -49664,10 +49676,10 @@
   end
   f64.const inf
   f64.neg
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49678,7 +49690,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.neg
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49693,7 +49706,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49708,7 +49721,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49723,9 +49736,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49738,9 +49751,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
-  f64.const -1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49753,11 +49766,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49769,7 +49782,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49784,12 +49796,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const inf
   f64.neg
-  f64.const 1
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49800,10 +49812,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 1
   f64.const inf
   f64.neg
-  f64.const -1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49816,12 +49828,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -1
   f64.const inf
   f64.neg
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -49833,7 +49845,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
   f64.neg
   f64.const nan:0x8000000000000
@@ -49849,11 +49860,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const -0.25
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_rem
   i32.eqz
   if
@@ -49864,9 +49877,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
+  f64.const 1.75
   f64.const 0.5
-  f64.const 0.25
+  f64.const -0.25
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -49879,6 +49892,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.25
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3240
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.75
   f64.const -0.5
   f64.const -0.25
@@ -49889,7 +49917,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3240
+   i32.const 3241
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49904,7 +49932,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3241
+   i32.const 3242
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49919,7 +49947,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3242
+   i32.const 3243
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49934,7 +49962,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3251
+   i32.const 3252
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49949,7 +49977,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3252
+   i32.const 3253
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49964,7 +49992,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3253
+   i32.const 3254
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49979,7 +50007,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3254
+   i32.const 3255
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -49994,7 +50022,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3255
+   i32.const 3256
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50009,7 +50037,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3256
+   i32.const 3257
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50024,7 +50052,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3257
+   i32.const 3258
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50039,7 +50067,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3258
+   i32.const 3259
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50054,7 +50082,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3259
+   i32.const 3260
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50069,7 +50097,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3260
+   i32.const 3261
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50077,21 +50105,6 @@
   f32.const 0
   f32.const 1
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3263
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50104,9 +50117,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0
   f32.const 1
-  f32.const 0.5
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50119,6 +50132,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3266
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -0.5
   f32.const 1
   f32.const -0.5
@@ -50129,7 +50157,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3266
+   i32.const 3267
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50144,7 +50172,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3267
+   i32.const 3268
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50159,7 +50187,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3268
+   i32.const 3269
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50174,7 +50202,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3269
+   i32.const 3270
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50189,7 +50217,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3270
+   i32.const 3271
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50204,7 +50232,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3271
+   i32.const 3272
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50219,28 +50247,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3272
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3273
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
@@ -50255,11 +50267,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50270,9 +50283,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -1
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50285,9 +50298,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -1
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50300,6 +50313,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3278
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0.5
   f32.const -1
   f32.const 0.5
@@ -50310,7 +50338,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3278
+   i32.const 3279
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50325,7 +50353,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3279
+   i32.const 3280
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50340,7 +50368,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3280
+   i32.const 3281
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50355,7 +50383,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3281
+   i32.const 3282
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50370,7 +50398,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3282
+   i32.const 3283
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50385,7 +50413,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3283
+   i32.const 3284
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50400,7 +50428,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3284
+   i32.const 3285
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50415,28 +50443,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3285
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3286
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const -1
   f32.const nan:0x400000
   f32.const 0
@@ -50451,11 +50463,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const -1
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50466,11 +50479,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50482,7 +50495,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -50497,10 +50510,10 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
+  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50513,7 +50526,6 @@
   end
   f32.const 0
   f32.const inf
-  f32.neg
   f32.const 0
   f32.const 0
   i32.const 0
@@ -50528,8 +50540,9 @@
    unreachable
   end
   f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50542,11 +50555,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 0
   f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50558,7 +50571,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -50573,6 +50586,21 @@
    unreachable
   end
   f32.const -0
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3296
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const inf
   f32.const -0
   f32.const 0
@@ -50582,7 +50610,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3296
+   i32.const 3297
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50598,7 +50626,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3297
+   i32.const 3298
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50613,7 +50641,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3298
+   i32.const 3299
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -50628,27 +50656,12 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3299
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  global.get $std/math/INVALID
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3300
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -50664,7 +50677,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -50679,11 +50691,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50694,11 +50707,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50709,7 +50722,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -50725,7 +50738,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -50740,11 +50752,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50755,11 +50768,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50771,7 +50784,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -50786,10 +50799,10 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50801,11 +50814,10 @@
    unreachable
   end
   f32.const inf
-  f32.neg
-  f32.const 2
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50818,7 +50830,7 @@
   end
   f32.const inf
   f32.neg
-  f32.const -0.5
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
   global.get $std/math/INVALID
@@ -50834,10 +50846,10 @@
   end
   f32.const inf
   f32.neg
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50848,7 +50860,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
+  f32.neg
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -50863,7 +50876,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -50878,7 +50891,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -50893,9 +50906,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50908,9 +50921,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
-  f32.const -1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50923,11 +50936,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -50939,7 +50952,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
   f32.const nan:0x400000
   f32.const 0
@@ -50954,12 +50966,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
   f32.neg
-  f32.const 1
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -50970,10 +50982,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 1
   f32.const inf
   f32.neg
-  f32.const -1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -50986,12 +50998,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -1
   f32.const inf
   f32.neg
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -51003,7 +51015,6 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
   f32.neg
   f32.const nan:0x400000
@@ -51019,11 +51030,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const -0.25
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  global.get $std/math/INVALID
   call $std/math/test_remf
   i32.eqz
   if
@@ -51034,9 +51047,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
+  f32.const 1.75
   f32.const 0.5
-  f32.const 0.25
+  f32.const -0.25
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -51049,6 +51062,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.25
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3327
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.75
   f32.const -0.5
   f32.const -0.25
@@ -51059,7 +51087,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3327
+   i32.const 3328
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51074,7 +51102,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3328
+   i32.const 3329
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51089,7 +51117,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3329
+   i32.const 3330
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51103,7 +51131,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3341
+   i32.const 3342
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51117,7 +51145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3342
+   i32.const 3343
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51131,7 +51159,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3343
+   i32.const 3344
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51145,7 +51173,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3344
+   i32.const 3345
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51159,7 +51187,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3345
+   i32.const 3346
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51173,7 +51201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3346
+   i32.const 3347
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51187,7 +51215,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3347
+   i32.const 3348
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51201,7 +51229,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3348
+   i32.const 3349
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51215,7 +51243,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3349
+   i32.const 3350
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51229,7 +51257,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3350
+   i32.const 3351
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51243,7 +51271,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3353
+   i32.const 3354
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51257,27 +51285,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3354
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3355
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51290,12 +51304,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 5e-324
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
   call $std/math/test_sin
   i32.eqz
   if
@@ -51306,8 +51318,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
-  f64.const -5e-324
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51322,10 +51334,12 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -5e-324
+  f64.const -5e-324
   f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
   call $std/math/test_sin
   i32.eqz
   if
@@ -51336,8 +51350,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_sin
@@ -51350,10 +51364,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
+  f64.const -0
+  f64.const -0
   f64.const 0
-  global.get $std/math/INEXACT
+  i32.const 0
   call $std/math/test_sin
   i32.eqz
   if
@@ -51364,8 +51378,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51378,8 +51392,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51392,8 +51406,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51406,6 +51420,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3365
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4.450147717014406e-308
   f64.const 4.450147717014406e-308
   f64.const 0
@@ -51415,7 +51443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3365
+   i32.const 3366
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51429,7 +51457,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3366
+   i32.const 3367
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51443,7 +51471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3367
+   i32.const 3368
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51457,27 +51485,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3368
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3369
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51490,8 +51504,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51504,8 +51518,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51518,8 +51532,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51532,8 +51546,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
@@ -51546,9 +51560,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1175870895385742e-08
-  f64.const -1.1175870895385742e-08
-  f64.const -0.140625
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
+  f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sin
   i32.eqz
@@ -51560,9 +51574,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
+  f64.const -1.1175870895385742e-08
+  f64.const -1.1175870895385742e-08
+  f64.const -0.140625
   global.get $std/math/INEXACT
   call $std/math/test_sin
   i32.eqz
@@ -51588,12 +51602,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
   call $std/math/test_sin
   i32.eqz
   if
@@ -51604,8 +51616,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51620,8 +51632,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51636,8 +51648,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51652,8 +51664,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51668,8 +51680,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51684,8 +51696,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51700,8 +51712,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51716,8 +51728,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const -4.4e-323
+  f64.const -4.4e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51732,8 +51744,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51748,8 +51760,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51764,8 +51776,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -51780,6 +51792,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3390
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -51789,7 +51817,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3392
+   i32.const 3393
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51803,7 +51831,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3393
+   i32.const 3394
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51817,7 +51845,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3394
+   i32.const 3395
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51832,7 +51860,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3395
+   i32.const 3396
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51846,7 +51874,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3396
+   i32.const 3397
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51856,28 +51884,6 @@
   f64.div
   call $~lib/math/NativeMath.sin
   global.get $std/math/kPI
-  f64.const 2
-  f64.div
-  call $~lib/bindings/Math/sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3399
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2
-  global.get $std/math/kPI
-  f64.mul
-  f64.const 2
-  f64.div
-  call $~lib/math/NativeMath.sin
-  f64.const 2
-  global.get $std/math/kPI
-  f64.mul
   f64.const 2
   f64.div
   call $~lib/bindings/Math/sin
@@ -51891,6 +51897,28 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 2
+  global.get $std/math/kPI
+  f64.mul
+  f64.const 2
+  f64.div
+  call $~lib/math/NativeMath.sin
+  f64.const 2
+  global.get $std/math/kPI
+  f64.mul
+  f64.const 2
+  f64.div
+  call $~lib/bindings/Math/sin
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3401
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 2.3283064365386963e-10
   f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.sin
@@ -51899,7 +51927,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3403
+   i32.const 3404
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51912,7 +51940,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3404
+   i32.const 3405
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51925,7 +51953,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3406
+   i32.const 3407
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51938,7 +51966,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3407
+   i32.const 3408
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51951,7 +51979,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3410
+   i32.const 3411
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51964,7 +51992,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3411
+   i32.const 3412
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51979,7 +52007,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3412
+   i32.const 3413
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -51995,7 +52023,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3413
+   i32.const 3414
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52008,7 +52036,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3415
+   i32.const 3416
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52023,7 +52051,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3416
+   i32.const 3417
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52040,7 +52068,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3418
+   i32.const 3419
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52057,7 +52085,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3419
+   i32.const 3420
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52074,7 +52102,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3420
+   i32.const 3421
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52091,7 +52119,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3421
+   i32.const 3422
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52108,7 +52136,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3422
+   i32.const 3423
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52121,7 +52149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3425
+   i32.const 3426
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52135,7 +52163,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3426
+   i32.const 3427
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52149,7 +52177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3435
+   i32.const 3436
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52163,7 +52191,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3436
+   i32.const 3437
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52177,7 +52205,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3437
+   i32.const 3438
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52191,7 +52219,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3438
+   i32.const 3439
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52205,7 +52233,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3439
+   i32.const 3440
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52219,7 +52247,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3440
+   i32.const 3441
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52233,7 +52261,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3441
+   i32.const 3442
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52247,7 +52275,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3442
+   i32.const 3443
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52261,7 +52289,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3443
+   i32.const 3444
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52275,27 +52303,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3444
+   i32.const 3445
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3447
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_sinf
@@ -52304,6 +52318,20 @@
    i32.const 0
    i32.const 32
    i32.const 3448
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3449
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52317,7 +52345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3449
+   i32.const 3450
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52332,7 +52360,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3450
+   i32.const 3451
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52346,7 +52374,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3451
+   i32.const 3452
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52360,7 +52388,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3454
+   i32.const 3455
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52374,27 +52402,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3455
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3456
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sinf
@@ -52407,12 +52421,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
   call $std/math/test_sinf
   i32.eqz
   if
@@ -52423,8 +52435,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52439,10 +52451,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
   f32.const 0
   global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
   call $std/math/test_sinf
   i32.eqz
   if
@@ -52453,8 +52467,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sinf
@@ -52467,8 +52481,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sinf
@@ -52481,8 +52495,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sinf
@@ -52495,6 +52509,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3464
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   f32.const 2.3509895424236536e-38
   f32.const 0
@@ -52504,7 +52532,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3464
+   i32.const 3465
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52518,7 +52546,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3465
+   i32.const 3466
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52532,7 +52560,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3466
+   i32.const 3467
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52546,7 +52574,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3467
+   i32.const 3468
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52560,7 +52588,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3468
+   i32.const 3469
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52574,27 +52602,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3469
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3470
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sinf
@@ -52607,8 +52621,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sinf
@@ -52621,8 +52635,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.350988701644575e-38
-  f32.const -2.350988701644575e-38
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_sinf
@@ -52635,6 +52649,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -2.350988701644575e-38
+  f32.const -2.350988701644575e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3474
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -2.3509895424236536e-38
   f32.const -2.3509895424236536e-38
   f32.const 0
@@ -52644,7 +52672,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3474
+   i32.const 3475
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52658,7 +52686,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3475
+   i32.const 3476
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52672,7 +52700,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3476
+   i32.const 3477
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52686,7 +52714,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3477
+   i32.const 3478
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52700,7 +52728,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3478
+   i32.const 3479
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52714,29 +52742,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3479
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3480
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const 2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52751,8 +52763,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52767,8 +52779,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52783,8 +52795,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52799,8 +52811,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52815,8 +52827,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52831,8 +52843,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52847,8 +52859,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52863,8 +52875,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52879,8 +52891,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52895,8 +52907,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -52911,6 +52923,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3492
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 255.99993896484375
   f32.const -0.9992055892944336
   f32.const 0
@@ -52920,7 +52948,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3494
+   i32.const 3495
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52934,7 +52962,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3495
+   i32.const 3496
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52948,7 +52976,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3496
+   i32.const 3497
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52962,7 +52990,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3497
+   i32.const 3498
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52976,7 +53004,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3498
+   i32.const 3499
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -52990,7 +53018,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3499
+   i32.const 3500
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53004,7 +53032,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3500
+   i32.const 3501
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53018,7 +53046,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3501
+   i32.const 3502
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53032,7 +53060,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3502
+   i32.const 3503
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53046,7 +53074,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3503
+   i32.const 3504
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53060,7 +53088,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3504
+   i32.const 3505
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53074,7 +53102,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3505
+   i32.const 3506
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53088,7 +53116,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3506
+   i32.const 3507
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53103,7 +53131,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3507
+   i32.const 3508
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53117,7 +53145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3519
+   i32.const 3520
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53131,7 +53159,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3520
+   i32.const 3521
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53145,7 +53173,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3521
+   i32.const 3522
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53159,7 +53187,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3522
+   i32.const 3523
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53173,7 +53201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3523
+   i32.const 3524
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53187,7 +53215,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3524
+   i32.const 3525
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53201,7 +53229,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3525
+   i32.const 3526
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53215,7 +53243,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3526
+   i32.const 3527
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53229,7 +53257,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3527
+   i32.const 3528
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53243,27 +53271,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3528
+   i32.const 3529
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3531
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_sinh
@@ -53276,8 +53290,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_sinh
@@ -53291,6 +53305,20 @@
    unreachable
   end
   f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3534
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.neg
   f64.const inf
   f64.neg
@@ -53301,7 +53329,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3534
+   i32.const 3535
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53315,7 +53343,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3535
+   i32.const 3536
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53329,7 +53357,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3544
+   i32.const 3545
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53343,7 +53371,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3545
+   i32.const 3546
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53357,7 +53385,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3546
+   i32.const 3547
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53371,7 +53399,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3547
+   i32.const 3548
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53385,7 +53413,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3548
+   i32.const 3549
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53399,7 +53427,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3549
+   i32.const 3550
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53413,7 +53441,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3550
+   i32.const 3551
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53427,7 +53455,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3551
+   i32.const 3552
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53441,7 +53469,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3552
+   i32.const 3553
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53455,27 +53483,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3553
+   i32.const 3554
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3556
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_sinhf
@@ -53488,8 +53502,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_sinhf
@@ -53503,6 +53517,20 @@
    unreachable
   end
   f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3559
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.neg
   f32.const inf
   f32.neg
@@ -53513,7 +53541,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3559
+   i32.const 3560
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53527,7 +53555,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3560
+   i32.const 3561
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53541,7 +53569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3572
+   i32.const 3573
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53555,7 +53583,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3573
+   i32.const 3574
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53569,7 +53597,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3574
+   i32.const 3575
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53583,7 +53611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3575
+   i32.const 3576
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53597,7 +53625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3576
+   i32.const 3577
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53611,7 +53639,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3577
+   i32.const 3578
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53625,7 +53653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3578
+   i32.const 3579
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53639,7 +53667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3579
+   i32.const 3580
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53653,7 +53681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3580
+   i32.const 3581
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53667,27 +53695,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3581
+   i32.const 3582
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3584
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_sqrt
@@ -53696,6 +53710,20 @@
    i32.const 0
    i32.const 32
    i32.const 3585
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3586
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53710,27 +53738,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3586
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3587
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_sqrt
@@ -53743,6 +53757,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3589
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -53752,7 +53780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3589
+   i32.const 3590
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53766,7 +53794,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3590
+   i32.const 3591
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53780,7 +53808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3591
+   i32.const 3592
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53794,7 +53822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3592
+   i32.const 3593
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53808,7 +53836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3593
+   i32.const 3594
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53822,7 +53850,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3594
+   i32.const 3595
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53836,7 +53864,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3595
+   i32.const 3596
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53850,7 +53878,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3596
+   i32.const 3597
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53864,7 +53892,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3597
+   i32.const 3598
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53878,7 +53906,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3598
+   i32.const 3599
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53892,7 +53920,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3599
+   i32.const 3600
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53906,7 +53934,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3600
+   i32.const 3601
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53920,7 +53948,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3601
+   i32.const 3602
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53934,7 +53962,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3602
+   i32.const 3603
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53948,7 +53976,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3603
+   i32.const 3604
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53962,7 +53990,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3604
+   i32.const 3605
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53976,7 +54004,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3605
+   i32.const 3606
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -53990,7 +54018,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3606
+   i32.const 3607
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54004,7 +54032,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3607
+   i32.const 3608
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54018,7 +54046,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3608
+   i32.const 3609
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54032,7 +54060,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3609
+   i32.const 3610
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54046,7 +54074,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3610
+   i32.const 3611
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54060,7 +54088,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3611
+   i32.const 3612
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54074,7 +54102,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3612
+   i32.const 3613
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54088,7 +54116,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3613
+   i32.const 3614
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54102,7 +54130,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3614
+   i32.const 3615
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54116,7 +54144,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3615
+   i32.const 3616
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54130,7 +54158,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3616
+   i32.const 3617
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54144,7 +54172,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3617
+   i32.const 3618
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54158,7 +54186,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3618
+   i32.const 3619
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54172,7 +54200,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3619
+   i32.const 3620
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54186,7 +54214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3620
+   i32.const 3621
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54200,7 +54228,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3621
+   i32.const 3622
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54214,7 +54242,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3622
+   i32.const 3623
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54228,7 +54256,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3623
+   i32.const 3624
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54242,7 +54270,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3624
+   i32.const 3625
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54256,7 +54284,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3625
+   i32.const 3626
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54270,7 +54298,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3626
+   i32.const 3627
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54284,7 +54312,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3627
+   i32.const 3628
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54298,7 +54326,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3628
+   i32.const 3629
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54312,7 +54340,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3629
+   i32.const 3630
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54326,7 +54354,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3630
+   i32.const 3631
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54340,7 +54368,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3631
+   i32.const 3632
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54354,7 +54382,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3632
+   i32.const 3633
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54368,7 +54396,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3633
+   i32.const 3634
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54382,7 +54410,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3634
+   i32.const 3635
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54396,7 +54424,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3635
+   i32.const 3636
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54410,7 +54438,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3636
+   i32.const 3637
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54424,7 +54452,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3637
+   i32.const 3638
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54438,7 +54466,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3638
+   i32.const 3639
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54452,7 +54480,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3639
+   i32.const 3640
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54466,7 +54494,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3640
+   i32.const 3641
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54480,7 +54508,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3641
+   i32.const 3642
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54494,7 +54522,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3642
+   i32.const 3643
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54508,7 +54536,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3643
+   i32.const 3644
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54522,7 +54550,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3644
+   i32.const 3645
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54536,7 +54564,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3645
+   i32.const 3646
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54550,7 +54578,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3646
+   i32.const 3647
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54564,7 +54592,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3647
+   i32.const 3648
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54578,7 +54606,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3648
+   i32.const 3649
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54592,7 +54620,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3649
+   i32.const 3650
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54606,7 +54634,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3650
+   i32.const 3651
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54620,7 +54648,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3651
+   i32.const 3652
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54634,7 +54662,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3652
+   i32.const 3653
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54648,7 +54676,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3653
+   i32.const 3654
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54662,7 +54690,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3654
+   i32.const 3655
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54676,7 +54704,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3655
+   i32.const 3656
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54690,7 +54718,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3656
+   i32.const 3657
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54704,7 +54732,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3657
+   i32.const 3658
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54718,7 +54746,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3666
+   i32.const 3667
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54732,7 +54760,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3667
+   i32.const 3668
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54746,7 +54774,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3668
+   i32.const 3669
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54760,7 +54788,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3669
+   i32.const 3670
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54774,7 +54802,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3670
+   i32.const 3671
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54788,7 +54816,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3671
+   i32.const 3672
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54802,7 +54830,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3672
+   i32.const 3673
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54816,7 +54844,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3673
+   i32.const 3674
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54830,7 +54858,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3674
+   i32.const 3675
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54844,27 +54872,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3675
+   i32.const 3676
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3678
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_sqrtf
@@ -54873,6 +54887,20 @@
    i32.const 0
    i32.const 32
    i32.const 3679
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3680
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54887,27 +54915,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3680
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3681
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_sqrtf
@@ -54920,6 +54934,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3683
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 1
   f32.const 0
@@ -54929,7 +54957,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3683
+   i32.const 3684
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54943,7 +54971,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3684
+   i32.const 3685
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54957,7 +54985,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3685
+   i32.const 3686
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54971,7 +54999,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3686
+   i32.const 3687
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54985,7 +55013,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3687
+   i32.const 3688
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -54999,7 +55027,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3688
+   i32.const 3689
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55013,7 +55041,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3689
+   i32.const 3690
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55027,7 +55055,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3690
+   i32.const 3691
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55041,7 +55069,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3691
+   i32.const 3692
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55055,7 +55083,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3692
+   i32.const 3693
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55069,7 +55097,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3693
+   i32.const 3694
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55083,7 +55111,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3694
+   i32.const 3695
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55097,7 +55125,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3695
+   i32.const 3696
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55111,7 +55139,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3696
+   i32.const 3697
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55125,7 +55153,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3697
+   i32.const 3698
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55139,7 +55167,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3698
+   i32.const 3699
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55153,7 +55181,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3699
+   i32.const 3700
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55167,7 +55195,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3711
+   i32.const 3712
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55181,7 +55209,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3712
+   i32.const 3713
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55195,7 +55223,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3713
+   i32.const 3714
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55209,7 +55237,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3714
+   i32.const 3715
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55223,7 +55251,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3715
+   i32.const 3716
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55237,7 +55265,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3716
+   i32.const 3717
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55251,7 +55279,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3717
+   i32.const 3718
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55265,7 +55293,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3718
+   i32.const 3719
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55279,7 +55307,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3719
+   i32.const 3720
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55293,7 +55321,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3720
+   i32.const 3721
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55307,7 +55335,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3723
+   i32.const 3724
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55321,27 +55349,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3724
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3725
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tan
@@ -55354,12 +55368,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 5e-324
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
   call $std/math/test_tan
   i32.eqz
   if
@@ -55370,8 +55382,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
-  f64.const -5e-324
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55386,6 +55398,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -5e-324
+  f64.const -5e-324
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3729
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -55395,7 +55423,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3729
+   i32.const 3730
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55409,7 +55437,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3730
+   i32.const 3731
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55423,7 +55451,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3731
+   i32.const 3732
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55437,27 +55465,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3732
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3733
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tan
@@ -55470,8 +55484,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tan
@@ -55484,8 +55498,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tan
@@ -55498,6 +55512,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3737
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4.450147717014406e-308
   f64.const 4.450147717014406e-308
   f64.const 0
@@ -55507,7 +55535,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3737
+   i32.const 3738
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55521,7 +55549,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3738
+   i32.const 3739
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55535,7 +55563,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3739
+   i32.const 3740
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55549,27 +55577,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3740
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3741
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tan
@@ -55582,8 +55596,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tan
@@ -55596,8 +55610,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
   f64.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tan
@@ -55610,6 +55624,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3745
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -4.450147717014406e-308
   f64.const -4.450147717014406e-308
   f64.const 0
@@ -55619,7 +55647,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3745
+   i32.const 3746
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55633,7 +55661,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3746
+   i32.const 3747
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55647,7 +55675,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3747
+   i32.const 3748
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -55661,29 +55689,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3748
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3749
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55698,8 +55710,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55714,8 +55726,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55730,8 +55742,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55746,8 +55758,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55762,8 +55774,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55778,8 +55790,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55794,8 +55806,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const -4.4e-323
+  f64.const -4.4e-323
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55810,8 +55822,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55826,8 +55838,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55842,8 +55854,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -55858,23 +55870,25 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3763
+   i32.const 3761
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
+  f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
+  f64.const 2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55886,13 +55900,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 11
-  f64.const 16
-  f64.div
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const 11
-  f64.const 16
-  f64.div
+  f64.const -2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55904,11 +55914,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -11
+  f64.const 11
   f64.const 16
   f64.div
   call $~lib/math/NativeMath.tan
-  f64.const -11
+  f64.const 11
   f64.const 16
   f64.div
   call $~lib/bindings/Math/tan
@@ -55922,9 +55932,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.39269908169872414
+  f64.const -11
+  f64.const 16
+  f64.div
   call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
+  f64.const -11
+  f64.const 16
+  f64.div
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55936,9 +55950,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6743358
+  f64.const 0.39269908169872414
   call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
+  f64.const 0.39269908169872414
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55950,9 +55964,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
+  f64.const 0.6743358
   call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const 0.6743358
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55964,13 +55978,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/math/kPI
-  f64.const 2
-  f64.div
+  f64.const 3.725290298461914e-09
   call $~lib/math/NativeMath.tan
-  global.get $std/math/kPI
-  f64.const 2
-  f64.div
+  f64.const 3.725290298461914e-09
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -55982,23 +55992,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  global.get $std/math/kPI
+  f64.const 2
+  f64.div
   call $~lib/math/NativeMath.tan
-  f64.const 0.5
+  global.get $std/math/kPI
+  f64.const 2
+  f64.div
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3772
+   i32.const 3771
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.107148717794091
+  f64.const 0.5
   call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -56010,17 +56024,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  f64.const 7
-  f64.const 4
-  f64.div
-  global.get $std/math/kPI
-  f64.mul
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -56032,13 +56038,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 9
+  f64.const 7
   f64.const 4
   f64.div
   global.get $std/math/kPI
   f64.mul
   call $~lib/math/NativeMath.tan
-  f64.const 9
+  f64.const 7
   f64.const 4
   f64.div
   global.get $std/math/kPI
@@ -56054,14 +56060,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1048576
-  f64.const 2
+  f64.const 9
+  f64.const 4
   f64.div
   global.get $std/math/kPI
   f64.mul
   call $~lib/math/NativeMath.tan
-  f64.const 1048576
-  f64.const 2
+  f64.const 9
+  f64.const 4
   f64.div
   global.get $std/math/kPI
   f64.mul
@@ -56076,13 +56082,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1048575
+  f64.const 1048576
   f64.const 2
   f64.div
   global.get $std/math/kPI
   f64.mul
   call $~lib/math/NativeMath.tan
-  f64.const 1048575
+  f64.const 1048576
   f64.const 2
   f64.div
   global.get $std/math/kPI
@@ -56098,9 +56104,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/math/kTwo120
+  f64.const 1048575
+  f64.const 2
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
   call $~lib/math/NativeMath.tan
-  global.get $std/math/kTwo120
+  f64.const 1048575
+  f64.const 2
+  f64.div
+  global.get $std/math/kPI
+  f64.mul
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -56113,10 +56127,8 @@
    unreachable
   end
   global.get $std/math/kTwo120
-  f64.neg
   call $~lib/math/NativeMath.tan
   global.get $std/math/kTwo120
-  f64.neg
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -56128,22 +56140,24 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_tan
+  global.get $std/math/kTwo120
+  f64.neg
+  call $~lib/math/NativeMath.tan
+  global.get $std/math/kTwo120
+  f64.neg
+  call $~lib/bindings/Math/tan
+  f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 3782
+   i32.const 3780
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_tan
@@ -56156,10 +56170,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const -0
   f64.const 0
-  global.get $std/math/INVALID
+  i32.const 0
   call $std/math/test_tan
   i32.eqz
   if
@@ -56171,7 +56185,6 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const nan:0x8000000000000
   f64.const 0
   global.get $std/math/INVALID
@@ -56185,6 +56198,21 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.neg
+  f64.const nan:0x8000000000000
+  f64.const 0
+  global.get $std/math/INVALID
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3786
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -56194,7 +56222,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3786
+   i32.const 3787
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56208,7 +56236,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3795
+   i32.const 3796
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56222,7 +56250,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3796
+   i32.const 3797
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56236,7 +56264,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3797
+   i32.const 3798
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56250,7 +56278,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3798
+   i32.const 3799
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56264,7 +56292,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3799
+   i32.const 3800
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56278,7 +56306,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3800
+   i32.const 3801
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56292,7 +56320,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3801
+   i32.const 3802
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56306,7 +56334,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3802
+   i32.const 3803
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56320,7 +56348,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3803
+   i32.const 3804
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56334,27 +56362,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3804
+   i32.const 3805
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3807
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_tanf
@@ -56363,6 +56377,20 @@
    i32.const 0
    i32.const 32
    i32.const 3808
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3809
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56376,7 +56404,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3809
+   i32.const 3810
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56391,7 +56419,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3810
+   i32.const 3811
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56405,7 +56433,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3811
+   i32.const 3812
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56419,7 +56447,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3814
+   i32.const 3815
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56433,27 +56461,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3815
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3816
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tanf
@@ -56466,12 +56480,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
   call $std/math/test_tanf
   i32.eqz
   if
@@ -56482,8 +56494,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56498,10 +56510,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
   f32.const 0
   global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
   call $std/math/test_tanf
   i32.eqz
   if
@@ -56512,8 +56526,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tanf
@@ -56526,8 +56540,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tanf
@@ -56540,8 +56554,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tanf
@@ -56554,6 +56568,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3824
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   f32.const 2.3509895424236536e-38
   f32.const 0
@@ -56563,7 +56591,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3824
+   i32.const 3825
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56577,7 +56605,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3825
+   i32.const 3826
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56591,7 +56619,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3826
+   i32.const 3827
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56605,7 +56633,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3827
+   i32.const 3828
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56619,27 +56647,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3828
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  global.get $std/math/INEXACT
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3829
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tanf
@@ -56652,8 +56666,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tanf
@@ -56666,8 +56680,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   global.get $std/math/INEXACT
   call $std/math/test_tanf
@@ -56680,6 +56694,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3833
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -2.3509895424236536e-38
   f32.const -2.3509895424236536e-38
   f32.const 0
@@ -56689,7 +56717,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3833
+   i32.const 3834
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56703,7 +56731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3834
+   i32.const 3835
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56717,7 +56745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3835
+   i32.const 3836
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56731,7 +56759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3836
+   i32.const 3837
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56745,29 +56773,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3837
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  global.get $std/math/INEXACT
-  global.get $std/math/UNDERFLOW
-  i32.or
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 3838
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const 2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56782,8 +56794,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56798,8 +56810,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56814,8 +56826,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56830,8 +56842,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56846,8 +56858,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56862,8 +56874,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56878,8 +56890,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56894,8 +56906,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56910,8 +56922,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56926,8 +56938,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   global.get $std/math/INEXACT
   global.get $std/math/UNDERFLOW
@@ -56942,6 +56954,22 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
+  f32.const 0
+  global.get $std/math/INEXACT
+  global.get $std/math/UNDERFLOW
+  i32.or
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3850
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -8.06684839057968
   f64.const -0.999999803096032
   f64.const 0.012793331407010555
@@ -56951,7 +56979,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3861
+   i32.const 3862
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56965,7 +56993,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3862
+   i32.const 3863
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56979,7 +57007,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3863
+   i32.const 3864
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -56993,7 +57021,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3864
+   i32.const 3865
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57007,7 +57035,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3865
+   i32.const 3866
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57021,7 +57049,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3866
+   i32.const 3867
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57035,7 +57063,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3867
+   i32.const 3868
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57049,7 +57077,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3868
+   i32.const 3869
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57063,7 +57091,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3869
+   i32.const 3870
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57077,27 +57105,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3870
+   i32.const 3871
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_tanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3873
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_tanh
@@ -57110,8 +57124,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 1
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_tanh
@@ -57125,6 +57139,20 @@
    unreachable
   end
   f64.const inf
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_tanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3876
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.neg
   f64.const -1
   f64.const 0
@@ -57134,7 +57162,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3876
+   i32.const 3877
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57148,7 +57176,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3877
+   i32.const 3878
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57162,7 +57190,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3886
+   i32.const 3887
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57176,7 +57204,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3887
+   i32.const 3888
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57190,7 +57218,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3888
+   i32.const 3889
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57204,7 +57232,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3889
+   i32.const 3890
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57218,7 +57246,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3890
+   i32.const 3891
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57232,7 +57260,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3891
+   i32.const 3892
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57246,7 +57274,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3892
+   i32.const 3893
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57260,7 +57288,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3893
+   i32.const 3894
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57274,7 +57302,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3894
+   i32.const 3895
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57288,27 +57316,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3895
+   i32.const 3896
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_tanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3898
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_tanhf
@@ -57321,8 +57335,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 1
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_tanhf
@@ -57336,6 +57350,20 @@
    unreachable
   end
   f32.const inf
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_tanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3901
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.neg
   f32.const -1
   f32.const 0
@@ -57345,7 +57373,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3901
+   i32.const 3902
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57359,7 +57387,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3902
+   i32.const 3903
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57373,7 +57401,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3914
+   i32.const 3915
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57387,7 +57415,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3915
+   i32.const 3916
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57401,7 +57429,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3916
+   i32.const 3917
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57415,7 +57443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3917
+   i32.const 3918
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57429,7 +57457,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3918
+   i32.const 3919
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57443,7 +57471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3919
+   i32.const 3920
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57457,7 +57485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3920
+   i32.const 3921
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57471,7 +57499,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3921
+   i32.const 3922
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57485,7 +57513,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3922
+   i32.const 3923
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57499,27 +57527,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3923
+   i32.const 3924
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3926
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -57533,9 +57547,7 @@
    unreachable
   end
   f64.const inf
-  f64.neg
   f64.const inf
-  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -57548,8 +57560,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const inf
+  f64.neg
+  f64.const inf
+  f64.neg
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -57562,8 +57576,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -57576,6 +57590,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3931
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 1
   f64.const 0
@@ -57585,7 +57613,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3931
+   i32.const 3932
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57599,7 +57627,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3932
+   i32.const 3933
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57613,7 +57641,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3933
+   i32.const 3934
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57627,7 +57655,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3934
+   i32.const 3935
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57641,7 +57669,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3935
+   i32.const 3936
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57655,7 +57683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3936
+   i32.const 3937
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57669,7 +57697,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3937
+   i32.const 3938
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57683,7 +57711,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3938
+   i32.const 3939
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57697,7 +57725,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3939
+   i32.const 3940
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57711,7 +57739,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3940
+   i32.const 3941
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57725,7 +57753,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3949
+   i32.const 3950
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57739,7 +57767,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3950
+   i32.const 3951
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57753,7 +57781,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3951
+   i32.const 3952
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57767,7 +57795,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3952
+   i32.const 3953
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57781,7 +57809,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3953
+   i32.const 3954
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57795,7 +57823,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3954
+   i32.const 3955
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57809,7 +57837,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3955
+   i32.const 3956
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57823,7 +57851,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3956
+   i32.const 3957
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57837,7 +57865,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3957
+   i32.const 3958
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57851,27 +57879,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3958
+   i32.const 3959
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3961
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -57885,9 +57899,7 @@
    unreachable
   end
   f32.const inf
-  f32.neg
   f32.const inf
-  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -57900,8 +57912,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const inf
+  f32.neg
+  f32.const inf
+  f32.neg
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -57914,8 +57928,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -57928,6 +57942,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3966
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 1
   f32.const 0
@@ -57937,7 +57965,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3966
+   i32.const 3967
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57951,7 +57979,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3967
+   i32.const 3968
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57965,7 +57993,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3968
+   i32.const 3969
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57979,7 +58007,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3969
+   i32.const 3970
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -57993,7 +58021,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3970
+   i32.const 3971
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58007,7 +58035,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3971
+   i32.const 3972
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58021,7 +58049,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3972
+   i32.const 3973
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58035,7 +58063,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3973
+   i32.const 3974
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58049,7 +58077,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3974
+   i32.const 3975
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58063,7 +58091,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3975
+   i32.const 3976
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58157,7 +58185,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4016
+   i32.const 4017
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58171,7 +58199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4017
+   i32.const 4018
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58185,7 +58213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4018
+   i32.const 4019
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58199,7 +58227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4019
+   i32.const 4020
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58213,27 +58241,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4020
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.e+60
-  f64.const 1.e+60
-  call $~lib/math/NativeMath.imul
-  f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 4021
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+60
-  f64.const -1.e+60
+  f64.const 1.e+60
   call $~lib/math/NativeMath.imul
   f64.const 0
   f64.eq
@@ -58246,7 +58260,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.e+60
+  f64.const 1.e+60
   f64.const -1.e+60
   call $~lib/math/NativeMath.imul
   f64.const 0
@@ -58260,10 +58274,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.e+24
-  f64.const 100
+  f64.const -1.e+60
+  f64.const -1.e+60
   call $~lib/math/NativeMath.imul
-  f64.const -2147483648
+  f64.const 0
   f64.eq
   i32.eqz
   if
@@ -58274,10 +58288,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
+  f64.const 1.e+24
+  f64.const 100
   call $~lib/math/NativeMath.imul
-  f64.const 0
+  f64.const -2147483648
   f64.eq
   i32.eqz
   if
@@ -58288,8 +58302,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const inf
   call $~lib/math/NativeMath.imul
   f64.const 0
   f64.eq
@@ -58302,8 +58316,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/builtins/f64.MAX_VALUE
-  global.get $~lib/builtins/f64.MAX_VALUE
+  f64.const 1
+  f64.const inf
   call $~lib/math/NativeMath.imul
   f64.const 0
   f64.eq
@@ -58316,6 +58330,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  global.get $~lib/builtins/f64.MAX_VALUE
+  global.get $~lib/builtins/f64.MAX_VALUE
+  call $~lib/math/NativeMath.imul
+  f64.const 0
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4028
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   call $~lib/math/NativeMath.clz32
   f64.const 32
@@ -58324,7 +58352,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4031
+   i32.const 4032
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58337,7 +58365,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4032
+   i32.const 4033
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58350,7 +58378,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4033
+   i32.const 4034
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58363,7 +58391,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4034
+   i32.const 4035
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58376,7 +58404,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4035
+   i32.const 4036
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58389,7 +58417,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4036
+   i32.const 4037
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58402,7 +58430,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4037
+   i32.const 4038
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58415,7 +58443,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4038
+   i32.const 4039
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58428,7 +58456,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4039
+   i32.const 4040
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58441,7 +58469,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4040
+   i32.const 4041
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58454,7 +58482,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4041
+   i32.const 4042
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58468,7 +58496,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4042
+   i32.const 4043
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58481,7 +58509,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4043
+   i32.const 4044
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58494,7 +58522,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4044
+   i32.const 4045
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58508,7 +58536,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4045
+   i32.const 4046
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58521,7 +58549,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4046
+   i32.const 4047
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58530,20 +58558,6 @@
   i64.const 0
   call $~lib/math/ipow64
   i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4050
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i64.const 1
-  call $~lib/math/ipow64
-  i64.const 0
   i64.eq
   i32.eqz
   if
@@ -58555,7 +58569,7 @@
    unreachable
   end
   i64.const 0
-  i64.const 2
+  i64.const 1
   call $~lib/math/ipow64
   i64.const 0
   i64.eq
@@ -58569,7 +58583,7 @@
    unreachable
   end
   i64.const 0
-  i64.const 3
+  i64.const 2
   call $~lib/math/ipow64
   i64.const 0
   i64.eq
@@ -58582,22 +58596,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 1
   i64.const 0
+  i64.const 3
   call $~lib/math/ipow64
-  i64.const 1
+  i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
-   i32.const 4055
+   i32.const 4054
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
-  i64.const 1
+  i64.const 0
   call $~lib/math/ipow64
   i64.const 1
   i64.eq
@@ -58611,7 +58625,7 @@
    unreachable
   end
   i64.const 1
-  i64.const 2
+  i64.const 1
   call $~lib/math/ipow64
   i64.const 1
   i64.eq
@@ -58625,7 +58639,7 @@
    unreachable
   end
   i64.const 1
-  i64.const 3
+  i64.const 2
   call $~lib/math/ipow64
   i64.const 1
   i64.eq
@@ -58634,6 +58648,20 @@
    i32.const 0
    i32.const 32
    i32.const 4058
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i64.const 3
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4059
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58647,7 +58675,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4060
+   i32.const 4061
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58661,7 +58689,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4061
+   i32.const 4062
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58675,7 +58703,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4062
+   i32.const 4063
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58689,7 +58717,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4063
+   i32.const 4064
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58703,7 +58731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4065
+   i32.const 4066
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58717,7 +58745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4066
+   i32.const 4067
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58731,7 +58759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4067
+   i32.const 4068
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58745,7 +58773,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4068
+   i32.const 4069
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58759,7 +58787,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4070
+   i32.const 4071
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58773,7 +58801,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4071
+   i32.const 4072
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58787,7 +58815,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4072
+   i32.const 4073
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58801,7 +58829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4073
+   i32.const 4074
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58815,7 +58843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4075
+   i32.const 4076
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58829,7 +58857,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4076
+   i32.const 4077
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58843,7 +58871,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4077
+   i32.const 4078
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58857,7 +58885,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4078
+   i32.const 4079
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58871,7 +58899,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4079
+   i32.const 4080
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58880,20 +58908,6 @@
   i64.const -1
   call $~lib/math/ipow64
   i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4081
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 2
-  i64.const -1
-  call $~lib/math/ipow64
-  i64.const 0
   i64.eq
   i32.eqz
   if
@@ -58905,7 +58919,7 @@
    unreachable
   end
   i64.const 2
-  i64.const 64
+  i64.const -1
   call $~lib/math/ipow64
   i64.const 0
   i64.eq
@@ -58919,7 +58933,7 @@
    unreachable
   end
   i64.const 2
-  i64.const 128
+  i64.const 64
   call $~lib/math/ipow64
   i64.const 0
   i64.eq
@@ -58928,6 +58942,20 @@
    i32.const 0
    i32.const 32
    i32.const 4084
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 2
+  i64.const 128
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4085
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58959,7 +58987,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4090
+   i32.const 4091
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58973,7 +59001,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4091
+   i32.const 4092
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -58987,7 +59015,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4092
+   i32.const 4093
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59001,7 +59029,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4093
+   i32.const 4094
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59015,7 +59043,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4094
+   i32.const 4095
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59029,7 +59057,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4095
+   i32.const 4096
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59043,7 +59071,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4097
+   i32.const 4098
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59057,7 +59085,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4098
+   i32.const 4099
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59089,27 +59117,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4101
+   i32.const 4102
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1
   i32.const -2
-  call $~lib/math/ipow32
-  i32.const 1
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4103
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 1
-  i32.const -1
   call $~lib/math/ipow32
   i32.const 1
   i32.eq
@@ -59123,6 +59137,20 @@
    unreachable
   end
   i32.const 1
+  i32.const -1
+  call $~lib/math/ipow32
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4105
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
   i32.const 0
   i32.const 0
   i32.eq
@@ -59149,7 +59177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4107
+   i32.const 4108
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59164,7 +59192,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4109
+   i32.const 4110
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59179,7 +59207,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4110
+   i32.const 4111
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59195,7 +59223,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4111
+   i32.const 4112
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59211,7 +59239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4112
+   i32.const 4113
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59227,7 +59255,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4113
+   i32.const 4114
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59236,26 +59264,26 @@
   i64.const 0
   call $~lib/math/ipow64
   i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4115
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i64.const 1
-  call $~lib/math/ipow64
-  i64.const 0
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 4116
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i64.const 1
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4117
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59269,7 +59297,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4117
+   i32.const 4118
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59283,7 +59311,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4118
+   i32.const 4119
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59297,7 +59325,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4119
+   i32.const 4120
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59311,7 +59339,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4120
+   i32.const 4121
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59320,20 +59348,6 @@
   i64.const 8
   call $~lib/math/ipow64
   i64.const -15762478437236735
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 4121
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 61731
-  i64.const 4
-  call $~lib/math/ipow64
-  i64.const -3925184889716469295
   i64.eq
   i32.eqz
   if
@@ -59358,6 +59372,20 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const 61731
+  i64.const 4
+  call $~lib/math/ipow64
+  i64.const -3925184889716469295
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4124
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 57055
   i64.const 3
   call $~lib/math/ipow64
@@ -59373,7 +59401,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4125
+   i32.const 4126
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59391,7 +59419,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4126
+   i32.const 4127
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59406,7 +59434,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4128
+   i32.const 4129
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59421,7 +59449,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4129
+   i32.const 4130
    i32.const 1
    call $~lib/builtins/abort
    unreachable
@@ -59436,27 +59464,13 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 4130
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
    i32.const 4131
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const 0
+  f64.const 0
   call $~lib/math/NativeMath.pow
   f64.const 1
   f64.eq
@@ -59465,6 +59479,20 @@
    i32.const 0
    i32.const 32
    i32.const 4132
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  call $~lib/math/NativeMath.pow
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 4133
    i32.const 1
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -11442,7 +11442,7 @@
   if
    i32.const 0
    i32.const 13376
-   i32.const 1419
+   i32.const 1421
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/wasi/seed.optimized.wat
+++ b/tests/compiler/wasi/seed.optimized.wat
@@ -28,7 +28,7 @@
   (local $6 i32)
   i32.const 5
   local.set $3
-  i32.const 1417
+  i32.const 1421
   local.set $4
   i32.const 0
   i32.const 12

--- a/tests/compiler/wasi/seed.untouched.wat
+++ b/tests/compiler/wasi/seed.untouched.wat
@@ -611,7 +611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 1417
+   i32.const 1421
    i32.const 5
    call $~lib/wasi/index/abort
    unreachable


### PR DESCRIPTION
Some negative inputs for `acosh` may produce non-NaN values while all range `x < 1` should always return NaN. This PR fix this.

Thanks to @Yaffle for finding this [edge case](https://github.com/AssemblyScript/assemblyscript/issues/1856#issuecomment-850974607)

- [x] I've read the contributing guidelines