### PR TITLE
Refactor and clean up Binaryen bindings

### DIFF
--- a/scripts/build-dts.js
+++ b/scripts/build-dts.js
@@ -436,9 +436,7 @@ module.exports.default({
   project: path.resolve(__dirname, "..", "src"),
   prefix: "assemblyscript",
   exclude: [
-    "glue/js/index.ts",
-    "glue/js/node.d.ts",
-    "glue/binaryen.d.ts"
+    "glue/**",
   ],
   verbose: true,
   sendMessage: console.log,
@@ -451,6 +449,20 @@ module.exports.default({
   project: path.resolve(__dirname, "..", "std/assembly/shared"),
   prefix: "assemblyscript/std/assembly/shared",
   exclude: [],
+  verbose: true,
+  sendMessage: console.log,
+  stdout: stdout
+});
+
+stdout.write("\n");
+
+module.exports.default({
+  project: path.resolve(__dirname, "..", "src/glue"),
+  prefix: "assemblyscript/src/glue",
+  exclude: [
+    "js/index.ts",
+    "js/node.d.ts"
+  ],
   verbose: true,
   sendMessage: console.log,
   stdout: stdout

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -61,7 +61,7 @@ import {
   SIMDLoadOp,
   SIMDLoadStoreLaneOp,
   RefIsOp,
-  NativeType,
+  TypeRef,
   ExpressionRef,
   ExpressionId,
   getExpressionId,
@@ -1259,13 +1259,13 @@ function builtin_rotl(ctx: BuiltinContext): ExpressionRef {
           ),
           module.binary(
             BinaryOp.ShrU32,
-            module.local_get(temp1.index, NativeType.I32),
+            module.local_get(temp1.index, TypeRef.I32),
             module.binary(
               BinaryOp.AndI32,
               module.binary(
                 BinaryOp.SubI32,
                 module.i32(0),
-                module.local_get(temp2.index, NativeType.I32)
+                module.local_get(temp2.index, TypeRef.I32)
               ),
               module.i32(type.size - 1)
             )
@@ -1340,13 +1340,13 @@ function builtin_rotr(ctx: BuiltinContext): ExpressionRef {
           ),
           module.binary(
             BinaryOp.ShlI32,
-            module.local_get(temp1.index, NativeType.I32),
+            module.local_get(temp1.index, TypeRef.I32),
             module.binary(
               BinaryOp.AndI32,
               module.binary(
                 BinaryOp.SubI32,
                 module.i32(0),
-                module.local_get(temp2.index, NativeType.I32)
+                module.local_get(temp2.index, TypeRef.I32)
               ),
               module.i32(type.size - 1)
             )
@@ -1415,9 +1415,9 @@ function builtin_abs(ctx: BuiltinContext): ExpressionRef {
               ),
               false // i32
             ),
-            module.local_get(temp1.index, NativeType.I32)
+            module.local_get(temp1.index, TypeRef.I32)
           ),
-          module.local_get(temp2.index, NativeType.I32)
+          module.local_get(temp2.index, TypeRef.I32)
         );
         flow.freeTempLocal(temp2);
         flow.freeTempLocal(temp1);
@@ -1440,9 +1440,9 @@ function builtin_abs(ctx: BuiltinContext): ExpressionRef {
               ),
               false // i32/i64
             ),
-            module.local_get(temp1.index, options.nativeSizeType)
+            module.local_get(temp1.index, options.sizeTypeRef)
           ),
-          module.local_get(temp2.index, options.nativeSizeType)
+          module.local_get(temp2.index, options.sizeTypeRef)
         );
         flow.freeTempLocal(temp2);
         flow.freeTempLocal(temp1);
@@ -1464,9 +1464,9 @@ function builtin_abs(ctx: BuiltinContext): ExpressionRef {
               ),
               false // i64
             ),
-            module.local_get(temp1.index, NativeType.I64)
+            module.local_get(temp1.index, TypeRef.I64)
           ),
-          module.local_get(temp2.index, NativeType.I64)
+          module.local_get(temp2.index, TypeRef.I64)
         );
         flow.freeTempLocal(temp2);
         flow.freeTempLocal(temp1);
@@ -1543,7 +1543,7 @@ function builtin_max(ctx: BuiltinContext): ExpressionRef {
     }
     if (op != -1) {
       let flow = compiler.currentFlow;
-      let nativeType = type.toNativeType();
+      let typeRef = type.toRef();
       let temp1 = flow.getTempLocal(type, findUsedLocals(arg1));
       flow.setLocalFlag(temp1.index, LocalFlags.WRAPPED);
       let temp2 = flow.getTempLocal(type);
@@ -1552,8 +1552,8 @@ function builtin_max(ctx: BuiltinContext): ExpressionRef {
         module.local_tee(temp1.index, arg0, false), // numeric
         module.local_tee(temp2.index, arg1, false), // numeric
         module.binary(op,
-          module.local_get(temp1.index, nativeType),
-          module.local_get(temp2.index, nativeType)
+          module.local_get(temp1.index, typeRef),
+          module.local_get(temp2.index, typeRef)
         )
       );
       flow.freeTempLocal(temp2);
@@ -1622,7 +1622,7 @@ function builtin_min(ctx: BuiltinContext): ExpressionRef {
     }
     if (op != -1) {
       let flow = compiler.currentFlow;
-      let nativeType = type.toNativeType();
+      let typeRef = type.toRef();
       let temp1 = flow.getTempLocal(type, findUsedLocals(arg1));
       flow.setLocalFlag(temp1.index, LocalFlags.WRAPPED);
       let temp2 = flow.getTempLocal(type);
@@ -1631,8 +1631,8 @@ function builtin_min(ctx: BuiltinContext): ExpressionRef {
         module.local_tee(temp1.index, arg0, false), // numeric
         module.local_tee(temp2.index, arg1, false), // numeric
         module.binary(op,
-          module.local_get(temp1.index, nativeType),
-          module.local_get(temp2.index, nativeType)
+          module.local_get(temp1.index, typeRef),
+          module.local_get(temp2.index, typeRef)
         )
       );
       flow.freeTempLocal(temp2);
@@ -1962,14 +1962,14 @@ function builtin_isNaN(ctx: BuiltinContext): ExpressionRef {
         if (getExpressionId(arg0) == ExpressionId.LocalGet) {
           return module.binary(BinaryOp.NeF32,
             arg0,
-            module.local_get(getLocalGetIndex(arg0), NativeType.F32)
+            module.local_get(getLocalGetIndex(arg0), TypeRef.F32)
           );
         }
         let flow = compiler.currentFlow;
         let temp = flow.getTempLocal(Type.f32);
         let ret = module.binary(BinaryOp.NeF32,
           module.local_tee(temp.index, arg0, false), // f32
-          module.local_get(temp.index, NativeType.F32)
+          module.local_get(temp.index, TypeRef.F32)
         );
         flow.freeTempLocal(temp);
         return ret;
@@ -1978,14 +1978,14 @@ function builtin_isNaN(ctx: BuiltinContext): ExpressionRef {
         if (getExpressionId(arg0) == ExpressionId.LocalGet) {
           return module.binary(BinaryOp.NeF64,
             arg0,
-            module.local_get(getLocalGetIndex(arg0), NativeType.F64)
+            module.local_get(getLocalGetIndex(arg0), TypeRef.F64)
           );
         }
         let flow = compiler.currentFlow;
         let temp = flow.getTempLocal(Type.f64);
         let ret = module.binary(BinaryOp.NeF64,
           module.local_tee(temp.index, arg0, false), // f64
-          module.local_get(temp.index, NativeType.F64)
+          module.local_get(temp.index, TypeRef.F64)
         );
         flow.freeTempLocal(temp);
         return ret;
@@ -2039,7 +2039,7 @@ function builtin_isFinite(ctx: BuiltinContext): ExpressionRef {
           return module.binary(BinaryOp.EqF32,
             module.binary(BinaryOp.SubF32,
               arg0,
-              module.local_get(getLocalGetIndex(arg0), NativeType.F32)
+              module.local_get(getLocalGetIndex(arg0), TypeRef.F32)
             ),
             module.f32(0)
           );
@@ -2049,7 +2049,7 @@ function builtin_isFinite(ctx: BuiltinContext): ExpressionRef {
         let ret = module.binary(BinaryOp.EqF32,
           module.binary(BinaryOp.SubF32,
             module.local_tee(temp.index, arg0, false), // f32
-            module.local_get(temp.index, NativeType.F32)
+            module.local_get(temp.index, TypeRef.F32)
           ),
           module.f32(0)
         );
@@ -2061,7 +2061,7 @@ function builtin_isFinite(ctx: BuiltinContext): ExpressionRef {
           return module.binary(BinaryOp.EqF64,
             module.binary(BinaryOp.SubF64,
               arg0,
-              module.local_get(getLocalGetIndex(arg0), NativeType.F64)
+              module.local_get(getLocalGetIndex(arg0), TypeRef.F64)
             ),
             module.f64(0)
           );
@@ -2071,7 +2071,7 @@ function builtin_isFinite(ctx: BuiltinContext): ExpressionRef {
         let ret = module.binary(BinaryOp.EqF64,
           module.binary(BinaryOp.SubF64,
             module.local_tee(temp.index, arg0, false), // f64
-            module.local_get(temp.index, NativeType.F64)
+            module.local_get(temp.index, TypeRef.F64)
           ),
           module.f64(0)
         );
@@ -2131,7 +2131,7 @@ function builtin_load(ctx: BuiltinContext): ExpressionRef {
     type.byteSize,
     type.isSignedIntegerValue,
     arg0,
-    outType.toNativeType(),
+    outType.toRef(),
     immOffset,
     immAlign
   );
@@ -2194,7 +2194,7 @@ function builtin_store(ctx: BuiltinContext): ExpressionRef {
     }
   }
   compiler.currentType = Type.void;
-  return module.store(type.byteSize, arg0, arg1, inType.toNativeType(), immOffset, immAlign);
+  return module.store(type.byteSize, arg0, arg1, inType.toRef(), immOffset, immAlign);
 }
 builtins.set(BuiltinNames.store, builtin_store);
 
@@ -2452,7 +2452,7 @@ function builtin_atomic_load(ctx: BuiltinContext): ExpressionRef {
   return module.atomic_load(
     type.byteSize,
     arg0,
-    outType.toNativeType(),
+    outType.toRef(),
     immOffset
   );
 }
@@ -2511,7 +2511,7 @@ function builtin_atomic_store(ctx: BuiltinContext): ExpressionRef {
     return module.unreachable();
   }
   compiler.currentType = Type.void;
-  return module.atomic_store(type.byteSize, arg0, arg1, inType.toNativeType(), immOffset);
+  return module.atomic_store(type.byteSize, arg0, arg1, inType.toRef(), immOffset);
 }
 builtins.set(BuiltinNames.atomic_store, builtin_atomic_store);
 
@@ -2569,7 +2569,7 @@ function builtin_atomic_binary(ctx: BuiltinContext, op: AtomicRMWOp, opName: str
     return module.unreachable();
   }
   compiler.currentType = inType;
-  return module.atomic_rmw(op, type.byteSize, immOffset, arg0, arg1, inType.toNativeType());
+  return module.atomic_rmw(op, type.byteSize, immOffset, arg0, arg1, inType.toRef());
 }
 
 // atomic.add<T!>(ptr, value: T, immOffset?: usize) -> T
@@ -2667,7 +2667,7 @@ function builtin_atomic_cmpxchg(ctx: BuiltinContext): ExpressionRef {
     return module.unreachable();
   }
   compiler.currentType = inType;
-  return module.atomic_cmpxchg(type.byteSize, immOffset, arg0, arg1, arg2, inType.toNativeType());
+  return module.atomic_cmpxchg(type.byteSize, immOffset, arg0, arg1, arg2, inType.toRef());
 }
 builtins.set(BuiltinNames.atomic_cmpxchg, builtin_atomic_cmpxchg);
 
@@ -2696,7 +2696,7 @@ function builtin_atomic_wait(ctx: BuiltinContext): ExpressionRef {
     case TypeKind.ISIZE:
     case TypeKind.U32:
     case TypeKind.U64:
-    case TypeKind.USIZE: return module.atomic_wait(arg0, arg1, arg2, type.toNativeType());
+    case TypeKind.USIZE: return module.atomic_wait(arg0, arg1, arg2, type.toRef());
   }
   compiler.error(
     DiagnosticCode.Operation_0_cannot_be_applied_to_type_1,
@@ -3069,25 +3069,25 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
   var evaled = module.runExpression(arg0, ExpressionRunnerFlags.Default);
   if (evaled) {
     switch (<u32>getExpressionType(evaled)) {
-      case <u32>NativeType.I32: {
+      case <u32>TypeRef.I32: {
         if (getConstValueI32(evaled)) {
           return arg0;
         }
         break;
       }
-      case <u32>NativeType.I64: {
+      case <u32>TypeRef.I64: {
         if (getConstValueI64Low(evaled) | getConstValueI64High(evaled)) {
           return arg0;
         }
         break;
       }
-      case <u32>NativeType.F32: {
+      case <u32>TypeRef.F32: {
         if (getConstValueF32(evaled)) {
           return arg0;
         }
         break;
       }
-      case <u32>NativeType.F64: {
+      case <u32>TypeRef.F64: {
         if (getConstValueF64(evaled)) {
           return arg0;
         }
@@ -3149,7 +3149,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
         flow.setLocalFlag(temp.index, LocalFlags.WRAPPED); // arg0 is wrapped
         let ret = module.if(
           module.local_tee(temp.index, arg0, false), // numeric
-          module.local_get(temp.index, NativeType.I32),
+          module.local_get(temp.index, TypeRef.I32),
           abort
         );
         flow.freeTempLocal(temp);
@@ -3163,7 +3163,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
             module.local_tee(temp.index, arg0, false) // i64
           ),
           abort,
-          module.local_get(temp.index, NativeType.I64)
+          module.local_get(temp.index, TypeRef.I64)
         );
         flow.freeTempLocal(temp);
         return ret;
@@ -3179,7 +3179,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
             module.local_tee(temp.index, arg0, type.isManaged)
           ),
           abort,
-          module.local_get(temp.index, compiler.options.nativeSizeType)
+          module.local_get(temp.index, compiler.options.sizeTypeRef)
         );
         flow.freeTempLocal(temp);
         return ret;
@@ -3192,7 +3192,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
             module.f32(0)
           ),
           abort,
-          module.local_get(temp.index, NativeType.F32)
+          module.local_get(temp.index, TypeRef.F32)
         );
         flow.freeTempLocal(temp);
         return ret;
@@ -3205,7 +3205,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
             module.f64(0)
           ),
           abort,
-          module.local_get(temp.index, NativeType.F64)
+          module.local_get(temp.index, TypeRef.F64)
         );
         flow.freeTempLocal(temp);
         return ret;
@@ -3222,7 +3222,7 @@ function builtin_assert(ctx: BuiltinContext): ExpressionRef {
             module.local_tee(temp.index, arg0, false) // ref
           ),
           abort,
-          module.local_get(temp.index, type.toNativeType())
+          module.local_get(temp.index, type.toRef())
         );
         flow.freeTempLocal(temp);
         return ret;
@@ -3276,13 +3276,13 @@ function builtin_call_indirect(ctx: BuiltinContext): ExpressionRef {
   var indexArg = compiler.compileExpression(operands[0], Type.u32, Constraints.CONV_IMPLICIT);
   var numOperands = operands.length - 1;
   var operandExprs = new Array<ExpressionRef>(numOperands);
-  var nativeParamTypes = new Array<NativeType>(numOperands);
+  var paramTypeRefs = new Array<TypeRef>(numOperands);
   for (let i = 0; i < numOperands; ++i) {
     operandExprs[i] = compiler.compileExpression(operands[1 + i], Type.auto);
-    nativeParamTypes[i] = compiler.currentType.toNativeType();
+    paramTypeRefs[i] = compiler.currentType.toRef();
   }
   compiler.currentType = returnType;
-  return module.call_indirect(indexArg, operandExprs, createType(nativeParamTypes), returnType.toNativeType());
+  return module.call_indirect(indexArg, operandExprs, createType(paramTypeRefs), returnType.toRef());
 }
 builtins.set(BuiltinNames.call_indirect, builtin_call_indirect);
 
@@ -6058,7 +6058,7 @@ function builtin_visit_globals(ctx: BuiltinContext): ExpressionRef {
   var arg0 = compiler.compileExpression(operands[0], Type.u32, Constraints.CONV_IMPLICIT);
   compiler.runtimeFeatures |= RuntimeFeatures.visitGlobals;
   compiler.currentType = Type.void;
-  return module.call(BuiltinNames.visit_globals, [ arg0 ], NativeType.None);
+  return module.call(BuiltinNames.visit_globals, [ arg0 ], TypeRef.None);
 }
 builtins.set(BuiltinNames.visit_globals, builtin_visit_globals);
 
@@ -6078,7 +6078,7 @@ function builtin_visit_members(ctx: BuiltinContext): ExpressionRef {
   var arg1 = compiler.compileExpression(operands[1], Type.u32, Constraints.CONV_IMPLICIT);
   compiler.runtimeFeatures |= RuntimeFeatures.visitMembers;
   compiler.currentType = Type.void;
-  return module.call(BuiltinNames.visit_members, [ arg0, arg1 ], NativeType.None);
+  return module.call(BuiltinNames.visit_members, [ arg0, arg1 ], TypeRef.None);
 }
 builtins.set(BuiltinNames.visit_members, builtin_visit_members);
 
@@ -9454,7 +9454,7 @@ builtins.set(BuiltinNames.f64x2_promote_low_f32x4, builtin_f64x4_promote_low_f32
 export function compileVisitGlobals(compiler: Compiler): void {
   var module = compiler.module;
   var exprs = new Array<ExpressionRef>();
-  var nativeSizeType = compiler.options.nativeSizeType;
+  var sizeTypeRef = compiler.options.sizeTypeRef;
   var visitInstance = assert(compiler.program.visitInstance);
 
   // this function is @lazy: make sure it exists
@@ -9480,30 +9480,30 @@ export function compileVisitGlobals(compiler: Compiler): void {
               compiler.options.isWasm64
                 ? module.i64(i64_low(value), i64_high(value))
                 : module.i32(i64_low(value)),
-              module.local_get(0, NativeType.I32) // cookie
-            ], NativeType.None)
+              module.local_get(0, TypeRef.I32) // cookie
+            ], TypeRef.None)
           );
         }
       } else {
         exprs.push(
           module.if(
             module.local_tee(1,
-              module.global_get(global.internalName, nativeSizeType),
+              module.global_get(global.internalName, sizeTypeRef),
               false // internal
             ),
             module.call(visitInstance.internalName, [
-              module.local_get(1, nativeSizeType), // tempRef != null
-              module.local_get(0, NativeType.I32) // cookie
-            ], NativeType.None)
+              module.local_get(1, sizeTypeRef), // tempRef != null
+              module.local_get(0, TypeRef.I32) // cookie
+            ], TypeRef.None)
           )
         );
       }
     }
   }
   module.addFunction(BuiltinNames.visit_globals,
-    NativeType.I32,  // cookie
-    NativeType.None, // => void
-    [ nativeSizeType ],
+    TypeRef.I32,  // cookie
+    TypeRef.None, // => void
+    [ sizeTypeRef ],
     exprs.length
       ? module.block(null, exprs)
       : module.nop()
@@ -9518,8 +9518,8 @@ function ensureVisitMembersOf(compiler: Compiler, instance: Class): void {
   var program = compiler.program;
   var module = compiler.module;
   var usizeType = program.options.usizeType;
-  var nativeSizeType = usizeType.toNativeType();
-  var nativeSizeSize = usizeType.byteSize;
+  var sizeTypeRef = usizeType.toRef();
+  var sizeTypeSize = usizeType.byteSize;
   var visitInstance = assert(program.visitInstance);
   var body = new Array<ExpressionRef>();
 
@@ -9528,9 +9528,9 @@ function ensureVisitMembersOf(compiler: Compiler, instance: Class): void {
   if (base) {
     body.push(
       module.call(base.internalName + "~visit", [
-        module.local_get(0, nativeSizeType), // this
-        module.local_get(1, NativeType.I32)  // cookie
-      ], NativeType.None)
+        module.local_get(0, sizeTypeRef), // this
+        module.local_get(1, TypeRef.I32)  // cookie
+      ], TypeRef.None)
     );
   }
 
@@ -9557,9 +9557,9 @@ function ensureVisitMembersOf(compiler: Compiler, instance: Class): void {
         );
         body.push(
           module.call(visitInstance.internalName, [
-            module.local_get(0, nativeSizeType), // this
-            module.local_get(1, NativeType.I32)  // cookie
-          ], NativeType.None)
+            module.local_get(0, sizeTypeRef), // this
+            module.local_get(1, TypeRef.I32)  // cookie
+          ], TypeRef.None)
         );
       }
       hasVisitImpl = true;
@@ -9586,16 +9586,16 @@ function ensureVisitMembersOf(compiler: Compiler, instance: Class): void {
                 // if ($2 = value) __visit($2, $1)
                 module.if(
                   module.local_tee(2,
-                    module.load(nativeSizeSize, false,
-                      module.local_get(0, nativeSizeType),
-                      nativeSizeType, fieldOffset
+                    module.load(sizeTypeSize, false,
+                      module.local_get(0, sizeTypeRef),
+                      sizeTypeRef, fieldOffset
                     ),
                     false // internal
                   ),
                   module.call(visitInstance.internalName, [
-                    module.local_get(2, nativeSizeType), // value
-                    module.local_get(1, NativeType.I32)  // cookie
-                  ], NativeType.None)
+                    module.local_get(2, sizeTypeRef), // value
+                    module.local_get(1, TypeRef.I32)  // cookie
+                  ], TypeRef.None)
                 )
               );
             }
@@ -9607,10 +9607,10 @@ function ensureVisitMembersOf(compiler: Compiler, instance: Class): void {
 
   // Create the visitor function
   instance.visitRef = module.addFunction(instance.internalName + "~visit",
-    createType([nativeSizeType, NativeType.I32]),
-    NativeType.None,
-    needsTempValue ? [ nativeSizeType ] : null,
-    module.flatten(body, NativeType.None)
+    createType([sizeTypeRef, TypeRef.I32]),
+    TypeRef.None,
+    needsTempValue ? [ sizeTypeRef ] : null,
+    module.flatten(body, TypeRef.None)
   );
 
   // And make sure the base visitor function exists
@@ -9622,7 +9622,7 @@ export function compileVisitMembers(compiler: Compiler): void {
   var program = compiler.program;
   var module = compiler.module;
   var usizeType = program.options.usizeType;
-  var nativeSizeType = usizeType.toNativeType();
+  var sizeTypeRef = usizeType.toRef();
   var managedClasses = program.managedClasses;
   var visitInstance = assert(program.visitInstance);
   compiler.compileFunction(visitInstance, true); // is lazy, make sure it is compiled
@@ -9642,11 +9642,11 @@ export function compileVisitMembers(compiler: Compiler): void {
     } else {
       cases[i] = module.block(null, [
         module.call(instance.internalName + "~visit", [
-          module.local_get(0, nativeSizeType), // this
-          module.local_get(1, NativeType.I32)  // cookie
-        ], NativeType.None),
+          module.local_get(0, sizeTypeRef), // this
+          module.local_get(1, TypeRef.I32)  // cookie
+        ], TypeRef.None),
         module.return()
-      ], NativeType.None);
+      ], TypeRef.None);
       ensureVisitMembersOf(compiler, instance);
     }
   }
