### PR TITLE
Include env/RT in generated definitions

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -639,7 +639,7 @@ export class TSDBuilder extends ExportsWalker {
       sb.push("export function __collect(): usize;\n");
       sb.push("export const __rtti_base: usize;\n");
     }
-    sb.push("export const __setArgumentsLength: ((n: i32) => usize) | undefined;\n");
+    sb.push("export const __setArgumentsLength: ((n: i32) => void) | undefined;\n");
     return this.sb.join("");
   }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -636,7 +636,7 @@ export class TSDBuilder extends ExportsWalker {
       sb.push("export function __new(size: usize, id: u32): usize;\n");
       sb.push("export function __pin(ptr: usize): usize;\n");
       sb.push("export function __unpin(ptr: usize): usize;\n");
-      sb.push("export function __collect(): usize;\n");
+      sb.push("export function __collect(): void;\n");
       sb.push("export const __rtti_base: usize;\n");
     }
     sb.push("export const __setArgumentsLength: ((n: i32) => void) | undefined;\n");

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -635,7 +635,7 @@ export class TSDBuilder extends ExportsWalker {
     if (options.exportRuntime) {
       sb.push("export function __new(size: usize, id: u32): usize;\n");
       sb.push("export function __pin(ptr: usize): usize;\n");
-      sb.push("export function __unpin(ptr: usize): usize;\n");
+      sb.push("export function __unpin(ptr: usize): void;\n");
       sb.push("export function __collect(): void;\n");
       sb.push("export const __rtti_base: usize;\n");
     }


### PR DESCRIPTION
With the definitions now being in a format that can be picked up by bundlers (anticipating ESM integration) even when not using the loader, it may be useful to also declare the memory and the table, as well as exported runtime helpers.

* `memory` if exported
* `table` if exported
* `_start` if explicit
* `__new`, `__pin`, `__unpin`, `__collect` and `__rtti_base` if exported
* `__setArgumentsLength` if there are exported varargs functions

Also fixes #1900

- [x] I've read the contributing guidelines