### PR TITLE
Fixed stdlib builtins not working with typedoc

### DIFF
--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -2302,11 +2302,17 @@ export abstract class i31 { // FIXME: usage of 'new' requires a class :(
 
   // @ts-ignore: decorator
   @builtin
-  static new(value: i32): i31ref { return unreachable(); }
+  static new(value: i32): i31ref { 
+    unreachable();
+    return 0;
+  }
 
   // @ts-ignore: decorator
   @builtin
-  static get(i31expr: i31ref): i32 { return unreachable(); }
+  static get(i31expr: i31ref): i32 { 
+    unreachable();
+    return 0;
+  }
 }
 
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -2304,7 +2304,7 @@ export abstract class i31 { // FIXME: usage of 'new' requires a class :(
   @builtin
   static new(value: i32): i31ref { 
     unreachable();
-    return 0;
+    return changetype<i31ref>(0);
   }
 
   // @ts-ignore: decorator

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -170,7 +170,7 @@ export declare function select<T>(ifTrue: T, ifFalse: T, condition: bool): T;
 
 // @ts-ignore: decorator
 @unsafe @builtin
-export declare function unreachable(): void;
+export declare function unreachable(): auto;
 
 // @ts-ignore: decorator
 @builtin
@@ -2302,17 +2302,11 @@ export abstract class i31 { // FIXME: usage of 'new' requires a class :(
 
   // @ts-ignore: decorator
   @builtin
-  static new(value: i32): i31ref { 
-    unreachable();
-    return changetype<i31ref>(0);
-  }
+  static new(value: i32): i31ref { return changetype<i31ref>(unreachable()); }
 
   // @ts-ignore: decorator
   @builtin
-  static get(i31expr: i31ref): i32 { 
-    unreachable();
-    return 0;
-  }
+  static get(i31expr: i31ref): i32 { return unreachable(); }
 }
 
 /* eslint-disable @typescript-eslint/no-unused-vars */


### PR DESCRIPTION
Hello!

This is just something I noticed when working on the [Fastly AS SDK](https://www.npmjs.com/package/@fastly/as-compute).

It seems like in version `0.18.13`, we introduced a change in which caused a type error, as we try to assign `void` to an `i32`, and `i31ref`:

![Screenshot from 2021-06-08 17-19-44](https://user-images.githubusercontent.com/1448289/121274287-0a0da400-c87f-11eb-83b5-1ac2e9bba730.png)

I got the error above when running typedoc on version `0.19.1`, but it works again on `0.18.12`. So, I assume unreachable is the instruction that causes things to crash. So instead of returning void, I still call the function, but return a "void number" (0), which I assume is the expected behavior?

With this fix, things start working again in the type system:

![Screenshot from 2021-06-08 17-26-09](https://user-images.githubusercontent.com/1448289/121274387-3cb79c80-c87f-11eb-94b9-776786200539.png)

Thanks to whoever picks up this review! 😄 🎉 

cc @dcodeIO @MaxGraey 😄 