@@ -9656,38 +9656,38 @@ export function compileVisitMembers(compiler: Compiler): void {
     module.switch(names, "invalid",
       // load<u32>(changetype<usize>(this) - 8)
       module.load(4, false,
-        nativeSizeType == NativeType.I64
+        sizeTypeRef == TypeRef.I64
           ? module.binary(BinaryOp.SubI64,
-              module.local_get(0, nativeSizeType),
+              module.local_get(0, sizeTypeRef),
               module.i64(8)
             )
           : module.binary(BinaryOp.SubI32,
-              module.local_get(0, nativeSizeType),
+              module.local_get(0, sizeTypeRef),
               module.i32(8) // rtId is at -8
             ),
-        NativeType.I32, 0
+        TypeRef.I32, 0
       )
     )
-  ], NativeType.None);
+  ], TypeRef.None);
 
   // Wrap blocks in order
   for (let i = 0, k = names.length - 1; i < k; ++i) {
     current = module.block(names[i + 1], [
       current,
       cases[i]
-    ], NativeType.None);
+    ], TypeRef.None);
   }
 
   // Wrap the last id in an 'invalid' block to break out of on invalid ids
   current = module.block("invalid", [
     current,
     cases[names.length - 1]
-  ], NativeType.None);
+  ], TypeRef.None);
 
   // Add the function, executing an unreachable if breaking to 'invalid'
   module.addFunction(BuiltinNames.visit_members,
-    createType([ nativeSizeType, NativeType.I32 ]), // this, cookie
-    NativeType.None, // => void
+    createType([ sizeTypeRef, TypeRef.I32 ]), // this, cookie
+    TypeRef.None, // => void
     null,
     module.flatten([
       current,
@@ -9763,16 +9763,16 @@ export function compileRTTI(compiler: Compiler): void {
   var segment = compiler.addAlignedMemorySegment(data);
   if (usizeType.size == 8) {
     let offset = segment.offset;
-    module.addGlobal(BuiltinNames.rtti_base, NativeType.I64, false, module.i64(i64_low(offset), i64_high(offset)));
+    module.addGlobal(BuiltinNames.rtti_base, TypeRef.I64, false, module.i64(i64_low(offset), i64_high(offset)));
   } else {
-    module.addGlobal(BuiltinNames.rtti_base, NativeType.I32, false, module.i32(i64_low(segment.offset)));
+    module.addGlobal(BuiltinNames.rtti_base, TypeRef.I32, false, module.i32(i64_low(segment.offset)));
   }
 }
 
 /** Compiles a class-specific instanceof helper, checking a ref against all concrete instances. */
 export function compileClassInstanceOf(compiler: Compiler, prototype: ClassPrototype): void {
   var module = compiler.module;
-  var nativeSizeType = compiler.options.nativeSizeType;
+  var sizeTypeRef = compiler.options.sizeTypeRef;
   var instanceofInstance = assert(prototype.program.instanceofInstance);
   compiler.compileFunction(instanceofInstance);
 
@@ -9782,10 +9782,10 @@ export function compileClassInstanceOf(compiler: Compiler, prototype: ClassProto
   stmts.push(
     module.if(
       module.unary(
-        nativeSizeType == NativeType.I64
+        sizeTypeRef == TypeRef.I64
           ? UnaryOp.EqzI64
           : UnaryOp.EqzI32,
-        module.local_get(0, nativeSizeType)
+        module.local_get(0, sizeTypeRef)
       ),
       module.return(
         module.i32(0)
@@ -9802,9 +9802,9 @@ export function compileClassInstanceOf(compiler: Compiler, prototype: ClassProto
       stmts.push(
         module.if(
           module.call(instanceofInstance.internalName, [
-            module.local_get(0, nativeSizeType),
+            module.local_get(0, sizeTypeRef),
             module.i32(instance.id)
-          ], NativeType.I32),
+          ], TypeRef.I32),
           module.return(
             module.i32(1)
           )
@@ -9820,7 +9820,7 @@ export function compileClassInstanceOf(compiler: Compiler, prototype: ClassProto
     )
   );
 
-  module.addFunction(prototype.internalName + "~instanceof", nativeSizeType, NativeType.I32, null, module.flatten(stmts));
+  module.addFunction(prototype.internalName + "~instanceof", sizeTypeRef, TypeRef.I32, null, module.flatten(stmts));
 }
 
 // Helpers

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -32,7 +32,7 @@ import {
 } from "./program";
 
 import {
-  NativeType,
+  TypeRef,
   ExpressionId,
   ExpressionRef,
   BinaryOp,
@@ -297,18 +297,18 @@ export class Flow {
   getTempLocal(type: Type, except: Set<i32> | null = null): Local {
     var parentFunction = this.parentFunction;
     var temps: Local[] | null;
-    switch (<u32>type.toNativeType()) {
-      case <u32>NativeType.I32: { temps = parentFunction.tempI32s; break; }
-      case <u32>NativeType.I64: { temps = parentFunction.tempI64s; break; }
-      case <u32>NativeType.F32: { temps = parentFunction.tempF32s; break; }
-      case <u32>NativeType.F64: { temps = parentFunction.tempF64s; break; }
-      case <u32>NativeType.V128: { temps = parentFunction.tempV128s; break; }
-      case <u32>NativeType.Funcref: { temps = parentFunction.tempFuncrefs; break; }
-      case <u32>NativeType.Externref: { temps = parentFunction.tempExternrefs; break; }
-      case <u32>NativeType.Anyref: { temps = parentFunction.tempAnyrefs; break; }
-      case <u32>NativeType.Eqref: { temps = parentFunction.tempEqrefs; break; }
-      case <u32>NativeType.I31ref: { temps = parentFunction.tempI31refs; break; }
-      case <u32>NativeType.Dataref: { temps = parentFunction.tempDatarefs; break; }
+    switch (<u32>type.toRef()) {
+      case <u32>TypeRef.I32: { temps = parentFunction.tempI32s; break; }
+      case <u32>TypeRef.I64: { temps = parentFunction.tempI64s; break; }
+      case <u32>TypeRef.F32: { temps = parentFunction.tempF32s; break; }
+      case <u32>TypeRef.F64: { temps = parentFunction.tempF64s; break; }
+      case <u32>TypeRef.V128: { temps = parentFunction.tempV128s; break; }
+      case <u32>TypeRef.Funcref: { temps = parentFunction.tempFuncrefs; break; }
+      case <u32>TypeRef.Externref: { temps = parentFunction.tempExternrefs; break; }
+      case <u32>TypeRef.Anyref: { temps = parentFunction.tempAnyrefs; break; }
+      case <u32>TypeRef.Eqref: { temps = parentFunction.tempEqrefs; break; }
+      case <u32>TypeRef.I31ref: { temps = parentFunction.tempI31refs; break; }
+      case <u32>TypeRef.Dataref: { temps = parentFunction.tempDatarefs; break; }
       default: throw new Error("concrete type expected");
     }
     var local: Local;
@@ -349,68 +349,68 @@ export class Flow {
     var temps: Local[];
     assert(local.type != null); // internal error
     local.resetTemporaryName();
-    switch (<u32>local.type.toNativeType()) {
-      case <u32>NativeType.I32: {
+    switch (<u32>local.type.toRef()) {
+      case <u32>TypeRef.I32: {
         let tempI32s = parentFunction.tempI32s;
         if (tempI32s) temps = tempI32s;
         else parentFunction.tempI32s = temps = [];
         break;
       }
-      case <u32>NativeType.I64: {
+      case <u32>TypeRef.I64: {
         let tempI64s = parentFunction.tempI64s;
         if (tempI64s) temps = tempI64s;
         else parentFunction.tempI64s = temps = [];
         break;
       }
-      case <u32>NativeType.F32: {
+      case <u32>TypeRef.F32: {
         let tempF32s = parentFunction.tempF32s;
         if (tempF32s) temps = tempF32s;
         else parentFunction.tempF32s = temps = [];
         break;
       }
-      case <u32>NativeType.F64: {
+      case <u32>TypeRef.F64: {
         let tempF64s = parentFunction.tempF64s;
         if (tempF64s) temps = tempF64s;
         else parentFunction.tempF64s = temps = [];
         break;
       }
-      case <u32>NativeType.V128: {
+      case <u32>TypeRef.V128: {
         let tempV128s = parentFunction.tempV128s;
         if (tempV128s) temps = tempV128s;
         else parentFunction.tempV128s = temps = [];
         break;
       }
-      case <u32>NativeType.Funcref: {
+      case <u32>TypeRef.Funcref: {
         let tempFuncrefs = parentFunction.tempFuncrefs;
         if (tempFuncrefs) temps = tempFuncrefs;
         else parentFunction.tempFuncrefs = temps = [];
         break;
       }
-      case <u32>NativeType.Externref: {
+      case <u32>TypeRef.Externref: {
         let tempExternrefs = parentFunction.tempExternrefs;
         if (tempExternrefs) temps = tempExternrefs;
         else parentFunction.tempExternrefs = temps = [];
         break;
       }
-      case <u32>NativeType.Anyref: {
+      case <u32>TypeRef.Anyref: {
         let tempAnyrefs = parentFunction.tempAnyrefs;
         if (tempAnyrefs) temps = tempAnyrefs;
         else parentFunction.tempAnyrefs = temps = [];
         break;
       }
-      case <u32>NativeType.Eqref: {
+      case <u32>TypeRef.Eqref: {
         let tempEqrefs = parentFunction.tempEqrefs;
         if (tempEqrefs) temps = tempEqrefs;
         else parentFunction.tempEqrefs = temps = [];
         break;
       }
-      case <u32>NativeType.I31ref: {
+      case <u32>TypeRef.I31ref: {
         let tempI31refs = parentFunction.tempI31refs;
         if (tempI31refs) temps = tempI31refs;
         else parentFunction.tempI31refs = temps = [];
         break;
       }
-      case <u32>NativeType.Dataref: {
+      case <u32>TypeRef.Dataref: {
         let tempDatarefs = parentFunction.tempDatarefs;
         if (tempDatarefs) temps = tempDatarefs;
         else parentFunction.tempDatarefs = temps = [];
@@ -1024,8 +1024,8 @@ export class Flow {
           // Logical AND: (if (condition ifTrue 0))
           // the only way this had become true is if condition and ifTrue are true
           if (
-            (getExpressionType(ifFalse) == NativeType.I32 && getConstValueI32(ifFalse) == 0) ||
-            (getExpressionType(ifFalse) == NativeType.I64 && getConstValueI64Low(ifFalse) == 0 && getConstValueI64High(ifFalse) == 0)
+            (getExpressionType(ifFalse) == TypeRef.I32 && getConstValueI32(ifFalse) == 0) ||
+            (getExpressionType(ifFalse) == TypeRef.I64 && getConstValueI64Low(ifFalse) == 0 && getConstValueI64High(ifFalse) == 0)
           ) {
             this.inheritNonnullIfTrue(getIfCondition(expr), iff);
             this.inheritNonnullIfTrue(getIfTrue(expr), iff);
@@ -1119,8 +1119,8 @@ export class Flow {
           // the only way this had become false is if condition and ifFalse are false
           let exprType = getExpressionType(ifTrue);
           if (
-            (exprType == NativeType.I32 && getConstValueI32(ifTrue) != 0) ||
-            (exprType == NativeType.I64 && (getConstValueI64Low(ifTrue) != 0 || getConstValueI64High(ifTrue) != 0))
+            (exprType == TypeRef.I32 && getConstValueI32(ifTrue) != 0) ||
+            (exprType == TypeRef.I64 && (getConstValueI64Low(ifTrue) != 0 || getConstValueI64High(ifTrue) != 0))
           ) {
             this.inheritNonnullIfFalse(getIfCondition(expr), iff);
             this.inheritNonnullIfFalse(getIfFalse(expr), iff);
@@ -1359,10 +1359,10 @@ export class Flow {
       case ExpressionId.Const: {
         let value: i32 = 0;
         switch (<u32>getExpressionType(expr)) {
-          case <u32>NativeType.I32: { value = getConstValueI32(expr); break; }
-          case <u32>NativeType.I64: { value = getConstValueI64Low(expr); break; } // discards upper bits
-          case <u32>NativeType.F32: { value = i32(getConstValueF32(expr)); break; }
-          case <u32>NativeType.F64: { value = i32(getConstValueF64(expr)); break; }
+          case <u32>TypeRef.I32: { value = getConstValueI32(expr); break; }
+          case <u32>TypeRef.I64: { value = getConstValueI64Low(expr); break; } // discards upper bits
+          case <u32>TypeRef.F32: { value = i32(getConstValueF32(expr)); break; }
+          case <u32>TypeRef.F64: { value = i32(getConstValueF64(expr)); break; }
           default: assert(false);
         }
         switch (type.kind) {

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -8,6 +8,613 @@
  * @license Apache-2.0
  */
 
+export type StringRef = usize;
+export type ArrayRef<T> = usize;
+export type Index = u32;
+export type FeatureFlags = u32;
+export type Type = usize;
+export type ExpressionId = i32;
+export type ModuleRef = usize;
+export type Literal = usize;
+export type Op = i32;
+export type ExpressionRef = usize;
+export type FunctionRef = usize;
+export type ImportRef = usize;
+export type ExportRef = usize;
+export type ExternalKind = u32;
+export type GlobalRef = usize;
+export type EventRef = usize;
+export type TableRef = usize;
+export type ElementSegmentRef = usize;
+export type SideEffects = u32;
+export type RelooperRef = usize;
+export type RelooperBlockRef = usize;
+export type ExpressionRunnerRef = usize;
+export type ExpressionRunnerFlags = u32;
+
+export declare function _BinaryenTypeCreate(types: ArrayRef<Type>, numTypes: u32): Type;
+export declare function _BinaryenTypeArity(type: Type): u32;
+export declare function _BinaryenTypeExpand(type: Type, typesOut: ArrayRef<Type>): void;
+
+export declare function _BinaryenModuleCreate(): ModuleRef;
+export declare function _BinaryenModuleDispose(module: ModuleRef): void;
+
+export declare function _BinaryenSizeofLiteral(): usize;
+export declare function _BinaryenLiteralInt32(literalOut: Literal, x: i32): void;
+export declare function _BinaryenLiteralInt64(literalOut: Literal, x: i32, y: i32): void;
+export declare function _BinaryenLiteralFloat32(literalOut: Literal, x: f32): void;
+export declare function _BinaryenLiteralFloat64(literalOut: Literal, x: f64): void;
+export declare function _BinaryenLiteralVec128(literalOut: Literal, x: ArrayRef<u8>): void;
+export declare function _BinaryenLiteralFloat32Bits(literalOut: Literal, x: i32): void;
+export declare function _BinaryenLiteralFloat64Bits(literalOut: Literal, x: i32, y: i32): void;
+
+export declare function _BinaryenExpressionGetId(expr: ExpressionRef): ExpressionId;
+export declare function _BinaryenExpressionGetType(expr: ExpressionRef): Type;
+export declare function _BinaryenExpressionSetType(expr: ExpressionRef, type: Type): void;
+export declare function _BinaryenExpressionPrint(expr: ExpressionRef): void;
+export declare function _BinaryenExpressionCopy(expr: ExpressionRef, module: ModuleRef): ExpressionRef;
+export declare function _BinaryenExpressionFinalize(expr: ExpressionRef): void;
+
+export declare function _BinaryenBlock(module: ModuleRef, name: StringRef, childExprs: ArrayRef<ExpressionRef>, numChildren: Index, type: Type): ExpressionRef;
+export declare function _BinaryenBlockGetName(expr: ExpressionRef): StringRef;
+export declare function _BinaryenBlockSetName(expr: ExpressionRef, name: StringRef): void;
+export declare function _BinaryenBlockGetNumChildren(expr: ExpressionRef): Index;
+export declare function _BinaryenBlockGetChildAt(expr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenBlockSetChildAt(expr: ExpressionRef, index: Index, childExpr: ExpressionRef): void;
+export declare function _BinaryenBlockAppendChild(expr: ExpressionRef, childExpr: ExpressionRef): Index;
+export declare function _BinaryenBlockInsertChildAt(expr: ExpressionRef, index: Index, childExpr: ExpressionRef): void;
+export declare function _BinaryenBlockRemoveChildAt(expr: ExpressionRef, index: Index): ExpressionRef;
+
+export declare function _BinaryenIf(module: ModuleRef, conditionExpr: ExpressionRef, ifTrueExpr: ExpressionRef, ifFalseExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenIfGetCondition(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenIfSetCondition(expr: ExpressionRef, conditionExpr: ExpressionRef): void;
+export declare function _BinaryenIfGetIfTrue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenIfSetIfTrue(expr: ExpressionRef, ifTrueExpr: ExpressionRef): void;
+export declare function _BinaryenIfGetIfFalse(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenIfSetIfFalse(expr: ExpressionRef, ifFalseExpr: ExpressionRef): void;
+
+export declare function _BinaryenLoop(module: ModuleRef, name: StringRef, bodyExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenLoopGetName(expr: ExpressionRef): StringRef;
+export declare function _BinaryenLoopSetName(expr: ExpressionRef, name: StringRef): void;
+export declare function _BinaryenLoopGetBody(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenLoopSetBody(expr: ExpressionRef, bodyExpr: ExpressionRef): void;
+
+export declare function _BinaryenBreak(module: ModuleRef, name: StringRef, conditionExpr: ExpressionRef, valueExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenBreakGetName(expr: ExpressionRef): StringRef;
+export declare function _BinaryenBreakSetName(expr: ExpressionRef, name: StringRef): void;
+export declare function _BinaryenBreakGetCondition(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenBreakSetCondition(expr: ExpressionRef, conditionExpr: ExpressionRef): void;
+export declare function _BinaryenBreakGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenBreakSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenSwitch(module: ModuleRef, names: ArrayRef<StringRef>, numNames: Index, defaultName: StringRef, conditionExpr: ExpressionRef, valueExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSwitchGetNumNames(expr: ExpressionRef): Index;
+export declare function _BinaryenSwitchGetNameAt(expr: ExpressionRef, index: Index): StringRef;
+export declare function _BinaryenSwitchSetNameAt(expr: ExpressionRef, index: Index, name: StringRef): void;
+export declare function _BinaryenSwitchAppendName(expr: ExpressionRef, name: StringRef): Index;
+export declare function _BinaryenSwitchInsertNameAt(expr: ExpressionRef, index: Index, name: StringRef): void;
+export declare function _BinaryenSwitchRemoveNameAt(expr: ExpressionRef, index: Index): StringRef;
+export declare function _BinaryenSwitchGetDefaultName(expr: ExpressionRef): StringRef;
+export declare function _BinaryenSwitchSetDefaultName(expr: ExpressionRef, defaultName: StringRef): void;
+export declare function _BinaryenSwitchGetCondition(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSwitchSetCondition(expr: ExpressionRef, conditionExpr: ExpressionRef): void;
+export declare function _BinaryenSwitchGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSwitchSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenCall(module: ModuleRef, targetName: StringRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, returnType: Type): ExpressionRef;
+export declare function _BinaryenCallGetTarget(expr: ExpressionRef): StringRef;
+export declare function _BinaryenCallSetTarget(expr: ExpressionRef, targetName: StringRef): void;
+export declare function _BinaryenCallGetNumOperands(expr: ExpressionRef): Index;
+export declare function _BinaryenCallGetOperandAt(expr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenCallSetOperandAt(expr: ExpressionRef, index: Index, operandExpr: ExpressionRef): void;
+export declare function _BinaryenCallAppendOperand(expr: ExpressionRef, operandExpr: ExpressionRef): Index;
+export declare function _BinaryenCallInsertOperandAt(expr: ExpressionRef, index: Index, operandExpr: ExpressionRef): void;
+export declare function _BinaryenCallRemoveOperandAt(expr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenCallIsReturn(expr: ExpressionRef): bool;
+export declare function _BinaryenCallSetReturn(expr: ExpressionRef, isReturn: bool): void;
+// ^ with return = true
+export declare function _BinaryenReturnCall(module: ModuleRef, targetName: StringRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, returnType: Type): ExpressionRef;
+
+export declare function _BinaryenCallIndirect(module: ModuleRef, table: StringRef, targetExpr: ExpressionRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, params: Type, results: Type): ExpressionRef;
+export declare function _BinaryenCallIndirectGetTable(expr: ExpressionRef): StringRef;
+export declare function _BinaryenCallIndirectSetTable(expr: ExpressionRef, table: StringRef): void;
+export declare function _BinaryenCallIndirectGetTarget(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenCallIndirectSetTarget(expr: ExpressionRef, targetExpr: ExpressionRef): void;
+export declare function _BinaryenCallIndirectGetNumOperands(expr: ExpressionRef): Index;
+export declare function _BinaryenCallIndirectGetOperandAt(expr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenCallIndirectSetOperandAt(expr: ExpressionRef, index: Index, operandExpr: ExpressionRef): void;
+export declare function _BinaryenCallIndirectAppendOperand(expr: ExpressionRef, operandExpr: ExpressionRef): Index;
+export declare function _BinaryenCallIndirectInsertOperandAt(expr: ExpressionRef, index: Index, operandExpr: ExpressionRef): void;
+export declare function _BinaryenCallIndirectRemoveOperandAt(expr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenCallIndirectIsReturn(expr: ExpressionRef): bool;
+export declare function _BinaryenCallIndirectSetReturn(expr: ExpressionRef, isReturn: bool): void;
+// ^ with return = true
+export declare function _BinaryenReturnCallIndirect(module: ModuleRef, table: StringRef, targetExpr: ExpressionRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, params: Type, results: Type): ExpressionRef;
+
+export declare function _BinaryenLocalGet(module: ModuleRef, index: Index, type: Type): ExpressionRef;
+export declare function _BinaryenLocalGetGetIndex(expr: ExpressionRef): Index;
+export declare function _BinaryenLocalGetSetIndex(expr: ExpressionRef, index: Index): void;
+
+export declare function _BinaryenLocalSet(module: ModuleRef, index: Index, valueExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenLocalSetIsTee(expr: ExpressionRef): bool;
+export declare function _BinaryenLocalSetGetIndex(expr: ExpressionRef): Index;
+export declare function _BinaryenLocalSetSetIndex(expr: ExpressionRef, index: Index): void;
+export declare function _BinaryenLocalSetGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenLocalSetSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+// ^ with type != none
+export declare function _BinaryenLocalTee(module: ModuleRef, index: Index, valueExpr: ExpressionRef, type: Type): ExpressionRef;
+
+export declare function _BinaryenGlobalGet(module: ModuleRef, name: StringRef, type: Type): ExpressionRef;
+export declare function _BinaryenGlobalGetGetName(expr: ExpressionRef): StringRef;
+export declare function _BinaryenGlobalGetSetName(expr: ExpressionRef, name: StringRef): void;
+
+export declare function _BinaryenGlobalSet(module: ModuleRef, name: StringRef, value: ExpressionRef): ExpressionRef;
+export declare function _BinaryenGlobalSetGetName(expr: ExpressionRef): StringRef;
+export declare function _BinaryenGlobalSetSetName(expr: ExpressionRef, name: StringRef): void;
+export declare function _BinaryenGlobalSetGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenGlobalSetSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenMemorySize(module: ModuleRef): ExpressionRef;
+
+export declare function _BinaryenMemoryGrow(module: ModuleRef, delta: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryGrowGetDelta(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryGrowSetDelta(expr: ExpressionRef, delta: ExpressionRef): void;
+
+export declare function _BinaryenLoad(module: ModuleRef, bytes: u32, signed: bool, offset: u32, align: u32, type: Type, ptrExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenLoadIsAtomic(expr: ExpressionRef): bool;
+export declare function _BinaryenLoadSetAtomic(expr: ExpressionRef, isAtomic: bool): void;
+export declare function _BinaryenLoadIsSigned(expr: ExpressionRef): bool;
+export declare function _BinaryenLoadSetSigned(expr: ExpressionRef, isSigned: bool): void;
+export declare function _BinaryenLoadGetOffset(expr: ExpressionRef): u32;
+export declare function _BinaryenLoadSetOffset(expr: ExpressionRef, offset: u32): void;
+export declare function _BinaryenLoadGetBytes(expr: ExpressionRef): u32;
+export declare function _BinaryenLoadSetBytes(expr: ExpressionRef, bytes: u32): void;
+export declare function _BinaryenLoadGetAlign(expr: ExpressionRef): u32;
+export declare function _BinaryenLoadSetAlign(expr: ExpressionRef, align: u32): void;
+export declare function _BinaryenLoadGetPtr(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenLoadSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
+// ^ with atomic = true
+export declare function _BinaryenAtomicLoad(module: ModuleRef, bytes: Index, offset: Index, type: Type, ptrExpr: ExpressionRef): ExpressionRef;
+
+export declare function _BinaryenStore(module: ModuleRef, bytes: u32, offset: u32, align: u32, ptrExpr: ExpressionRef, valueExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenStoreIsAtomic(expr: ExpressionRef): bool;
+export declare function _BinaryenStoreSetAtomic(expr: ExpressionRef, isAtomic: bool): void;
+export declare function _BinaryenStoreGetBytes(expr: ExpressionRef): u32;
+export declare function _BinaryenStoreSetBytes(expr: ExpressionRef, bytes: u32): void;
+export declare function _BinaryenStoreGetOffset(expr: ExpressionRef): u32;
+export declare function _BinaryenStoreSetOffset(expr: ExpressionRef, offset: u32): void;
+export declare function _BinaryenStoreGetAlign(expr: ExpressionRef): u32;
+export declare function _BinaryenStoreSetAlign(expr: ExpressionRef, align: u32): void;
+export declare function _BinaryenStoreGetPtr(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenStoreSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
+export declare function _BinaryenStoreGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenStoreSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+export declare function _BinaryenStoreGetValueType(expr: ExpressionRef): Type;
+export declare function _BinaryenStoreSetValueType(expr: ExpressionRef, valueType: Type): void;
+// ^ with atomic = true
+export declare function _BinaryenAtomicStore(module: ModuleRef, bytes: Index, offset: Index, ptrExpr: ExpressionRef, valueExpr: ExpressionRef, type: Type): ExpressionRef;
+
+export declare function _BinaryenConst(module: ModuleRef, value: Literal): ExpressionRef;
+export declare function _BinaryenConstGetValueI32(expr: ExpressionRef): i32;
+export declare function _BinaryenConstSetValueI32(expr: ExpressionRef, value: i32): void;
+export declare function _BinaryenConstGetValueI64Low(expr: ExpressionRef): i32;
+export declare function _BinaryenConstSetValueI64Low(expr: ExpressionRef, value: i32): void;
+export declare function _BinaryenConstGetValueI64High(expr: ExpressionRef): i32;
+export declare function _BinaryenConstSetValueI64High(expr: ExpressionRef, value: i32): void;
+export declare function _BinaryenConstGetValueF32(expr: ExpressionRef): f32;
+export declare function _BinaryenConstSetValueF32(expr: ExpressionRef, value: f32): void;
+export declare function _BinaryenConstGetValueF64(expr: ExpressionRef): f64;
+export declare function _BinaryenConstSetValueF64(expr: ExpressionRef, value: f64): void;
+export declare function _BinaryenConstGetValueV128(expr: ExpressionRef, valueOut: ArrayRef<u8>): void;
+export declare function _BinaryenConstSetValueV128(expr: ExpressionRef, value: ArrayRef<u8>): void;
+
+export declare function _BinaryenUnary(module: ModuleRef, op: Op, valueExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenUnaryGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenUnarySetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenUnaryGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenUnarySetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenBinary(module: ModuleRef, op: Op, leftExpr: ExpressionRef, rightExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenBinaryGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenBinarySetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenBinaryGetLeft(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenBinarySetLeft(expr: ExpressionRef, leftExpr: ExpressionRef): void;
+export declare function _BinaryenBinaryGetRight(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenBinarySetRight(expr: ExpressionRef, rightExpr: ExpressionRef): void;
+
+export declare function _BinaryenSelect(module: ModuleRef, conditionExpr: ExpressionRef, ifTrueExpr: ExpressionRef, ifFalseExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenSelectGetIfTrue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSelectSetIfTrue(expr: ExpressionRef, ifTrueExpr: ExpressionRef): void;
+export declare function _BinaryenSelectGetIfFalse(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSelectSetIfFalse(expr: ExpressionRef, ifFalseExpr: ExpressionRef): void;
+export declare function _BinaryenSelectGetCondition(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSelectSetCondition(expr: ExpressionRef, conditionExpr: ExpressionRef): void;
+
+export declare function _BinaryenDrop(module: ModuleRef, valueExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenDropGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenDropSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenReturn(module: ModuleRef, valueExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenReturnGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenReturnSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenNop(module: ModuleRef): ExpressionRef;
+
+export declare function _BinaryenUnreachable(module: ModuleRef): ExpressionRef;
+
+export declare function _BinaryenAtomicRMW(module: ModuleRef, op: Op, bytes: u32, offset: u32, ptrExpr: ExpressionRef, valueExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenAtomicRMWGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenAtomicRMWSetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenAtomicRMWGetBytes(expr: ExpressionRef): u32;
+export declare function _BinaryenAtomicRMWSetBytes(expr: ExpressionRef, bytes: u32): void;
+export declare function _BinaryenAtomicRMWGetOffset(expr: ExpressionRef): u32;
+export declare function _BinaryenAtomicRMWSetOffset(expr: ExpressionRef, offset: u32): void;
+export declare function _BinaryenAtomicRMWGetPtr(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicRMWSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
+export declare function _BinaryenAtomicRMWGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicRMWSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenAtomicCmpxchg(module: ModuleRef, bytes: u32, offset: u32, ptrExpr: ExpressionRef, expectedExpr: ExpressionRef, replacementExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenAtomicCmpxchgGetBytes(expr: ExpressionRef): u32;
+export declare function _BinaryenAtomicCmpxchgSetBytes(expr: ExpressionRef, bytes: u32): void;
+export declare function _BinaryenAtomicCmpxchgGetOffset(expr: ExpressionRef): u32;
+export declare function _BinaryenAtomicCmpxchgSetOffset(expr: ExpressionRef, offset: u32): void;
+export declare function _BinaryenAtomicCmpxchgGetPtr(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicCmpxchgSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
+export declare function _BinaryenAtomicCmpxchgGetExpected(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicCmpxchgSetExpected(expr: ExpressionRef, expectedExpr: ExpressionRef): void;
+export declare function _BinaryenAtomicCmpxchgGetReplacement(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicCmpxchgSetReplacement(expr: ExpressionRef, replacementExpr: ExpressionRef): void;
+
+export declare function _BinaryenAtomicWait(module: ModuleRef, ptrExpr: ExpressionRef, expectedExpr: ExpressionRef, timeoutExpr: ExpressionRef, expectedType: Type): ExpressionRef;
+export declare function _BinaryenAtomicWaitGetPtr(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicWaitSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
+export declare function _BinaryenAtomicWaitGetExpected(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicWaitSetExpected(expr: ExpressionRef, expectedExpr: ExpressionRef): void;
+export declare function _BinaryenAtomicWaitGetTimeout(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicWaitSetTimeout(expr: ExpressionRef, timeoutExpr: ExpressionRef): void;
+export declare function _BinaryenAtomicWaitGetExpectedType(expr: ExpressionRef): Type;
+export declare function _BinaryenAtomicWaitSetExpectedType(expr: ExpressionRef, expectedType: Type): void;
+
+export declare function _BinaryenAtomicNotify(module: ModuleRef, ptrExpr: ExpressionRef, notifyCountExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicNotifyGetPtr(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicNotifySetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
+export declare function _BinaryenAtomicNotifyGetNotifyCount(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicNotifySetNotifyCount(expr: ExpressionRef, notifyCountExpr: ExpressionRef): void;
+
+export declare function _BinaryenAtomicFence(module: ModuleRef): ExpressionRef;
+export declare function _BinaryenAtomicFenceGetOrder(expr: ExportRef): u8; // unused
+export declare function _BinaryenAtomicFenceSetOrder(expr: ExportRef, order: u8): void; // unused
+
+export declare function _BinaryenSIMDExtract(module: ModuleRef, op: Op, vecExpr: ExpressionRef, index: u8): ExpressionRef;
+export declare function _BinaryenSIMDExtractGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenSIMDExtractSetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenSIMDExtractGetVec(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDExtractSetVec(expr: ExpressionRef, vecExpr: ExpressionRef): void;
+export declare function _BinaryenSIMDExtractGetIndex(expr: ExpressionRef): u8;
+export declare function _BinaryenSIMDExtractSetIndex(expr: ExpressionRef, index: u8): void;
+
+export declare function _BinaryenSIMDReplace(module: ModuleRef, op: Op, vecEpr: ExpressionRef, index: u8, valueExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDReplaceGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenSIMDReplaceSetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenSIMDReplaceGetVec(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDReplaceSetVec(expr: ExpressionRef, vecExpr: ExpressionRef): void;
+export declare function _BinaryenSIMDReplaceGetIndex(expr: ExpressionRef): u8;
+export declare function _BinaryenSIMDReplaceSetIndex(expr: ExpressionRef, index: u8): void;
+export declare function _BinaryenSIMDReplaceGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDReplaceSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenSIMDShuffle(module: ModuleRef, leftExpr: ExpressionRef, rightExpr: ExpressionRef, mask: ArrayRef<u8>): ExpressionRef;
+export declare function _BinaryenSIMDShuffleGetLeft(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDShuffleSetLeft(expr: ExpressionRef, leftExpr: ExpressionRef): void;
+export declare function _BinaryenSIMDShuffleGetRight(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDShuffleSetRight(expr: ExpressionRef, rightExpr: ExpressionRef): void;
+export declare function _BinaryenSIMDShuffleGetMask(expr: ExpressionRef, maskOut: ArrayRef<u8>): void;
+export declare function _BinaryenSIMDShuffleSetMask(expr: ExpressionRef, mask: ArrayRef<u8>): void;
+
+export declare function _BinaryenSIMDTernary(module: ModuleRef, op: Op, aExpr: ExpressionRef, bExpr: ExpressionRef, cExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDTernaryGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenSIMDTernarySetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenSIMDTernaryGetA(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDTernarySetA(expr: ExpressionRef, aExpr: ExpressionRef): void;
+export declare function _BinaryenSIMDTernaryGetB(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDTernarySetB(expr: ExpressionRef, bExpr: ExpressionRef): void;
+export declare function _BinaryenSIMDTernaryGetC(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDTernarySetC(expr: ExpressionRef, cExpr: ExpressionRef): void;
+
+export declare function _BinaryenSIMDShift(module: ModuleRef, op: Op, vecExpr: ExpressionRef, shiftExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDShiftGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenSIMDShiftSetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenSIMDShiftGetVec(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDShiftSetVec(expr: ExpressionRef, vecExpr: ExpressionRef): void;
+export declare function _BinaryenSIMDShiftGetShift(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDShiftSetShift(expr: ExpressionRef, shiftExpr: ExpressionRef): void;
+
+export declare function _BinaryenSIMDLoad(module: ModuleRef, op: Op, offset: u32, align: u32, ptrExpr: ExportRef): ExpressionRef;
+export declare function _BinaryenSIMDLoadGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenSIMDLoadSetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenSIMDLoadGetOffset(expr: ExpressionRef): u32;
+export declare function _BinaryenSIMDLoadSetOffset(expr: ExpressionRef, offset: u32): void;
+export declare function _BinaryenSIMDLoadGetAlign(expr: ExpressionRef): u32;
+export declare function _BinaryenSIMDLoadSetAlign(expr: ExpressionRef, align: u32): void;
+export declare function _BinaryenSIMDLoadGetPtr(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDLoadSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
+
+export declare function _BinaryenSIMDLoadStoreLane(module: ModuleRef, op: Op, offset: u32, align: u32, index: u8, ptr: ExpressionRef, vec: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDLoadStoreLaneGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenSIMDLoadStoreLaneSetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenSIMDLoadStoreLaneGetOffset(expr: ExpressionRef): u32;
+export declare function _BinaryenSIMDLoadStoreLaneSetOffset(expr: ExpressionRef, offset: u32): void;
+export declare function _BinaryenSIMDLoadStoreLaneGetAlign(expr: ExpressionRef): u32;
+export declare function _BinaryenSIMDLoadStoreLaneSetAlign(expr: ExpressionRef, align: u32): void;
+export declare function _BinaryenSIMDLoadStoreLaneGetIndex(expr: ExpressionRef): u8;
+export declare function _BinaryenSIMDLoadStoreLaneSetIndex(expr: ExpressionRef, index: u8): void;
+export declare function _BinaryenSIMDLoadStoreLaneGetPtr(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDLoadStoreLaneSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
+export declare function _BinaryenSIMDLoadStoreLaneGetVec(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenSIMDLoadStoreLaneSetVec(expr: ExpressionRef, vecExpr: ExpressionRef): void;
+export declare function _BinaryenSIMDLoadStoreLaneIsStore(expr: ExpressionRef): bool;
+
+export declare function _BinaryenMemoryInit(module: ModuleRef, segmentIndex: u32, destExpr: ExpressionRef, offsetExpr: ExpressionRef, sizeExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryInitGetSegment(expr: ExpressionRef): u32;
+export declare function _BinaryenMemoryInitSetSegment(expr: ExpressionRef, segmentIndex: u32): void;
+export declare function _BinaryenMemoryInitGetDest(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryInitSetDest(expr: ExpressionRef, destExpr: ExpressionRef): void;
+export declare function _BinaryenMemoryInitGetOffset(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryInitSetOffset(expr: ExpressionRef, offsetExpr: ExpressionRef): void;
+export declare function _BinaryenMemoryInitGetSize(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryInitSetSize(expr: ExpressionRef, sizeExpr: ExpressionRef): void;
+
+export declare function _BinaryenDataDrop(module: ModuleRef, segmentIndex: u32): ExpressionRef;
+export declare function _BinaryenDataDropGetSegment(expr: ExpressionRef): u32;
+export declare function _BinaryenDataDropSetSegment(expr: ExpressionRef, segmentIndex: u32): void;
+
+export declare function _BinaryenMemoryCopy(module: ModuleRef, destExpr: ExpressionRef, sourceExpr: ExpressionRef, sizeExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryCopyGetDest(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryCopySetDest(expr: ExpressionRef, destExpr: ExpressionRef): void;
+export declare function _BinaryenMemoryCopyGetSource(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryCopySetSource(expr: ExpressionRef, sourceExpr: ExpressionRef): void;
+export declare function _BinaryenMemoryCopyGetSize(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryCopySetSize(expr: ExpressionRef, sizeExpr: ExpressionRef): void;
+
+export declare function _BinaryenMemoryFill(module: ModuleRef, destExpr: ExpressionRef, valueExpr: ExpressionRef, sizeExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryFillGetDest(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryFillSetDest(expr: ExpressionRef, destExpr: ExpressionRef): void;
+export declare function _BinaryenMemoryFillGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryFillSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+export declare function _BinaryenMemoryFillGetSize(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenMemoryFillSetSize(expr: ExpressionRef, sizeExpr: ExpressionRef): void;
+
+export declare function _BinaryenRefNull(module: ModuleRef, type: Type): ExpressionRef;
+
+export declare function _BinaryenRefIs(module: ModuleRef, op: Op, valueExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenRefIsGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenRefIsSetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenRefIsGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenRefIsSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenRefAs(module: ModuleRef, op: Op, valueExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenRefAsGetOp(expr: ExpressionRef): Op;
+export declare function _BinaryenRefAsSetOp(expr: ExpressionRef, op: Op): void;
+export declare function _BinaryenRefAsGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenRefAsSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenRefFunc(module: ModuleRef, funcName: StringRef, type: Type): ExpressionRef;
+export declare function _BinaryenRefFuncGetFunc(expr: ExpressionRef): StringRef;
+export declare function _BinaryenRefFuncSetFunc(expr: ExpressionRef, funcName: StringRef): void;
+
+export declare function _BinaryenRefEq(module: ModuleRef, leftExpr: ExpressionRef, rightExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenRefEqGetLeft(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenRefEqSetLeft(expr: ExpressionRef, leftExpr: ExpressionRef): void;
+export declare function _BinaryenRefEqGetRight(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenRefEqSetRight(expr: ExpressionRef, rightExpr: ExpressionRef): void;
+
+export declare function _BinaryenTry(module: ModuleRef, name: StringRef, bodyExpr: ExpressionRef, catchEvents: ArrayRef<StringRef>, numCatchEvents: Index, catchBodies: ArrayRef<ExpressionRef>, numCatchBodies: Index, delegateTarget: StringRef): ExpressionRef;
+export declare function _BinaryenTryGetName(expr: ExpressionRef): StringRef;
+export declare function _BinaryenTrySetName(expr: ExpressionRef, name: StringRef): void;
+export declare function _BinaryenTryGetBody(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenTrySetBody(expr: ExpressionRef, bodyExpr: ExpressionRef): void;
+export declare function _BinaryenTryGetNumCatchEvents(expr: ExpressionRef): Index;
+export declare function _BinaryenTryGetNumCatchBodies(expr: ExpressionRef): Index;
+export declare function _BinaryenTryGetCatchEventAt(expr: ExpressionRef, index: Index): StringRef;
+export declare function _BinaryenTrySetCatchEventAt(expr: ExpressionRef, index: Index, catchEvent: StringRef): void;
+export declare function _BinaryenTryAppendCatchEvent(expr: ExpressionRef, catchEvent: StringRef): Index;
+export declare function _BinaryenTryInsertCatchEventAt(expr: ExpressionRef, index: Index, catchEvent: StringRef): void;
+export declare function _BinaryenTryRemoveCatchEventAt(expr: ExpressionRef, index: Index): StringRef;
+export declare function _BinaryenTryGetCatchBodyAt(expr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenTrySetCatchBodyAt(expr: ExpressionRef, index: Index, catchExpr: ExpressionRef): void;
+export declare function _BinaryenTryAppendCatchBody(expr: ExpressionRef, catchExpr: ExpressionRef): Index;
+export declare function _BinaryenTryInsertCatchBodyAt(expr: ExpressionRef, index: Index, catchExpr: ExpressionRef): void;
+export declare function _BinaryenTryRemoveCatchBodyAt(expr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenTryHasCatchAll(expr: ExpressionRef): bool;
+export declare function _BinaryenTryGetDelegateTarget(expr: ExpressionRef): StringRef;
+export declare function _BinaryenTrySetDelegateTarget(expr: ExpressionRef, delegateTarget: StringRef): void;
+export declare function _BinaryenTryIsDelegate(expr: ExpressionRef): bool;
+
+export declare function _BinaryenThrow(module: ModuleRef, eventName: StringRef, operands: ArrayRef<ExpressionRef>, numOperands: Index): ExpressionRef;
+export declare function _BinaryenThrowGetEvent(expr: ExpressionRef): StringRef;
+export declare function _BinaryenThrowSetEvent(expr: ExpressionRef, eventName: StringRef): void;
+export declare function _BinaryenThrowGetNumOperands(expr: ExpressionRef): Index;
+export declare function _BinaryenThrowGetOperandAt(expr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenThrowSetOperandAt(expr: ExpressionRef, index: Index, operandExpr: ExpressionRef): void;
+export declare function _BinaryenThrowAppendOperand(expr: ExpressionRef, operandExpr: ExpressionRef): Index;
+export declare function _BinaryenThrowInsertOperandAt(expr: ExpressionRef, index: Index, operandExpr: ExpressionRef): void;
+export declare function _BinaryenThrowRemoveOperandAt(expr: ExpressionRef, index: Index): ExpressionRef;
+
+export declare function _BinaryenRethrow(module: ModuleRef, target: StringRef): ExpressionRef;
+export declare function _BinaryenRethrowGetTarget(expr: ExpressionRef): StringRef;
+export declare function _BinaryenRethrowSetDepth(expr: ExpressionRef, target: StringRef): void;
+
+export declare function _BinaryenTupleMake(module: ModuleRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index): ExpressionRef;
+export declare function _BinaryenTupleMakeGetNumOperands(expr: ExpressionRef): Index;
+export declare function _BinaryenTupleMakeGetOperandAt(expr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenTupleMakeSetOperandAt(expr: ExpressionRef, index: Index, operandExpr: ExpressionRef): void;
+export declare function _BinaryenTupleMakeAppendOperand(expr: ExpressionRef, operandExpr: ExpressionRef): Index;
+export declare function _BinaryenTupleMakeInsertOperandAt(expr: ExpressionRef, index: Index, operandExpr: ExpressionRef): void;
+export declare function _BinaryenTupleMakeRemoveOperandAt(expr: ExpressionRef, index: Index): ExpressionRef;
+
+export declare function _BinaryenTupleExtract(module: ModuleRef, tupleExpr: ExpressionRef, index: Index): ExpressionRef;
+export declare function _BinaryenTupleExtractGetTuple(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenTupleExtractSetTuple(expr: ExpressionRef, tupleExpr: ExpressionRef): void;
+export declare function _BinaryenTupleExtractGetIndex(expr: ExpressionRef): Index;
+export declare function _BinaryenTupleExtractSetIndex(expr: ExpressionRef, index: Index): void;
+
+export declare function _BinaryenPop(module: ModuleRef, type: Type): ExpressionRef;
+
+export declare function _BinaryenI31New(module: ModuleRef, value: ExpressionRef): ExpressionRef;
+export declare function _BinaryenI31NewGetValue(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenI31NewSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
+
+export declare function _BinaryenI31Get(module: ModuleRef, i31Expr: ExpressionRef, signed: bool): ExpressionRef;
+export declare function _BinaryenI31GetGetI31(expr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenI31GetSetI31(expr: ExpressionRef, i31Expr: ExpressionRef): void;
+export declare function _BinaryenI31GetIsSigned(expr: ExpressionRef): bool;
+export declare function _BinaryenI31GetSetSigned(expr: ExpressionRef, signed: bool): void;
+
+export declare function _BinaryenAddFunction(module: ModuleRef, name: StringRef, params: Type, results: Type, varTypes: ArrayRef<Type>, numVarTypes: Index, body: ExpressionRef): FunctionRef;
+export declare function _BinaryenGetFunction(module: ModuleRef, name: StringRef): FunctionRef;
+export declare function _BinaryenRemoveFunction(module: ModuleRef, name: StringRef): void;
+export declare function _BinaryenGetNumFunctions(module: ModuleRef): Index;
+export declare function _BinaryenGetFunctionByIndex(module: ModuleRef, index: Index): FunctionRef;
+
+export declare function _BinaryenFunctionGetName(func: FunctionRef): StringRef;
+export declare function _BinaryenFunctionGetParams(func: FunctionRef): Type;
+export declare function _BinaryenFunctionGetResults(func: FunctionRef): Type;
+export declare function _BinaryenFunctionGetNumVars(func: FunctionRef): Index;
+export declare function _BinaryenFunctionGetVar(func: FunctionRef, index: Index): Type;
+export declare function _BinaryenFunctionGetNumLocals(func: FunctionRef): Index;
+export declare function _BinaryenFunctionHasLocalName(func: FunctionRef, index: Index): bool;
+export declare function _BinaryenFunctionGetLocalName(func: FunctionRef, index: Index): StringRef;
+export declare function _BinaryenFunctionSetLocalName(func: FunctionRef, index: Index, name: StringRef): void;
+export declare function _BinaryenFunctionGetBody(func: FunctionRef): ExpressionRef;
+export declare function _BinaryenFunctionSetBody(func: FunctionRef, bodyExpr: ExpressionRef): void;
+export declare function _BinaryenFunctionOptimize(func: FunctionRef, module: ModuleRef): void;
+export declare function _BinaryenFunctionRunPasses(func: FunctionRef, module: ModuleRef, passes: ArrayRef<StringRef>, numPasses: Index): void;
+export declare function _BinaryenFunctionSetDebugLocation(func: FunctionRef, expr: ExpressionRef, fileIndex: Index, lineNumber: Index, columnNumber: Index): void;
+
+export declare function _BinaryenAddFunctionImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, params: Type, results: Type): void;
+export declare function _BinaryenAddTableImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef): void;
+export declare function _BinaryenAddMemoryImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, shared:bool): void;
+export declare function _BinaryenAddGlobalImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, globalType: Type, mutable: bool): void;
+export declare function _BinaryenAddEventImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, attribute: u32, params: Type, results: Type): void;
+
+export declare function _BinaryenAddFunctionExport(module: ModuleRef, internalName: StringRef, externalName: StringRef): ExportRef;
+export declare function _BinaryenAddTableExport(module: ModuleRef, internalName: StringRef, externalName: StringRef): ExportRef;
+export declare function _BinaryenAddMemoryExport(module: ModuleRef, internalName: StringRef, externalName: StringRef): ExportRef;
+export declare function _BinaryenAddGlobalExport(module: ModuleRef, internalName: StringRef, externalName: StringRef): ExportRef;
+export declare function _BinaryenAddEventExport(module: ModuleRef, internalName: StringRef, externalName: StringRef): ExportRef;
+export declare function _BinaryenGetExport(module: ModuleRef, externalName: StringRef): ExportRef;
+export declare function _BinaryenRemoveExport(module: ModuleRef, externalName: StringRef): void;
+export declare function _BinaryenGetNumExports(module: ModuleRef): Index;
+export declare function _BinaryenGetExportByIndex(module: ModuleRef, index: Index): ExportRef;
+export declare function _BinaryenExportGetKind(ref: ExportRef): ExternalKind;
+export declare function _BinaryenExportGetName(ref: ExportRef): StringRef;
+export declare function _BinaryenExportGetValue(ref: ExportRef): StringRef;
+
+export declare function _BinaryenAddGlobal(module: ModuleRef, name: StringRef, type: Type, mutable: bool, init: ExpressionRef): GlobalRef;
+export declare function _BinaryenGetGlobal(module: ModuleRef, name: StringRef): GlobalRef;
+export declare function _BinaryenRemoveGlobal(module: ModuleRef, name: StringRef): void;
+export declare function _BinaryenGetNumGlobals(module: ModuleRef): Index;
+export declare function _BinaryenGetGlobalByIndex(module: ModuleRef, index: Index): GlobalRef;
+
+export declare function _BinaryenGlobalGetName(global: GlobalRef): StringRef;
+export declare function _BinaryenGlobalGetType(global: GlobalRef): Type;
+export declare function _BinaryenGlobalIsMutable(global: GlobalRef): bool;
+export declare function _BinaryenGlobalGetInitExpr(global: GlobalRef): ExpressionRef;
+
+export declare function _BinaryenAddEvent(module: ModuleRef, name: StringRef, attribute: u32, params: Type, results: Type): EventRef;
+export declare function _BinaryenGetEvent(module: ModuleRef, name: StringRef): EventRef;
+export declare function _BinaryenRemoveEvent(module: ModuleRef, name: StringRef): void;
+
+export declare function _BinaryenEventGetName(event: EventRef): StringRef;
+export declare function _BinaryenEventGetAttribute(event: EventRef): u32;
+export declare function _BinaryenEventGetParams(event: EventRef): Type;
+export declare function _BinaryenEventGetResults(event: EventRef): Type;
+
+export declare function _BinaryenAddTable(module: ModuleRef, name: StringRef, initial: Index, maximum: Index): TableRef;
+export declare function _BinaryenRemoveTable(module: ModuleRef, table: StringRef): void;
+export declare function _BinaryenGetNumTables(module: ModuleRef): Index;
+export declare function _BinaryenGetTable(module: ModuleRef, name: StringRef): TableRef;
+export declare function _BinaryenGetTableByIndex(module: ModuleRef, index: Index): TableRef;
+
+export declare function _BinaryenTableGetName(table: TableRef): StringRef;
+export declare function _BinaryenTableSetName(table: TableRef, name: StringRef): void;
+export declare function _BinaryenTableGetInitial(table: TableRef): Index;
+export declare function _BinaryenTableSetInitial(table: TableRef, initial: Index): void;
+export declare function _BinaryenTableHasMax(table: TableRef): bool;
+export declare function _BinaryenTableGetMax(table: TableRef): Index;
+export declare function _BinaryenTableSetMax(table: TableRef, max: Index): void;
+
+export declare function _BinaryenAddActiveElementSegment(module: ModuleRef, table: StringRef, name: StringRef, funcNames: ArrayRef<StringRef>, numFuncNames: Index, offset: ExpressionRef): ElementSegmentRef;
+export declare function _BinaryenAddPassiveElementSegment(module: ModuleRef, name: StringRef, funcNames: ArrayRef<StringRef>, numFuncNames: Index): ElementSegmentRef;
+export declare function _BinaryenRemoveElementSegment(module: ModuleRef, name: StringRef): void;
+export declare function _BinaryenGetNumElementSegments(module: ModuleRef, name: StringRef): Index;
+export declare function _BinaryenGetElementSegment(module: ModuleRef, name: StringRef): ElementSegmentRef;
+export declare function _BinaryenGetElementSegmentByIndex(module: ModuleRef, index: Index): ElementSegmentRef;
+
+export declare function _BinaryenSetMemory(module: ModuleRef, initial: Index, maximum: Index, exportName: StringRef, segments: ArrayRef<ArrayRef<u8>>, segmentPassive: ArrayRef<bool>, segmentOffsets: ArrayRef<usize>, segmentSizes: ArrayRef<u32>, numSegments: Index, shared: bool): void;
+export declare function _BinaryenGetNumMemorySegments(module: ModuleRef): Index;
+export declare function _BinaryenGetMemorySegmentByteOffset(module: ModuleRef, index: Index): u32;
+export declare function _BinaryenGetMemorySegmentByteLength(module: ModuleRef, id: Index): usize;
+export declare function _BinaryenCopyMemorySegmentData(module: ModuleRef, id: Index, buffer: ArrayRef<u8>): void;
+
+export declare function _BinaryenSetStart(module: ModuleRef, start: FunctionRef): void;
+
+export declare function _BinaryenModuleParse(text: StringRef): ModuleRef;
+export declare function _BinaryenModulePrint(module: ModuleRef): void;
+export declare function _BinaryenModulePrintAsmjs(module: ModuleRef): void;
+export declare function _BinaryenModuleValidate(module: ModuleRef): i32;
+export declare function _BinaryenModuleOptimize(module: ModuleRef): void;
+export declare function _BinaryenModuleRunPasses(module: ModuleRef, passes: ArrayRef<StringRef>, numPasses: Index): void;
+export declare function _BinaryenModuleAutoDrop(module: ModuleRef): void;
+export declare function _BinaryenModuleAllocateAndWrite(out: ArrayRef<u8>, module: ModuleRef, sourceMapUrl: StringRef): void;
+export declare function _BinaryenModuleRead(input: ArrayRef<u8>, inputSize: usize): ModuleRef;
+export declare function _BinaryenModuleInterpret(module: ModuleRef): void;
+export declare function _BinaryenModuleAddDebugInfoFileName(module: ModuleRef, filename: StringRef): Index;
+export declare function _BinaryenModuleGetDebugInfoFileName(module: ModuleRef, index: Index): StringRef;
+export declare function _BinaryenModuleGetFeatures(module: ModuleRef): FeatureFlags;
+export declare function _BinaryenModuleSetFeatures(module: ModuleRef, featureFlags: FeatureFlags): void;
+
+export declare function _BinaryenAddCustomSection(module: ModuleRef, name: StringRef, contents: ArrayRef<u8>, contentsSize: Index): void;
+
+export declare function _BinaryenExpressionGetSideEffects(expr: ExpressionRef, features: FeatureFlags): SideEffects;
+
+export declare function _RelooperCreate(module: ModuleRef): RelooperRef;
+export declare function _RelooperAddBlock(relooper: RelooperRef, code: ExpressionRef): RelooperBlockRef;
+export declare function _RelooperAddBranch(from: RelooperBlockRef, to: RelooperBlockRef, condition: ExpressionRef, code: ExpressionRef): void;
+export declare function _RelooperAddBlockWithSwitch(relooper: RelooperRef, code: ExpressionRef, condition: ExpressionRef): RelooperBlockRef;
+export declare function _RelooperAddBranchForSwitch(from: RelooperBlockRef, to: RelooperBlockRef, indexes: ArrayRef<Index>, numIndexes: Index, code: ExpressionRef): void;
+export declare function _RelooperRenderAndDispose(relooper: RelooperRef, entry: RelooperBlockRef, labelHelper: Index): ExpressionRef;
+
+export declare function _ExpressionRunnerCreate(module: ModuleRef, flags: ExpressionRunnerFlags, maxDepth: Index, maxLoopIterations: Index): ExpressionRunnerRef;
+export declare function _ExpressionRunnerSetLocalValue(runner: ExpressionRunnerRef, index: Index, value: ExpressionRef): bool;
+export declare function _ExpressionRunnerSetGlobalValue(runner: ExpressionRunnerRef, name: StringRef, value: ExpressionRef): bool;
+export declare function _ExpressionRunnerRunAndDispose(runner: ExpressionRunnerRef, expr: ExpressionRef): ExpressionRef;
+
+export declare function _BinaryenGetOptimizeLevel(): i32;
+export declare function _BinaryenSetOptimizeLevel(level: i32): void;
+export declare function _BinaryenGetShrinkLevel(): i32;
+export declare function _BinaryenSetShrinkLevel(level: i32): void;
+export declare function _BinaryenGetDebugInfo(): bool;
+export declare function _BinaryenSetDebugInfo(on: bool): void;
+export declare function _BinaryenGetLowMemoryUnused(): bool;
+export declare function _BinaryenSetLowMemoryUnused(on: bool): void;
+export declare function _BinaryenGetFastMath(): bool;
+export declare function _BinaryenSetFastMath(on: bool): void;
+export declare function _BinaryenGetPassArgument(key: StringRef): StringRef;
+export declare function _BinaryenSetPassArgument(key: StringRef, value: StringRef): void;
+export declare function _BinaryenClearPassArguments(): void;
+export declare function _BinaryenGetAlwaysInlineMaxSize(): Index;
+export declare function _BinaryenSetAlwaysInlineMaxSize(size: Index): void;
+export declare function _BinaryenGetFlexibleInlineMaxSize(): Index;
+export declare function _BinaryenSetFlexibleInlineMaxSize(size: Index): void;
+export declare function _BinaryenGetOneCallerInlineMaxSize(): Index;
+export declare function _BinaryenSetOneCallerInlineMaxSize(size: Index): void;
+export declare function _BinaryenGetAllowInliningFunctionsWithLoops(): bool;
+export declare function _BinaryenSetAllowInliningFunctionsWithLoops(enabled: bool): void;
+
+// Helpers
+
 export declare function _malloc(size: usize): usize;
 export declare function _free(ptr: usize): void;
 export declare function __i32_store8(ptr: usize, value: number): void;
@@ -22,1061 +629,3 @@ export declare function __i32_load16_u(ptr: usize): u16;
 export declare function __i32_load(ptr: usize): i32;
 export declare function __f32_load(ptr: usize): f32;
 export declare function __f64_load(ptr: usize): f64;
-
-type BinaryenIndex = u32;
-type BinaryenType = usize;
-type BinaryenString = usize;
-type BinaryenArray<T> = usize;
-
-export declare function _BinaryenTypeNone(): BinaryenType;
-export declare function _BinaryenTypeInt32(): BinaryenType;
-export declare function _BinaryenTypeInt64(): BinaryenType;
-export declare function _BinaryenTypeFloat32(): BinaryenType;
-export declare function _BinaryenTypeFloat64(): BinaryenType;
-export declare function _BinaryenTypeVec128(): BinaryenType;
-export declare function _BinaryenTypeFuncref(): BinaryenType;
-export declare function _BinaryenTypeExternref(): BinaryenType;
-export declare function _BinaryenTypeAnyref(): BinaryenType;
-export declare function _BinaryenTypeEqref(): BinaryenType;
-export declare function _BinaryenTypeI31ref(): BinaryenType;
-export declare function _BinaryenTypeDataref(): BinaryenType;
-export declare function _BinaryenTypeUnreachable(): BinaryenType;
-export declare function _BinaryenTypeAuto(): BinaryenType;
-
-export declare function _BinaryenTypeCreate(types: BinaryenArray<BinaryenType>, numTypes: u32): BinaryenType;
-export declare function _BinaryenTypeArity(type: BinaryenType): u32;
-export declare function _BinaryenTypeExpand(type: BinaryenType, typesOut: BinaryenArray<BinaryenType>): void;
-
-type BinaryenFeatureFlags = u32;
-
-export declare function _BinaryenFeatureMVP(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureAtomics(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureMutableGlobals(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureNontrappingFPToInt(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureSIMD128(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureBulkMemory(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureSignExt(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureExceptionHandling(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureTailCall(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureReferenceTypes(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureMultivalue(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureGC(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureTypedFunctionReferences(): BinaryenFeatureFlags;
-export declare function _BinaryenFeatureAll(): BinaryenFeatureFlags;
-
-type BinaryenExpressionId = i32;
-
-export declare function _BinaryenInvalidId(): BinaryenExpressionId;
-export declare function _BinaryenBlockId(): BinaryenExpressionId;
-export declare function _BinaryenIfId(): BinaryenExpressionId;
-export declare function _BinaryenLoopId(): BinaryenExpressionId;
-export declare function _BinaryenBreakId(): BinaryenExpressionId;
-export declare function _BinaryenSwitchId(): BinaryenExpressionId;
-export declare function _BinaryenCallId(): BinaryenExpressionId;
-export declare function _BinaryenCallIndirectId(): BinaryenExpressionId;
-export declare function _BinaryenLocalGetId(): BinaryenExpressionId;
-export declare function _BinaryenLocalSetId(): BinaryenExpressionId;
-export declare function _BinaryenGlobalGetId(): BinaryenExpressionId;
-export declare function _BinaryenGlobalSetId(): BinaryenExpressionId;
-export declare function _BinaryenLoadId(): BinaryenExpressionId;
-export declare function _BinaryenStoreId(): BinaryenExpressionId;
-export declare function _BinaryenConstId(): BinaryenExpressionId;
-export declare function _BinaryenUnaryId(): BinaryenExpressionId;
-export declare function _BinaryenBinaryId(): BinaryenExpressionId;
-export declare function _BinaryenSelectId(): BinaryenExpressionId;
-export declare function _BinaryenDropId(): BinaryenExpressionId;
-export declare function _BinaryenReturnId(): BinaryenExpressionId;
-export declare function _BinaryenMemorySizeId(): BinaryenExpressionId;
-export declare function _BinaryenMemoryGrowId(): BinaryenExpressionId;
-export declare function _BinaryenNopId(): BinaryenExpressionId;
-export declare function _BinaryenUnreachableId(): BinaryenExpressionId;
-export declare function _BinaryenAtomicCmpxchgId(): BinaryenExpressionId;
-export declare function _BinaryenAtomicRMWId(): BinaryenExpressionId;
-export declare function _BinaryenAtomicWaitId(): BinaryenExpressionId;
-export declare function _BinaryenAtomicNotifyId(): BinaryenExpressionId;
-export declare function _BinaryenAtomicFenceId(): BinaryenExpressionId;
-export declare function _BinaryenSIMDExtractId(): BinaryenExpressionId;
-export declare function _BinaryenSIMDReplaceId(): BinaryenExpressionId;
-export declare function _BinaryenSIMDShuffleId(): BinaryenExpressionId;
-export declare function _BinaryenSIMDTernaryId(): BinaryenExpressionId;
-export declare function _BinaryenSIMDShiftId(): BinaryenExpressionId;
-export declare function _BinaryenSIMDLoadId(): BinaryenExpressionId;
-export declare function _BinaryenMemoryInitId(): BinaryenExpressionId;
-export declare function _BinaryenDataDropId(): BinaryenExpressionId;
-export declare function _BinaryenMemoryCopyId(): BinaryenExpressionId;
-export declare function _BinaryenMemoryFillId(): BinaryenExpressionId;
-export declare function _BinaryenRefNullId(): BinaryenExpressionId;
-export declare function _BinaryenRefIsId(): BinaryenExpressionId;
-export declare function _BinaryenRefFuncId(): BinaryenExpressionId;
-export declare function _BinaryenRefEqId(): BinaryenExpressionId;
-export declare function _BinaryenTryId(): BinaryenExpressionId;
-export declare function _BinaryenThrowId(): BinaryenExpressionId;
-export declare function _BinaryenRethrowId(): BinaryenExpressionId;
-export declare function _BinaryenBrOnId(): BinaryenExpressionId;
-export declare function _BinaryenTupleMakeId(): BinaryenExpressionId;
-export declare function _BinaryenTupleExtractId(): BinaryenExpressionId;
-export declare function _BinaryenPopId(): BinaryenExpressionId;
-
-type BinaryenModuleRef = usize;
-
-export declare function _BinaryenModuleCreate(): BinaryenModuleRef;
-export declare function _BinaryenModuleDispose(module: BinaryenModuleRef): void;
-
-type BinaryenLiteral = usize;
-
-export declare function _BinaryenSizeofLiteral(): usize;
-export declare function _BinaryenLiteralInt32(literalOut: BinaryenLiteral, x: i32): void;
-export declare function _BinaryenLiteralInt64(literalOut: BinaryenLiteral, x: i32, y: i32): void;
-export declare function _BinaryenLiteralFloat32(literalOut: BinaryenLiteral, x: f32): void;
-export declare function _BinaryenLiteralFloat64(literalOut: BinaryenLiteral, x: f64): void;
-export declare function _BinaryenLiteralVec128(literalOut: BinaryenLiteral, x: BinaryenArray<u8>): void;
-export declare function _BinaryenLiteralFloat32Bits(literalOut: BinaryenLiteral, x: i32): void;
-export declare function _BinaryenLiteralFloat64Bits(literalOut: BinaryenLiteral, x: i32, y: i32): void;
-
-type BinaryenOp = i32;
-
-export declare function _BinaryenClzInt32(): BinaryenOp;
-export declare function _BinaryenCtzInt32(): BinaryenOp;
-export declare function _BinaryenPopcntInt32(): BinaryenOp;
-export declare function _BinaryenNegFloat32(): BinaryenOp;
-export declare function _BinaryenAbsFloat32(): BinaryenOp;
-export declare function _BinaryenCeilFloat32(): BinaryenOp;
-export declare function _BinaryenFloorFloat32(): BinaryenOp;
-export declare function _BinaryenTruncFloat32(): BinaryenOp;
-export declare function _BinaryenNearestFloat32(): BinaryenOp;
-export declare function _BinaryenSqrtFloat32(): BinaryenOp;
-export declare function _BinaryenEqZInt32(): BinaryenOp;
-export declare function _BinaryenClzInt64(): BinaryenOp;
-export declare function _BinaryenCtzInt64(): BinaryenOp;
-export declare function _BinaryenPopcntInt64(): BinaryenOp;
-export declare function _BinaryenNegFloat64(): BinaryenOp;
-export declare function _BinaryenAbsFloat64(): BinaryenOp;
-export declare function _BinaryenCeilFloat64(): BinaryenOp;
-export declare function _BinaryenFloorFloat64(): BinaryenOp;
-export declare function _BinaryenTruncFloat64(): BinaryenOp;
-export declare function _BinaryenNearestFloat64(): BinaryenOp;
-export declare function _BinaryenSqrtFloat64(): BinaryenOp;
-export declare function _BinaryenEqZInt64(): BinaryenOp;
-export declare function _BinaryenExtendSInt32(): BinaryenOp;
-export declare function _BinaryenExtendUInt32(): BinaryenOp;
-export declare function _BinaryenWrapInt64(): BinaryenOp;
-export declare function _BinaryenTruncSFloat32ToInt32(): BinaryenOp;
-export declare function _BinaryenTruncSFloat32ToInt64(): BinaryenOp;
-export declare function _BinaryenTruncUFloat32ToInt32(): BinaryenOp;
-export declare function _BinaryenTruncUFloat32ToInt64(): BinaryenOp;
-export declare function _BinaryenTruncSFloat64ToInt32(): BinaryenOp;
-export declare function _BinaryenTruncSFloat64ToInt64(): BinaryenOp;
-export declare function _BinaryenTruncUFloat64ToInt32(): BinaryenOp;
-export declare function _BinaryenTruncUFloat64ToInt64(): BinaryenOp;
-export declare function _BinaryenTruncSatSFloat32ToInt32(): BinaryenOp;
-export declare function _BinaryenTruncSatSFloat32ToInt64(): BinaryenOp;
-export declare function _BinaryenTruncSatUFloat32ToInt32(): BinaryenOp;
-export declare function _BinaryenTruncSatUFloat32ToInt64(): BinaryenOp;
-export declare function _BinaryenTruncSatSFloat64ToInt32(): BinaryenOp;
-export declare function _BinaryenTruncSatSFloat64ToInt64(): BinaryenOp;
-export declare function _BinaryenTruncSatUFloat64ToInt32(): BinaryenOp;
-export declare function _BinaryenTruncSatUFloat64ToInt64(): BinaryenOp;
-export declare function _BinaryenReinterpretFloat32(): BinaryenOp;
-export declare function _BinaryenReinterpretFloat64(): BinaryenOp;
-export declare function _BinaryenConvertSInt32ToFloat32(): BinaryenOp;
-export declare function _BinaryenConvertSInt32ToFloat64(): BinaryenOp;
-export declare function _BinaryenConvertUInt32ToFloat32(): BinaryenOp;
-export declare function _BinaryenConvertUInt32ToFloat64(): BinaryenOp;
-export declare function _BinaryenConvertSInt64ToFloat32(): BinaryenOp;
-export declare function _BinaryenConvertSInt64ToFloat64(): BinaryenOp;
-export declare function _BinaryenConvertUInt64ToFloat32(): BinaryenOp;
-export declare function _BinaryenConvertUInt64ToFloat64(): BinaryenOp;
-export declare function _BinaryenPromoteFloat32(): BinaryenOp;
-export declare function _BinaryenDemoteFloat64(): BinaryenOp;
-export declare function _BinaryenReinterpretInt32(): BinaryenOp;
-export declare function _BinaryenReinterpretInt64(): BinaryenOp;
-export declare function _BinaryenExtendS8Int32(): BinaryenOp;
-export declare function _BinaryenExtendS16Int32(): BinaryenOp;
-export declare function _BinaryenExtendS8Int64(): BinaryenOp;
-export declare function _BinaryenExtendS16Int64(): BinaryenOp;
-export declare function _BinaryenExtendS32Int64(): BinaryenOp;
-export declare function _BinaryenAddInt32(): BinaryenOp;
-export declare function _BinaryenSubInt32(): BinaryenOp;
-export declare function _BinaryenMulInt32(): BinaryenOp;
-export declare function _BinaryenDivSInt32(): BinaryenOp;
-export declare function _BinaryenDivUInt32(): BinaryenOp;
-export declare function _BinaryenRemSInt32(): BinaryenOp;
-export declare function _BinaryenRemUInt32(): BinaryenOp;
-export declare function _BinaryenAndInt32(): BinaryenOp;
-export declare function _BinaryenOrInt32(): BinaryenOp;
-export declare function _BinaryenXorInt32(): BinaryenOp;
-export declare function _BinaryenShlInt32(): BinaryenOp;
-export declare function _BinaryenShrUInt32(): BinaryenOp;
-export declare function _BinaryenShrSInt32(): BinaryenOp;
-export declare function _BinaryenRotLInt32(): BinaryenOp;
-export declare function _BinaryenRotRInt32(): BinaryenOp;
-export declare function _BinaryenEqInt32(): BinaryenOp;
-export declare function _BinaryenNeInt32(): BinaryenOp;
-export declare function _BinaryenLtSInt32(): BinaryenOp;
-export declare function _BinaryenLtUInt32(): BinaryenOp;
-export declare function _BinaryenLeSInt32(): BinaryenOp;
-export declare function _BinaryenLeUInt32(): BinaryenOp;
-export declare function _BinaryenGtSInt32(): BinaryenOp;
-export declare function _BinaryenGtUInt32(): BinaryenOp;
-export declare function _BinaryenGeSInt32(): BinaryenOp;
-export declare function _BinaryenGeUInt32(): BinaryenOp;
-export declare function _BinaryenAddInt64(): BinaryenOp;
-export declare function _BinaryenSubInt64(): BinaryenOp;
-export declare function _BinaryenMulInt64(): BinaryenOp;
-export declare function _BinaryenDivSInt64(): BinaryenOp;
-export declare function _BinaryenDivUInt64(): BinaryenOp;
-export declare function _BinaryenRemSInt64(): BinaryenOp;
-export declare function _BinaryenRemUInt64(): BinaryenOp;
-export declare function _BinaryenAndInt64(): BinaryenOp;
-export declare function _BinaryenOrInt64(): BinaryenOp;
-export declare function _BinaryenXorInt64(): BinaryenOp;
-export declare function _BinaryenShlInt64(): BinaryenOp;
-export declare function _BinaryenShrUInt64(): BinaryenOp;
-export declare function _BinaryenShrSInt64(): BinaryenOp;
-export declare function _BinaryenRotLInt64(): BinaryenOp;
-export declare function _BinaryenRotRInt64(): BinaryenOp;
-export declare function _BinaryenEqInt64(): BinaryenOp;
-export declare function _BinaryenNeInt64(): BinaryenOp;
-export declare function _BinaryenLtSInt64(): BinaryenOp;
-export declare function _BinaryenLtUInt64(): BinaryenOp;
-export declare function _BinaryenLeSInt64(): BinaryenOp;
-export declare function _BinaryenLeUInt64(): BinaryenOp;
-export declare function _BinaryenGtSInt64(): BinaryenOp;
-export declare function _BinaryenGtUInt64(): BinaryenOp;
-export declare function _BinaryenGeSInt64(): BinaryenOp;
-export declare function _BinaryenGeUInt64(): BinaryenOp;
-export declare function _BinaryenAddFloat32(): BinaryenOp;
-export declare function _BinaryenSubFloat32(): BinaryenOp;
-export declare function _BinaryenMulFloat32(): BinaryenOp;
-export declare function _BinaryenDivFloat32(): BinaryenOp;
-export declare function _BinaryenCopySignFloat32(): BinaryenOp;
-export declare function _BinaryenMinFloat32(): BinaryenOp;
-export declare function _BinaryenMaxFloat32(): BinaryenOp;
-export declare function _BinaryenEqFloat32(): BinaryenOp;
-export declare function _BinaryenNeFloat32(): BinaryenOp;
-export declare function _BinaryenLtFloat32(): BinaryenOp;
-export declare function _BinaryenLeFloat32(): BinaryenOp;
-export declare function _BinaryenGtFloat32(): BinaryenOp;
-export declare function _BinaryenGeFloat32(): BinaryenOp;
-export declare function _BinaryenAddFloat64(): BinaryenOp;
-export declare function _BinaryenSubFloat64(): BinaryenOp;
-export declare function _BinaryenMulFloat64(): BinaryenOp;
-export declare function _BinaryenDivFloat64(): BinaryenOp;
-export declare function _BinaryenCopySignFloat64(): BinaryenOp;
-export declare function _BinaryenMinFloat64(): BinaryenOp;
-export declare function _BinaryenMaxFloat64(): BinaryenOp;
-export declare function _BinaryenEqFloat64(): BinaryenOp;
-export declare function _BinaryenNeFloat64(): BinaryenOp;
-export declare function _BinaryenLtFloat64(): BinaryenOp;
-export declare function _BinaryenLeFloat64(): BinaryenOp;
-export declare function _BinaryenGtFloat64(): BinaryenOp;
-export declare function _BinaryenGeFloat64(): BinaryenOp;
-
-export declare function _BinaryenAtomicRMWAdd(): BinaryenOp;
-export declare function _BinaryenAtomicRMWSub(): BinaryenOp;
-export declare function _BinaryenAtomicRMWAnd(): BinaryenOp;
-export declare function _BinaryenAtomicRMWOr(): BinaryenOp;
-export declare function _BinaryenAtomicRMWXor(): BinaryenOp;
-export declare function _BinaryenAtomicRMWXchg(): BinaryenOp;
-
-export declare function _BinaryenSplatVecI8x16(): BinaryenOp;
-export declare function _BinaryenExtractLaneSVecI8x16(): BinaryenOp;
-export declare function _BinaryenExtractLaneUVecI8x16(): BinaryenOp;
-export declare function _BinaryenReplaceLaneVecI8x16(): BinaryenOp;
-export declare function _BinaryenSplatVecI16x8(): BinaryenOp;
-export declare function _BinaryenExtractLaneSVecI16x8(): BinaryenOp;
-export declare function _BinaryenExtractLaneUVecI16x8(): BinaryenOp;
-export declare function _BinaryenReplaceLaneVecI16x8(): BinaryenOp;
-export declare function _BinaryenSplatVecI32x4(): BinaryenOp;
-export declare function _BinaryenExtractLaneVecI32x4(): BinaryenOp;
-export declare function _BinaryenReplaceLaneVecI32x4(): BinaryenOp;
-export declare function _BinaryenSplatVecI64x2(): BinaryenOp;
-export declare function _BinaryenExtractLaneVecI64x2(): BinaryenOp;
-export declare function _BinaryenReplaceLaneVecI64x2(): BinaryenOp;
-export declare function _BinaryenSplatVecF32x4(): BinaryenOp;
-export declare function _BinaryenExtractLaneVecF32x4(): BinaryenOp;
-export declare function _BinaryenReplaceLaneVecF32x4(): BinaryenOp;
-export declare function _BinaryenSplatVecF64x2(): BinaryenOp;
-export declare function _BinaryenExtractLaneVecF64x2(): BinaryenOp;
-export declare function _BinaryenReplaceLaneVecF64x2(): BinaryenOp;
-export declare function _BinaryenEqVecI8x16(): BinaryenOp;
-export declare function _BinaryenNeVecI8x16(): BinaryenOp;
-export declare function _BinaryenLtSVecI8x16(): BinaryenOp;
-export declare function _BinaryenLtUVecI8x16(): BinaryenOp;
-export declare function _BinaryenGtSVecI8x16(): BinaryenOp;
-export declare function _BinaryenGtUVecI8x16(): BinaryenOp;
-export declare function _BinaryenLeSVecI8x16(): BinaryenOp;
-export declare function _BinaryenLeUVecI8x16(): BinaryenOp;
-export declare function _BinaryenGeSVecI8x16(): BinaryenOp;
-export declare function _BinaryenGeUVecI8x16(): BinaryenOp;
-export declare function _BinaryenEqVecI16x8(): BinaryenOp;
-export declare function _BinaryenNeVecI16x8(): BinaryenOp;
-export declare function _BinaryenLtSVecI16x8(): BinaryenOp;
-export declare function _BinaryenLtUVecI16x8(): BinaryenOp;
-export declare function _BinaryenGtSVecI16x8(): BinaryenOp;
-export declare function _BinaryenGtUVecI16x8(): BinaryenOp;
-export declare function _BinaryenLeSVecI16x8(): BinaryenOp;
-export declare function _BinaryenLeUVecI16x8(): BinaryenOp;
-export declare function _BinaryenGeSVecI16x8(): BinaryenOp;
-export declare function _BinaryenGeUVecI16x8(): BinaryenOp;
-export declare function _BinaryenEqVecI32x4(): BinaryenOp;
-export declare function _BinaryenNeVecI32x4(): BinaryenOp;
-export declare function _BinaryenLtSVecI32x4(): BinaryenOp;
-export declare function _BinaryenLtUVecI32x4(): BinaryenOp;
-export declare function _BinaryenGtSVecI32x4(): BinaryenOp;
-export declare function _BinaryenGtUVecI32x4(): BinaryenOp;
-export declare function _BinaryenLeSVecI32x4(): BinaryenOp;
-export declare function _BinaryenLeUVecI32x4(): BinaryenOp;
-export declare function _BinaryenGeSVecI32x4(): BinaryenOp;
-export declare function _BinaryenGeUVecI32x4(): BinaryenOp;
-export declare function _BinaryenEqVecF32x4(): BinaryenOp;
-export declare function _BinaryenNeVecF32x4(): BinaryenOp;
-export declare function _BinaryenLtVecF32x4(): BinaryenOp;
-export declare function _BinaryenGtVecF32x4(): BinaryenOp;
-export declare function _BinaryenLeVecF32x4(): BinaryenOp;
-export declare function _BinaryenGeVecF32x4(): BinaryenOp;
-export declare function _BinaryenEqVecF64x2(): BinaryenOp;
-export declare function _BinaryenNeVecF64x2(): BinaryenOp;
-export declare function _BinaryenLtVecF64x2(): BinaryenOp;
-export declare function _BinaryenGtVecF64x2(): BinaryenOp;
-export declare function _BinaryenLeVecF64x2(): BinaryenOp;
-export declare function _BinaryenGeVecF64x2(): BinaryenOp;
-export declare function _BinaryenNotVec128(): BinaryenOp;
-export declare function _BinaryenAndVec128(): BinaryenOp;
-export declare function _BinaryenOrVec128(): BinaryenOp;
-export declare function _BinaryenXorVec128(): BinaryenOp;
-export declare function _BinaryenAndNotVec128(): BinaryenOp;
-export declare function _BinaryenBitselectVec128(): BinaryenOp;
-export declare function _BinaryenAbsVecI8x16(): BinaryenOp;
-export declare function _BinaryenNegVecI8x16(): BinaryenOp;
-export declare function _BinaryenAnyTrueVecI8x16(): BinaryenOp;
-export declare function _BinaryenAllTrueVecI8x16(): BinaryenOp;
-export declare function _BinaryenBitmaskVecI8x16(): BinaryenOp;
-export declare function _BinaryenShlVecI8x16(): BinaryenOp;
-export declare function _BinaryenShrSVecI8x16(): BinaryenOp;
-export declare function _BinaryenShrUVecI8x16(): BinaryenOp;
-export declare function _BinaryenAddVecI8x16(): BinaryenOp;
-export declare function _BinaryenAddSatSVecI8x16(): BinaryenOp;
-export declare function _BinaryenAddSatUVecI8x16(): BinaryenOp;
-export declare function _BinaryenSubVecI8x16(): BinaryenOp;
-export declare function _BinaryenSubSatSVecI8x16(): BinaryenOp;
-export declare function _BinaryenSubSatUVecI8x16(): BinaryenOp;
-export declare function _BinaryenMulVecI8x16(): BinaryenOp;
-export declare function _BinaryenMinSVecI8x16(): BinaryenOp;
-export declare function _BinaryenMinUVecI8x16(): BinaryenOp;
-export declare function _BinaryenMaxSVecI8x16(): BinaryenOp;
-export declare function _BinaryenMaxUVecI8x16(): BinaryenOp;
-export declare function _BinaryenAvgrUVecI8x16(): BinaryenOp;
-export declare function _BinaryenAbsVecI16x8(): BinaryenOp;
-export declare function _BinaryenNegVecI16x8(): BinaryenOp;
-export declare function _BinaryenAnyTrueVecI16x8(): BinaryenOp;
-export declare function _BinaryenAllTrueVecI16x8(): BinaryenOp;
-export declare function _BinaryenBitmaskVecI16x8(): BinaryenOp;
-export declare function _BinaryenShlVecI16x8(): BinaryenOp;
-export declare function _BinaryenShrSVecI16x8(): BinaryenOp;
-export declare function _BinaryenShrUVecI16x8(): BinaryenOp;
-export declare function _BinaryenAddVecI16x8(): BinaryenOp;
-export declare function _BinaryenAddSatSVecI16x8(): BinaryenOp;
-export declare function _BinaryenAddSatUVecI16x8(): BinaryenOp;
-export declare function _BinaryenSubVecI16x8(): BinaryenOp;
-export declare function _BinaryenSubSatSVecI16x8(): BinaryenOp;
-export declare function _BinaryenSubSatUVecI16x8(): BinaryenOp;
-export declare function _BinaryenMulVecI16x8(): BinaryenOp;
-export declare function _BinaryenMinSVecI16x8(): BinaryenOp;
-export declare function _BinaryenMinUVecI16x8(): BinaryenOp;
-export declare function _BinaryenMaxSVecI16x8(): BinaryenOp;
-export declare function _BinaryenMaxUVecI16x8(): BinaryenOp;
-export declare function _BinaryenAvgrUVecI16x8(): BinaryenOp;
-export declare function _BinaryenAbsVecI32x4(): BinaryenOp;
-export declare function _BinaryenNegVecI32x4(): BinaryenOp;
-export declare function _BinaryenAnyTrueVecI32x4(): BinaryenOp;
-export declare function _BinaryenAllTrueVecI32x4(): BinaryenOp;
-export declare function _BinaryenBitmaskVecI32x4(): BinaryenOp;
-export declare function _BinaryenShlVecI32x4(): BinaryenOp;
-export declare function _BinaryenShrSVecI32x4(): BinaryenOp;
-export declare function _BinaryenShrUVecI32x4(): BinaryenOp;
-export declare function _BinaryenAddVecI32x4(): BinaryenOp;
-export declare function _BinaryenSubVecI32x4(): BinaryenOp;
-export declare function _BinaryenMulVecI32x4(): BinaryenOp;
-export declare function _BinaryenMinSVecI32x4(): BinaryenOp;
-export declare function _BinaryenMinUVecI32x4(): BinaryenOp;
-export declare function _BinaryenMaxSVecI32x4(): BinaryenOp;
-export declare function _BinaryenMaxUVecI32x4(): BinaryenOp;
-export declare function _BinaryenDotSVecI16x8ToVecI32x4(): BinaryenOp;
-export declare function _BinaryenNegVecI64x2(): BinaryenOp;
-export declare function _BinaryenAnyTrueVecI64x2(): BinaryenOp;
-export declare function _BinaryenAllTrueVecI64x2(): BinaryenOp;
-export declare function _BinaryenShlVecI64x2(): BinaryenOp;
-export declare function _BinaryenShrSVecI64x2(): BinaryenOp;
-export declare function _BinaryenShrUVecI64x2(): BinaryenOp;
-export declare function _BinaryenAddVecI64x2(): BinaryenOp;
-export declare function _BinaryenSubVecI64x2(): BinaryenOp;
-export declare function _BinaryenAbsVecF32x4(): BinaryenOp;
-export declare function _BinaryenNegVecF32x4(): BinaryenOp;
-export declare function _BinaryenSqrtVecF32x4(): BinaryenOp;
-export declare function _BinaryenQFMAVecF32x4(): BinaryenOp;
-export declare function _BinaryenQFMSVecF32x4(): BinaryenOp;
-export declare function _BinaryenAddVecF32x4(): BinaryenOp;
-export declare function _BinaryenSubVecF32x4(): BinaryenOp;
-export declare function _BinaryenMulVecF32x4(): BinaryenOp;
-export declare function _BinaryenDivVecF32x4(): BinaryenOp;
-export declare function _BinaryenMinVecF32x4(): BinaryenOp;
-export declare function _BinaryenMaxVecF32x4(): BinaryenOp;
-export declare function _BinaryenAbsVecF64x2(): BinaryenOp;
-export declare function _BinaryenNegVecF64x2(): BinaryenOp;
-export declare function _BinaryenSqrtVecF64x2(): BinaryenOp;
-export declare function _BinaryenQFMAVecF64x2(): BinaryenOp;
-export declare function _BinaryenQFMSVecF64x2(): BinaryenOp;
-export declare function _BinaryenAddVecF64x2(): BinaryenOp;
-export declare function _BinaryenSubVecF64x2(): BinaryenOp;
-export declare function _BinaryenMulVecF64x2(): BinaryenOp;
-export declare function _BinaryenDivVecF64x2(): BinaryenOp;
-export declare function _BinaryenMinVecF64x2(): BinaryenOp;
-export declare function _BinaryenMaxVecF64x2(): BinaryenOp;
-export declare function _BinaryenTruncSatSVecF32x4ToVecI32x4(): BinaryenOp;
-export declare function _BinaryenTruncSatUVecF32x4ToVecI32x4(): BinaryenOp;
-export declare function _BinaryenTruncSatSVecF64x2ToVecI64x2(): BinaryenOp;
-export declare function _BinaryenTruncSatUVecF64x2ToVecI64x2(): BinaryenOp;
-export declare function _BinaryenConvertSVecI32x4ToVecF32x4(): BinaryenOp;
-export declare function _BinaryenConvertUVecI32x4ToVecF32x4(): BinaryenOp;
-export declare function _BinaryenConvertSVecI64x2ToVecF64x2(): BinaryenOp;
-export declare function _BinaryenConvertUVecI64x2ToVecF64x2(): BinaryenOp;
-export declare function _BinaryenLoadSplatVec8x16(): BinaryenOp;
-export declare function _BinaryenLoadSplatVec16x8(): BinaryenOp;
-export declare function _BinaryenLoadSplatVec32x4(): BinaryenOp;
-export declare function _BinaryenLoadSplatVec64x2(): BinaryenOp;
-export declare function _BinaryenLoadExtSVec8x8ToVecI16x8(): BinaryenOp;
-export declare function _BinaryenLoadExtUVec8x8ToVecI16x8(): BinaryenOp;
-export declare function _BinaryenLoadExtSVec16x4ToVecI32x4(): BinaryenOp;
-export declare function _BinaryenLoadExtUVec16x4ToVecI32x4(): BinaryenOp;
-export declare function _BinaryenLoadExtSVec32x2ToVecI64x2(): BinaryenOp;
-export declare function _BinaryenLoadExtUVec32x2ToVecI64x2(): BinaryenOp;
-export declare function _BinaryenNarrowSVecI16x8ToVecI8x16(): BinaryenOp;
-export declare function _BinaryenNarrowUVecI16x8ToVecI8x16(): BinaryenOp;
-export declare function _BinaryenNarrowSVecI32x4ToVecI16x8(): BinaryenOp;
-export declare function _BinaryenNarrowUVecI32x4ToVecI16x8(): BinaryenOp;
-export declare function _BinaryenWidenLowSVecI8x16ToVecI16x8(): BinaryenOp;
-export declare function _BinaryenWidenHighSVecI8x16ToVecI16x8(): BinaryenOp;
-export declare function _BinaryenWidenLowUVecI8x16ToVecI16x8(): BinaryenOp;
-export declare function _BinaryenWidenHighUVecI8x16ToVecI16x8(): BinaryenOp;
-export declare function _BinaryenWidenLowSVecI16x8ToVecI32x4(): BinaryenOp;
-export declare function _BinaryenWidenHighSVecI16x8ToVecI32x4(): BinaryenOp;
-export declare function _BinaryenWidenLowUVecI16x8ToVecI32x4(): BinaryenOp;
-export declare function _BinaryenWidenHighUVecI16x8ToVecI32x4(): BinaryenOp;
-export declare function _BinaryenSwizzleVec8x16(): BinaryenOp;
-
-export declare function _BinaryenRefIsNull(): BinaryenOp;
-export declare function _BinaryenRefIsFunc(): BinaryenOp;
-export declare function _BinaryenRefIsData(): BinaryenOp;
-export declare function _BinaryenRefIsI31(): BinaryenOp;
-
-export declare function _BinaryenRefAsNonNull(): BinaryenOp;
-export declare function _BinaryenRefAsFunc(): BinaryenOp;
-export declare function _BinaryenRefAsData(): BinaryenOp;
-export declare function _BinaryenRefAsAsI31(): BinaryenOp;
-
-type BinaryenExpressionRef = usize;
-
-export declare function _BinaryenExpressionGetId(expr: BinaryenExpressionRef): BinaryenExpressionId;
-export declare function _BinaryenExpressionGetType(expr: BinaryenExpressionRef): BinaryenType;
-export declare function _BinaryenExpressionSetType(expr: BinaryenExpressionRef, type: BinaryenType): void;
-export declare function _BinaryenExpressionPrint(expr: BinaryenExpressionRef): void;
-export declare function _BinaryenExpressionCopy(expr: BinaryenExpressionRef, module: BinaryenModuleRef): BinaryenExpressionRef;
-export declare function _BinaryenExpressionFinalize(expr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenBlock(module: BinaryenModuleRef, name: BinaryenString, childExprs: BinaryenArray<BinaryenExpressionRef>, numChildren: BinaryenIndex, type: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenBlockGetName(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenBlockSetName(expr: BinaryenExpressionRef, name: BinaryenString): void;
-export declare function _BinaryenBlockGetNumChildren(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenBlockGetChildAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenBlockSetChildAt(expr: BinaryenExpressionRef, index: BinaryenIndex, childExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenBlockAppendChild(expr: BinaryenExpressionRef, childExpr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenBlockInsertChildAt(expr: BinaryenExpressionRef, index: BinaryenIndex, childExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenBlockRemoveChildAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-
-export declare function _BinaryenIf(module: BinaryenModuleRef, conditionExpr: BinaryenExpressionRef, ifTrueExpr: BinaryenExpressionRef, ifFalseExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenIfGetCondition(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenIfSetCondition(expr: BinaryenExpressionRef, conditionExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenIfGetIfTrue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenIfSetIfTrue(expr: BinaryenExpressionRef, ifTrueExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenIfGetIfFalse(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenIfSetIfFalse(expr: BinaryenExpressionRef, ifFalseExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenLoop(module: BinaryenModuleRef, name: BinaryenString, bodyExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenLoopGetName(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenLoopSetName(expr: BinaryenExpressionRef, name: BinaryenString): void;
-export declare function _BinaryenLoopGetBody(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenLoopSetBody(expr: BinaryenExpressionRef, bodyExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenBreak(module: BinaryenModuleRef, name: BinaryenString, conditionExpr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenBreakGetName(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenBreakSetName(expr: BinaryenExpressionRef, name: BinaryenString): void;
-export declare function _BinaryenBreakGetCondition(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenBreakSetCondition(expr: BinaryenExpressionRef, conditionExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenBreakGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenBreakSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenSwitch(module: BinaryenModuleRef, names: BinaryenArray<BinaryenString>, numNames: BinaryenIndex, defaultName: BinaryenString, conditionExpr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSwitchGetNumNames(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenSwitchGetNameAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenString;
-export declare function _BinaryenSwitchSetNameAt(expr: BinaryenExpressionRef, index: BinaryenIndex, name: BinaryenString): void;
-export declare function _BinaryenSwitchAppendName(expr: BinaryenExpressionRef, name: BinaryenString): BinaryenIndex;
-export declare function _BinaryenSwitchInsertNameAt(expr: BinaryenExpressionRef, index: BinaryenIndex, name: BinaryenString): void;
-export declare function _BinaryenSwitchRemoveNameAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenString;
-export declare function _BinaryenSwitchGetDefaultName(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenSwitchSetDefaultName(expr: BinaryenExpressionRef, defaultName: BinaryenString): void;
-export declare function _BinaryenSwitchGetCondition(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSwitchSetCondition(expr: BinaryenExpressionRef, conditionExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSwitchGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSwitchSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenCall(module: BinaryenModuleRef, targetName: BinaryenString, operandExprs: BinaryenArray<BinaryenExpressionRef>, numOperands: BinaryenIndex, returnType: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenCallGetTarget(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenCallSetTarget(expr: BinaryenExpressionRef, targetName: BinaryenString): void;
-export declare function _BinaryenCallGetNumOperands(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenCallGetOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenCallSetOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex, operandExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenCallAppendOperand(expr: BinaryenExpressionRef, operandExpr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenCallInsertOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex, operandExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenCallRemoveOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenCallIsReturn(expr: BinaryenExpressionRef): bool;
-export declare function _BinaryenCallSetReturn(expr: BinaryenExpressionRef, isReturn: bool): void;
-// ^ with return = true
-export declare function _BinaryenReturnCall(module: BinaryenModuleRef, targetName: BinaryenString, operandExprs: BinaryenArray<BinaryenExpressionRef>, numOperands: BinaryenIndex, returnType: BinaryenType): BinaryenExpressionRef;
-
-export declare function _BinaryenCallIndirect(module: BinaryenModuleRef, table: BinaryenString, targetExpr: BinaryenExpressionRef, operandExprs: BinaryenArray<BinaryenExpressionRef>, numOperands: BinaryenIndex, params: BinaryenType, results: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenCallIndirectGetTable(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenCallIndirectSetTable(expr: BinaryenExpressionRef, table: BinaryenString): void;
-export declare function _BinaryenCallIndirectGetTarget(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenCallIndirectSetTarget(expr: BinaryenExpressionRef, targetExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenCallIndirectGetNumOperands(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenCallIndirectGetOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenCallIndirectSetOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex, operandExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenCallIndirectAppendOperand(expr: BinaryenExpressionRef, operandExpr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenCallIndirectInsertOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex, operandExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenCallIndirectRemoveOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenCallIndirectIsReturn(expr: BinaryenExpressionRef): bool;
-export declare function _BinaryenCallIndirectSetReturn(expr: BinaryenExpressionRef, isReturn: bool): void;
-// ^ with return = true
-export declare function _BinaryenReturnCallIndirect(module: BinaryenModuleRef, table: BinaryenString, targetExpr: BinaryenExpressionRef, operandExprs: BinaryenArray<BinaryenExpressionRef>, numOperands: BinaryenIndex, params: BinaryenType, results: BinaryenType): BinaryenExpressionRef;
-
-export declare function _BinaryenLocalGet(module: BinaryenModuleRef, index: BinaryenIndex, type: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenLocalGetGetIndex(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenLocalGetSetIndex(expr: BinaryenExpressionRef, index: BinaryenIndex): void;
-
-export declare function _BinaryenLocalSet(module: BinaryenModuleRef, index: BinaryenIndex, valueExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenLocalSetIsTee(expr: BinaryenExpressionRef): bool;
-export declare function _BinaryenLocalSetGetIndex(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenLocalSetSetIndex(expr: BinaryenExpressionRef, index: BinaryenIndex): void;
-export declare function _BinaryenLocalSetGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenLocalSetSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-// ^ with type != none
-export declare function _BinaryenLocalTee(module: BinaryenModuleRef, index: BinaryenIndex, valueExpr: BinaryenExpressionRef, type: BinaryenType): BinaryenExpressionRef;
-
-export declare function _BinaryenGlobalGet(module: BinaryenModuleRef, name: BinaryenString, type: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenGlobalGetGetName(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenGlobalGetSetName(expr: BinaryenExpressionRef, name: BinaryenString): void;
-
-export declare function _BinaryenGlobalSet(module: BinaryenModuleRef, name: BinaryenString, value: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenGlobalSetGetName(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenGlobalSetSetName(expr: BinaryenExpressionRef, name: BinaryenString): void;
-export declare function _BinaryenGlobalSetGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenGlobalSetSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenMemorySize(module: BinaryenModuleRef): BinaryenExpressionRef;
-
-export declare function _BinaryenMemoryGrow(module: BinaryenModuleRef, delta: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryGrowGetDelta(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryGrowSetDelta(expr: BinaryenExpressionRef, delta: BinaryenExpressionRef): void;
-
-export declare function _BinaryenLoad(module: BinaryenModuleRef, bytes: u32, signed: bool, offset: u32, align: u32, type: BinaryenType, ptrExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenLoadIsAtomic(expr: BinaryenExpressionRef): bool;
-export declare function _BinaryenLoadSetAtomic(expr: BinaryenExpressionRef, isAtomic: bool): void;
-export declare function _BinaryenLoadIsSigned(expr: BinaryenExpressionRef): bool;
-export declare function _BinaryenLoadSetSigned(expr: BinaryenExpressionRef, isSigned: bool): void;
-export declare function _BinaryenLoadGetOffset(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenLoadSetOffset(expr: BinaryenExpressionRef, offset: u32): void;
-export declare function _BinaryenLoadGetBytes(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenLoadSetBytes(expr: BinaryenExpressionRef, bytes: u32): void;
-export declare function _BinaryenLoadGetAlign(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenLoadSetAlign(expr: BinaryenExpressionRef, align: u32): void;
-export declare function _BinaryenLoadGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenLoadSetPtr(expr: BinaryenExpressionRef, ptrExpr: BinaryenExpressionRef): void;
-// ^ with atomic = true
-export declare function _BinaryenAtomicLoad(module: BinaryenModuleRef, bytes: BinaryenIndex, offset: BinaryenIndex, type: BinaryenType, ptrExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-
-export declare function _BinaryenStore(module: BinaryenModuleRef, bytes: u32, offset: u32, align: u32, ptrExpr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef, type: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenStoreIsAtomic(expr: BinaryenExpressionRef): bool;
-export declare function _BinaryenStoreSetAtomic(expr: BinaryenExpressionRef, isAtomic: bool): void;
-export declare function _BinaryenStoreGetBytes(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenStoreSetBytes(expr: BinaryenExpressionRef, bytes: u32): void;
-export declare function _BinaryenStoreGetOffset(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenStoreSetOffset(expr: BinaryenExpressionRef, offset: u32): void;
-export declare function _BinaryenStoreGetAlign(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenStoreSetAlign(expr: BinaryenExpressionRef, align: u32): void;
-export declare function _BinaryenStoreGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenStoreSetPtr(expr: BinaryenExpressionRef, ptrExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenStoreGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenStoreSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenStoreGetValueType(expr: BinaryenExpressionRef): BinaryenType;
-export declare function _BinaryenStoreSetValueType(expr: BinaryenExpressionRef, valueType: BinaryenType): void;
-// ^ with atomic = true
-export declare function _BinaryenAtomicStore(module: BinaryenModuleRef, bytes: BinaryenIndex, offset: BinaryenIndex, ptrExpr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef, type: BinaryenType): BinaryenExpressionRef;
-
-export declare function _BinaryenConst(module: BinaryenModuleRef, value: BinaryenLiteral): BinaryenExpressionRef;
-export declare function _BinaryenConstGetValueI32(expr: BinaryenExpressionRef): i32;
-export declare function _BinaryenConstSetValueI32(expr: BinaryenExpressionRef, value: i32): void;
-export declare function _BinaryenConstGetValueI64Low(expr: BinaryenExpressionRef): i32;
-export declare function _BinaryenConstSetValueI64Low(expr: BinaryenExpressionRef, value: i32): void;
-export declare function _BinaryenConstGetValueI64High(expr: BinaryenExpressionRef): i32;
-export declare function _BinaryenConstSetValueI64High(expr: BinaryenExpressionRef, value: i32): void;
-export declare function _BinaryenConstGetValueF32(expr: BinaryenExpressionRef): f32;
-export declare function _BinaryenConstSetValueF32(expr: BinaryenExpressionRef, value: f32): void;
-export declare function _BinaryenConstGetValueF64(expr: BinaryenExpressionRef): f64;
-export declare function _BinaryenConstSetValueF64(expr: BinaryenExpressionRef, value: f64): void;
-export declare function _BinaryenConstGetValueV128(expr: BinaryenExpressionRef, valueOut: BinaryenArray<u8>): void;
-export declare function _BinaryenConstSetValueV128(expr: BinaryenExpressionRef, value: BinaryenArray<u8>): void;
-
-export declare function _BinaryenUnary(module: BinaryenModuleRef, op: BinaryenOp, valueExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenUnaryGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenUnarySetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenUnaryGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenUnarySetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenBinary(module: BinaryenModuleRef, op: BinaryenOp, leftExpr: BinaryenExpressionRef, rightExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenBinaryGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenBinarySetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenBinaryGetLeft(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenBinarySetLeft(expr: BinaryenExpressionRef, leftExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenBinaryGetRight(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenBinarySetRight(expr: BinaryenExpressionRef, rightExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenSelect(module: BinaryenModuleRef, conditionExpr: BinaryenExpressionRef, ifTrueExpr: BinaryenExpressionRef, ifFalseExpr: BinaryenExpressionRef, type: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenSelectGetIfTrue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSelectSetIfTrue(expr: BinaryenExpressionRef, ifTrueExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSelectGetIfFalse(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSelectSetIfFalse(expr: BinaryenExpressionRef, ifFalseExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSelectGetCondition(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSelectSetCondition(expr: BinaryenExpressionRef, conditionExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenDrop(module: BinaryenModuleRef, valueExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenDropGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenDropSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenReturn(module: BinaryenModuleRef, valueExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenReturnGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenReturnSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenNop(module: BinaryenModuleRef): BinaryenExpressionRef;
-
-export declare function _BinaryenUnreachable(module: BinaryenModuleRef): BinaryenExpressionRef;
-
-export declare function _BinaryenAtomicRMW(module: BinaryenModuleRef, op: BinaryenOp, bytes: u32, offset: u32, ptrExpr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef, type: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenAtomicRMWGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenAtomicRMWSetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenAtomicRMWGetBytes(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenAtomicRMWSetBytes(expr: BinaryenExpressionRef, bytes: u32): void;
-export declare function _BinaryenAtomicRMWGetOffset(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenAtomicRMWSetOffset(expr: BinaryenExpressionRef, offset: u32): void;
-export declare function _BinaryenAtomicRMWGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicRMWSetPtr(expr: BinaryenExpressionRef, ptrExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenAtomicRMWGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicRMWSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenAtomicCmpxchg(module: BinaryenModuleRef, bytes: u32, offset: u32, ptrExpr: BinaryenExpressionRef, expectedExpr: BinaryenExpressionRef, replacementExpr: BinaryenExpressionRef, type: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenAtomicCmpxchgGetBytes(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenAtomicCmpxchgSetBytes(expr: BinaryenExpressionRef, bytes: u32): void;
-export declare function _BinaryenAtomicCmpxchgGetOffset(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenAtomicCmpxchgSetOffset(expr: BinaryenExpressionRef, offset: u32): void;
-export declare function _BinaryenAtomicCmpxchgGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicCmpxchgSetPtr(expr: BinaryenExpressionRef, ptrExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenAtomicCmpxchgGetExpected(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicCmpxchgSetExpected(expr: BinaryenExpressionRef, expectedExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenAtomicCmpxchgGetReplacement(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicCmpxchgSetReplacement(expr: BinaryenExpressionRef, replacementExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenAtomicWait(module: BinaryenModuleRef, ptrExpr: BinaryenExpressionRef, expectedExpr: BinaryenExpressionRef, timeoutExpr: BinaryenExpressionRef, expectedType: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenAtomicWaitGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicWaitSetPtr(expr: BinaryenExpressionRef, ptrExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenAtomicWaitGetExpected(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicWaitSetExpected(expr: BinaryenExpressionRef, expectedExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenAtomicWaitGetTimeout(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicWaitSetTimeout(expr: BinaryenExpressionRef, timeoutExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenAtomicWaitGetExpectedType(expr: BinaryenExpressionRef): BinaryenType;
-export declare function _BinaryenAtomicWaitSetExpectedType(expr: BinaryenExpressionRef, expectedType: BinaryenType): void;
-
-export declare function _BinaryenAtomicNotify(module: BinaryenModuleRef, ptrExpr: BinaryenExpressionRef, notifyCountExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicNotifyGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicNotifySetPtr(expr: BinaryenExpressionRef, ptrExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenAtomicNotifyGetNotifyCount(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicNotifySetNotifyCount(expr: BinaryenExpressionRef, notifyCountExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenAtomicFence(module: BinaryenModuleRef): BinaryenExpressionRef;
-export declare function _BinaryenAtomicFenceGetOrder(expr: BinaryenExportRef): u8; // unused
-export declare function _BinaryenAtomicFenceSetOrder(expr: BinaryenExportRef, order: u8): void; // unused
-
-export declare function _BinaryenSIMDExtract(module: BinaryenModuleRef, op: BinaryenOp, vecExpr: BinaryenExpressionRef, index: u8): BinaryenExpressionRef;
-export declare function _BinaryenSIMDExtractGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenSIMDExtractSetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenSIMDExtractGetVec(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDExtractSetVec(expr: BinaryenExpressionRef, vecExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSIMDExtractGetIndex(expr: BinaryenExpressionRef): u8;
-export declare function _BinaryenSIMDExtractSetIndex(expr: BinaryenExpressionRef, index: u8): void;
-
-export declare function _BinaryenSIMDReplace(module: BinaryenModuleRef, op: BinaryenOp, vecEpr: BinaryenExpressionRef, index: u8, valueExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDReplaceGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenSIMDReplaceSetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenSIMDReplaceGetVec(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDReplaceSetVec(expr: BinaryenExpressionRef, vecExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSIMDReplaceGetIndex(expr: BinaryenExpressionRef): u8;
-export declare function _BinaryenSIMDReplaceSetIndex(expr: BinaryenExpressionRef, index: u8): void;
-export declare function _BinaryenSIMDReplaceGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDReplaceSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenSIMDShuffle(module: BinaryenModuleRef, leftExpr: BinaryenExpressionRef, rightExpr: BinaryenExpressionRef, mask: BinaryenArray<u8>): BinaryenExpressionRef;
-export declare function _BinaryenSIMDShuffleGetLeft(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDShuffleSetLeft(expr: BinaryenExpressionRef, leftExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSIMDShuffleGetRight(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDShuffleSetRight(expr: BinaryenExpressionRef, rightExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSIMDShuffleGetMask(expr: BinaryenExpressionRef, maskOut: BinaryenArray<u8>): void;
-export declare function _BinaryenSIMDShuffleSetMask(expr: BinaryenExpressionRef, mask: BinaryenArray<u8>): void;
-
-export declare function _BinaryenSIMDTernary(module: BinaryenModuleRef, op: BinaryenOp, aExpr: BinaryenExpressionRef, bExpr: BinaryenExpressionRef, cExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDTernaryGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenSIMDTernarySetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenSIMDTernaryGetA(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDTernarySetA(expr: BinaryenExpressionRef, aExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSIMDTernaryGetB(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDTernarySetB(expr: BinaryenExpressionRef, bExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSIMDTernaryGetC(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDTernarySetC(expr: BinaryenExpressionRef, cExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenSIMDShift(module: BinaryenModuleRef, op: BinaryenOp, vecExpr: BinaryenExpressionRef, shiftExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDShiftGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenSIMDShiftSetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenSIMDShiftGetVec(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDShiftSetVec(expr: BinaryenExpressionRef, vecExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSIMDShiftGetShift(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDShiftSetShift(expr: BinaryenExpressionRef, shiftExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenSIMDLoad(module: BinaryenModuleRef, op: BinaryenOp, offset: u32, align: u32, ptrExpr: BinaryenExportRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDLoadGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenSIMDLoadSetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenSIMDLoadGetOffset(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenSIMDLoadSetOffset(expr: BinaryenExpressionRef, offset: u32): void;
-export declare function _BinaryenSIMDLoadGetAlign(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenSIMDLoadSetAlign(expr: BinaryenExpressionRef, align: u32): void;
-export declare function _BinaryenSIMDLoadGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDLoadSetPtr(expr: BinaryenExpressionRef, ptrExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenSIMDLoadStoreLane(module: BinaryenModuleRef, op: BinaryenOp, offset: u32, align: u32, index: u8, ptr: BinaryenExpressionRef, vec: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDLoadStoreLaneGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenSIMDLoadStoreLaneSetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenSIMDLoadStoreLaneGetOffset(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenSIMDLoadStoreLaneSetOffset(expr: BinaryenExpressionRef, offset: u32): void;
-export declare function _BinaryenSIMDLoadStoreLaneGetAlign(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenSIMDLoadStoreLaneSetAlign(expr: BinaryenExpressionRef, align: u32): void;
-export declare function _BinaryenSIMDLoadStoreLaneGetIndex(expr: BinaryenExpressionRef): u8;
-export declare function _BinaryenSIMDLoadStoreLaneSetIndex(expr: BinaryenExpressionRef, index: u8): void;
-export declare function _BinaryenSIMDLoadStoreLaneGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDLoadStoreLaneSetPtr(expr: BinaryenExpressionRef, ptrExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSIMDLoadStoreLaneGetVec(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSIMDLoadStoreLaneSetVec(expr: BinaryenExpressionRef, vecExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenSIMDLoadStoreLaneIsStore(expr: BinaryenExpressionRef): bool;
-
-export declare function _BinaryenMemoryInit(module: BinaryenModuleRef, segmentIndex: u32, destExpr: BinaryenExpressionRef, offsetExpr: BinaryenExpressionRef, sizeExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryInitGetSegment(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenMemoryInitSetSegment(expr: BinaryenExpressionRef, segmentIndex: u32): void;
-export declare function _BinaryenMemoryInitGetDest(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryInitSetDest(expr: BinaryenExpressionRef, destExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenMemoryInitGetOffset(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryInitSetOffset(expr: BinaryenExpressionRef, offsetExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenMemoryInitGetSize(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryInitSetSize(expr: BinaryenExpressionRef, sizeExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenDataDrop(module: BinaryenModuleRef, segmentIndex: u32): BinaryenExpressionRef;
-export declare function _BinaryenDataDropGetSegment(expr: BinaryenExpressionRef): u32;
-export declare function _BinaryenDataDropSetSegment(expr: BinaryenExpressionRef, segmentIndex: u32): void;
-
-export declare function _BinaryenMemoryCopy(module: BinaryenModuleRef, destExpr: BinaryenExpressionRef, sourceExpr: BinaryenExpressionRef, sizeExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryCopyGetDest(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryCopySetDest(expr: BinaryenExpressionRef, destExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenMemoryCopyGetSource(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryCopySetSource(expr: BinaryenExpressionRef, sourceExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenMemoryCopyGetSize(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryCopySetSize(expr: BinaryenExpressionRef, sizeExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenMemoryFill(module: BinaryenModuleRef, destExpr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef, sizeExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryFillGetDest(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryFillSetDest(expr: BinaryenExpressionRef, destExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenMemoryFillGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryFillSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenMemoryFillGetSize(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenMemoryFillSetSize(expr: BinaryenExpressionRef, sizeExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenRefNull(module: BinaryenModuleRef, type: BinaryenType): BinaryenExpressionRef;
-
-export declare function _BinaryenRefIs(module: BinaryenModuleRef, op: BinaryenOp, valueExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenRefIsGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenRefIsSetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenRefIsGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenRefIsSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenRefAs(module: BinaryenModuleRef, op: BinaryenOp, valueExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenRefAsGetOp(expr: BinaryenExpressionRef): BinaryenOp;
-export declare function _BinaryenRefAsSetOp(expr: BinaryenExpressionRef, op: BinaryenOp): void;
-export declare function _BinaryenRefAsGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenRefAsSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenRefFunc(module: BinaryenModuleRef, funcName: BinaryenString, type: BinaryenType): BinaryenExpressionRef;
-export declare function _BinaryenRefFuncGetFunc(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenRefFuncSetFunc(expr: BinaryenExpressionRef, funcName: BinaryenString): void;
-
-export declare function _BinaryenRefEq(module: BinaryenModuleRef, leftExpr: BinaryenExpressionRef, rightExpr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenRefEqGetLeft(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenRefEqSetLeft(expr: BinaryenExpressionRef, leftExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenRefEqGetRight(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenRefEqSetRight(expr: BinaryenExpressionRef, rightExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenTry(module: BinaryenModuleRef, name: BinaryenString, bodyExpr: BinaryenExpressionRef, catchEvents: BinaryenArray<BinaryenString>, numCatchEvents: BinaryenIndex, catchBodies: BinaryenArray<BinaryenExpressionRef>, numCatchBodies: BinaryenIndex, delegateTarget: BinaryenString): BinaryenExpressionRef;
-export declare function _BinaryenTryGetName(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenTrySetName(expr: BinaryenExpressionRef, name: BinaryenString): void;
-export declare function _BinaryenTryGetBody(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenTrySetBody(expr: BinaryenExpressionRef, bodyExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenTryGetNumCatchEvents(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenTryGetNumCatchBodies(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenTryGetCatchEventAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenString;
-export declare function _BinaryenTrySetCatchEventAt(expr: BinaryenExpressionRef, index: BinaryenIndex, catchEvent: BinaryenString): void;
-export declare function _BinaryenTryAppendCatchEvent(expr: BinaryenExpressionRef, catchEvent: BinaryenString): BinaryenIndex;
-export declare function _BinaryenTryInsertCatchEventAt(expr: BinaryenExpressionRef, index: BinaryenIndex, catchEvent: BinaryenString): void;
-export declare function _BinaryenTryRemoveCatchEventAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenString;
-export declare function _BinaryenTryGetCatchBodyAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenTrySetCatchBodyAt(expr: BinaryenExpressionRef, index: BinaryenIndex, catchExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenTryAppendCatchBody(expr: BinaryenExpressionRef, catchExpr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenTryInsertCatchBodyAt(expr: BinaryenExpressionRef, index: BinaryenIndex, catchExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenTryRemoveCatchBodyAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenTryHasCatchAll(expr: BinaryenExpressionRef): bool;
-export declare function _BinaryenTryGetDelegateTarget(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenTrySetDelegateTarget(expr: BinaryenExpressionRef, delegateTarget: BinaryenString): void;
-export declare function _BinaryenTryIsDelegate(expr: BinaryenExpressionRef): bool;
-
-export declare function _BinaryenThrow(module: BinaryenModuleRef, eventName: BinaryenString, operands: BinaryenArray<BinaryenExpressionRef>, numOperands: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenThrowGetEvent(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenThrowSetEvent(expr: BinaryenExpressionRef, eventName: BinaryenString): void;
-export declare function _BinaryenThrowGetNumOperands(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenThrowGetOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenThrowSetOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex, operandExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenThrowAppendOperand(expr: BinaryenExpressionRef, operandExpr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenThrowInsertOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex, operandExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenThrowRemoveOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-
-export declare function _BinaryenRethrow(module: BinaryenModuleRef, target: BinaryenString): BinaryenExpressionRef;
-export declare function _BinaryenRethrowGetTarget(expr: BinaryenExpressionRef): BinaryenString;
-export declare function _BinaryenRethrowSetDepth(expr: BinaryenExpressionRef, target: BinaryenString): void;
-
-export declare function _BinaryenTupleMake(module: BinaryenModuleRef, operandExprs: BinaryenArray<BinaryenExpressionRef>, numOperands: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenTupleMakeGetNumOperands(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenTupleMakeGetOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenTupleMakeSetOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex, operandExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenTupleMakeAppendOperand(expr: BinaryenExpressionRef, operandExpr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenTupleMakeInsertOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex, operandExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenTupleMakeRemoveOperandAt(expr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-
-export declare function _BinaryenTupleExtract(module: BinaryenModuleRef, tupleExpr: BinaryenExpressionRef, index: BinaryenIndex): BinaryenExpressionRef;
-export declare function _BinaryenTupleExtractGetTuple(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenTupleExtractSetTuple(expr: BinaryenExpressionRef, tupleExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenTupleExtractGetIndex(expr: BinaryenExpressionRef): BinaryenIndex;
-export declare function _BinaryenTupleExtractSetIndex(expr: BinaryenExpressionRef, index: BinaryenIndex): void;
-
-export declare function _BinaryenPop(module: BinaryenModuleRef, type: BinaryenType): BinaryenExpressionRef;
-
-export declare function _BinaryenI31New(module: BinaryenModuleRef, value: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenI31NewGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenI31NewSetValue(expr: BinaryenExpressionRef, valueExpr: BinaryenExpressionRef): void;
-
-export declare function _BinaryenI31Get(module: BinaryenModuleRef, i31Expr: BinaryenExpressionRef, signed: bool): BinaryenExpressionRef;
-export declare function _BinaryenI31GetGetI31(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenI31GetSetI31(expr: BinaryenExpressionRef, i31Expr: BinaryenExpressionRef): void;
-export declare function _BinaryenI31GetIsSigned(expr: BinaryenExpressionRef): bool;
-export declare function _BinaryenI31GetSetSigned(expr: BinaryenExpressionRef, signed: bool): void;
-
-type BinaryenFunctionRef = usize;
-
-export declare function _BinaryenAddFunction(module: BinaryenModuleRef, name: BinaryenString, params: BinaryenType, results: BinaryenType, varTypes: BinaryenArray<BinaryenType>, numVarTypes: BinaryenIndex, body: BinaryenExpressionRef): BinaryenFunctionRef;
-export declare function _BinaryenGetFunction(module: BinaryenModuleRef, name: BinaryenString): BinaryenFunctionRef;
-export declare function _BinaryenRemoveFunction(module: BinaryenModuleRef, name: BinaryenString): void;
-export declare function _BinaryenGetNumFunctions(module: BinaryenModuleRef): BinaryenIndex;
-export declare function _BinaryenGetFunctionByIndex(module: BinaryenModuleRef, index: BinaryenIndex): BinaryenFunctionRef;
-
-export declare function _BinaryenFunctionGetName(func: BinaryenFunctionRef): BinaryenString;
-export declare function _BinaryenFunctionGetParams(func: BinaryenFunctionRef): BinaryenType;
-export declare function _BinaryenFunctionGetResults(func: BinaryenFunctionRef): BinaryenType;
-export declare function _BinaryenFunctionGetNumVars(func: BinaryenFunctionRef): BinaryenIndex;
-export declare function _BinaryenFunctionGetVar(func: BinaryenFunctionRef, index: BinaryenIndex): BinaryenType;
-export declare function _BinaryenFunctionGetNumLocals(func: BinaryenFunctionRef): BinaryenIndex;
-export declare function _BinaryenFunctionHasLocalName(func: BinaryenFunctionRef, index: BinaryenIndex): bool;
-export declare function _BinaryenFunctionGetLocalName(func: BinaryenFunctionRef, index: BinaryenIndex): BinaryenString;
-export declare function _BinaryenFunctionSetLocalName(func: BinaryenFunctionRef, index: BinaryenIndex, name: BinaryenString): void;
-export declare function _BinaryenFunctionGetBody(func: BinaryenFunctionRef): BinaryenExpressionRef;
-export declare function _BinaryenFunctionSetBody(func: BinaryenFunctionRef, bodyExpr: BinaryenExpressionRef): void;
-export declare function _BinaryenFunctionOptimize(func: BinaryenFunctionRef, module: BinaryenModuleRef): void;
-export declare function _BinaryenFunctionRunPasses(func: BinaryenFunctionRef, module: BinaryenModuleRef, passes: BinaryenArray<BinaryenString>, numPasses: BinaryenIndex): void;
-export declare function _BinaryenFunctionSetDebugLocation(func: BinaryenFunctionRef, expr: BinaryenExpressionRef, fileIndex: BinaryenIndex, lineNumber: BinaryenIndex, columnNumber: BinaryenIndex): void;
-
-type BinaryenImportRef = usize;
-
-export declare function _BinaryenAddFunctionImport(module: BinaryenModuleRef, internalName: BinaryenString, externalModuleName: BinaryenString, externalBaseName: BinaryenString, params: BinaryenType, results: BinaryenType): void;
-export declare function _BinaryenAddTableImport(module: BinaryenModuleRef, internalName: BinaryenString, externalModuleName: BinaryenString, externalBaseName: BinaryenString): void;
-export declare function _BinaryenAddMemoryImport(module: BinaryenModuleRef, internalName: BinaryenString, externalModuleName: BinaryenString, externalBaseName: BinaryenString, shared:bool): void;
-export declare function _BinaryenAddGlobalImport(module: BinaryenModuleRef, internalName: BinaryenString, externalModuleName: BinaryenString, externalBaseName: BinaryenString, globalType: BinaryenType, mutable: bool): void;
-export declare function _BinaryenAddEventImport(module: BinaryenModuleRef, internalName: BinaryenString, externalModuleName: BinaryenString, externalBaseName: BinaryenString, attribute: u32, params: BinaryenType, results: BinaryenType): void;
-
-type BinaryenExportRef = usize;
-type BinaryenExternalKind = u32;
-
-export declare function _BinaryenAddFunctionExport(module: BinaryenModuleRef, internalName: BinaryenString, externalName: BinaryenString): BinaryenExportRef;
-export declare function _BinaryenAddTableExport(module: BinaryenModuleRef, internalName: BinaryenString, externalName: BinaryenString): BinaryenExportRef;
-export declare function _BinaryenAddMemoryExport(module: BinaryenModuleRef, internalName: BinaryenString, externalName: BinaryenString): BinaryenExportRef;
-export declare function _BinaryenAddGlobalExport(module: BinaryenModuleRef, internalName: BinaryenString, externalName: BinaryenString): BinaryenExportRef;
-export declare function _BinaryenAddEventExport(module: BinaryenModuleRef, internalName: BinaryenString, externalName: BinaryenString): BinaryenExportRef;
-export declare function _BinaryenGetExport(module: BinaryenModuleRef, externalName: BinaryenString): BinaryenExportRef;
-export declare function _BinaryenRemoveExport(module: BinaryenModuleRef, externalName: BinaryenString): void;
-export declare function _BinaryenGetNumExports(module: BinaryenModuleRef): BinaryenIndex;
-export declare function _BinaryenGetExportByIndex(module: BinaryenModuleRef, index: BinaryenIndex): BinaryenExportRef;
-export declare function _BinaryenExportGetKind(ref: BinaryenExportRef): BinaryenExternalKind;
-export declare function _BinaryenExportGetName(ref: BinaryenExportRef): BinaryenString;
-export declare function _BinaryenExportGetValue(ref: BinaryenExportRef): BinaryenString;
-
-type BinaryenGlobalRef = usize;
-
-export declare function _BinaryenAddGlobal(module: BinaryenModuleRef, name: BinaryenString, type: BinaryenType, mutable: bool, init: BinaryenExpressionRef): BinaryenGlobalRef;
-export declare function _BinaryenGetGlobal(module: BinaryenModuleRef, name: BinaryenString): BinaryenGlobalRef;
-export declare function _BinaryenRemoveGlobal(module: BinaryenModuleRef, name: BinaryenString): void;
-export declare function _BinaryenGetNumGlobals(module: BinaryenModuleRef): BinaryenIndex;
-export declare function _BinaryenGetGlobalByIndex(module: BinaryenModuleRef, index: BinaryenIndex): BinaryenGlobalRef;
-
-export declare function _BinaryenGlobalGetName(global: BinaryenGlobalRef): BinaryenString;
-export declare function _BinaryenGlobalGetType(global: BinaryenGlobalRef): BinaryenType;
-export declare function _BinaryenGlobalIsMutable(global: BinaryenGlobalRef): bool;
-export declare function _BinaryenGlobalGetInitExpr(global: BinaryenGlobalRef): BinaryenExpressionRef;
-
-type BinaryenEventRef = usize;
-
-export declare function _BinaryenAddEvent(module: BinaryenModuleRef, name: BinaryenString, attribute: u32, params: BinaryenType, results: BinaryenType): BinaryenEventRef;
-export declare function _BinaryenGetEvent(module: BinaryenModuleRef, name: BinaryenString): BinaryenEventRef;
-export declare function _BinaryenRemoveEvent(module: BinaryenModuleRef, name: BinaryenString): void;
-
-export declare function _BinaryenEventGetName(event: BinaryenEventRef): BinaryenString;
-export declare function _BinaryenEventGetAttribute(event: BinaryenEventRef): u32;
-export declare function _BinaryenEventGetParams(event: BinaryenEventRef): BinaryenType;
-export declare function _BinaryenEventGetResults(event: BinaryenEventRef): BinaryenType;
-
-type BinaryenTableRef = usize;
-
-export declare function _BinaryenAddTable(module: BinaryenModuleRef, name: BinaryenString, initial: BinaryenIndex, maximum: BinaryenIndex): BinaryenTableRef;
-export declare function _BinaryenRemoveTable(module: BinaryenModuleRef, table: BinaryenString): void;
-export declare function _BinaryenGetNumTables(module: BinaryenModuleRef): BinaryenIndex;
-export declare function _BinaryenGetTable(module: BinaryenModuleRef, name: BinaryenString): BinaryenTableRef;
-export declare function _BinaryenGetTableByIndex(module: BinaryenModuleRef, index: BinaryenIndex): BinaryenTableRef;
-
-export declare function _BinaryenTableGetName(table: BinaryenTableRef): BinaryenString;
-export declare function _BinaryenTableSetName(table: BinaryenTableRef, name: BinaryenString): void;
-export declare function _BinaryenTableGetInitial(table: BinaryenTableRef): BinaryenIndex;
-export declare function _BinaryenTableSetInitial(table: BinaryenTableRef, initial: BinaryenIndex): void;
-export declare function _BinaryenTableHasMax(table: BinaryenTableRef): bool;
-export declare function _BinaryenTableGetMax(table: BinaryenTableRef): BinaryenIndex;
-export declare function _BinaryenTableSetMax(table: BinaryenTableRef, max: BinaryenIndex): void;
-
-type BinaryenElementSegmentRef = usize;
-
-export declare function _BinaryenAddActiveElementSegment(module: BinaryenModuleRef, table: BinaryenString, name: BinaryenString, funcNames: BinaryenArray<BinaryenString>, numFuncNames: BinaryenIndex, offset: BinaryenExpressionRef): BinaryenElementSegmentRef;
-export declare function _BinaryenAddPassiveElementSegment(module: BinaryenModuleRef, name: BinaryenString, funcNames: BinaryenArray<BinaryenString>, numFuncNames: BinaryenIndex): BinaryenElementSegmentRef;
-export declare function _BinaryenRemoveElementSegment(module: BinaryenModuleRef, name: BinaryenString): void;
-export declare function _BinaryenGetNumElementSegments(module: BinaryenModuleRef, name: BinaryenString): BinaryenIndex;
-export declare function _BinaryenGetElementSegment(module: BinaryenModuleRef, name: BinaryenString): BinaryenElementSegmentRef;
-export declare function _BinaryenGetElementSegmentByIndex(module: BinaryenModuleRef, index: BinaryenIndex): BinaryenElementSegmentRef;
-
-export declare function _BinaryenSetMemory(module: BinaryenModuleRef, initial: BinaryenIndex, maximum: BinaryenIndex, exportName: BinaryenString, segments: BinaryenArray<BinaryenArray<u8>>, segmentPassive: BinaryenArray<bool>, segmentOffsets: BinaryenArray<usize>, segmentSizes: BinaryenArray<u32>, numSegments: BinaryenIndex, shared: bool): void;
-export declare function _BinaryenGetNumMemorySegments(module: BinaryenModuleRef): BinaryenIndex;
-export declare function _BinaryenGetMemorySegmentByteOffset(module: BinaryenModuleRef, index: BinaryenIndex): u32;
-export declare function _BinaryenGetMemorySegmentByteLength(module: BinaryenModuleRef, id: BinaryenIndex): usize;
-export declare function _BinaryenCopyMemorySegmentData(module: BinaryenModuleRef, id: BinaryenIndex, buffer: BinaryenArray<u8>): void;
-
-export declare function _BinaryenSetStart(module: BinaryenModuleRef, start: BinaryenFunctionRef): void;
-
-export declare function _BinaryenModuleParse(text: BinaryenString): BinaryenModuleRef;
-export declare function _BinaryenModulePrint(module: BinaryenModuleRef): void;
-export declare function _BinaryenModulePrintAsmjs(module: BinaryenModuleRef): void;
-export declare function _BinaryenModuleValidate(module: BinaryenModuleRef): i32;
-export declare function _BinaryenModuleOptimize(module: BinaryenModuleRef): void;
-export declare function _BinaryenModuleRunPasses(module: BinaryenModuleRef, passes: BinaryenArray<BinaryenString>, numPasses: BinaryenIndex): void;
-export declare function _BinaryenModuleAutoDrop(module: BinaryenModuleRef): void;
-export declare function _BinaryenModuleAllocateAndWrite(out: BinaryenArray<u8>, module: BinaryenModuleRef, sourceMapUrl: BinaryenString): void;
-export declare function _BinaryenModuleRead(input: BinaryenArray<u8>, inputSize: usize): BinaryenModuleRef;
-export declare function _BinaryenModuleInterpret(module: BinaryenModuleRef): void;
-export declare function _BinaryenModuleAddDebugInfoFileName(module: BinaryenModuleRef, filename: BinaryenString): BinaryenIndex;
-export declare function _BinaryenModuleGetDebugInfoFileName(module: BinaryenModuleRef, index: BinaryenIndex): BinaryenString;
-export declare function _BinaryenModuleGetFeatures(module: BinaryenModuleRef): BinaryenFeatureFlags;
-export declare function _BinaryenModuleSetFeatures(module: BinaryenModuleRef, featureFlags: BinaryenFeatureFlags): void;
-
-export declare function _BinaryenAddCustomSection(module: BinaryenModuleRef, name: BinaryenString, contents: BinaryenArray<u8>, contentsSize: BinaryenIndex): void;
-
-type BinaryenSideEffects = u32;
-
-export declare function _BinaryenSideEffectNone(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectBranches(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectCalls(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectReadsLocal(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectWritesLocal(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectReadsGlobal(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectWritesGlobal(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectReadsMemory(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectWritesMemory(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectImplicitTrap(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectIsAtomic(): BinaryenSideEffects;
-export declare function _BinaryenSideEffectAny(): BinaryenSideEffects;
-
-export declare function _BinaryenExpressionGetSideEffects(expr: BinaryenExpressionRef, features: BinaryenFeatureFlags): BinaryenSideEffects;
-
-type BinaryenRelooperRef = usize;
-type BinaryenRelooperBlockRef = usize;
-
-export declare function _RelooperCreate(module: BinaryenModuleRef): BinaryenRelooperRef;
-export declare function _RelooperAddBlock(relooper: BinaryenRelooperRef, code: BinaryenExpressionRef): BinaryenRelooperBlockRef;
-export declare function _RelooperAddBranch(from: BinaryenRelooperBlockRef, to: BinaryenRelooperBlockRef, condition: BinaryenExpressionRef, code: BinaryenExpressionRef): void;
-export declare function _RelooperAddBlockWithSwitch(relooper: BinaryenRelooperRef, code: BinaryenExpressionRef, condition: BinaryenExpressionRef): BinaryenRelooperBlockRef;
-export declare function _RelooperAddBranchForSwitch(from: BinaryenRelooperBlockRef, to: BinaryenRelooperBlockRef, indexes: BinaryenArray<BinaryenIndex>, numIndexes: BinaryenIndex, code: BinaryenExpressionRef): void;
-export declare function _RelooperRenderAndDispose(relooper: BinaryenRelooperRef, entry: BinaryenRelooperBlockRef, labelHelper: BinaryenIndex): BinaryenExpressionRef;
-
-type BinaryenExpressionRunnerRef = usize;
-type BinaryenExpressionRunnerFlags = u32;
-
-export declare function _ExpressionRunnerFlagsDefault(): BinaryenExpressionRunnerFlags;
-export declare function _ExpressionRunnerFlagsPreserveSideeffects(): BinaryenExpressionRunnerFlags;
-export declare function _ExpressionRunnerFlagsTraverseCalls(): BinaryenExpressionRunnerFlags;
-export declare function _ExpressionRunnerCreate(module: BinaryenModuleRef, flags: BinaryenExpressionRunnerFlags, maxDepth: BinaryenIndex, maxLoopIterations: BinaryenIndex): BinaryenExpressionRunnerRef;
-export declare function _ExpressionRunnerSetLocalValue(runner: BinaryenExpressionRunnerRef, index: BinaryenIndex, value: BinaryenExpressionRef): bool;
-export declare function _ExpressionRunnerSetGlobalValue(runner: BinaryenExpressionRunnerRef, name: BinaryenString, value: BinaryenExpressionRef): bool;
-export declare function _ExpressionRunnerRunAndDispose(runner: BinaryenExpressionRunnerRef, expr: BinaryenExpressionRef): BinaryenExpressionRef;
-
-export declare function _BinaryenGetOptimizeLevel(): i32;
-export declare function _BinaryenSetOptimizeLevel(level: i32): void;
-export declare function _BinaryenGetShrinkLevel(): i32;
-export declare function _BinaryenSetShrinkLevel(level: i32): void;
-export declare function _BinaryenGetDebugInfo(): bool;
-export declare function _BinaryenSetDebugInfo(on: bool): void;
-export declare function _BinaryenGetLowMemoryUnused(): bool;
-export declare function _BinaryenSetLowMemoryUnused(on: bool): void;
-export declare function _BinaryenGetFastMath(): bool;
-export declare function _BinaryenSetFastMath(on: bool): void;
-export declare function _BinaryenGetPassArgument(key: BinaryenString): BinaryenString;
-export declare function _BinaryenSetPassArgument(key: BinaryenString, value: BinaryenString): void;
-export declare function _BinaryenClearPassArguments(): void;
-export declare function _BinaryenGetAlwaysInlineMaxSize(): BinaryenIndex;
-export declare function _BinaryenSetAlwaysInlineMaxSize(size: BinaryenIndex): void;
-export declare function _BinaryenGetFlexibleInlineMaxSize(): BinaryenIndex;
-export declare function _BinaryenSetFlexibleInlineMaxSize(size: BinaryenIndex): void;
-export declare function _BinaryenGetOneCallerInlineMaxSize(): BinaryenIndex;
-export declare function _BinaryenSetOneCallerInlineMaxSize(size: BinaryenIndex): void;
-export declare function _BinaryenGetAllowInliningFunctionsWithLoops(): bool;
-export declare function _BinaryenSetAllowInliningFunctionsWithLoops(enabled: bool): void;

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -8,54 +8,55 @@
  * @license Apache-2.0
  */
 
-export type StringRef = usize;
-export type ArrayRef<T> = usize;
 export type Index = u32;
-export type FeatureFlags = u32;
-export type Type = usize;
 export type ExpressionId = i32;
-export type ModuleRef = usize;
-export type Literal = usize;
+export type FeatureFlags = u32;
 export type Op = i32;
-export type ExpressionRef = usize;
-export type FunctionRef = usize;
-export type ImportRef = usize;
-export type ExportRef = usize;
 export type ExternalKind = u32;
-export type GlobalRef = usize;
-export type EventRef = usize;
-export type TableRef = usize;
-export type ElementSegmentRef = usize;
 export type SideEffects = u32;
-export type RelooperRef = usize;
-export type RelooperBlockRef = usize;
-export type ExpressionRunnerRef = usize;
 export type ExpressionRunnerFlags = u32;
+type Ref = usize;
+export type StringRef = Ref;
+export type ArrayRef<T> = Ref;
+export type TypeRef = Ref;
+export type ModuleRef = Ref;
+export type LiteralRef = Ref;
+export type ExpressionRef = Ref;
+export type FunctionRef = Ref;
+export type ImportRef = Ref;
+export type ExportRef = Ref;
+export type GlobalRef = Ref;
+export type EventRef = Ref;
+export type TableRef = Ref;
+export type ElementSegmentRef = Ref;
+export type RelooperRef = Ref;
+export type RelooperBlockRef = Ref;
+export type ExpressionRunnerRef = Ref;
 
-export declare function _BinaryenTypeCreate(types: ArrayRef<Type>, numTypes: u32): Type;
-export declare function _BinaryenTypeArity(type: Type): u32;
-export declare function _BinaryenTypeExpand(type: Type, typesOut: ArrayRef<Type>): void;
+export declare function _BinaryenTypeCreate(types: ArrayRef<TypeRef>, numTypes: u32): TypeRef;
+export declare function _BinaryenTypeArity(type: TypeRef): u32;
+export declare function _BinaryenTypeExpand(type: TypeRef, typesOut: ArrayRef<TypeRef>): void;
 
 export declare function _BinaryenModuleCreate(): ModuleRef;
 export declare function _BinaryenModuleDispose(module: ModuleRef): void;
 
 export declare function _BinaryenSizeofLiteral(): usize;
-export declare function _BinaryenLiteralInt32(literalOut: Literal, x: i32): void;
-export declare function _BinaryenLiteralInt64(literalOut: Literal, x: i32, y: i32): void;
-export declare function _BinaryenLiteralFloat32(literalOut: Literal, x: f32): void;
-export declare function _BinaryenLiteralFloat64(literalOut: Literal, x: f64): void;
-export declare function _BinaryenLiteralVec128(literalOut: Literal, x: ArrayRef<u8>): void;
-export declare function _BinaryenLiteralFloat32Bits(literalOut: Literal, x: i32): void;
-export declare function _BinaryenLiteralFloat64Bits(literalOut: Literal, x: i32, y: i32): void;
+export declare function _BinaryenLiteralInt32(literalOut: LiteralRef, x: i32): void;
+export declare function _BinaryenLiteralInt64(literalOut: LiteralRef, x: i32, y: i32): void;
+export declare function _BinaryenLiteralFloat32(literalOut: LiteralRef, x: f32): void;
+export declare function _BinaryenLiteralFloat64(literalOut: LiteralRef, x: f64): void;
+export declare function _BinaryenLiteralVec128(literalOut: LiteralRef, x: ArrayRef<u8>): void;
+export declare function _BinaryenLiteralFloat32Bits(literalOut: LiteralRef, x: i32): void;
+export declare function _BinaryenLiteralFloat64Bits(literalOut: LiteralRef, x: i32, y: i32): void;
 
 export declare function _BinaryenExpressionGetId(expr: ExpressionRef): ExpressionId;
-export declare function _BinaryenExpressionGetType(expr: ExpressionRef): Type;
-export declare function _BinaryenExpressionSetType(expr: ExpressionRef, type: Type): void;
+export declare function _BinaryenExpressionGetType(expr: ExpressionRef): TypeRef;
+export declare function _BinaryenExpressionSetType(expr: ExpressionRef, type: TypeRef): void;
 export declare function _BinaryenExpressionPrint(expr: ExpressionRef): void;
 export declare function _BinaryenExpressionCopy(expr: ExpressionRef, module: ModuleRef): ExpressionRef;
 export declare function _BinaryenExpressionFinalize(expr: ExpressionRef): void;
 
-export declare function _BinaryenBlock(module: ModuleRef, name: StringRef, childExprs: ArrayRef<ExpressionRef>, numChildren: Index, type: Type): ExpressionRef;
+export declare function _BinaryenBlock(module: ModuleRef, name: StringRef, childExprs: ArrayRef<ExpressionRef>, numChildren: Index, type: TypeRef): ExpressionRef;
 export declare function _BinaryenBlockGetName(expr: ExpressionRef): StringRef;
 export declare function _BinaryenBlockSetName(expr: ExpressionRef, name: StringRef): void;
 export declare function _BinaryenBlockGetNumChildren(expr: ExpressionRef): Index;
@@ -101,7 +102,7 @@ export declare function _BinaryenSwitchSetCondition(expr: ExpressionRef, conditi
 export declare function _BinaryenSwitchGetValue(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenSwitchSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
 
-export declare function _BinaryenCall(module: ModuleRef, targetName: StringRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, returnType: Type): ExpressionRef;
+export declare function _BinaryenCall(module: ModuleRef, targetName: StringRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, returnType: TypeRef): ExpressionRef;
 export declare function _BinaryenCallGetTarget(expr: ExpressionRef): StringRef;
 export declare function _BinaryenCallSetTarget(expr: ExpressionRef, targetName: StringRef): void;
 export declare function _BinaryenCallGetNumOperands(expr: ExpressionRef): Index;
@@ -113,9 +114,9 @@ export declare function _BinaryenCallRemoveOperandAt(expr: ExpressionRef, index:
 export declare function _BinaryenCallIsReturn(expr: ExpressionRef): bool;
 export declare function _BinaryenCallSetReturn(expr: ExpressionRef, isReturn: bool): void;
 // ^ with return = true
-export declare function _BinaryenReturnCall(module: ModuleRef, targetName: StringRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, returnType: Type): ExpressionRef;
+export declare function _BinaryenReturnCall(module: ModuleRef, targetName: StringRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, returnType: TypeRef): ExpressionRef;
 
-export declare function _BinaryenCallIndirect(module: ModuleRef, table: StringRef, targetExpr: ExpressionRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, params: Type, results: Type): ExpressionRef;
+export declare function _BinaryenCallIndirect(module: ModuleRef, table: StringRef, targetExpr: ExpressionRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, params: TypeRef, results: TypeRef): ExpressionRef;
 export declare function _BinaryenCallIndirectGetTable(expr: ExpressionRef): StringRef;
 export declare function _BinaryenCallIndirectSetTable(expr: ExpressionRef, table: StringRef): void;
 export declare function _BinaryenCallIndirectGetTarget(expr: ExpressionRef): ExpressionRef;
@@ -129,9 +130,9 @@ export declare function _BinaryenCallIndirectRemoveOperandAt(expr: ExpressionRef
 export declare function _BinaryenCallIndirectIsReturn(expr: ExpressionRef): bool;
 export declare function _BinaryenCallIndirectSetReturn(expr: ExpressionRef, isReturn: bool): void;
 // ^ with return = true
-export declare function _BinaryenReturnCallIndirect(module: ModuleRef, table: StringRef, targetExpr: ExpressionRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, params: Type, results: Type): ExpressionRef;
+export declare function _BinaryenReturnCallIndirect(module: ModuleRef, table: StringRef, targetExpr: ExpressionRef, operandExprs: ArrayRef<ExpressionRef>, numOperands: Index, params: TypeRef, results: TypeRef): ExpressionRef;
 
-export declare function _BinaryenLocalGet(module: ModuleRef, index: Index, type: Type): ExpressionRef;
+export declare function _BinaryenLocalGet(module: ModuleRef, index: Index, type: TypeRef): ExpressionRef;
 export declare function _BinaryenLocalGetGetIndex(expr: ExpressionRef): Index;
 export declare function _BinaryenLocalGetSetIndex(expr: ExpressionRef, index: Index): void;
 
@@ -142,9 +143,9 @@ export declare function _BinaryenLocalSetSetIndex(expr: ExpressionRef, index: In
 export declare function _BinaryenLocalSetGetValue(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenLocalSetSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
 // ^ with type != none
-export declare function _BinaryenLocalTee(module: ModuleRef, index: Index, valueExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenLocalTee(module: ModuleRef, index: Index, valueExpr: ExpressionRef, type: TypeRef): ExpressionRef;
 
-export declare function _BinaryenGlobalGet(module: ModuleRef, name: StringRef, type: Type): ExpressionRef;
+export declare function _BinaryenGlobalGet(module: ModuleRef, name: StringRef, type: TypeRef): ExpressionRef;
 export declare function _BinaryenGlobalGetGetName(expr: ExpressionRef): StringRef;
 export declare function _BinaryenGlobalGetSetName(expr: ExpressionRef, name: StringRef): void;
 
@@ -160,7 +161,7 @@ export declare function _BinaryenMemoryGrow(module: ModuleRef, delta: Expression
 export declare function _BinaryenMemoryGrowGetDelta(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenMemoryGrowSetDelta(expr: ExpressionRef, delta: ExpressionRef): void;
 
-export declare function _BinaryenLoad(module: ModuleRef, bytes: u32, signed: bool, offset: u32, align: u32, type: Type, ptrExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenLoad(module: ModuleRef, bytes: u32, signed: bool, offset: u32, align: u32, type: TypeRef, ptrExpr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenLoadIsAtomic(expr: ExpressionRef): bool;
 export declare function _BinaryenLoadSetAtomic(expr: ExpressionRef, isAtomic: bool): void;
 export declare function _BinaryenLoadIsSigned(expr: ExpressionRef): bool;
@@ -174,9 +175,9 @@ export declare function _BinaryenLoadSetAlign(expr: ExpressionRef, align: u32): 
 export declare function _BinaryenLoadGetPtr(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenLoadSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
 // ^ with atomic = true
-export declare function _BinaryenAtomicLoad(module: ModuleRef, bytes: Index, offset: Index, type: Type, ptrExpr: ExpressionRef): ExpressionRef;
+export declare function _BinaryenAtomicLoad(module: ModuleRef, bytes: Index, offset: Index, type: TypeRef, ptrExpr: ExpressionRef): ExpressionRef;
 
-export declare function _BinaryenStore(module: ModuleRef, bytes: u32, offset: u32, align: u32, ptrExpr: ExpressionRef, valueExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenStore(module: ModuleRef, bytes: u32, offset: u32, align: u32, ptrExpr: ExpressionRef, valueExpr: ExpressionRef, type: TypeRef): ExpressionRef;
 export declare function _BinaryenStoreIsAtomic(expr: ExpressionRef): bool;
 export declare function _BinaryenStoreSetAtomic(expr: ExpressionRef, isAtomic: bool): void;
 export declare function _BinaryenStoreGetBytes(expr: ExpressionRef): u32;
@@ -189,12 +190,12 @@ export declare function _BinaryenStoreGetPtr(expr: ExpressionRef): ExpressionRef
 export declare function _BinaryenStoreSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
 export declare function _BinaryenStoreGetValue(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenStoreSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
-export declare function _BinaryenStoreGetValueType(expr: ExpressionRef): Type;
-export declare function _BinaryenStoreSetValueType(expr: ExpressionRef, valueType: Type): void;
+export declare function _BinaryenStoreGetValueType(expr: ExpressionRef): TypeRef;
+export declare function _BinaryenStoreSetValueType(expr: ExpressionRef, valueType: TypeRef): void;
 // ^ with atomic = true
-export declare function _BinaryenAtomicStore(module: ModuleRef, bytes: Index, offset: Index, ptrExpr: ExpressionRef, valueExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenAtomicStore(module: ModuleRef, bytes: Index, offset: Index, ptrExpr: ExpressionRef, valueExpr: ExpressionRef, type: TypeRef): ExpressionRef;
 
-export declare function _BinaryenConst(module: ModuleRef, value: Literal): ExpressionRef;
+export declare function _BinaryenConst(module: ModuleRef, value: LiteralRef): ExpressionRef;
 export declare function _BinaryenConstGetValueI32(expr: ExpressionRef): i32;
 export declare function _BinaryenConstSetValueI32(expr: ExpressionRef, value: i32): void;
 export declare function _BinaryenConstGetValueI64Low(expr: ExpressionRef): i32;
@@ -222,7 +223,7 @@ export declare function _BinaryenBinarySetLeft(expr: ExpressionRef, leftExpr: Ex
 export declare function _BinaryenBinaryGetRight(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenBinarySetRight(expr: ExpressionRef, rightExpr: ExpressionRef): void;
 
-export declare function _BinaryenSelect(module: ModuleRef, conditionExpr: ExpressionRef, ifTrueExpr: ExpressionRef, ifFalseExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenSelect(module: ModuleRef, conditionExpr: ExpressionRef, ifTrueExpr: ExpressionRef, ifFalseExpr: ExpressionRef, type: TypeRef): ExpressionRef;
 export declare function _BinaryenSelectGetIfTrue(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenSelectSetIfTrue(expr: ExpressionRef, ifTrueExpr: ExpressionRef): void;
 export declare function _BinaryenSelectGetIfFalse(expr: ExpressionRef): ExpressionRef;
@@ -242,7 +243,7 @@ export declare function _BinaryenNop(module: ModuleRef): ExpressionRef;
 
 export declare function _BinaryenUnreachable(module: ModuleRef): ExpressionRef;
 
-export declare function _BinaryenAtomicRMW(module: ModuleRef, op: Op, bytes: u32, offset: u32, ptrExpr: ExpressionRef, valueExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenAtomicRMW(module: ModuleRef, op: Op, bytes: u32, offset: u32, ptrExpr: ExpressionRef, valueExpr: ExpressionRef, type: TypeRef): ExpressionRef;
 export declare function _BinaryenAtomicRMWGetOp(expr: ExpressionRef): Op;
 export declare function _BinaryenAtomicRMWSetOp(expr: ExpressionRef, op: Op): void;
 export declare function _BinaryenAtomicRMWGetBytes(expr: ExpressionRef): u32;
@@ -254,7 +255,7 @@ export declare function _BinaryenAtomicRMWSetPtr(expr: ExpressionRef, ptrExpr: E
 export declare function _BinaryenAtomicRMWGetValue(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenAtomicRMWSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
 
-export declare function _BinaryenAtomicCmpxchg(module: ModuleRef, bytes: u32, offset: u32, ptrExpr: ExpressionRef, expectedExpr: ExpressionRef, replacementExpr: ExpressionRef, type: Type): ExpressionRef;
+export declare function _BinaryenAtomicCmpxchg(module: ModuleRef, bytes: u32, offset: u32, ptrExpr: ExpressionRef, expectedExpr: ExpressionRef, replacementExpr: ExpressionRef, type: TypeRef): ExpressionRef;
 export declare function _BinaryenAtomicCmpxchgGetBytes(expr: ExpressionRef): u32;
 export declare function _BinaryenAtomicCmpxchgSetBytes(expr: ExpressionRef, bytes: u32): void;
 export declare function _BinaryenAtomicCmpxchgGetOffset(expr: ExpressionRef): u32;
@@ -266,15 +267,15 @@ export declare function _BinaryenAtomicCmpxchgSetExpected(expr: ExpressionRef, e
 export declare function _BinaryenAtomicCmpxchgGetReplacement(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenAtomicCmpxchgSetReplacement(expr: ExpressionRef, replacementExpr: ExpressionRef): void;
 
-export declare function _BinaryenAtomicWait(module: ModuleRef, ptrExpr: ExpressionRef, expectedExpr: ExpressionRef, timeoutExpr: ExpressionRef, expectedType: Type): ExpressionRef;
+export declare function _BinaryenAtomicWait(module: ModuleRef, ptrExpr: ExpressionRef, expectedExpr: ExpressionRef, timeoutExpr: ExpressionRef, expectedType: TypeRef): ExpressionRef;
 export declare function _BinaryenAtomicWaitGetPtr(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenAtomicWaitSetPtr(expr: ExpressionRef, ptrExpr: ExpressionRef): void;
 export declare function _BinaryenAtomicWaitGetExpected(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenAtomicWaitSetExpected(expr: ExpressionRef, expectedExpr: ExpressionRef): void;
 export declare function _BinaryenAtomicWaitGetTimeout(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenAtomicWaitSetTimeout(expr: ExpressionRef, timeoutExpr: ExpressionRef): void;
-export declare function _BinaryenAtomicWaitGetExpectedType(expr: ExpressionRef): Type;
-export declare function _BinaryenAtomicWaitSetExpectedType(expr: ExpressionRef, expectedType: Type): void;
+export declare function _BinaryenAtomicWaitGetExpectedType(expr: ExpressionRef): TypeRef;
+export declare function _BinaryenAtomicWaitSetExpectedType(expr: ExpressionRef, expectedType: TypeRef): void;
 
 export declare function _BinaryenAtomicNotify(module: ModuleRef, ptrExpr: ExpressionRef, notifyCountExpr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenAtomicNotifyGetPtr(expr: ExpressionRef): ExpressionRef;
@@ -385,7 +386,7 @@ export declare function _BinaryenMemoryFillSetValue(expr: ExpressionRef, valueEx
 export declare function _BinaryenMemoryFillGetSize(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenMemoryFillSetSize(expr: ExpressionRef, sizeExpr: ExpressionRef): void;
 
-export declare function _BinaryenRefNull(module: ModuleRef, type: Type): ExpressionRef;
+export declare function _BinaryenRefNull(module: ModuleRef, type: TypeRef): ExpressionRef;
 
 export declare function _BinaryenRefIs(module: ModuleRef, op: Op, valueExpr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenRefIsGetOp(expr: ExpressionRef): Op;
@@ -399,7 +400,7 @@ export declare function _BinaryenRefAsSetOp(expr: ExpressionRef, op: Op): void;
 export declare function _BinaryenRefAsGetValue(expr: ExpressionRef): ExpressionRef;
 export declare function _BinaryenRefAsSetValue(expr: ExpressionRef, valueExpr: ExpressionRef): void;
 
-export declare function _BinaryenRefFunc(module: ModuleRef, funcName: StringRef, type: Type): ExpressionRef;
+export declare function _BinaryenRefFunc(module: ModuleRef, funcName: StringRef, type: TypeRef): ExpressionRef;
 export declare function _BinaryenRefFuncGetFunc(expr: ExpressionRef): StringRef;
 export declare function _BinaryenRefFuncSetFunc(expr: ExpressionRef, funcName: StringRef): void;
 
@@ -459,7 +460,7 @@ export declare function _BinaryenTupleExtractSetTuple(expr: ExpressionRef, tuple
 export declare function _BinaryenTupleExtractGetIndex(expr: ExpressionRef): Index;
 export declare function _BinaryenTupleExtractSetIndex(expr: ExpressionRef, index: Index): void;
 
-export declare function _BinaryenPop(module: ModuleRef, type: Type): ExpressionRef;
+export declare function _BinaryenPop(module: ModuleRef, type: TypeRef): ExpressionRef;
 
 export declare function _BinaryenI31New(module: ModuleRef, value: ExpressionRef): ExpressionRef;
 export declare function _BinaryenI31NewGetValue(expr: ExpressionRef): ExpressionRef;
@@ -471,17 +472,17 @@ export declare function _BinaryenI31GetSetI31(expr: ExpressionRef, i31Expr: Expr
 export declare function _BinaryenI31GetIsSigned(expr: ExpressionRef): bool;
 export declare function _BinaryenI31GetSetSigned(expr: ExpressionRef, signed: bool): void;
 
-export declare function _BinaryenAddFunction(module: ModuleRef, name: StringRef, params: Type, results: Type, varTypes: ArrayRef<Type>, numVarTypes: Index, body: ExpressionRef): FunctionRef;
+export declare function _BinaryenAddFunction(module: ModuleRef, name: StringRef, params: TypeRef, results: TypeRef, varTypes: ArrayRef<TypeRef>, numVarTypes: Index, body: ExpressionRef): FunctionRef;
 export declare function _BinaryenGetFunction(module: ModuleRef, name: StringRef): FunctionRef;
 export declare function _BinaryenRemoveFunction(module: ModuleRef, name: StringRef): void;
 export declare function _BinaryenGetNumFunctions(module: ModuleRef): Index;
 export declare function _BinaryenGetFunctionByIndex(module: ModuleRef, index: Index): FunctionRef;
 
 export declare function _BinaryenFunctionGetName(func: FunctionRef): StringRef;
-export declare function _BinaryenFunctionGetParams(func: FunctionRef): Type;
-export declare function _BinaryenFunctionGetResults(func: FunctionRef): Type;
+export declare function _BinaryenFunctionGetParams(func: FunctionRef): TypeRef;
+export declare function _BinaryenFunctionGetResults(func: FunctionRef): TypeRef;
 export declare function _BinaryenFunctionGetNumVars(func: FunctionRef): Index;
-export declare function _BinaryenFunctionGetVar(func: FunctionRef, index: Index): Type;
+export declare function _BinaryenFunctionGetVar(func: FunctionRef, index: Index): TypeRef;
 export declare function _BinaryenFunctionGetNumLocals(func: FunctionRef): Index;
 export declare function _BinaryenFunctionHasLocalName(func: FunctionRef, index: Index): bool;
 export declare function _BinaryenFunctionGetLocalName(func: FunctionRef, index: Index): StringRef;
@@ -492,11 +493,11 @@ export declare function _BinaryenFunctionOptimize(func: FunctionRef, module: Mod
 export declare function _BinaryenFunctionRunPasses(func: FunctionRef, module: ModuleRef, passes: ArrayRef<StringRef>, numPasses: Index): void;
 export declare function _BinaryenFunctionSetDebugLocation(func: FunctionRef, expr: ExpressionRef, fileIndex: Index, lineNumber: Index, columnNumber: Index): void;
 
-export declare function _BinaryenAddFunctionImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, params: Type, results: Type): void;
+export declare function _BinaryenAddFunctionImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, params: TypeRef, results: TypeRef): void;
 export declare function _BinaryenAddTableImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef): void;
 export declare function _BinaryenAddMemoryImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, shared:bool): void;
-export declare function _BinaryenAddGlobalImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, globalType: Type, mutable: bool): void;
-export declare function _BinaryenAddEventImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, attribute: u32, params: Type, results: Type): void;
+export declare function _BinaryenAddGlobalImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, globalType: TypeRef, mutable: bool): void;
+export declare function _BinaryenAddEventImport(module: ModuleRef, internalName: StringRef, externalModuleName: StringRef, externalBaseName: StringRef, attribute: u32, params: TypeRef, results: TypeRef): void;
 
 export declare function _BinaryenAddFunctionExport(module: ModuleRef, internalName: StringRef, externalName: StringRef): ExportRef;
 export declare function _BinaryenAddTableExport(module: ModuleRef, internalName: StringRef, externalName: StringRef): ExportRef;
@@ -511,25 +512,25 @@ export declare function _BinaryenExportGetKind(ref: ExportRef): ExternalKind;
 export declare function _BinaryenExportGetName(ref: ExportRef): StringRef;
 export declare function _BinaryenExportGetValue(ref: ExportRef): StringRef;
 
-export declare function _BinaryenAddGlobal(module: ModuleRef, name: StringRef, type: Type, mutable: bool, init: ExpressionRef): GlobalRef;
+export declare function _BinaryenAddGlobal(module: ModuleRef, name: StringRef, type: TypeRef, mutable: bool, init: ExpressionRef): GlobalRef;
 export declare function _BinaryenGetGlobal(module: ModuleRef, name: StringRef): GlobalRef;
 export declare function _BinaryenRemoveGlobal(module: ModuleRef, name: StringRef): void;
 export declare function _BinaryenGetNumGlobals(module: ModuleRef): Index;
 export declare function _BinaryenGetGlobalByIndex(module: ModuleRef, index: Index): GlobalRef;
 
 export declare function _BinaryenGlobalGetName(global: GlobalRef): StringRef;
-export declare function _BinaryenGlobalGetType(global: GlobalRef): Type;
+export declare function _BinaryenGlobalGetType(global: GlobalRef): TypeRef;
 export declare function _BinaryenGlobalIsMutable(global: GlobalRef): bool;
 export declare function _BinaryenGlobalGetInitExpr(global: GlobalRef): ExpressionRef;
 
-export declare function _BinaryenAddEvent(module: ModuleRef, name: StringRef, attribute: u32, params: Type, results: Type): EventRef;
+export declare function _BinaryenAddEvent(module: ModuleRef, name: StringRef, attribute: u32, params: TypeRef, results: TypeRef): EventRef;
 export declare function _BinaryenGetEvent(module: ModuleRef, name: StringRef): EventRef;
 export declare function _BinaryenRemoveEvent(module: ModuleRef, name: StringRef): void;
 
 export declare function _BinaryenEventGetName(event: EventRef): StringRef;
 export declare function _BinaryenEventGetAttribute(event: EventRef): u32;
-export declare function _BinaryenEventGetParams(event: EventRef): Type;
-export declare function _BinaryenEventGetResults(event: EventRef): Type;
+export declare function _BinaryenEventGetParams(event: EventRef): TypeRef;
+export declare function _BinaryenEventGetResults(event: EventRef): TypeRef;
 
 export declare function _BinaryenAddTable(module: ModuleRef, name: StringRef, initial: Index, maximum: Index): TableRef;
 export declare function _BinaryenRemoveTable(module: ModuleRef, table: StringRef): void;

--- a/src/glue/tsconfig.json
+++ b/src/glue/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./wasm/**"
+  ]
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -12,17 +12,28 @@ import { BuiltinNames } from "./builtins";
 import { Target } from "./common";
 import * as binaryen from "./glue/binaryen";
 
-export type ModuleRef = usize;
-export type FunctionRef = usize;
-export type ExpressionRef = usize;
-export type GlobalRef = usize;
-export type EventRef = usize;
-export type ImportRef = usize;
-export type ExportRef = usize;
-export type RelooperRef = usize;
-export type RelooperBlockRef = usize;
-export type Index = u32;
-export type CString = usize;
+/** A Binaryen-compatible index. */
+export type Index = binaryen.Index;
+/** Reference to a Binaryen-compatible string. */
+export type StringRef = binaryen.StringRef;
+/** Reference to a Binaryen module. */
+export type ModuleRef = binaryen.ModuleRef;
+/** Reference to a Binaryen function. */
+export type FunctionRef = binaryen.FunctionRef;
+/** Reference to a Binaryen expression. */
+export type ExpressionRef = binaryen.ExpressionRef;
+/** Reference to a Binaryen global. */
+export type GlobalRef = binaryen.GlobalRef;
+/** Reference to a Binaryen event. */
+export type EventRef = binaryen.EventRef;
+/** Reference to a Binaryen import. */
+export type ImportRef = binaryen.ImportRef;
+/** Reference to a Binaryen export. */
+export type ExportRef = binaryen.ExportRef;
+/** Reference to a Binaryen relooper. */
+export type RelooperRef = binaryen.RelooperRef;
+/** Reference to a Binaryen relooper block. */
+export type RelooperBlockRef = binaryen.RelooperBlockRef;
 
 // The following constants must be updated by running scripts/update-constants.
 // This is necessary because the functions are not yet callable with Binaryen
@@ -30,24 +41,26 @@ export type CString = usize;
 // that this essentially fixes the compiler to specific versions of Binaryen
 // sometimes, because these constants can differ between Binaryen versions.
 
-export type NativeType = usize;
-export namespace NativeType {
-  export const None: NativeType = 0 /* _BinaryenTypeNone */;
-  export const Unreachable: NativeType = 1 /* _BinaryenTypeUnreachable */;
-  export const I32: NativeType = 2 /* _BinaryenTypeInt32 */;
-  export const I64: NativeType = 3 /* _BinaryenTypeInt64 */;
-  export const F32: NativeType = 4 /* _BinaryenTypeFloat32 */;
-  export const F64: NativeType = 5 /* _BinaryenTypeFloat64 */;
-  export const V128: NativeType = 6 /* _BinaryenTypeVec128 */;
-  export const Funcref: NativeType = 7 /* _BinaryenTypeFuncref */;
-  export const Externref: NativeType = 8 /* _BinaryenTypeExternref */;
-  export const Anyref: NativeType = 9 /* _BinaryenTypeAnyref */;
-  export const Eqref: NativeType = 10 /* _BinaryenTypeEqref */;
-  export const I31ref: NativeType = 11 /* _BinaryenTypeI31ref */;
-  export const Dataref: NativeType = 12 /* _BinaryenTypeDataref */;
-  export const Auto: NativeType = -1 /* _BinaryenTypeAuto */;
+/** Reference to a Binaryen type. */
+export type TypeRef = binaryen.Type;
+export namespace TypeRef {
+  export const None: TypeRef = 0 /* _BinaryenTypeNone */;
+  export const Unreachable: TypeRef = 1 /* _BinaryenTypeUnreachable */;
+  export const I32: TypeRef = 2 /* _BinaryenTypeInt32 */;
+  export const I64: TypeRef = 3 /* _BinaryenTypeInt64 */;
+  export const F32: TypeRef = 4 /* _BinaryenTypeFloat32 */;
+  export const F64: TypeRef = 5 /* _BinaryenTypeFloat64 */;
+  export const V128: TypeRef = 6 /* _BinaryenTypeVec128 */;
+  export const Funcref: TypeRef = 7 /* _BinaryenTypeFuncref */;
+  export const Externref: TypeRef = 8 /* _BinaryenTypeExternref */;
+  export const Anyref: TypeRef = 9 /* _BinaryenTypeAnyref */;
+  export const Eqref: TypeRef = 10 /* _BinaryenTypeEqref */;
+  export const I31ref: TypeRef = 11 /* _BinaryenTypeI31ref */;
+  export const Dataref: TypeRef = 12 /* _BinaryenTypeDataref */;
+  export const Auto: TypeRef = -1 /* _BinaryenTypeAuto */;
 }
 
+/** Binaryen feature constants. */
 export enum FeatureFlags {
   MVP = 0 /* _BinaryenFeatureMVP */,
   Atomics = 1 /* _BinaryenFeatureAtomics */,
@@ -62,10 +75,11 @@ export enum FeatureFlags {
   MultiValue = 512 /* _BinaryenFeatureMultivalue */,
   GC = 1024 /* _BinaryenFeatureGC */,
   Memory64 = 2048 /* _BinaryenFeatureMemory64 */,
-  TypedFunctionReferences  = 4096, /* _BinaryenTypedFunctionReferences */
+  TypedFunctionReferences  = 4096 /* _BinaryenTypedFunctionReferences */,
   All = 8191 /* _BinaryenFeatureAll */
 }
 
+/** Binaryen expression id constants. */
 export enum ExpressionId {
   Invalid = 0 /* _BinaryenInvalidId */,
   Block = 1 /* _BinaryenBlockId */,
@@ -135,14 +149,16 @@ export enum ExpressionId {
   RefAs = 65 /* _BinaryenRefAsId */
 }
 
+/** Binaryen external kind constants. */
 export enum ExternalKind {
-  Function = 0, /* _BinaryenExternalFunction */
-  Table = 1, /* _BinaryenExternalTable */
-  Memory = 2, /* _BinaryenExternalMemory */
-  Global = 3, /* _BinaryenExternalGlobal */
+  Function = 0 /* _BinaryenExternalFunction */,
+  Table = 1 /* _BinaryenExternalTable */,
+  Memory = 2 /* _BinaryenExternalMemory */,
+  Global = 3 /* _BinaryenExternalGlobal */,
   Event = 4 /* _BinaryenExternalEvent */
 }
 
+/** Binaryen unary operation constants. */
 export enum UnaryOp {
   /** i32.clz */
   ClzI32 = 0 /* _BinaryenClzInt32 */,
@@ -418,6 +434,7 @@ export enum UnaryOp {
   EqzSize
 }
 
+/** Binaryen binary operation constants. */
 export enum BinaryOp {
   /** i32.add */
   AddI32 = 0 /* _BinaryenAddInt32 */,
@@ -871,6 +888,7 @@ export enum BinaryOp {
   GeUSize
 }
 
+/** Binaryen atomic read-modify-write operation constants. */
 export enum AtomicRMWOp {
   /** i32.atomic.rmw.add, i32.atomic.rmw8.add_u, i32.atomic.rmw16.add_u, i64.atomic.rmw.add, i64.atomic.rmw8.add_u, i64.atomic.rmw16.add_u, i64.atomic.rmw32.add_u */
   Add = 0 /* _BinaryenAtomicRMWAdd */,
@@ -886,6 +904,7 @@ export enum AtomicRMWOp {
   Xchg = 5 /* _BinaryenAtomicRMWXchg */
 }
 
+/** Binaryen SIMD extract operation constants. */
 export enum SIMDExtractOp {
   /** i8x16.extract_lane_s */
   ExtractLaneI8x16 = 0 /* _BinaryenExtractLaneSVecI8x16 */,
@@ -905,6 +924,7 @@ export enum SIMDExtractOp {
   ExtractLaneF64x2 = 7 /* _BinaryenExtractLaneVecF64x2 */,
 }
 
+/** Binaryen SIMD replace operation constants. */
 export enum SIMDReplaceOp {
   /** i8x16.replace_lane */
   ReplaceLaneI8x16 = 0 /* _BinaryenReplaceLaneVecI8x16 */,
@@ -920,6 +940,7 @@ export enum SIMDReplaceOp {
   ReplaceLaneF64x2 = 5 /* _BinaryenReplaceLaneVecF64x2 */
 }
 
+/** Binaryen SIMD shift operation constants. */
 export enum SIMDShiftOp {
   /** i8x16.shl */
   ShlI8x16 = 0 /* _BinaryenShlVecI8x16 */,
@@ -947,6 +968,7 @@ export enum SIMDShiftOp {
   ShrU64x2 = 11 /* _BinaryenShrUVecI64x2 */
 }
 
+/** Binaryen SIMD load operation constants. */
 export enum SIMDLoadOp {
   /** v128.load8_splat */
   Load8Splat = 0 /* _BinaryenLoad8SplatVec128 */,
@@ -974,6 +996,7 @@ export enum SIMDLoadOp {
   Load64Zero = 11 /* _BinaryenLoad64ZeroVec128 */,
 }
 
+/** Binaryen SIMD load/store lane operation constants. */
 export enum SIMDLoadStoreLaneOp {
   /** v128.load8_lane */
   Load8Lane = 0 /* _BinaryenLoad8LaneVec128 */,
@@ -993,11 +1016,13 @@ export enum SIMDLoadStoreLaneOp {
   Store64Lane = 7 /* _BinaryenStore64LaneVec128 */,
 }
 
+/** Binaryen SIMD ternary operation constants. */
 export enum SIMDTernaryOp {
   /** v128.bitselect */
   Bitselect = 0 /* _BinaryenBitselectVec128 */
 }
 
+/** Binaryen RefIs operation constants. */
 export enum RefIsOp {
   /** ref.is_null */
   RefIsNull = 0 /* _BinaryenRefIsNull */,
@@ -1009,6 +1034,7 @@ export enum RefIsOp {
   RefIsI31 = 3 /* _BinaryenRefIsI31 */
 }
 
+/** Binaryen RefAs operation constants. */
 export enum RefAsOp {
   /** ref.as_non_null */
   RefAsNonNull = 0 /* _BinaryenRefAsNonNull */,
@@ -1020,6 +1046,7 @@ export enum RefAsOp {
   RefAsI31 = 3 /* _BinaryenRefAsI31 */
 }
 
+/** Binaryen BrOn operation constants. */
 export enum BrOnOp {
   /** br_on_null */
   BrOnNull = 0 /* TODO_BinaryenBrOnNull */,
@@ -1033,6 +1060,7 @@ export enum BrOnOp {
   BrOnI31 = 4 /* TODO_BinaryenBrOnI31 */
 }
 
+/** Binaryen expression runner flags. */
 export enum ExpressionRunnerFlags {
   Default = 0 /* _ExpressionRunnerFlagsDefault */,
   PreserveSideeffects = 1 /* _ExpressionRunnerFlagsPreserveSideeffects */,
@@ -1055,19 +1083,19 @@ export class Module {
     /** Whether a shadow stack is used. */
     public useShadowStack: bool,
     /** Architecture-dependent size type. */
-    public sizeType: NativeType
+    public sizeType: TypeRef
   ) {
-    assert(sizeType == NativeType.I32 || sizeType == NativeType.I64);
+    assert(sizeType == TypeRef.I32 || sizeType == TypeRef.I64);
     this.lit = binaryen._malloc(binaryen._BinaryenSizeofLiteral());
   }
 
   private lit: usize;
 
-  static create(useShadowStack: bool, sizeType: NativeType): Module {
+  static create(useShadowStack: bool, sizeType: TypeRef): Module {
     return new Module(binaryen._BinaryenModuleCreate(), useShadowStack, sizeType);
   }
 
-  static createFrom(buffer: Uint8Array, useShadowStack: bool, sizeType: NativeType): Module {
+  static createFrom(buffer: Uint8Array, useShadowStack: bool, sizeType: TypeRef): Module {
     var cArr = allocU8Array(buffer);
     var module = new Module(binaryen._BinaryenModuleRead(cArr, buffer.length), useShadowStack, sizeType);
     binaryen._free(changetype<usize>(cArr));
@@ -1090,26 +1118,26 @@ export class Module {
 
   // isize<T>(value: T): ExpressionRef {
   //   if (i64_is(value)) {
-  //     if (this.sizeType == NativeType.I64) {
+  //     if (this.sizeType == TypeRef.I64) {
   //       return this.i64(i64_low(value), i64_high(value));
   //     }
   //     assert(i64_is_i32(value));
   //     return this.i32(i64_low(value));
   //   }
-  //   return this.sizeType == NativeType.I64
+  //   return this.sizeType == TypeRef.I64
   //     ? this.i64(i32(value), i32(value) < 0 ? -1 : 0)
   //     : this.i32(i32(value));
   // }
 
   usize<T>(value: T): ExpressionRef {
     if (i64_is(value)) {
-      if (this.sizeType == NativeType.I64) {
+      if (this.sizeType == TypeRef.I64) {
         return this.i64(i64_low(value), i64_high(value));
       }
       assert(i64_is_u32(value));
       return this.i32(i64_low(value));
     }
-    return this.sizeType == NativeType.I64
+    return this.sizeType == TypeRef.I64
       ? this.i64(i32(value))
       : this.i32(i32(value));
   }
@@ -1136,7 +1164,7 @@ export class Module {
     return binaryen._BinaryenConst(this.ref, out);
   }
 
-  ref_null(type: NativeType): ExpressionRef {
+  ref_null(type: TypeRef): ExpressionRef {
     return binaryen._BinaryenRefNull(this.ref, type);
   }
 
@@ -1151,7 +1179,7 @@ export class Module {
     value: ExpressionRef
   ): ExpressionRef {
     if (op > UnaryOp._last) {
-      let isWam64 = this.sizeType == NativeType.I64;
+      let isWam64 = this.sizeType == TypeRef.I64;
       switch (op) {
         case UnaryOp.ClzSize: return this.unary(isWam64 ? UnaryOp.ClzI64 : UnaryOp.ClzI32, value);
         case UnaryOp.CtzSize: return this.unary(isWam64 ? UnaryOp.CtzI64 : UnaryOp.CtzI32, value);
@@ -1169,7 +1197,7 @@ export class Module {
     right: ExpressionRef
   ): ExpressionRef {
     if (op > BinaryOp._last) {
-      let isWasm64 = this.sizeType == NativeType.I64;
+      let isWasm64 = this.sizeType == TypeRef.I64;
       switch (op) {
         case BinaryOp.AddSize: return this.binary(isWasm64 ? BinaryOp.AddI64 : BinaryOp.AddI32, left, right);
         case BinaryOp.SubSize: return this.binary(isWasm64 ? BinaryOp.SubI64 : BinaryOp.SubI32, left, right);
@@ -1212,7 +1240,7 @@ export class Module {
 
   local_get(
     index: i32,
-    type: NativeType
+    type: TypeRef
   ): ExpressionRef {
     return binaryen._BinaryenLocalGet(this.ref, index, type);
   }
@@ -1220,7 +1248,7 @@ export class Module {
   tostack(value: ExpressionRef): ExpressionRef {
     if (this.useShadowStack) {
       let type = binaryen._BinaryenExpressionGetType(value);
-      assert(type == NativeType.I32 || type == NativeType.Unreachable);
+      assert(type == TypeRef.I32 || type == TypeRef.Unreachable);
       return this.call(BuiltinNames.tostack, [ value ], type);
     }
     return value;
@@ -1230,9 +1258,9 @@ export class Module {
     index: i32,
     value: ExpressionRef,
     isManaged: bool,
-    type: NativeType = NativeType.Auto,
+    type: TypeRef = TypeRef.Auto,
   ): ExpressionRef {
-    if (type == NativeType.Auto) type = binaryen._BinaryenExpressionGetType(value);
+    if (type == TypeRef.Auto) type = binaryen._BinaryenExpressionGetType(value);
     if (isManaged && this.useShadowStack) {
       value = this.tostack(value);
     }
@@ -1241,7 +1269,7 @@ export class Module {
 
   global_get(
     name: string,
-    type: NativeType
+    type: TypeRef
   ): ExpressionRef {
     var cStr = this.allocStringCached(name);
     return binaryen._BinaryenGlobalGet(this.ref, cStr, type);
@@ -1251,7 +1279,7 @@ export class Module {
     bytes: Index,
     signed: bool,
     ptr: ExpressionRef,
-    type: NativeType,
+    type: TypeRef,
     offset: Index = 0,
     align: Index = bytes // naturally aligned by default
   ): ExpressionRef {
@@ -1262,7 +1290,7 @@ export class Module {
     bytes: Index,
     ptr: ExpressionRef,
     value: ExpressionRef,
-    type: NativeType,
+    type: TypeRef,
     offset: Index = 0,
     align: Index = bytes // naturally aligned by default
   ): ExpressionRef {
@@ -1272,7 +1300,7 @@ export class Module {
   atomic_load(
     bytes: Index,
     ptr: ExpressionRef,
-    type: NativeType,
+    type: TypeRef,
     offset: Index = 0
   ): ExpressionRef {
     return binaryen._BinaryenAtomicLoad(this.ref, bytes, offset, type, ptr);
@@ -1282,7 +1310,7 @@ export class Module {
     bytes: Index,
     ptr: ExpressionRef,
     value: ExpressionRef,
-    type: NativeType,
+    type: TypeRef,
     offset: Index = 0
   ): ExpressionRef {
     return binaryen._BinaryenAtomicStore(this.ref, bytes, offset, ptr, value, type);
@@ -1294,7 +1322,7 @@ export class Module {
     offset: Index,
     ptr: ExpressionRef,
     value: ExpressionRef,
-    type: NativeType
+    type: TypeRef
   ): ExpressionRef {
     return binaryen._BinaryenAtomicRMW(this.ref, op, bytes, offset, ptr, value, type);
   }
@@ -1305,7 +1333,7 @@ export class Module {
     ptr: ExpressionRef,
     expected: ExpressionRef,
     replacement: ExpressionRef,
-    type: NativeType
+    type: TypeRef
   ): ExpressionRef {
     return binaryen._BinaryenAtomicCmpxchg(this.ref, bytes, offset, ptr, expected, replacement, type);
   }
@@ -1314,7 +1342,7 @@ export class Module {
     ptr: ExpressionRef,
     expected: ExpressionRef,
     timeout: ExpressionRef,
-    expectedType: NativeType
+    expectedType: TypeRef
   ): ExpressionRef {
     return binaryen._BinaryenAtomicWait(this.ref, ptr, expected, timeout, expectedType);
   }
@@ -1354,7 +1382,7 @@ export class Module {
   block(
     label: string | null,
     children: ExpressionRef[],
-    type: NativeType = NativeType.None
+    type: TypeRef = TypeRef.None
   ): ExpressionRef {
     var cStr = this.allocStringCached(label);
     var cArr = allocPtrArray(children);
@@ -1366,7 +1394,7 @@ export class Module {
   /** Attempts to trivially flatten a series of expressions instead of emitting a block. */
   flatten(
     stmts: ExpressionRef[],
-    type: NativeType = NativeType.None
+    type: TypeRef = TypeRef.None
   ): ExpressionRef {
     var length = stmts.length;
     if (length == 0) return this.nop(); // usually filtered out again
@@ -1381,7 +1409,7 @@ export class Module {
         }
       }
       let singleType = getExpressionType(single);
-      assert(singleType == NativeType.Unreachable || singleType == type);
+      assert(singleType == TypeRef.Unreachable || singleType == type);
       return single;
     }
     return this.block(null, stmts, type);
@@ -1446,9 +1474,9 @@ export class Module {
     ifTrue: ExpressionRef,
     ifFalse: ExpressionRef,
     condition: ExpressionRef,
-    type: NativeType = NativeType.Auto
+    type: TypeRef = TypeRef.Auto
   ): ExpressionRef {
-    if (type == NativeType.Auto) {
+    if (type == TypeRef.Auto) {
       type = binaryen._BinaryenExpressionGetType(ifTrue);
       assert(type == binaryen._BinaryenExpressionGetType(ifFalse));
     }
@@ -1462,7 +1490,7 @@ export class Module {
     value: ExpressionRef = 0
   ): ExpressionRef {
     var numNames = names.length;
-    var strs = new Array<CString>(numNames);
+    var strs = new Array<StringRef>(numNames);
     for (let i = 0; i < numNames; ++i) {
       strs[i] = this.allocStringCached(names[i]);
     }
@@ -1476,7 +1504,7 @@ export class Module {
   call(
     target: string,
     operands: ExpressionRef[] | null,
-    returnType: NativeType,
+    returnType: TypeRef,
     isReturn: bool = false
   ): ExpressionRef {
     var cStr = this.allocStringCached(target);
@@ -1495,7 +1523,7 @@ export class Module {
   return_call(
     target: string,
     operands: ExpressionRef[] | null,
-    returnType: NativeType
+    returnType: TypeRef
   ): ExpressionRef {
     return this.call(target, operands, returnType, true);
   }
@@ -1503,8 +1531,8 @@ export class Module {
   call_indirect(
     index: ExpressionRef,
     operands: ExpressionRef[] | null,
-    params: NativeType,
-    results: NativeType,
+    params: TypeRef,
+    results: TypeRef,
     isReturn: bool = false
   ): ExpressionRef {
     var cStr = this.allocStringCached("0"); // TODO: multiple tables
@@ -1524,8 +1552,8 @@ export class Module {
     tableName: string,
     index: ExpressionRef,
     operands: ExpressionRef[] | null,
-    params: NativeType,
-    results: NativeType
+    params: TypeRef,
+    results: TypeRef
   ): ExpressionRef {
     return this.call_indirect(index, operands, params, results, true);
   }
@@ -1593,7 +1621,7 @@ export class Module {
   // multi value (pseudo instructions)
 
   pop(
-    type: NativeType
+    type: TypeRef
   ): ExpressionRef {
     return binaryen._BinaryenPop(this.ref, type);
   }
@@ -1695,7 +1723,7 @@ export class Module {
 
   ref_func(
     name: string,
-    type: NativeType
+    type: TypeRef
   ): ExpressionRef {
     var cStr = this.allocStringCached(name);
     return binaryen._BinaryenRefFunc(this.ref, cStr, type);
@@ -1718,7 +1746,7 @@ export class Module {
 
   addGlobal(
     name: string,
-    type: NativeType,
+    type: TypeRef,
     mutable: bool,
     initializer: ExpressionRef
   ): GlobalRef {
@@ -1745,8 +1773,8 @@ export class Module {
   addEvent(
     name: string,
     attribute: u32,
-    params: NativeType,
-    results: NativeType
+    params: TypeRef,
+    results: TypeRef
   ): EventRef {
     var cStr = this.allocStringCached(name);
     return binaryen._BinaryenAddEvent(this.ref, cStr, attribute, params, results);
@@ -1770,9 +1798,9 @@ export class Module {
 
   addFunction(
     name: string,
-    params: NativeType,
-    results: NativeType,
-    varTypes: NativeType[] | null,
+    params: TypeRef,
+    results: TypeRef,
+    varTypes: TypeRef[] | null,
     body: ExpressionRef
   ): FunctionRef {
     var cStr = this.allocStringCached(name);
@@ -1810,8 +1838,8 @@ export class Module {
   private hasTemporaryFunction: bool = false;
 
   addTemporaryFunction(
-    result: NativeType,
-    paramTypes: NativeType[] | null,
+    result: TypeRef,
+    paramTypes: TypeRef[] | null,
     body: ExpressionRef
   ): FunctionRef {
     this.hasTemporaryFunction = assert(!this.hasTemporaryFunction);
@@ -1901,8 +1929,8 @@ export class Module {
     internalName: string,
     externalModuleName: string,
     externalBaseName: string,
-    params: NativeType,
-    results: NativeType
+    params: TypeRef,
+    results: TypeRef
   ): void {
     var cStr1 = this.allocStringCached(internalName);
     var cStr2 = this.allocStringCached(externalModuleName);
@@ -1937,7 +1965,7 @@ export class Module {
     internalName: string,
     externalModuleName: string,
     externalBaseName: string,
-    globalType: NativeType,
+    globalType: TypeRef,
     mutable: bool = false
   ): void {
     var cStr1 = this.allocStringCached(internalName);
@@ -1951,8 +1979,8 @@ export class Module {
     externalModuleName: string,
     externalBaseName: string,
     attribute: u32,
-    params: NativeType,
-    results: NativeType
+    params: TypeRef,
+    results: TypeRef
   ): void {
     var cStr1 = this.allocStringCached(internalName);
     var cStr2 = this.allocStringCached(externalModuleName);
@@ -2022,7 +2050,7 @@ export class Module {
   ): void {
     var cStr = this.allocStringCached(name);
     var numNames = funcs.length;
-    var names = new Array<CString>(numNames);
+    var names = new Array<StringRef>(numNames);
     for (let i = 0; i < numNames; ++i) {
       names[i] = this.allocStringCached(funcs[i]);
     }
@@ -2177,7 +2205,7 @@ export class Module {
 
   runPasses(passes: string[], func: FunctionRef = 0): void {
     var numNames = passes.length;
-    var cStrs = new Array<CString>(numNames);
+    var cStrs = new Array<StringRef>(numNames);
     for (let i = 0; i < numNames; ++i) {
       cStrs[i] = allocString(passes[i]);
     }
@@ -2473,27 +2501,27 @@ export class Module {
     switch (binaryen._BinaryenExpressionGetId(expr)) {
       case ExpressionId.Const: {
         switch (<u32>binaryen._BinaryenExpressionGetType(expr)) {
-          case <u32>NativeType.I32: {
+          case <u32>TypeRef.I32: {
             return this.i32(binaryen._BinaryenConstGetValueI32(expr));
           }
-          case <u32>NativeType.I64: {
+          case <u32>TypeRef.I64: {
             return this.i64(
               binaryen._BinaryenConstGetValueI64Low(expr),
               binaryen._BinaryenConstGetValueI64High(expr)
             );
           }
-          case <u32>NativeType.F32: {
+          case <u32>TypeRef.F32: {
             return this.f32(binaryen._BinaryenConstGetValueF32(expr));
           }
-          case <u32>NativeType.F64: {
+          case <u32>TypeRef.F64: {
             return this.f64(binaryen._BinaryenConstGetValueF64(expr));
           }
-          case <u32>NativeType.V128: {
+          case <u32>TypeRef.V128: {
             // TODO
             return 0;
           }
           // Not possible to clone an externref as it is opaque
-          case <u32>NativeType.Externref: {
+          case <u32>TypeRef.Externref: {
             return 0;
           }
           default: {
@@ -2612,10 +2640,10 @@ export class Module {
 
 // types
 
-export function createType(types: NativeType[] | null): NativeType {
-  if (!types) return NativeType.None;
+export function createType(types: TypeRef[] | null): TypeRef {
+  if (!types) return TypeRef.None;
   switch (types.length) {
-    case 0: return NativeType.None;
+    case 0: return TypeRef.None;
     case 1: return types[0];
   }
   var cArr = allocPtrArray(types);
@@ -2624,11 +2652,11 @@ export function createType(types: NativeType[] | null): NativeType {
   return ret;
 }
 
-export function expandType(type: NativeType): NativeType[] {
+export function expandType(type: TypeRef): TypeRef[] {
   var arity = binaryen._BinaryenTypeArity(type);
   var cArr = binaryen._malloc(<usize>arity << 2);
   binaryen._BinaryenTypeExpand(type, cArr);
-  var types = new Array<NativeType>(arity);
+  var types = new Array<TypeRef>(arity);
   for (let i: u32 = 0; i < arity; ++i) {
     types[i] = binaryen.__i32_load(cArr + (<usize>i << 2));
   }
@@ -2642,7 +2670,7 @@ export function getExpressionId(expr: ExpressionRef): ExpressionId {
   return binaryen._BinaryenExpressionGetId(expr);
 }
 
-export function getExpressionType(expr: ExpressionRef): NativeType {
+export function getExpressionType(expr: ExpressionRef): TypeRef {
   return binaryen._BinaryenExpressionGetType(expr);
 }
 
@@ -2669,10 +2697,10 @@ export function getConstValueF64(expr: ExpressionRef): f64 {
 export function isConstZero(expr: ExpressionRef): bool {
   if (getExpressionId(expr) != ExpressionId.Const) return false;
   var type = getExpressionType(expr);
-  if (type == NativeType.I32) return getConstValueI32(expr) == 0;
-  if (type == NativeType.I64) return getConstValueI64Low(expr) == 0 && getConstValueI64High(expr) == 0;
-  if (type == NativeType.F32) return getConstValueF32(expr) == 0;
-  if (type == NativeType.F64) return getConstValueF64(expr) == 0;
+  if (type == TypeRef.I32) return getConstValueI32(expr) == 0;
+  if (type == TypeRef.I64) return getConstValueI64Low(expr) == 0 && getConstValueI64High(expr) == 0;
+  if (type == TypeRef.F32) return getConstValueF32(expr) == 0;
+  if (type == TypeRef.F64) return getConstValueF64(expr) == 0;
   return false;
 }
 
@@ -2834,17 +2862,17 @@ export function getFunctionName(func: FunctionRef): string | null {
   return readString(binaryen._BinaryenFunctionGetName(func));
 }
 
-export function getFunctionParams(func: FunctionRef): NativeType {
+export function getFunctionParams(func: FunctionRef): TypeRef {
   return binaryen._BinaryenFunctionGetParams(func);
 }
 
-export function getFunctionResults(func: FunctionRef): NativeType {
+export function getFunctionResults(func: FunctionRef): TypeRef {
   return binaryen._BinaryenFunctionGetResults(func);
 }
 
-export function getFunctionVars(func: FunctionRef): NativeType[] {
+export function getFunctionVars(func: FunctionRef): TypeRef[] {
   var count = binaryen._BinaryenFunctionGetNumVars(func);
-  var types = new Array<NativeType>(count);
+  var types = new Array<TypeRef>(count);
   for (let i: Index = 0; i < count; ++i) {
     types[i] = binaryen._BinaryenFunctionGetVar(func, i);
   }
@@ -2857,7 +2885,7 @@ export function getGlobalName(global: GlobalRef): string | null {
   return readString(binaryen._BinaryenGlobalGetName(global));
 }
 
-export function getGlobalType(global: GlobalRef): NativeType {
+export function getGlobalType(global: GlobalRef): TypeRef {
   return binaryen._BinaryenGlobalGetType(global);
 }
 
@@ -2879,11 +2907,11 @@ export function getEventAttribute(event: EventRef): u32 {
   return binaryen._BinaryenEventGetAttribute(event);
 }
 
-export function getEventParams(event: EventRef): NativeType {
+export function getEventParams(event: EventRef): TypeRef {
   return binaryen._BinaryenEventGetParams(event);
 }
 
-export function getEventResults(event: EventRef): NativeType {
+export function getEventResults(event: EventRef): TypeRef {
   return binaryen._BinaryenEventGetResults(event);
 }
 
@@ -2993,7 +3021,7 @@ export class SwitchBuilder {
       let index = indexes[i];
       entry[1 + i] = module.br(labels[index],
         module.binary(BinaryOp.EqI32,
-          module.local_get(localIndex, NativeType.I32),
+          module.local_get(localIndex, TypeRef.I32),
           module.i32(values[i])
         )
       );
@@ -3211,7 +3239,7 @@ export class BinaryModule {
 /** Tests if an expression needs an explicit 'unreachable' when it is the terminating statement. */
 export function needsExplicitUnreachable(expr: ExpressionRef): bool {
   // not applicable if pushing a value to the stack
-  if (binaryen._BinaryenExpressionGetType(expr) != NativeType.Unreachable) {
+  if (binaryen._BinaryenExpressionGetType(expr) != TypeRef.Unreachable) {
     return false;
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -42,7 +42,7 @@ export type RelooperBlockRef = binaryen.RelooperBlockRef;
 // sometimes, because these constants can differ between Binaryen versions.
 
 /** Reference to a Binaryen type. */
-export type TypeRef = binaryen.Type;
+export type TypeRef = binaryen.TypeRef;
 export namespace TypeRef {
   export const None: TypeRef = 0 /* _BinaryenTypeNone */;
   export const Unreachable: TypeRef = 1 /* _BinaryenTypeUnreachable */;

--- a/src/passes/ministack.ts
+++ b/src/passes/ministack.ts
@@ -22,7 +22,7 @@ import {
   ExternalKind,
   Index,
   Module,
-  NativeType,
+  TypeRef,
   UnaryOp
 } from "../module";
 
@@ -80,7 +80,7 @@ export class MiniStack extends Pass {
       var params = _BinaryenFunctionGetParams(functionRef);
       var results = _BinaryenFunctionGetResults(functionRef);
       let numLocals = _BinaryenFunctionGetNumLocals(functionRef);
-      var vars = new Array<NativeType>();
+      var vars = new Array<TypeRef>();
 
       // Prepare a call to the original function
       var paramTypes = expandType(params);
@@ -97,13 +97,13 @@ export class MiniStack extends Pass {
         stmts.push(
           module.global_set(STACK_DEPTH,
             module.binary(BinaryOp.AddI32,
-              module.global_get(STACK_DEPTH, NativeType.I32),
+              module.global_get(STACK_DEPTH, TypeRef.I32),
               module.i32(1) // only need to know > 0
             )
           )
         );
       }
-      if (results == NativeType.None) {
+      if (results == TypeRef.None) {
         stmts.push(
           call
         );
@@ -117,7 +117,7 @@ export class MiniStack extends Pass {
         stmts.push(
           module.global_set(STACK_DEPTH,
             module.binary(BinaryOp.SubI32,
-              module.global_get(STACK_DEPTH, NativeType.I32),
+              module.global_get(STACK_DEPTH, TypeRef.I32),
               module.i32(1) // only need to know > 0
             )
           )
@@ -134,12 +134,12 @@ export class MiniStack extends Pass {
       stmts.push(
         module.if(
           module.unary(UnaryOp.EqzI32,
-            module.global_get(STACK_DEPTH, NativeType.I32)
+            module.global_get(STACK_DEPTH, TypeRef.I32)
           ),
-          module.call(AUTOCOLLECT, null, NativeType.None)
+          module.call(AUTOCOLLECT, null, TypeRef.None)
         )
       );
-      if (results != NativeType.None) {
+      if (results != TypeRef.None) {
         stmts.push(
           module.local_get(numParams, results)
         );
@@ -173,7 +173,7 @@ export class MiniStack extends Pass {
         for (let i = 0; i < numFunctionExports; ++i) {
           this.instrumentFunctionExport(functionExportRefs[i]);
         }
-        module.addGlobal(STACK_DEPTH, NativeType.I32, true, module.i32(0));
+        module.addGlobal(STACK_DEPTH, TypeRef.I32, true, module.i32(0));
         return true;
       }
     }

--- a/src/passes/pass.ts
+++ b/src/passes/pass.ts
@@ -10,7 +10,7 @@ import {
   FunctionRef,
   GlobalRef,
   Index,
-  CString
+  StringRef
 } from "../module";
 
 import {
@@ -472,11 +472,11 @@ export abstract class Visitor {
 
   // Immediates
 
-  visitName(name: CString): void {
+  visitName(name: StringRef): void {
     // unimp
   }
 
-  visitLabel(name: CString): void {
+  visitLabel(name: StringRef): void {
     // unimp
   }
 
@@ -484,7 +484,7 @@ export abstract class Visitor {
     // unimp
   }
 
-  visitEvent(name: CString): void {
+  visitEvent(name: StringRef): void {
     // unimp
   }
 

--- a/src/passes/rtrace.ts
+++ b/src/passes/rtrace.ts
@@ -19,7 +19,7 @@ import {
 import {
   createType,
   ExpressionRef,
-  NativeType
+  TypeRef
 } from "../module";
 
 import {
@@ -35,11 +35,11 @@ export class RtraceMemory extends Pass {
   /** Whether we've seen any stores. */
   seenStores: bool = false;
   /** Target pointer type. */
-  ptrType: NativeType;
+  ptrType: TypeRef;
 
   constructor(compiler: Compiler) {
     super(compiler.module);
-    this.ptrType = compiler.options.nativeSizeType;
+    this.ptrType = compiler.options.sizeTypeRef;
   }
 
   checkRT(): bool {
@@ -72,7 +72,7 @@ export class RtraceMemory extends Pass {
     super.walkModule();
     if (this.seenStores) {
       this.module.addFunctionImport("~onstore", "rtrace", "onstore",
-        createType([ this.ptrType, NativeType.I32, NativeType.I32, NativeType.I32 ]),
+        createType([ this.ptrType, TypeRef.I32, TypeRef.I32, TypeRef.I32 ]),
         this.ptrType
       );
     }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1587,7 +1587,7 @@ export class Resolver extends DiagnosticEmitter {
         case TypeKind.F64: return Type.f64;
       }
     }
-    // otherwise compile to best fitting native type
+    // otherwise compile to best fitting type
     if (i64_is_i32(intValue)) return Type.i32;
     if (i64_is_u32(intValue)) return Type.u32;
     return Type.i64; // TODO: u64 if positive and larger than i64?

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,7 +11,6 @@
     "./**/*.ts"
   ],
   "exclude": [
-    "./binary.ts",
     "./glue/wasm/**"
   ]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ import {
 } from "./program";
 
 import {
-  NativeType,
+  TypeRef,
   createType
 } from "./module";
 
@@ -512,8 +512,8 @@ export class Type {
 
   // Binaryen specific
 
-  /** Converts this type to its respective native type. */
-  toNativeType(): NativeType {
+  /** Converts this type to its respective type reference. */
+  toRef(): TypeRef {
     switch (this.kind) {
       default: assert(false);
       case TypeKind.I8:
@@ -522,22 +522,22 @@ export class Type {
       case TypeKind.U8:
       case TypeKind.U16:
       case TypeKind.U32:
-      case TypeKind.BOOL: return NativeType.I32;
+      case TypeKind.BOOL: return TypeRef.I32;
       case TypeKind.ISIZE:
-      case TypeKind.USIZE: if (this.size != 64) return NativeType.I32;
+      case TypeKind.USIZE: if (this.size != 64) return TypeRef.I32;
       case TypeKind.I64:
-      case TypeKind.U64: return NativeType.I64;
-      case TypeKind.F32: return NativeType.F32;
-      case TypeKind.F64: return NativeType.F64;
-      case TypeKind.V128: return NativeType.V128;
-      // TODO: nullable/non-nullable refs have different native types
-      case TypeKind.FUNCREF: return NativeType.Funcref;
-      case TypeKind.EXTERNREF: return NativeType.Externref;
-      case TypeKind.ANYREF: return NativeType.Anyref;
-      case TypeKind.EQREF: return NativeType.Eqref;
-      case TypeKind.I31REF: return NativeType.I31ref;
-      case TypeKind.DATAREF: return NativeType.Dataref;
-      case TypeKind.VOID: return NativeType.None;
+      case TypeKind.U64: return TypeRef.I64;
+      case TypeKind.F32: return TypeRef.F32;
+      case TypeKind.F64: return TypeRef.F64;
+      case TypeKind.V128: return TypeRef.V128;
+      // TODO: nullable/non-nullable refs have different type refs
+      case TypeKind.FUNCREF: return TypeRef.Funcref;
+      case TypeKind.EXTERNREF: return TypeRef.Externref;
+      case TypeKind.ANYREF: return TypeRef.Anyref;
+      case TypeKind.EQREF: return TypeRef.Eqref;
+      case TypeKind.I31REF: return TypeRef.I31ref;
+      case TypeKind.DATAREF: return TypeRef.Dataref;
+      case TypeKind.VOID: return TypeRef.None;
     }
   }
 
@@ -716,11 +716,11 @@ export class Type {
   static readonly auto: Type = new Type(Type.i32.kind, Type.i32.flags, Type.i32.size);
 }
 
-/** Converts an array of types to an array of native types. */
-export function typesToNativeTypes(types: Type[]): NativeType[] {
+/** Converts an array of types to an array of type references. */
+export function typesToRefs(types: Type[]): TypeRef[] {
   var numTypes = types.length;
-  var ret = new Array<NativeType>(numTypes);
-  for (let i = 0; i < numTypes; ++i) ret[i] = types[i].toNativeType();
+  var ret = new Array<TypeRef>(numTypes);
+  for (let i = 0; i < numTypes; ++i) ret[i] = types[i].toRef();
   return ret;
 }
 
@@ -783,27 +783,27 @@ export class Signature {
     program.uniqueSignatures.push(this);
   }
 
-  get nativeParams(): NativeType {
+  get paramRefs(): TypeRef {
     var thisType = this.thisType;
     var parameterTypes = this.parameterTypes;
     var numParameterTypes = parameterTypes.length;
     if (!numParameterTypes) {
-      if (!thisType) return NativeType.None;
-      return thisType.toNativeType();
+      if (!thisType) return TypeRef.None;
+      return thisType.toRef();
     }
     if (thisType) {
-      let nativeTypes = new Array<NativeType>(1 + numParameterTypes);
-      nativeTypes[0] = thisType.toNativeType();
+      let typeRefs = new Array<TypeRef>(1 + numParameterTypes);
+      typeRefs[0] = thisType.toRef();
       for (let i = 0; i < numParameterTypes; ++i) {
-        nativeTypes[i + 1] = parameterTypes[i].toNativeType();
+        typeRefs[i + 1] = parameterTypes[i].toRef();
       }
-      return createType(nativeTypes);
+      return createType(typeRefs);
     }
-    return createType(typesToNativeTypes(parameterTypes));
+    return createType(typesToRefs(parameterTypes));
   }
 
-  get nativeResults(): NativeType {
-    return this.returnType.toNativeType();
+  get resultRefs(): TypeRef {
+    return this.returnType.toRef();
   }
 
   /** Tests if this signature equals the specified. */


### PR DESCRIPTION
* Removes redundant bindings for Binaryen constants (no need to maintain these)
* Renames the oddly named `NativeType` to `TypeRef`
* Makes the binding's type definitions the single source of truth
* Adds comments for reference

- [x] I've read the contributing guidelines