### PR TITLE
[WIP] implement for..of loops and iterators

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -978,7 +978,8 @@ export enum DecoratorKind {
   EXTERNAL,
   BUILTIN,
   LAZY,
-  UNSAFE
+  UNSAFE,
+  ITERATOR
 }
 
 export namespace DecoratorKind {
@@ -1007,6 +1008,7 @@ export namespace DecoratorKind {
         }
         case CharCode.i: {
           if (nameStr == "inline") return DecoratorKind.INLINE;
+          if (nameStr == "iterator") return DecoratorKind.ITERATOR;
           break;
         }
         case CharCode.l: {

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -49,6 +49,7 @@ export enum DiagnosticCode {
   Exported_generic_function_or_class_has_no_concrete_instances = 232,
   Property_0_is_always_assigned_before_being_used = 233,
   Expression_refers_to_a_static_element_that_does_not_compile_to_a_value_at_runtime = 234,
+  Type_0_is_not_iterable = 235,
   Importing_the_table_disables_some_indirect_call_optimizations = 901,
   Exporting_the_table_disables_some_indirect_call_optimizations = 902,
   Expression_compiles_to_a_dynamic_check_at_runtime = 903,
@@ -105,6 +106,7 @@ export enum DiagnosticCode {
   Binary_digit_expected = 1177,
   Octal_digit_expected = 1178,
   An_implementation_cannot_be_declared_in_ambient_contexts = 1183,
+  Only_a_single_variable_declaration_is_allowed_in_a_for_of_statement = 1188,
   The_variable_declaration_of_a_for_of_statement_cannot_have_an_initializer = 1190,
   An_extended_Unicode_escape_value_must_be_between_0x0_and_0x10FFFF_inclusive = 1198,
   Unterminated_Unicode_escape_sequence = 1199,
@@ -229,6 +231,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 232: return "Exported generic function or class has no concrete instances.";
     case 233: return "Property '{0}' is always assigned before being used.";
     case 234: return "Expression refers to a static element that does not compile to a value at runtime.";
+    case 235: return "Type '{0}' is not iterable.";
     case 901: return "Importing the table disables some indirect call optimizations.";
     case 902: return "Exporting the table disables some indirect call optimizations.";
     case 903: return "Expression compiles to a dynamic check at runtime.";
@@ -285,6 +288,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 1177: return "Binary digit expected.";
     case 1178: return "Octal digit expected.";
     case 1183: return "An implementation cannot be declared in ambient contexts.";
+    case 1188: return "Only a single variable declaration is allowed in a 'for...of' statement";
     case 1190: return "The variable declaration of a 'for...of' statement cannot have an initializer.";
     case 1198: return "An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive.";
     case 1199: return "Unterminated Unicode escape sequence.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -44,6 +44,7 @@
   "Exported generic function or class has no concrete instances.": 232,
   "Property '{0}' is always assigned before being used.": 233,
   "Expression refers to a static element that does not compile to a value at runtime.": 234,
+  "Type '{0}' is not iterable.": 235,
 
   "Importing the table disables some indirect call optimizations.": 901,
   "Exporting the table disables some indirect call optimizations.": 902,
@@ -102,6 +103,7 @@
   "Binary digit expected.": 1177,
   "Octal digit expected.": 1178,
   "An implementation cannot be declared in ambient contexts.": 1183,
+  "Only a single variable declaration is allowed in a 'for...of' statement": 1188,
   "The variable declaration of a 'for...of' statement cannot have an initializer.": 1190,
   "An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive.": 1198,
   "Unterminated Unicode escape sequence.": 1199,

--- a/src/program.ts
+++ b/src/program.ts
@@ -4367,7 +4367,7 @@ export class Class extends TypedElement {
             if (member.kind == ElementKind.FUNCTION_PROTOTYPE) {
               return this.program.resolver.resolveFunction(<FunctionPrototype>member, null);
             }
-            return <Function>member
+            return <Function>member;
           }
         }
       }

--- a/src/program.ts
+++ b/src/program.ts
@@ -649,6 +649,7 @@ export class Program extends DiagnosticEmitter {
 
   /** Gets the standard `abort` instance, if not explicitly disabled. */
   get abortInstance(): Function | null {
+    if (this.options.trapAbort) return null
     var prototype = this.lookup(CommonNames.abort);
     if (!prototype || prototype.kind != ElementKind.FUNCTION_PROTOTYPE) return null;
     return this.resolver.resolveFunction(<FunctionPrototype>prototype, null);

--- a/src/program.ts
+++ b/src/program.ts
@@ -649,7 +649,6 @@ export class Program extends DiagnosticEmitter {
 
   /** Gets the standard `abort` instance, if not explicitly disabled. */
   get abortInstance(): Function | null {
-    if (this.options.trapAbort) return null
     var prototype = this.lookup(CommonNames.abort);
     if (!prototype || prototype.kind != ElementKind.FUNCTION_PROTOTYPE) return null;
     return this.resolver.resolveFunction(<FunctionPrototype>prototype, null);

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -35,10 +35,10 @@ class ArrayIterator<T> {
   i: i32 = 0
   constructor(public arr: Array<T>) {}
   next(): T {
-    return this.arr[this.i]
+    return this.arr[this.i];
   }
   done(): bool {
-    return this.i >= this.arr.length
+    return this.i >= this.arr.length;
   }
 }
 
@@ -139,7 +139,7 @@ export class Array<T> {
 
   @iterator
   private __iter(): ArrayIterator<T> {
-    return new ArrayIterator<T>(this)
+    return new ArrayIterator<T>(this);
   }
 
   at(index: i32): T {

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -31,6 +31,17 @@ function ensureCapacity(array: usize, newSize: usize, alignLog2: u32, canGrow: b
   }
 }
 
+class ArrayIterator<T> {
+  i: i32 = 0
+  constructor(public arr: Array<T>) {}
+  next(): T {
+    return this.arr[this.i]
+  }
+  done(): bool {
+    return this.i >= this.arr.length
+  }
+}
+
 export class Array<T> {
   [key: number]: T;
 
@@ -124,6 +135,11 @@ export class Array<T> {
     if (isManaged<T>()) {
       __link(changetype<usize>(this), changetype<usize>(value), true);
     }
+  }
+
+  @iterator
+  private __iter(): ArrayIterator<T> {
+    return new ArrayIterator<T>(this)
   }
 
   at(index: i32): T {

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -2191,6 +2191,13 @@ declare namespace operator {
   ) => TypedPropertyDescriptor<any> | void;
 }
 
+/** Annotates an element as an iterator. */
+declare function iterator(
+  target: any,
+  propertyKey: string,
+  descriptor: TypedPropertyDescriptor<any>
+): TypedPropertyDescriptor<any> | void;
+
 /** Annotates an element as a program global. */
 declare function global(...args: any[]): any;
 

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1712,6 +1712,8 @@ declare class Array<T> {
   /** Flattens an array of arrays. If any null entries exist in the array, they are ignored, unlike JavaScript's version of Array#flat(). */
   flat(): T extends unknown[] ? T : never;
   toString(): string;
+
+  [Symbol.iterator](): { next(): { value: T, done: boolean } }
 }
 
 /** Class representing a static (not resizable) sequence of values of type `T`. This class is @final. */

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -55,7 +55,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -261,7 +261,7 @@
    if
     i32.const 1184
     i32.const 1248
-    i32.const 99
+    i32.const 110
     i32.const 42
     call $~lib/builtins/abort
     unreachable
@@ -277,7 +277,7 @@
    if
     i32.const 1296
     i32.const 1248
-    i32.const 103
+    i32.const 114
     i32.const 40
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -310,7 +310,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -335,7 +335,7 @@
   if
    i32.const 272
    i32.const 224
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -366,7 +366,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -2724,7 +2724,7 @@
   if
    i32.const 432
    i32.const 480
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for-of.json
+++ b/tests/compiler/for-of.json
@@ -1,0 +1,5 @@
+{
+  "asc_flags": [
+  ],
+  "asc_rtrace": false
+}

--- a/tests/compiler/for-of.optimized.wat
+++ b/tests/compiler/for-of.optimized.wat
@@ -1,0 +1,1897 @@
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/visitCount (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/pinSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/iter (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/toSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 17916))
+ (memory $0 1)
+ (data (i32.const 1036) "<")
+ (data (i32.const 1048) "\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 1100) "<")
+ (data (i32.const 1112) "\01\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s")
+ (data (i32.const 1228) "<")
+ (data (i32.const 1240) "\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
+ (data (i32.const 1292) ",")
+ (data (i32.const 1304) "\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
+ (data (i32.const 1372) "<")
+ (data (i32.const 1384) "\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data (i32.const 1436) ",")
+ (data (i32.const 1448) "\01\00\00\00\12\00\00\00f\00o\00r\00-\00o\00f\00.\00t\00s")
+ (data (i32.const 1488) "\05\00\00\00 \00\00\00\00\00\00\00 ")
+ (data (i32.const 1516) " \00\00\00\00\00\00\00 ")
+ (export "memory" (memory $0))
+ (start $~start)
+ (func $~lib/rt/itcms/visitRoots
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 1248
+  call $~lib/rt/itcms/__visit
+  i32.const 1056
+  call $~lib/rt/itcms/__visit
+  global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.set $0
+  loop $while-continue|0
+   local.get $0
+   local.get $1
+   i32.ne
+   if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    i32.const 20
+    i32.add
+    call $~lib/rt/__visit_members
+    local.get $0
+    i32.load offset=4
+    i32.const -4
+    i32.and
+    local.set $0
+    br $while-continue|0
+   end
+  end
+ )
+ (func $~lib/rt/itcms/__visit (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  i32.eqz
+  if
+   return
+  end
+  global.get $~lib/rt/itcms/white
+  local.get $0
+  i32.const 20
+  i32.sub
+  local.tee $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.eq
+  if
+   local.get $0
+   global.get $~lib/rt/itcms/iter
+   i32.eq
+   if
+    local.get $0
+    i32.load offset=8
+    local.tee $1
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 147
+     i32.const 30
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    global.set $~lib/rt/itcms/iter
+   end
+   block $__inlined_func$~lib/rt/itcms/Object#unlink
+    local.get $0
+    i32.load offset=4
+    i32.const -4
+    i32.and
+    local.tee $2
+    i32.eqz
+    if
+     i32.const 0
+     local.get $0
+     i32.const 17916
+     i32.lt_u
+     local.get $0
+     i32.load offset=8
+     select
+     i32.eqz
+     if
+      i32.const 0
+      i32.const 1120
+      i32.const 127
+      i32.const 18
+      call $~lib/builtins/abort
+      unreachable
+     end
+     br $__inlined_func$~lib/rt/itcms/Object#unlink
+    end
+    local.get $0
+    i32.load offset=8
+    local.tee $1
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 131
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    local.get $1
+    i32.store offset=8
+    local.get $1
+    local.get $2
+    local.get $1
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.or
+    i32.store offset=4
+   end
+   global.get $~lib/rt/itcms/toSpace
+   local.set $1
+   local.get $0
+   i32.load offset=12
+   local.tee $2
+   i32.const 1
+   i32.le_u
+   if (result i32)
+    i32.const 1
+   else
+    local.get $2
+    i32.const 1488
+    i32.load
+    i32.gt_u
+    if
+     i32.const 1248
+     i32.const 1312
+     i32.const 22
+     i32.const 28
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 3
+    i32.shl
+    i32.const 1492
+    i32.add
+    i32.load
+    i32.const 32
+    i32.and
+   end
+   if (result i32)
+    global.get $~lib/rt/itcms/white
+    i32.eqz
+   else
+    i32.const 2
+   end
+   local.set $3
+   local.get $1
+   i32.load offset=8
+   local.set $2
+   local.get $0
+   local.get $1
+   local.get $3
+   i32.or
+   i32.store offset=4
+   local.get $0
+   local.get $2
+   i32.store offset=8
+   local.get $2
+   local.get $0
+   local.get $2
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   i32.or
+   i32.store offset=4
+   local.get $1
+   local.get $0
+   i32.store offset=8
+   global.get $~lib/rt/itcms/visitCount
+   i32.const 1
+   i32.add
+   global.set $~lib/rt/itcms/visitCount
+  end
+ )
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.load
+  local.tee $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 268
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const -4
+  i32.and
+  local.tee $2
+  i32.const 12
+  i32.lt_u
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 270
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 256
+  i32.lt_u
+  if
+   local.get $2
+   i32.const 4
+   i32.shr_u
+   local.set $2
+  else
+   i32.const 31
+   local.get $2
+   i32.const 1073741820
+   local.get $2
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $2
+   i32.clz
+   i32.sub
+   local.set $3
+   local.get $2
+   local.get $3
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $2
+   local.get $3
+   i32.const 7
+   i32.sub
+   local.set $3
+  end
+  local.get $2
+  i32.const 16
+  i32.lt_u
+  i32.const 0
+  local.get $3
+  i32.const 23
+  i32.lt_u
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 284
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load offset=8
+  local.set $4
+  local.get $1
+  i32.load offset=4
+  local.tee $5
+  if
+   local.get $5
+   local.get $4
+   i32.store offset=8
+  end
+  local.get $4
+  if
+   local.get $4
+   local.get $5
+   i32.store offset=4
+  end
+  local.get $1
+  local.get $0
+  local.get $2
+  local.get $3
+  i32.const 4
+  i32.shl
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  i32.eq
+  if
+   local.get $0
+   local.get $2
+   local.get $3
+   i32.const 4
+   i32.shl
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $4
+   i32.store offset=96
+   local.get $4
+   i32.eqz
+   if
+    local.get $0
+    local.get $3
+    i32.const 2
+    i32.shl
+    i32.add
+    local.tee $4
+    i32.load offset=4
+    i32.const -2
+    local.get $2
+    i32.rotl
+    i32.and
+    local.set $1
+    local.get $4
+    local.get $1
+    i32.store offset=4
+    local.get $1
+    i32.eqz
+    if
+     local.get $0
+     local.get $0
+     i32.load
+     i32.const -2
+     local.get $3
+     i32.rotl
+     i32.and
+     i32.store
+    end
+   end
+  end
+ )
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 201
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load
+  local.tee $3
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 203
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 4
+  i32.add
+  local.get $1
+  i32.load
+  i32.const -4
+  i32.and
+  i32.add
+  local.tee $4
+  i32.load
+  local.tee $2
+  i32.const 1
+  i32.and
+  if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $3
+   i32.const 4
+   i32.add
+   local.get $2
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $3
+   i32.store
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $4
+   i32.load
+   local.set $2
+  end
+  local.get $3
+  i32.const 2
+  i32.and
+  if
+   local.get $1
+   i32.const 4
+   i32.sub
+   i32.load
+   local.tee $1
+   i32.load
+   local.tee $6
+   i32.const 1
+   i32.and
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1392
+    i32.const 221
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $3
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $3
+   i32.store
+  end
+  local.get $4
+  local.get $2
+  i32.const 2
+  i32.or
+  i32.store
+  local.get $3
+  i32.const -4
+  i32.and
+  local.tee $3
+  i32.const 12
+  i32.lt_u
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 233
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  local.get $1
+  i32.const 4
+  i32.add
+  i32.add
+  local.get $4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 234
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 4
+  i32.sub
+  local.get $1
+  i32.store
+  local.get $3
+  i32.const 256
+  i32.lt_u
+  if (result i32)
+   local.get $3
+   i32.const 4
+   i32.shr_u
+  else
+   i32.const 31
+   local.get $3
+   i32.const 1073741820
+   local.get $3
+   i32.const 1073741820
+   i32.lt_u
+   select
+   local.tee $3
+   i32.clz
+   i32.sub
+   local.tee $4
+   i32.const 7
+   i32.sub
+   local.set $5
+   local.get $3
+   local.get $4
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+  end
+  local.tee $3
+  i32.const 16
+  i32.lt_u
+  i32.const 0
+  local.get $5
+  i32.const 23
+  i32.lt_u
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 251
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $3
+  local.get $5
+  i32.const 4
+  i32.shl
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  local.set $4
+  local.get $1
+  i32.const 0
+  i32.store offset=4
+  local.get $1
+  local.get $4
+  i32.store offset=8
+  local.get $4
+  if
+   local.get $4
+   local.get $1
+   i32.store offset=4
+  end
+  local.get $0
+  local.get $3
+  local.get $5
+  i32.const 4
+  i32.shl
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $1
+  i32.store offset=96
+  local.get $0
+  local.get $0
+  i32.load
+  i32.const 1
+  local.get $5
+  i32.shl
+  i32.or
+  i32.store
+  local.get $0
+  local.get $5
+  i32.const 2
+  i32.shl
+  i32.add
+  local.tee $0
+  local.get $0
+  i32.load offset=4
+  i32.const 1
+  local.get $3
+  i32.shl
+  i32.or
+  i32.store offset=4
+ )
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  local.get $2
+  i32.gt_u
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 377
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 19
+  i32.add
+  i32.const -16
+  i32.and
+  i32.const 4
+  i32.sub
+  local.set $1
+  local.get $2
+  i32.const -16
+  i32.and
+  local.get $0
+  i32.load offset=1568
+  local.tee $2
+  if
+   local.get $1
+   local.get $2
+   i32.const 4
+   i32.add
+   i32.lt_u
+   if
+    i32.const 0
+    i32.const 1392
+    i32.const 384
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $2
+   local.get $1
+   i32.const 16
+   i32.sub
+   i32.eq
+   if
+    local.get $2
+    i32.load
+    local.set $4
+    local.get $1
+    i32.const 16
+    i32.sub
+    local.set $1
+   end
+  else
+   local.get $1
+   local.get $0
+   i32.const 1572
+   i32.add
+   i32.lt_u
+   if
+    i32.const 0
+    i32.const 1392
+    i32.const 397
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $1
+  i32.sub
+  local.tee $2
+  i32.const 20
+  i32.lt_u
+  if
+   return
+  end
+  local.get $1
+  local.get $4
+  i32.const 2
+  i32.and
+  local.get $2
+  i32.const 8
+  i32.sub
+  local.tee $2
+  i32.const 1
+  i32.or
+  i32.or
+  i32.store
+  local.get $1
+  i32.const 0
+  i32.store offset=4
+  local.get $1
+  i32.const 0
+  i32.store offset=8
+  local.get $2
+  local.get $1
+  i32.const 4
+  i32.add
+  i32.add
+  local.tee $2
+  i32.const 2
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=1568
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+ )
+ (func $~lib/rt/tlsf/initialize
+  (local $0 i32)
+  (local $1 i32)
+  memory.size
+  local.tee $0
+  i32.const 1
+  i32.lt_s
+  if (result i32)
+   i32.const 1
+   local.get $0
+   i32.sub
+   memory.grow
+   i32.const 0
+   i32.lt_s
+  else
+   i32.const 0
+  end
+  if
+   unreachable
+  end
+  i32.const 17920
+  i32.const 0
+  i32.store
+  i32.const 19488
+  i32.const 0
+  i32.store
+  loop $for-loop|0
+   local.get $1
+   i32.const 23
+   i32.lt_u
+   if
+    local.get $1
+    i32.const 2
+    i32.shl
+    i32.const 17920
+    i32.add
+    i32.const 0
+    i32.store offset=4
+    i32.const 0
+    local.set $0
+    loop $for-loop|1
+     local.get $0
+     i32.const 16
+     i32.lt_u
+     if
+      local.get $0
+      local.get $1
+      i32.const 4
+      i32.shl
+      i32.add
+      i32.const 2
+      i32.shl
+      i32.const 17920
+      i32.add
+      i32.const 0
+      i32.store offset=96
+      local.get $0
+      i32.const 1
+      i32.add
+      local.set $0
+      br $for-loop|1
+     end
+    end
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $for-loop|0
+   end
+  end
+  i32.const 17920
+  i32.const 19492
+  memory.size
+  i32.const 16
+  i32.shl
+  call $~lib/rt/tlsf/addMemory
+  i32.const 17920
+  global.set $~lib/rt/tlsf/ROOT
+ )
+ (func $~lib/rt/itcms/step (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  block $folding-inner0
+   block $break|0
+    block $case2|0
+     block $case1|0
+      block $case0|0
+       global.get $~lib/rt/itcms/state
+       br_table $case0|0 $case1|0 $case2|0 $break|0
+      end
+      i32.const 1
+      global.set $~lib/rt/itcms/state
+      i32.const 0
+      global.set $~lib/rt/itcms/visitCount
+      call $~lib/rt/itcms/visitRoots
+      global.get $~lib/rt/itcms/toSpace
+      global.set $~lib/rt/itcms/iter
+      br $folding-inner0
+     end
+     global.get $~lib/rt/itcms/white
+     i32.eqz
+     local.set $1
+     global.get $~lib/rt/itcms/iter
+     i32.load offset=4
+     i32.const -4
+     i32.and
+     local.set $0
+     loop $while-continue|1
+      local.get $0
+      global.get $~lib/rt/itcms/toSpace
+      i32.ne
+      if
+       local.get $0
+       global.set $~lib/rt/itcms/iter
+       local.get $1
+       local.get $0
+       i32.load offset=4
+       i32.const 3
+       i32.and
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        local.get $0
+        i32.load offset=4
+        i32.const -4
+        i32.and
+        i32.or
+        i32.store offset=4
+        i32.const 0
+        global.set $~lib/rt/itcms/visitCount
+        local.get $0
+        i32.const 20
+        i32.add
+        call $~lib/rt/__visit_members
+        br $folding-inner0
+       end
+       local.get $0
+       i32.load offset=4
+       i32.const -4
+       i32.and
+       local.set $0
+       br $while-continue|1
+      end
+     end
+     i32.const 0
+     global.set $~lib/rt/itcms/visitCount
+     call $~lib/rt/itcms/visitRoots
+     global.get $~lib/rt/itcms/toSpace
+     global.get $~lib/rt/itcms/iter
+     i32.load offset=4
+     i32.const -4
+     i32.and
+     i32.eq
+     if
+      global.get $~lib/memory/__stack_pointer
+      local.set $0
+      loop $while-continue|0
+       local.get $0
+       i32.const 17916
+       i32.lt_u
+       if
+        local.get $0
+        i32.load
+        call $~lib/rt/itcms/__visit
+        local.get $0
+        i32.const 4
+        i32.add
+        local.set $0
+        br $while-continue|0
+       end
+      end
+      global.get $~lib/rt/itcms/iter
+      i32.load offset=4
+      i32.const -4
+      i32.and
+      local.set $0
+      loop $while-continue|2
+       local.get $0
+       global.get $~lib/rt/itcms/toSpace
+       i32.ne
+       if
+        local.get $1
+        local.get $0
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         local.get $0
+         local.get $1
+         local.get $0
+         i32.load offset=4
+         i32.const -4
+         i32.and
+         i32.or
+         i32.store offset=4
+         local.get $0
+         i32.const 20
+         i32.add
+         call $~lib/rt/__visit_members
+        end
+        local.get $0
+        i32.load offset=4
+        i32.const -4
+        i32.and
+        local.set $0
+        br $while-continue|2
+       end
+      end
+      global.get $~lib/rt/itcms/fromSpace
+      local.set $0
+      global.get $~lib/rt/itcms/toSpace
+      global.set $~lib/rt/itcms/fromSpace
+      local.get $0
+      global.set $~lib/rt/itcms/toSpace
+      local.get $1
+      global.set $~lib/rt/itcms/white
+      local.get $0
+      i32.load offset=4
+      i32.const -4
+      i32.and
+      global.set $~lib/rt/itcms/iter
+      i32.const 2
+      global.set $~lib/rt/itcms/state
+     end
+     br $folding-inner0
+    end
+    global.get $~lib/rt/itcms/iter
+    local.tee $0
+    global.get $~lib/rt/itcms/toSpace
+    i32.ne
+    if
+     local.get $0
+     i32.load offset=4
+     i32.const -4
+     i32.and
+     global.set $~lib/rt/itcms/iter
+     global.get $~lib/rt/itcms/white
+     i32.eqz
+     local.get $0
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     i32.ne
+     if
+      i32.const 0
+      i32.const 1120
+      i32.const 228
+      i32.const 20
+      call $~lib/builtins/abort
+      unreachable
+     end
+     local.get $0
+     i32.const 17916
+     i32.lt_u
+     if
+      local.get $0
+      i32.const 0
+      i32.store offset=4
+      local.get $0
+      i32.const 0
+      i32.store offset=8
+     else
+      global.get $~lib/rt/itcms/total
+      local.get $0
+      i32.load
+      i32.const -4
+      i32.and
+      i32.const 4
+      i32.add
+      i32.sub
+      global.set $~lib/rt/itcms/total
+      local.get $0
+      i32.const 4
+      i32.add
+      local.tee $0
+      i32.const 17916
+      i32.ge_u
+      if
+       global.get $~lib/rt/tlsf/ROOT
+       i32.eqz
+       if
+        call $~lib/rt/tlsf/initialize
+       end
+       global.get $~lib/rt/tlsf/ROOT
+       local.get $0
+       i32.const 4
+       i32.sub
+       local.set $1
+       local.get $0
+       i32.const 15
+       i32.and
+       i32.const 1
+       local.get $0
+       select
+       if (result i32)
+        i32.const 1
+       else
+        local.get $1
+        i32.load
+        i32.const 1
+        i32.and
+       end
+       if
+        i32.const 0
+        i32.const 1392
+        i32.const 559
+        i32.const 3
+        call $~lib/builtins/abort
+        unreachable
+       end
+       local.get $1
+       local.tee $0
+       i32.load
+       i32.const 1
+       i32.or
+       local.set $1
+       local.get $0
+       local.get $1
+       i32.store
+       local.get $0
+       call $~lib/rt/tlsf/insertBlock
+      end
+     end
+     i32.const 10
+     return
+    end
+    global.get $~lib/rt/itcms/toSpace
+    local.tee $0
+    local.get $0
+    i32.store offset=4
+    global.get $~lib/rt/itcms/toSpace
+    local.tee $0
+    local.get $0
+    i32.store offset=8
+    i32.const 0
+    global.set $~lib/rt/itcms/state
+   end
+   i32.const 0
+   return
+  end
+  global.get $~lib/rt/itcms/visitCount
+ )
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 256
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 4
+   i32.shr_u
+   local.set $1
+  else
+   local.get $1
+   i32.const 536870910
+   i32.lt_u
+   if
+    local.get $1
+    i32.const 1
+    i32.const 27
+    local.get $1
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.set $1
+   end
+   local.get $1
+   i32.const 31
+   local.get $1
+   i32.clz
+   i32.sub
+   local.tee $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $1
+   local.get $2
+   i32.const 7
+   i32.sub
+   local.set $2
+  end
+  local.get $1
+  i32.const 16
+  i32.lt_u
+  i32.const 0
+  local.get $2
+  i32.const 23
+  i32.lt_u
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 330
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const -1
+  local.get $1
+  i32.shl
+  i32.and
+  local.tee $1
+  if (result i32)
+   local.get $0
+   local.get $1
+   i32.ctz
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load offset=96
+  else
+   local.get $0
+   i32.load
+   i32.const -1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.shl
+   i32.and
+   local.tee $1
+   if (result i32)
+    local.get $0
+    local.get $1
+    i32.ctz
+    local.tee $1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.tee $2
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1392
+     i32.const 343
+     i32.const 18
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $2
+    i32.ctz
+    local.get $1
+    i32.const 4
+    i32.shl
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=96
+   else
+    i32.const 0
+   end
+  end
+ )
+ (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.const 1073741804
+  i32.ge_u
+  if
+   i32.const 1056
+   i32.const 1120
+   i32.const 260
+   i32.const 31
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/total
+  global.get $~lib/rt/itcms/threshold
+  i32.ge_u
+  if
+   block $__inlined_func$~lib/rt/itcms/interrupt
+    i32.const 2048
+    local.set $2
+    loop $do-continue|0
+     local.get $2
+     call $~lib/rt/itcms/step
+     i32.sub
+     local.set $2
+     global.get $~lib/rt/itcms/state
+     i32.eqz
+     if
+      global.get $~lib/rt/itcms/total
+      i64.extend_i32_u
+      i64.const 200
+      i64.mul
+      i64.const 100
+      i64.div_u
+      i32.wrap_i64
+      i32.const 1024
+      i32.add
+      global.set $~lib/rt/itcms/threshold
+      br $__inlined_func$~lib/rt/itcms/interrupt
+     end
+     local.get $2
+     i32.const 0
+     i32.gt_s
+     br_if $do-continue|0
+    end
+    global.get $~lib/rt/itcms/total
+    local.tee $2
+    local.get $2
+    global.get $~lib/rt/itcms/threshold
+    i32.sub
+    i32.const 1024
+    i32.lt_u
+    i32.const 10
+    i32.shl
+    i32.add
+    global.set $~lib/rt/itcms/threshold
+   end
+  end
+  local.get $0
+  i32.const 16
+  i32.add
+  local.set $2
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   call $~lib/rt/tlsf/initialize
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  local.set $3
+  local.get $2
+  i32.const 1073741820
+  i32.gt_u
+  if
+   i32.const 1056
+   i32.const 1392
+   i32.const 458
+   i32.const 29
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  local.get $2
+  i32.const 12
+  i32.le_u
+  if (result i32)
+   i32.const 12
+  else
+   local.get $2
+   i32.const 19
+   i32.add
+   i32.const -16
+   i32.and
+   i32.const 4
+   i32.sub
+  end
+  local.tee $2
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $4
+  i32.eqz
+  if
+   local.get $2
+   i32.const 536870910
+   i32.lt_u
+   if (result i32)
+    local.get $2
+    i32.const 1
+    i32.const 27
+    local.get $2
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.const 1
+    i32.sub
+    i32.add
+   else
+    local.get $2
+   end
+   i32.const 4
+   memory.size
+   local.tee $6
+   i32.const 16
+   i32.shl
+   i32.const 4
+   i32.sub
+   local.get $3
+   i32.load offset=1568
+   i32.ne
+   i32.shl
+   i32.add
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $5
+   local.get $6
+   local.get $5
+   local.get $5
+   local.get $6
+   i32.lt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $5
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+   local.get $3
+   local.get $6
+   i32.const 16
+   i32.shl
+   memory.size
+   i32.const 16
+   i32.shl
+   call $~lib/rt/tlsf/addMemory
+   local.get $3
+   local.get $2
+   call $~lib/rt/tlsf/searchBlock
+   local.tee $4
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1392
+    i32.const 496
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $2
+  local.get $4
+  i32.load
+  i32.const -4
+  i32.and
+  i32.gt_u
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 498
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/rt/tlsf/removeBlock
+  local.get $4
+  i32.load
+  local.set $6
+  local.get $2
+  i32.const 4
+  i32.add
+  i32.const 15
+  i32.and
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 357
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.const -4
+  i32.and
+  local.get $2
+  i32.sub
+  local.tee $5
+  i32.const 16
+  i32.ge_u
+  if
+   local.get $4
+   local.get $2
+   local.get $6
+   i32.const 2
+   i32.and
+   i32.or
+   i32.store
+   local.get $2
+   local.get $4
+   i32.const 4
+   i32.add
+   i32.add
+   local.tee $2
+   local.get $5
+   i32.const 4
+   i32.sub
+   i32.const 1
+   i32.or
+   i32.store
+   local.get $3
+   local.get $2
+   call $~lib/rt/tlsf/insertBlock
+  else
+   local.get $4
+   local.get $6
+   i32.const -2
+   i32.and
+   i32.store
+   local.get $4
+   i32.const 4
+   i32.add
+   local.tee $2
+   local.get $4
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.get $2
+   local.get $4
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   i32.load
+   i32.const -3
+   i32.and
+   i32.store
+  end
+  local.get $4
+  local.get $1
+  i32.store offset=12
+  local.get $4
+  local.get $0
+  i32.store offset=16
+  global.get $~lib/rt/itcms/fromSpace
+  local.tee $1
+  i32.load offset=8
+  local.set $2
+  local.get $4
+  local.get $1
+  global.get $~lib/rt/itcms/white
+  i32.or
+  i32.store offset=4
+  local.get $4
+  local.get $2
+  i32.store offset=8
+  local.get $2
+  local.get $4
+  local.get $2
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.or
+  i32.store offset=4
+  local.get $1
+  local.get $4
+  i32.store offset=8
+  global.get $~lib/rt/itcms/total
+  local.get $4
+  i32.load
+  i32.const -4
+  i32.and
+  i32.const 4
+  i32.add
+  i32.add
+  global.set $~lib/rt/itcms/total
+  local.get $4
+  i32.const 20
+  i32.add
+  local.tee $2
+  local.set $3
+  block $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.eqz
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $3
+   i32.const 0
+   i32.store8
+   local.get $0
+   local.get $3
+   i32.add
+   local.tee $1
+   i32.const 1
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $0
+   i32.const 2
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $3
+   i32.const 0
+   i32.store8 offset=1
+   local.get $3
+   i32.const 0
+   i32.store8 offset=2
+   local.get $1
+   i32.const 2
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $1
+   i32.const 3
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $0
+   i32.const 6
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $3
+   i32.const 0
+   i32.store8 offset=3
+   local.get $1
+   i32.const 4
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $0
+   i32.const 8
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $3
+   i32.const 0
+   local.get $3
+   i32.sub
+   i32.const 3
+   i32.and
+   local.tee $1
+   i32.add
+   local.tee $5
+   i32.const 0
+   i32.store
+   local.get $5
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const -4
+   i32.and
+   local.tee $3
+   i32.add
+   local.tee $0
+   i32.const 4
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $3
+   i32.const 8
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $5
+   i32.const 0
+   i32.store offset=4
+   local.get $5
+   i32.const 0
+   i32.store offset=8
+   local.get $0
+   i32.const 12
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $0
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $3
+   i32.const 24
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $5
+   i32.const 0
+   i32.store offset=12
+   local.get $5
+   i32.const 0
+   i32.store offset=16
+   local.get $5
+   i32.const 0
+   i32.store offset=20
+   local.get $5
+   i32.const 0
+   i32.store offset=24
+   local.get $0
+   i32.const 28
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $0
+   i32.const 24
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $0
+   i32.const 20
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $0
+   i32.const 16
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $5
+   local.get $5
+   i32.const 4
+   i32.and
+   i32.const 24
+   i32.add
+   local.tee $1
+   i32.add
+   local.set $0
+   local.get $3
+   local.get $1
+   i32.sub
+   local.set $1
+   loop $while-continue|0
+    local.get $1
+    i32.const 32
+    i32.ge_u
+    if
+     local.get $0
+     i64.const 0
+     i64.store
+     local.get $0
+     i64.const 0
+     i64.store offset=8
+     local.get $0
+     i64.const 0
+     i64.store offset=16
+     local.get $0
+     i64.const 0
+     i64.store offset=24
+     local.get $1
+     i32.const 32
+     i32.sub
+     local.set $1
+     local.get $0
+     i32.const 32
+     i32.add
+     local.set $0
+     br $while-continue|0
+    end
+   end
+  end
+  local.get $2
+ )
+ (func $~lib/rt/__visit_members (param $0 i32)
+  block $invalid
+   block $for-of/TestIterator
+    block $for-of/TestIterable
+     block $~lib/arraybuffer/ArrayBufferView
+      block $~lib/string/String
+       block $~lib/arraybuffer/ArrayBuffer
+        local.get $0
+        i32.const 8
+        i32.sub
+        i32.load
+        br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $for-of/TestIterable $for-of/TestIterator $invalid
+       end
+       return
+      end
+      return
+     end
+     local.get $0
+     i32.load
+     local.tee $0
+     if
+      local.get $0
+      call $~lib/rt/itcms/__visit
+     end
+     return
+    end
+    return
+   end
+   return
+  end
+  unreachable
+ )
+ (func $~start
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  block $__inlined_func$start:for-of
+   memory.size
+   i32.const 16
+   i32.shl
+   i32.const 17916
+   i32.sub
+   i32.const 1
+   i32.shr_u
+   global.set $~lib/rt/itcms/threshold
+   i32.const 1172
+   i32.const 1168
+   i32.store
+   i32.const 1176
+   i32.const 1168
+   i32.store
+   i32.const 1168
+   global.set $~lib/rt/itcms/pinSpace
+   i32.const 1204
+   i32.const 1200
+   i32.store
+   i32.const 1208
+   i32.const 1200
+   i32.store
+   i32.const 1200
+   global.set $~lib/rt/itcms/toSpace
+   i32.const 1348
+   i32.const 1344
+   i32.store
+   i32.const 1352
+   i32.const 1344
+   i32.store
+   i32.const 1344
+   global.set $~lib/rt/itcms/fromSpace
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   block $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1532
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $2
+    i64.const 0
+    i64.store
+    local.get $2
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1532
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    i32.const 0
+    i32.store
+    local.get $0
+    i32.const 0
+    i32.const 3
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    local.tee $3
+    local.get $0
+    i32.store
+    local.get $3
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1532
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    i32.const 0
+    i32.store
+    local.get $0
+    i32.const 4
+    i32.const 4
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store
+    local.get $0
+    i32.const 0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $2
+    local.get $0
+    i32.store offset=4
+    loop $for_of_loop
+     local.get $0
+     i32.load
+     i32.const 3
+     i32.ne
+     if
+      local.get $0
+      local.get $0
+      i32.load
+      i32.const 1
+      i32.add
+      i32.store
+      local.get $1
+      local.get $0
+      i32.load
+      i32.add
+      local.set $1
+      br $for_of_loop
+     end
+    end
+    local.get $1
+    i32.const 6
+    i32.ne
+    if
+     i32.const 0
+     i32.const 1456
+     i32.const 26
+     i32.const 5
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    br $__inlined_func$start:for-of
+   end
+   i32.const 17936
+   i32.const 17984
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+)

--- a/tests/compiler/for-of.ts
+++ b/tests/compiler/for-of.ts
@@ -1,0 +1,28 @@
+// this test skips rtrace because of an unavoidable memory leak
+
+declare function putint(i: i32): void;
+class TestIterator {
+  next(): i32 {
+    return ++this.index;
+  }
+  done(): bool {
+    return this.index == 3;
+  }
+  index: i32 = 0
+}
+class TestIterable {
+  @iterator
+  private iter(): TestIterator {
+    return new TestIterator();
+  }
+}
+function test(): void {
+  let sum = 0;
+  // @ts-ignore
+  for (let a of new TestIterable()) {
+    sum += a;
+  }
+
+  assert(sum == 6);
+}
+test();

--- a/tests/compiler/for-of.untouched.wat
+++ b/tests/compiler/for-of.untouched.wat
@@ -1,0 +1,2583 @@
+(module
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/visitCount (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/pinSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/iter (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/toSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 464))
+ (global $~lib/memory/__data_end i32 (i32.const 508))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 16892))
+ (global $~lib/memory/__heap_base i32 (i32.const 16892))
+ (memory $0 1)
+ (data (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
+ (data (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 144) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 176) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 204) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 268) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 412) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\12\00\00\00f\00o\00r\00-\00o\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 464) "\05\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00")
+ (table $0 1 funcref)
+ (elem $0 (i32.const 1))
+ (export "memory" (memory $0))
+ (start $~start)
+ (func $~lib/rt/itcms/Object#set:nextWithColor (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=4
+ )
+ (func $~lib/rt/itcms/Object#set:prev (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=8
+ )
+ (func $~lib/rt/itcms/initLazy (param $0 i32) (result i32)
+  local.get $0
+  local.get $0
+  call $~lib/rt/itcms/Object#set:nextWithColor
+  local.get $0
+  local.get $0
+  call $~lib/rt/itcms/Object#set:prev
+  local.get $0
+ )
+ (func $~lib/rt/itcms/Object#get:next (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+ )
+ (func $~lib/rt/itcms/Object#get:color (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+ )
+ (func $~lib/rt/itcms/visitRoots (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/__visit_globals
+  global.get $~lib/rt/itcms/pinSpace
+  local.set $1
+  local.get $1
+  call $~lib/rt/itcms/Object#get:next
+  local.set $2
+  loop $while-continue|0
+   local.get $2
+   local.get $1
+   i32.ne
+   local.set $3
+   local.get $3
+   if
+    i32.const 1
+    drop
+    local.get $2
+    call $~lib/rt/itcms/Object#get:color
+    i32.const 3
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $2
+    i32.const 20
+    i32.add
+    local.get $0
+    call $~lib/rt/__visit_members
+    local.get $2
+    call $~lib/rt/itcms/Object#get:next
+    local.set $2
+    br $while-continue|0
+   end
+  end
+ )
+ (func $~lib/rt/itcms/Object#set:color (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.get $1
+  i32.or
+  call $~lib/rt/itcms/Object#set:nextWithColor
+ )
+ (func $~lib/rt/itcms/Object#set:next (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.or
+  call $~lib/rt/itcms/Object#set:nextWithColor
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  call $~lib/rt/itcms/Object#get:next
+  local.set $1
+  local.get $1
+  i32.const 0
+  i32.eq
+  if
+   i32.const 1
+   drop
+   local.get $0
+   i32.load offset=8
+   i32.const 0
+   i32.eq
+   if (result i32)
+    local.get $0
+    global.get $~lib/memory/__heap_base
+    i32.lt_u
+   else
+    i32.const 0
+   end
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 96
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  i32.const 1
+  drop
+  local.get $2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 96
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  call $~lib/rt/itcms/Object#set:prev
+  local.get $2
+  local.get $1
+  call $~lib/rt/itcms/Object#set:next
+ )
+ (func $~lib/rt/__typeinfo (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/rt/__rtti_base
+  local.set $1
+  local.get $0
+  local.get $1
+  i32.load
+  i32.gt_u
+  if
+   i32.const 224
+   i32.const 288
+   i32.const 22
+   i32.const 28
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 4
+  i32.add
+  local.get $0
+  i32.const 8
+  i32.mul
+  i32.add
+  i32.load
+ )
+ (func $~lib/rt/itcms/Object#get:isPointerfree (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $1
+  local.get $1
+  i32.const 1
+  i32.le_u
+  if (result i32)
+   i32.const 1
+  else
+   local.get $1
+   call $~lib/rt/__typeinfo
+   i32.const 32
+   i32.and
+   i32.const 0
+   i32.ne
+  end
+ )
+ (func $~lib/rt/itcms/Object#linkTo (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  i32.load offset=8
+  local.set $3
+  local.get $0
+  local.get $1
+  local.get $2
+  i32.or
+  call $~lib/rt/itcms/Object#set:nextWithColor
+  local.get $0
+  local.get $3
+  call $~lib/rt/itcms/Object#set:prev
+  local.get $3
+  local.get $0
+  call $~lib/rt/itcms/Object#set:next
+  local.get $1
+  local.get $0
+  call $~lib/rt/itcms/Object#set:prev
+ )
+ (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  global.get $~lib/rt/itcms/iter
+  i32.eq
+  if
+   local.get $0
+   i32.load offset=8
+   local.tee $1
+   i32.eqz
+   if (result i32)
+    i32.const 0
+    i32.const 96
+    i32.const 147
+    i32.const 30
+    call $~lib/builtins/abort
+    unreachable
+   else
+    local.get $1
+   end
+   global.set $~lib/rt/itcms/iter
+  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
+  local.get $0
+  global.get $~lib/rt/itcms/toSpace
+  local.get $0
+  call $~lib/rt/itcms/Object#get:isPointerfree
+  if (result i32)
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+  else
+   i32.const 2
+  end
+  call $~lib/rt/itcms/Object#linkTo
+ )
+ (func $~lib/rt/itcms/__visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.eqz
+  if
+   return
+  end
+  local.get $0
+  i32.const 20
+  i32.sub
+  local.set $2
+  i32.const 0
+  drop
+  local.get $2
+  call $~lib/rt/itcms/Object#get:color
+  global.get $~lib/rt/itcms/white
+  i32.eq
+  if
+   local.get $2
+   call $~lib/rt/itcms/Object#makeGray
+   global.get $~lib/rt/itcms/visitCount
+   i32.const 1
+   i32.add
+   global.set $~lib/rt/itcms/visitCount
+  end
+ )
+ (func $~lib/rt/itcms/visitStack (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  local.set $1
+  loop $while-continue|0
+   local.get $1
+   global.get $~lib/memory/__heap_base
+   i32.lt_u
+   local.set $2
+   local.get $2
+   if
+    local.get $1
+    i32.load
+    local.get $0
+    call $~lib/rt/itcms/__visit
+    local.get $1
+    i32.const 4
+    i32.add
+    local.set $1
+    br $while-continue|0
+   end
+  end
+ )
+ (func $~lib/rt/itcms/Object#get:size (param $0 i32) (result i32)
+  i32.const 4
+  local.get $0
+  i32.load
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.add
+ )
+ (func $~lib/rt/tlsf/Root#set:flMap (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+ )
+ (func $~lib/rt/common/BLOCK#set:mmInfo (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+ )
+ (func $~lib/rt/tlsf/Block#set:prev (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=4
+ )
+ (func $~lib/rt/tlsf/Block#set:next (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=8
+ )
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  i32.load
+  local.set $2
+  i32.const 1
+  drop
+  local.get $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 268
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $3
+  i32.const 1
+  drop
+  local.get $3
+  i32.const 12
+  i32.ge_u
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 270
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $4
+   local.get $3
+   i32.const 4
+   i32.shr_u
+   local.set $5
+  else
+   local.get $3
+   local.tee $6
+   i32.const 1073741820
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.lt_u
+   select
+   local.set $6
+   i32.const 31
+   local.get $6
+   i32.clz
+   i32.sub
+   local.set $4
+   local.get $6
+   local.get $4
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $5
+   local.get $4
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $4
+  end
+  i32.const 1
+  drop
+  local.get $4
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $5
+   i32.const 16
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 284
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load offset=4
+  local.set $8
+  local.get $1
+  i32.load offset=8
+  local.set $9
+  local.get $8
+  if
+   local.get $8
+   local.get $9
+   call $~lib/rt/tlsf/Block#set:next
+  end
+  local.get $9
+  if
+   local.get $9
+   local.get $8
+   call $~lib/rt/tlsf/Block#set:prev
+  end
+  local.get $1
+  local.get $0
+  local.set $10
+  local.get $4
+  local.set $6
+  local.get $5
+  local.set $7
+  local.get $10
+  local.get $6
+  i32.const 4
+  i32.shl
+  local.get $7
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  i32.eq
+  if
+   local.get $0
+   local.set $11
+   local.get $4
+   local.set $10
+   local.get $5
+   local.set $6
+   local.get $9
+   local.set $7
+   local.get $11
+   local.get $10
+   i32.const 4
+   i32.shl
+   local.get $6
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $7
+   i32.store offset=96
+   local.get $9
+   i32.eqz
+   if
+    local.get $0
+    local.set $6
+    local.get $4
+    local.set $7
+    local.get $6
+    local.get $7
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.set $6
+    local.get $0
+    local.set $7
+    local.get $4
+    local.set $11
+    local.get $6
+    i32.const 1
+    local.get $5
+    i32.shl
+    i32.const -1
+    i32.xor
+    i32.and
+    local.tee $6
+    local.set $10
+    local.get $7
+    local.get $11
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $10
+    i32.store offset=4
+    local.get $6
+    i32.eqz
+    if
+     local.get $0
+     local.get $0
+     i32.load
+     i32.const 1
+     local.get $4
+     i32.shl
+     i32.const -1
+     i32.xor
+     i32.and
+     call $~lib/rt/tlsf/Root#set:flMap
+    end
+   end
+  end
+ )
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  i32.const 1
+  drop
+  local.get $1
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 201
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load
+  local.set $2
+  i32.const 1
+  drop
+  local.get $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 203
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const 4
+  i32.add
+  local.get $3
+  i32.load
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.add
+  local.set $4
+  local.get $4
+  i32.load
+  local.set $5
+  local.get $5
+  i32.const 1
+  i32.and
+  if
+   local.get $0
+   local.get $4
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 4
+   i32.add
+   local.get $5
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $3
+   local.get $3
+   i32.const 4
+   i32.add
+   local.get $3
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $5
+  end
+  local.get $2
+  i32.const 2
+  i32.and
+  if
+   local.get $1
+   local.set $3
+   local.get $3
+   i32.const 4
+   i32.sub
+   i32.load
+   local.set $3
+   local.get $3
+   i32.load
+   local.set $6
+   i32.const 1
+   drop
+   local.get $6
+   i32.const 1
+   i32.and
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 368
+    i32.const 221
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $3
+   call $~lib/rt/tlsf/removeBlock
+   local.get $3
+   local.set $1
+   local.get $1
+   local.get $6
+   i32.const 4
+   i32.add
+   local.get $2
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.tee $2
+   call $~lib/rt/common/BLOCK#set:mmInfo
+  end
+  local.get $4
+  local.get $5
+  i32.const 2
+  i32.or
+  call $~lib/rt/common/BLOCK#set:mmInfo
+  local.get $2
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $7
+  i32.const 1
+  drop
+  local.get $7
+  i32.const 12
+  i32.ge_u
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 233
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  drop
+  local.get $1
+  i32.const 4
+  i32.add
+  local.get $7
+  i32.add
+  local.get $4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 234
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 4
+  i32.sub
+  local.get $1
+  i32.store
+  local.get $7
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $8
+   local.get $7
+   i32.const 4
+   i32.shr_u
+   local.set $9
+  else
+   local.get $7
+   local.tee $3
+   i32.const 1073741820
+   local.tee $6
+   local.get $3
+   local.get $6
+   i32.lt_u
+   select
+   local.set $3
+   i32.const 31
+   local.get $3
+   i32.clz
+   i32.sub
+   local.set $8
+   local.get $3
+   local.get $8
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $9
+   local.get $8
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $8
+  end
+  i32.const 1
+  drop
+  local.get $8
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $9
+   i32.const 16
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 251
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.set $10
+  local.get $8
+  local.set $3
+  local.get $9
+  local.set $6
+  local.get $10
+  local.get $3
+  i32.const 4
+  i32.shl
+  local.get $6
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  local.set $11
+  local.get $1
+  i32.const 0
+  call $~lib/rt/tlsf/Block#set:prev
+  local.get $1
+  local.get $11
+  call $~lib/rt/tlsf/Block#set:next
+  local.get $11
+  if
+   local.get $11
+   local.get $1
+   call $~lib/rt/tlsf/Block#set:prev
+  end
+  local.get $0
+  local.set $12
+  local.get $8
+  local.set $10
+  local.get $9
+  local.set $3
+  local.get $1
+  local.set $6
+  local.get $12
+  local.get $10
+  i32.const 4
+  i32.shl
+  local.get $3
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $6
+  i32.store offset=96
+  local.get $0
+  local.get $0
+  i32.load
+  i32.const 1
+  local.get $8
+  i32.shl
+  i32.or
+  call $~lib/rt/tlsf/Root#set:flMap
+  local.get $0
+  local.set $13
+  local.get $8
+  local.set $12
+  local.get $0
+  local.set $3
+  local.get $8
+  local.set $6
+  local.get $3
+  local.get $6
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const 1
+  local.get $9
+  i32.shl
+  i32.or
+  local.set $10
+  local.get $13
+  local.get $12
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $10
+  i32.store offset=4
+ )
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  i32.const 1
+  drop
+  local.get $1
+  local.get $2
+  i32.le_u
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 377
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 4
+  i32.add
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 4
+  i32.sub
+  local.set $1
+  local.get $2
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $2
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  local.set $4
+  i32.const 0
+  local.set $5
+  local.get $4
+  if
+   i32.const 1
+   drop
+   local.get $1
+   local.get $4
+   i32.const 4
+   i32.add
+   i32.ge_u
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 368
+    i32.const 384
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 16
+   i32.sub
+   local.get $4
+   i32.eq
+   if
+    local.get $1
+    i32.const 16
+    i32.sub
+    local.set $1
+    local.get $4
+    i32.load
+    local.set $5
+   else
+    nop
+   end
+  else
+   i32.const 1
+   drop
+   local.get $1
+   local.get $0
+   i32.const 1572
+   i32.add
+   i32.ge_u
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 368
+    i32.const 397
+    i32.const 5
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $2
+  local.get $1
+  i32.sub
+  local.set $6
+  local.get $6
+  i32.const 4
+  i32.const 12
+  i32.add
+  i32.const 4
+  i32.add
+  i32.lt_u
+  if
+   i32.const 0
+   return
+  end
+  local.get $6
+  i32.const 2
+  i32.const 4
+  i32.mul
+  i32.sub
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  local.get $7
+  i32.const 1
+  i32.or
+  local.get $5
+  i32.const 2
+  i32.and
+  i32.or
+  call $~lib/rt/common/BLOCK#set:mmInfo
+  local.get $8
+  i32.const 0
+  call $~lib/rt/tlsf/Block#set:prev
+  local.get $8
+  i32.const 0
+  call $~lib/rt/tlsf/Block#set:next
+  local.get $1
+  i32.const 4
+  i32.add
+  local.get $7
+  i32.add
+  local.set $4
+  local.get $4
+  i32.const 0
+  i32.const 2
+  i32.or
+  call $~lib/rt/common/BLOCK#set:mmInfo
+  local.get $0
+  local.set $9
+  local.get $4
+  local.set $3
+  local.get $9
+  local.get $3
+  i32.store offset=1568
+  local.get $0
+  local.get $8
+  call $~lib/rt/tlsf/insertBlock
+  i32.const 1
+ )
+ (func $~lib/rt/tlsf/initialize
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  i32.const 0
+  drop
+  global.get $~lib/memory/__heap_base
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $0
+  i32.const 1572
+  i32.add
+  i32.const 65535
+  i32.add
+  i32.const 65535
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.shr_u
+  local.set $2
+  local.get $2
+  local.get $1
+  i32.gt_s
+  if (result i32)
+   local.get $2
+   local.get $1
+   i32.sub
+   memory.grow
+   i32.const 0
+   i32.lt_s
+  else
+   i32.const 0
+  end
+  if
+   unreachable
+  end
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.const 0
+  call $~lib/rt/tlsf/Root#set:flMap
+  local.get $3
+  local.set $5
+  i32.const 0
+  local.set $4
+  local.get $5
+  local.get $4
+  i32.store offset=1568
+  i32.const 0
+  local.set $5
+  loop $for-loop|0
+   local.get $5
+   i32.const 23
+   i32.lt_u
+   local.set $4
+   local.get $4
+   if
+    local.get $3
+    local.set $8
+    local.get $5
+    local.set $7
+    i32.const 0
+    local.set $6
+    local.get $8
+    local.get $7
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $6
+    i32.store offset=4
+    i32.const 0
+    local.set $8
+    loop $for-loop|1
+     local.get $8
+     i32.const 16
+     i32.lt_u
+     local.set $7
+     local.get $7
+     if
+      local.get $3
+      local.set $11
+      local.get $5
+      local.set $10
+      local.get $8
+      local.set $9
+      i32.const 0
+      local.set $6
+      local.get $11
+      local.get $10
+      i32.const 4
+      i32.shl
+      local.get $9
+      i32.add
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $6
+      i32.store offset=96
+      local.get $8
+      i32.const 1
+      i32.add
+      local.set $8
+      br $for-loop|1
+     end
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $for-loop|0
+   end
+  end
+  local.get $0
+  i32.const 1572
+  i32.add
+  local.set $12
+  i32.const 0
+  drop
+  local.get $3
+  local.get $12
+  memory.size
+  i32.const 16
+  i32.shl
+  call $~lib/rt/tlsf/addMemory
+  drop
+  local.get $3
+  global.set $~lib/rt/tlsf/ROOT
+ )
+ (func $~lib/rt/tlsf/checkUsedBlock (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.const 4
+  i32.sub
+  local.set $1
+  local.get $0
+  i32.const 0
+  i32.ne
+  if (result i32)
+   local.get $0
+   i32.const 15
+   i32.and
+   i32.eqz
+  else
+   i32.const 0
+  end
+  if (result i32)
+   local.get $1
+   i32.load
+   i32.const 1
+   i32.and
+   i32.eqz
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 559
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+ )
+ (func $~lib/rt/tlsf/freeBlock (param $0 i32) (param $1 i32)
+  i32.const 0
+  drop
+  local.get $1
+  local.get $1
+  i32.load
+  i32.const 1
+  i32.or
+  call $~lib/rt/common/BLOCK#set:mmInfo
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+ )
+ (func $~lib/rt/tlsf/__free (param $0 i32)
+  local.get $0
+  global.get $~lib/memory/__heap_base
+  i32.lt_u
+  if
+   return
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   call $~lib/rt/tlsf/initialize
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  local.get $0
+  call $~lib/rt/tlsf/checkUsedBlock
+  call $~lib/rt/tlsf/freeBlock
+ )
+ (func $~lib/rt/itcms/free (param $0 i32)
+  local.get $0
+  global.get $~lib/memory/__heap_base
+  i32.lt_u
+  if
+   local.get $0
+   i32.const 0
+   call $~lib/rt/itcms/Object#set:nextWithColor
+   local.get $0
+   i32.const 0
+   call $~lib/rt/itcms/Object#set:prev
+  else
+   global.get $~lib/rt/itcms/total
+   local.get $0
+   call $~lib/rt/itcms/Object#get:size
+   i32.sub
+   global.set $~lib/rt/itcms/total
+   i32.const 0
+   drop
+   local.get $0
+   i32.const 4
+   i32.add
+   call $~lib/rt/tlsf/__free
+  end
+ )
+ (func $~lib/rt/itcms/step (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  block $break|0
+   block $case2|0
+    block $case1|0
+     block $case0|0
+      global.get $~lib/rt/itcms/state
+      local.set $1
+      local.get $1
+      i32.const 0
+      i32.eq
+      br_if $case0|0
+      local.get $1
+      i32.const 1
+      i32.eq
+      br_if $case1|0
+      local.get $1
+      i32.const 2
+      i32.eq
+      br_if $case2|0
+      br $break|0
+     end
+     i32.const 1
+     global.set $~lib/rt/itcms/state
+     i32.const 0
+     global.set $~lib/rt/itcms/visitCount
+     i32.const 0
+     call $~lib/rt/itcms/visitRoots
+     global.get $~lib/rt/itcms/toSpace
+     global.set $~lib/rt/itcms/iter
+     global.get $~lib/rt/itcms/visitCount
+     i32.const 1
+     i32.mul
+     return
+    end
+    global.get $~lib/rt/itcms/white
+    i32.eqz
+    local.set $1
+    global.get $~lib/rt/itcms/iter
+    call $~lib/rt/itcms/Object#get:next
+    local.set $0
+    loop $while-continue|1
+     local.get $0
+     global.get $~lib/rt/itcms/toSpace
+     i32.ne
+     local.set $2
+     local.get $2
+     if
+      local.get $0
+      global.set $~lib/rt/itcms/iter
+      local.get $0
+      call $~lib/rt/itcms/Object#get:color
+      local.get $1
+      i32.ne
+      if
+       local.get $0
+       local.get $1
+       call $~lib/rt/itcms/Object#set:color
+       i32.const 0
+       global.set $~lib/rt/itcms/visitCount
+       local.get $0
+       i32.const 20
+       i32.add
+       i32.const 0
+       call $~lib/rt/__visit_members
+       global.get $~lib/rt/itcms/visitCount
+       i32.const 1
+       i32.mul
+       return
+      end
+      local.get $0
+      call $~lib/rt/itcms/Object#get:next
+      local.set $0
+      br $while-continue|1
+     end
+    end
+    i32.const 0
+    global.set $~lib/rt/itcms/visitCount
+    i32.const 0
+    call $~lib/rt/itcms/visitRoots
+    global.get $~lib/rt/itcms/iter
+    call $~lib/rt/itcms/Object#get:next
+    local.set $0
+    local.get $0
+    global.get $~lib/rt/itcms/toSpace
+    i32.eq
+    if
+     i32.const 0
+     call $~lib/rt/itcms/visitStack
+     global.get $~lib/rt/itcms/iter
+     call $~lib/rt/itcms/Object#get:next
+     local.set $0
+     loop $while-continue|2
+      local.get $0
+      global.get $~lib/rt/itcms/toSpace
+      i32.ne
+      local.set $2
+      local.get $2
+      if
+       local.get $0
+       call $~lib/rt/itcms/Object#get:color
+       local.get $1
+       i32.ne
+       if
+        local.get $0
+        local.get $1
+        call $~lib/rt/itcms/Object#set:color
+        local.get $0
+        i32.const 20
+        i32.add
+        i32.const 0
+        call $~lib/rt/__visit_members
+       end
+       local.get $0
+       call $~lib/rt/itcms/Object#get:next
+       local.set $0
+       br $while-continue|2
+      end
+     end
+     global.get $~lib/rt/itcms/fromSpace
+     local.set $2
+     global.get $~lib/rt/itcms/toSpace
+     global.set $~lib/rt/itcms/fromSpace
+     local.get $2
+     global.set $~lib/rt/itcms/toSpace
+     local.get $1
+     global.set $~lib/rt/itcms/white
+     local.get $2
+     call $~lib/rt/itcms/Object#get:next
+     global.set $~lib/rt/itcms/iter
+     i32.const 2
+     global.set $~lib/rt/itcms/state
+    end
+    global.get $~lib/rt/itcms/visitCount
+    i32.const 1
+    i32.mul
+    return
+   end
+   global.get $~lib/rt/itcms/iter
+   local.set $0
+   local.get $0
+   global.get $~lib/rt/itcms/toSpace
+   i32.ne
+   if
+    local.get $0
+    call $~lib/rt/itcms/Object#get:next
+    global.set $~lib/rt/itcms/iter
+    i32.const 1
+    drop
+    local.get $0
+    call $~lib/rt/itcms/Object#get:color
+    global.get $~lib/rt/itcms/white
+    i32.eqz
+    i32.eq
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 228
+     i32.const 20
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    call $~lib/rt/itcms/free
+    i32.const 10
+    return
+   end
+   global.get $~lib/rt/itcms/toSpace
+   global.get $~lib/rt/itcms/toSpace
+   call $~lib/rt/itcms/Object#set:nextWithColor
+   global.get $~lib/rt/itcms/toSpace
+   global.get $~lib/rt/itcms/toSpace
+   call $~lib/rt/itcms/Object#set:prev
+   i32.const 0
+   global.set $~lib/rt/itcms/state
+   br $break|0
+  end
+  i32.const 0
+ )
+ (func $~lib/rt/itcms/interrupt
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  drop
+  i32.const 0
+  drop
+  i32.const 1024
+  i32.const 200
+  i32.mul
+  i32.const 100
+  i32.div_u
+  local.set $0
+  loop $do-continue|0
+   local.get $0
+   call $~lib/rt/itcms/step
+   i32.sub
+   local.set $0
+   global.get $~lib/rt/itcms/state
+   i32.const 0
+   i32.eq
+   if
+    i32.const 0
+    drop
+    global.get $~lib/rt/itcms/total
+    i64.extend_i32_u
+    i64.const 200
+    i64.mul
+    i64.const 100
+    i64.div_u
+    i32.wrap_i64
+    i32.const 1024
+    i32.add
+    global.set $~lib/rt/itcms/threshold
+    i32.const 0
+    drop
+    return
+   end
+   local.get $0
+   i32.const 0
+   i32.gt_s
+   local.set $1
+   local.get $1
+   br_if $do-continue|0
+  end
+  i32.const 0
+  drop
+  global.get $~lib/rt/itcms/total
+  i32.const 1024
+  global.get $~lib/rt/itcms/total
+  global.get $~lib/rt/itcms/threshold
+  i32.sub
+  i32.const 1024
+  i32.lt_u
+  i32.mul
+  i32.add
+  global.set $~lib/rt/itcms/threshold
+  i32.const 0
+  drop
+ )
+ (func $~lib/rt/tlsf/computeSize (param $0 i32) (result i32)
+  local.get $0
+  i32.const 12
+  i32.le_u
+  if (result i32)
+   i32.const 12
+  else
+   local.get $0
+   i32.const 4
+   i32.add
+   i32.const 15
+   i32.add
+   i32.const 15
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 4
+   i32.sub
+  end
+ )
+ (func $~lib/rt/tlsf/prepareSize (param $0 i32) (result i32)
+  local.get $0
+  i32.const 1073741820
+  i32.gt_u
+  if
+   i32.const 32
+   i32.const 368
+   i32.const 458
+   i32.const 29
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/rt/tlsf/computeSize
+ )
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $1
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $2
+   local.get $1
+   i32.const 4
+   i32.shr_u
+   local.set $3
+  else
+   local.get $1
+   i32.const 536870910
+   i32.lt_u
+   if (result i32)
+    local.get $1
+    i32.const 1
+    i32.const 27
+    local.get $1
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+   else
+    local.get $1
+   end
+   local.set $4
+   i32.const 31
+   local.get $4
+   i32.clz
+   i32.sub
+   local.set $2
+   local.get $4
+   local.get $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $3
+   local.get $2
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $2
+  end
+  i32.const 1
+  drop
+  local.get $2
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $3
+   i32.const 16
+   i32.lt_u
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 330
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $5
+  local.get $4
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const 0
+  i32.const -1
+  i32.xor
+  local.get $3
+  i32.shl
+  i32.and
+  local.set $6
+  i32.const 0
+  local.set $7
+  local.get $6
+  i32.eqz
+  if
+   local.get $0
+   i32.load
+   i32.const 0
+   i32.const -1
+   i32.xor
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.shl
+   i32.and
+   local.set $5
+   local.get $5
+   i32.eqz
+   if
+    i32.const 0
+    local.set $7
+   else
+    local.get $5
+    i32.ctz
+    local.set $2
+    local.get $0
+    local.set $8
+    local.get $2
+    local.set $4
+    local.get $8
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.set $6
+    i32.const 1
+    drop
+    local.get $6
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 368
+     i32.const 343
+     i32.const 18
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.set $9
+    local.get $2
+    local.set $8
+    local.get $6
+    i32.ctz
+    local.set $4
+    local.get $9
+    local.get $8
+    i32.const 4
+    i32.shl
+    local.get $4
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=96
+    local.set $7
+   end
+  else
+   local.get $0
+   local.set $9
+   local.get $2
+   local.set $8
+   local.get $6
+   i32.ctz
+   local.set $4
+   local.get $9
+   local.get $8
+   i32.const 4
+   i32.shl
+   local.get $4
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load offset=96
+   local.set $7
+  end
+  local.get $7
+ )
+ (func $~lib/rt/tlsf/growMemory (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  i32.const 0
+  drop
+  local.get $1
+  i32.const 536870910
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
+  memory.size
+  local.set $2
+  local.get $1
+  i32.const 4
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 4
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.ne
+  i32.shl
+  i32.add
+  local.set $1
+  local.get $1
+  i32.const 65535
+  i32.add
+  i32.const 65535
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.shr_u
+  local.set $4
+  local.get $2
+  local.tee $3
+  local.get $4
+  local.tee $5
+  local.get $3
+  local.get $5
+  i32.gt_s
+  select
+  local.set $6
+  local.get $6
+  memory.grow
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    unreachable
+   end
+  end
+  memory.size
+  local.set $7
+  local.get $0
+  local.get $2
+  i32.const 16
+  i32.shl
+  local.get $7
+  i32.const 16
+  i32.shl
+  call $~lib/rt/tlsf/addMemory
+  drop
+ )
+ (func $~lib/rt/tlsf/prepareBlock (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.load
+  local.set $3
+  i32.const 1
+  drop
+  local.get $2
+  i32.const 4
+  i32.add
+  i32.const 15
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 357
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.get $2
+  i32.sub
+  local.set $4
+  local.get $4
+  i32.const 4
+  i32.const 12
+  i32.add
+  i32.ge_u
+  if
+   local.get $1
+   local.get $2
+   local.get $3
+   i32.const 2
+   i32.and
+   i32.or
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $2
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $4
+   i32.const 4
+   i32.sub
+   i32.const 1
+   i32.or
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $0
+   local.get $5
+   call $~lib/rt/tlsf/insertBlock
+  else
+   local.get $1
+   local.get $3
+   i32.const 1
+   i32.const -1
+   i32.xor
+   i32.and
+   call $~lib/rt/common/BLOCK#set:mmInfo
+   local.get $1
+   local.set $5
+   local.get $5
+   i32.const 4
+   i32.add
+   local.get $5
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.get $1
+   local.set $5
+   local.get $5
+   i32.const 4
+   i32.add
+   local.get $5
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   i32.load
+   i32.const 2
+   i32.const -1
+   i32.xor
+   i32.and
+   call $~lib/rt/common/BLOCK#set:mmInfo
+  end
+ )
+ (func $~lib/rt/tlsf/allocateBlock (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $1
+  call $~lib/rt/tlsf/prepareSize
+  local.set $2
+  local.get $0
+  local.get $2
+  call $~lib/rt/tlsf/searchBlock
+  local.set $3
+  local.get $3
+  i32.eqz
+  if
+   local.get $0
+   local.get $2
+   call $~lib/rt/tlsf/growMemory
+   local.get $0
+   local.get $2
+   call $~lib/rt/tlsf/searchBlock
+   local.set $3
+   i32.const 1
+   drop
+   local.get $3
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 368
+    i32.const 496
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 1
+  drop
+  local.get $3
+  i32.load
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.get $2
+  i32.ge_u
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 498
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $3
+  call $~lib/rt/tlsf/removeBlock
+  local.get $0
+  local.get $3
+  local.get $2
+  call $~lib/rt/tlsf/prepareBlock
+  i32.const 0
+  drop
+  local.get $3
+ )
+ (func $~lib/rt/tlsf/__alloc (param $0 i32) (result i32)
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   call $~lib/rt/tlsf/initialize
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  local.get $0
+  call $~lib/rt/tlsf/allocateBlock
+  i32.const 4
+  i32.add
+ )
+ (func $~lib/rt/itcms/Object#set:rtId (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/rt/itcms/Object#set:rtSize (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=16
+ )
+ (func $~lib/memory/memory.fill (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i64)
+  (local $10 i32)
+  block $~lib/util/memory/memset|inlined.0
+   local.get $0
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $3
+   i32.const 0
+   i32.const 1
+   i32.gt_s
+   drop
+   local.get $3
+   i32.eqz
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   local.get $3
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $4
+   i32.store8
+   local.get $6
+   i32.const 1
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $3
+   i32.const 2
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   local.get $4
+   i32.store8 offset=1
+   local.get $5
+   local.get $4
+   i32.store8 offset=2
+   local.get $6
+   i32.const 2
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $6
+   i32.const 3
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $3
+   i32.const 6
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   local.get $4
+   i32.store8 offset=3
+   local.get $6
+   i32.const 4
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $3
+   i32.const 8
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   i32.const 0
+   local.get $5
+   i32.sub
+   i32.const 3
+   i32.and
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.add
+   local.set $5
+   local.get $3
+   local.get $7
+   i32.sub
+   local.set $3
+   local.get $3
+   i32.const -4
+   i32.and
+   local.set $3
+   i32.const -1
+   i32.const 255
+   i32.div_u
+   local.get $4
+   i32.const 255
+   i32.and
+   i32.mul
+   local.set $8
+   local.get $5
+   local.get $3
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $8
+   i32.store
+   local.get $6
+   i32.const 4
+   i32.sub
+   local.get $8
+   i32.store
+   local.get $3
+   i32.const 8
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   local.get $8
+   i32.store offset=4
+   local.get $5
+   local.get $8
+   i32.store offset=8
+   local.get $6
+   i32.const 12
+   i32.sub
+   local.get $8
+   i32.store
+   local.get $6
+   i32.const 8
+   i32.sub
+   local.get $8
+   i32.store
+   local.get $3
+   i32.const 24
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   local.get $8
+   i32.store offset=12
+   local.get $5
+   local.get $8
+   i32.store offset=16
+   local.get $5
+   local.get $8
+   i32.store offset=20
+   local.get $5
+   local.get $8
+   i32.store offset=24
+   local.get $6
+   i32.const 28
+   i32.sub
+   local.get $8
+   i32.store
+   local.get $6
+   i32.const 24
+   i32.sub
+   local.get $8
+   i32.store
+   local.get $6
+   i32.const 20
+   i32.sub
+   local.get $8
+   i32.store
+   local.get $6
+   i32.const 16
+   i32.sub
+   local.get $8
+   i32.store
+   i32.const 24
+   local.get $5
+   i32.const 4
+   i32.and
+   i32.add
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.add
+   local.set $5
+   local.get $3
+   local.get $7
+   i32.sub
+   local.set $3
+   local.get $8
+   i64.extend_i32_u
+   local.get $8
+   i64.extend_i32_u
+   i64.const 32
+   i64.shl
+   i64.or
+   local.set $9
+   loop $while-continue|0
+    local.get $3
+    i32.const 32
+    i32.ge_u
+    local.set $10
+    local.get $10
+    if
+     local.get $5
+     local.get $9
+     i64.store
+     local.get $5
+     local.get $9
+     i64.store offset=8
+     local.get $5
+     local.get $9
+     i64.store offset=16
+     local.get $5
+     local.get $9
+     i64.store offset=24
+     local.get $3
+     i32.const 32
+     i32.sub
+     local.set $3
+     local.get $5
+     i32.const 32
+     i32.add
+     local.set $5
+     br $while-continue|0
+    end
+   end
+  end
+ )
+ (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  i32.const 1073741804
+  i32.ge_u
+  if
+   i32.const 32
+   i32.const 96
+   i32.const 260
+   i32.const 31
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/total
+  global.get $~lib/rt/itcms/threshold
+  i32.ge_u
+  if
+   call $~lib/rt/itcms/interrupt
+  end
+  i32.const 16
+  local.get $0
+  i32.add
+  call $~lib/rt/tlsf/__alloc
+  i32.const 4
+  i32.sub
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/itcms/Object#set:rtId
+  local.get $2
+  local.get $0
+  call $~lib/rt/itcms/Object#set:rtSize
+  local.get $2
+  global.get $~lib/rt/itcms/fromSpace
+  global.get $~lib/rt/itcms/white
+  call $~lib/rt/itcms/Object#linkTo
+  global.get $~lib/rt/itcms/total
+  local.get $2
+  call $~lib/rt/itcms/Object#get:size
+  i32.add
+  global.set $~lib/rt/itcms/total
+  local.get $2
+  i32.const 20
+  i32.add
+  local.set $3
+  local.get $3
+  i32.const 0
+  local.get $0
+  call $~lib/memory/memory.fill
+  local.get $3
+ )
+ (func $for-of/TestIterator#set:index (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+ )
+ (func $for-of/TestIterable#iter (param $0 i32) (result i32)
+  i32.const 0
+  call $for-of/TestIterator#constructor
+ )
+ (func $for-of/TestIterator#done (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  i32.const 3
+  i32.eq
+ )
+ (func $for-of/TestIterator#get:index (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+ )
+ (func $for-of/TestIterator#next (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  local.tee $1
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.add
+  call $for-of/TestIterator#set:index
+  local.get $1
+  call $for-of/TestIterator#get:index
+ )
+ (func $start:for-of
+  memory.size
+  i32.const 16
+  i32.shl
+  global.get $~lib/memory/__heap_base
+  i32.sub
+  i32.const 1
+  i32.shr_u
+  global.set $~lib/rt/itcms/threshold
+  i32.const 144
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/pinSpace
+  i32.const 176
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/toSpace
+  i32.const 320
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/fromSpace
+  call $for-of/test
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  i32.const 224
+  local.get $0
+  call $~lib/rt/itcms/__visit
+  i32.const 32
+  local.get $0
+  call $~lib/rt/itcms/__visit
+ )
+ (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/itcms/__visit
+  end
+ )
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
+  block $invalid
+   block $for-of/TestIterator
+    block $for-of/TestIterable
+     block $~lib/arraybuffer/ArrayBufferView
+      block $~lib/string/String
+       block $~lib/arraybuffer/ArrayBuffer
+        local.get $0
+        i32.const 8
+        i32.sub
+        i32.load
+        br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $for-of/TestIterable $for-of/TestIterator $invalid
+       end
+       return
+      end
+      return
+     end
+     local.get $0
+     local.get $1
+     call $~lib/arraybuffer/ArrayBufferView~visit
+     return
+    end
+    return
+   end
+   return
+  end
+  unreachable
+ )
+ (func $~start
+  call $start:for-of
+ )
+ (func $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__data_end
+  i32.lt_s
+  if
+   i32.const 16912
+   i32.const 16960
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $for-of/test
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  i32.const 0
+  local.set $0
+  block $for_of_done
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   call $for-of/TestIterable#constructor
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store
+   local.get $3
+   call $for-of/TestIterable#iter
+   local.tee $1
+   i32.store offset=4
+   loop $for_of_loop
+    local.get $1
+    call $for-of/TestIterator#done
+    i32.const 1
+    i32.eq
+    br_if $for_of_done
+    local.get $1
+    call $for-of/TestIterator#next
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.add
+    local.set $0
+    br $for_of_loop
+   end
+   unreachable
+  end
+  local.get $0
+  i32.const 6
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 26
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $for-of/TestIterable#constructor (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 3
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+  end
+  local.get $0
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $for-of/TestIterator#constructor (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.const 4
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+  end
+  local.get $0
+  i32.const 0
+  call $for-of/TestIterator#set:index
+  local.get $0
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+)

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -2872,7 +2872,7 @@
   end
   i32.const 1280
   i32.const 1488
-  i32.const 99
+  i32.const 110
   i32.const 42
   call $~lib/builtins/abort
   unreachable

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -3708,7 +3708,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3734,7 +3734,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3760,7 +3760,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3786,7 +3786,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3828,7 +3828,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4604,7 +4604,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4650,7 +4650,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4696,7 +4696,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4721,7 +4721,7 @@
   if
    i32.const 976
    i32.const 464
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -2567,7 +2567,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3224,7 +3224,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3244,7 +3244,7 @@
   if
    i32.const 1552
    i32.const 1104
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -3866,7 +3866,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4194,7 +4194,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -4289,7 +4289,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4314,7 +4314,7 @@
   if
    i32.const 528
    i32.const 80
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -3232,7 +3232,7 @@
   if
    i32.const 1280
    i32.const 1488
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -3708,7 +3708,7 @@
   if
    i32.const 256
    i32.const 464
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -156,7 +156,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -176,7 +176,7 @@
   if
    i32.const 1168
    i32.const 1120
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -227,7 +227,7 @@
    if
     i32.const 1056
     i32.const 1120
-    i32.const 99
+    i32.const 110
     i32.const 42
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -32,7 +32,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -402,7 +402,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -427,7 +427,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -458,7 +458,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -483,7 +483,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -514,7 +514,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -539,7 +539,7 @@
   if
    i32.const 144
    i32.const 96
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -63,7 +63,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -82,7 +82,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -69,7 +69,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -99,7 +99,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -48,9 +48,9 @@
  (global $~lib/util/number/_frc_pow (mut i64) (i64.const 0))
  (global $~lib/util/number/_exp_pow (mut i32) (i32.const 0))
  (global $std/array/ArrayU32 i32 (i32.const 40))
- (global $std/array/ArrayU8 i32 (i32.const 41))
- (global $std/array/ArrayStr i32 (i32.const 42))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 31428))
+ (global $std/array/ArrayU8 i32 (i32.const 42))
+ (global $std/array/ArrayStr i32 (i32.const 44))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 31452))
  (global $~started (mut i32) (i32.const 0))
  (memory $0 1)
  (data (i32.const 1036) ",")
@@ -573,16 +573,18 @@
  (data (i32.const 14556) "<")
  (data (i32.const 14568) "\01\00\00\00(\00\00\00I\00l\00l\00e\00g\00a\00l\00 \00g\00e\00n\00e\00r\00i\00c\00 \00t\00y\00p\00e")
  (data (i32.const 14620) "\1c")
- (data (i32.const 14632) "+\00\00\00\08\00\00\009")
+ (data (i32.const 14632) ".\00\00\00\08\00\00\009")
  (data (i32.const 14652) "\1c")
  (data (i32.const 14664) "\1e\00\00\00\08\00\00\00:")
- (data (i32.const 14688) ",\00\00\00 \00\00\00\00\00\00\00 ")
+ (data (i32.const 14688) "/\00\00\00 \00\00\00\00\00\00\00 ")
  (data (i32.const 14716) "\02\t\00\00\00\00\00\00 \00\00\00\00\00\00\00A\00\00\00\02\00\00\00B\00\00\00\00\00\00\00\02\01\00\00\00\00\00\00\02A\00\00\00\00\00\00\02\19\00\00\00\00\00\00\02\1a\00\00\00\00\00\00\02a")
  (data (i32.const 14868) "\02A")
  (data (i32.const 14884) " \00\00\00\00\00\00\00\02A")
  (data (i32.const 14908) "\02a")
  (data (i32.const 14924) "\02A")
- (data (i32.const 14940) "B\00\00\00\00\00\00\00B\08\00\00\00\00\00\00\82\00\00\00\00\00\00\00\02\02\00\00\00\00\00\00\02\n\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02\01\00\00\07\00\00\00B\00\00\00\06\00\00\00\02A\00\00\1d")
+ (data (i32.const 14940) "B\00\00\00\00\00\00\00B\08\00\00\00\00\00\00\82\00\00\00\00\00\00\00\02\02\00\00\00\00\00\00\02\n\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02\01\00\00\07")
+ (data (i32.const 15028) "B\00\00\00\06")
+ (data (i32.const 15044) "\02A\00\00\1d")
  (table $0 59 funcref)
  (elem $0 (i32.const 1) $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|2 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|16 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $~lib/util/sort/COMPARATOR<f32>~anonymous|0 $~lib/util/sort/COMPARATOR<f64>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $~lib/util/sort/COMPARATOR<u32>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/util/sort/COMPARATOR<~lib/string/String|null>~anonymous|0 $~lib/util/sort/COMPARATOR<~lib/string/String|null>~anonymous|0 $~lib/util/sort/COMPARATOR<u8>~anonymous|0 $~lib/util/sort/COMPARATOR<~lib/string/String|null>~anonymous|0)
  (export "ArrayU32" (global $std/array/ArrayU32))
@@ -770,7 +772,7 @@
    if
     i32.const 0
     local.get $0
-    i32.const 31428
+    i32.const 31452
     i32.lt_u
     local.get $0
     i32.load offset=8
@@ -1431,10 +1433,10 @@
   if
    unreachable
   end
-  i32.const 31440
+  i32.const 31456
   i32.const 0
   i32.store
-  i32.const 33008
+  i32.const 33024
   i32.const 0
   i32.store
   loop $for-loop|0
@@ -1445,7 +1447,7 @@
     local.get $1
     i32.const 2
     i32.shl
-    i32.const 31440
+    i32.const 31456
     i32.add
     i32.const 0
     i32.store offset=4
@@ -1463,7 +1465,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 31440
+      i32.const 31456
       i32.add
       i32.const 0
       i32.store offset=96
@@ -1481,20 +1483,20 @@
     br $for-loop|0
    end
   end
-  i32.const 31440
-  i32.const 33012
+  i32.const 31456
+  i32.const 33028
   memory.size
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 31440
+  i32.const 31456
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/tlsf/__free (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
-  i32.const 31428
+  i32.const 31452
   i32.lt_u
   if
    return
@@ -1623,7 +1625,7 @@
       local.set $0
       loop $while-continue|0
        local.get $0
-       i32.const 31428
+       i32.const 31452
        i32.lt_u
        if
         local.get $0
@@ -1718,7 +1720,7 @@
       unreachable
      end
      local.get $0
-     i32.const 31428
+     i32.const 31452
      i32.lt_u
      if
       local.get $0
@@ -3484,7 +3486,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3548,7 +3550,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3761,7 +3763,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3785,7 +3787,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 276
+   i32.const 292
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -3836,7 +3838,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 132
+   i32.const 148
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -4045,7 +4047,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4298,7 +4300,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5143,7 +5145,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5893,7 +5895,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6195,11 +6197,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -6472,11 +6474,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -6698,11 +6700,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -7986,11 +7988,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -8204,11 +8206,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -8979,11 +8981,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -9471,22 +9473,25 @@
   call $~lib/rt/itcms/__visit
  )
  (func $~lib/rt/__visit_members (param $0 i32)
-  block $folding-inner4
-   block $folding-inner3
-    block $folding-inner2
-     block $folding-inner1
-      block $folding-inner0
-       block $invalid
-        block $std/array/ArrayStr
-         block $std/array/Proxy<i32>
-          block $std/array/Ref
-           block $~lib/string/String
-            block $~lib/arraybuffer/ArrayBuffer
-             local.get $0
-             i32.const 8
-             i32.sub
-             i32.load
-             br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner4 $folding-inner0 $std/array/Ref $folding-inner4 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner1 $folding-inner2 $std/array/Proxy<i32> $folding-inner1 $folding-inner2 $folding-inner1 $folding-inner2 $folding-inner1 $folding-inner2 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner1 $folding-inner1 $folding-inner1 $folding-inner3 $folding-inner3 $std/array/ArrayStr $folding-inner2 $invalid
+  block $folding-inner5
+   block $folding-inner4
+    block $folding-inner3
+     block $folding-inner2
+      block $folding-inner1
+       block $folding-inner0
+        block $invalid
+         block $std/array/ArrayStr
+          block $std/array/Proxy<i32>
+           block $std/array/Ref
+            block $~lib/string/String
+             block $~lib/arraybuffer/ArrayBuffer
+              local.get $0
+              i32.const 8
+              i32.sub
+              i32.load
+              br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $folding-inner5 $folding-inner0 $std/array/Ref $folding-inner5 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner2 $folding-inner1 $folding-inner2 $std/array/Proxy<i32> $folding-inner1 $folding-inner2 $folding-inner1 $folding-inner2 $folding-inner1 $folding-inner2 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner1 $folding-inner1 $folding-inner1 $folding-inner1 $folding-inner3 $folding-inner4 $folding-inner3 $folding-inner4 $std/array/ArrayStr $folding-inner4 $folding-inner2 $invalid
+             end
+             return
             end
             return
            end
@@ -9494,31 +9499,38 @@
           end
           return
          end
+         local.get $0
+         call $~lib/array/Array<std/array/Ref>~visit
          return
         end
-        local.get $0
-        call $~lib/array/Array<std/array/Ref>~visit
-        return
+        unreachable
        end
-       unreachable
+       local.get $0
+       i32.load
+       call $~lib/rt/itcms/__visit
+       return
       end
       local.get $0
-      i32.load
-      call $~lib/rt/itcms/__visit
+      call $~lib/array/Array<std/array/Ref>~visit
       return
      end
      local.get $0
-     call $~lib/array/Array<std/array/Ref>~visit
+     i32.load offset=4
+     call $~lib/rt/itcms/__visit
      return
     end
     local.get $0
-    i32.load offset=4
+    i32.load
     call $~lib/rt/itcms/__visit
     return
    end
    local.get $0
-   i32.load
-   call $~lib/rt/itcms/__visit
+   i32.load offset=4
+   local.tee $0
+   if
+    local.get $0
+    call $~lib/rt/itcms/__visit
+   end
    return
   end
   local.get $0
@@ -9552,11 +9564,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -9635,11 +9647,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -9671,7 +9683,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -9691,7 +9703,7 @@
     i32.sub
     global.set $~lib/memory/__stack_pointer
     global.get $~lib/memory/__stack_pointer
-    i32.const 15044
+    i32.const 15068
     i32.lt_s
     br_if $folding-inner0
     global.get $~lib/memory/__stack_pointer
@@ -9768,8 +9780,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -9782,11 +9794,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -9814,11 +9826,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -9846,11 +9858,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -9878,11 +9890,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -9916,7 +9928,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -9937,7 +9949,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -10076,8 +10088,8 @@
    local.get $0
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -10105,7 +10117,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner2
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -10139,7 +10151,7 @@
    memory.size
    i32.const 16
    i32.shl
-   i32.const 31428
+   i32.const 31452
    i32.sub
    i32.const 1
    i32.shr_u
@@ -10183,7 +10195,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -10202,7 +10214,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -12215,7 +12227,7 @@
    if
     i32.const 2176
     i32.const 1104
-    i32.const 335
+    i32.const 351
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -15808,7 +15820,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -17698,7 +17710,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -19155,7 +19167,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -19403,7 +19415,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -19651,7 +19663,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -19970,7 +19982,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -19982,7 +19994,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -20092,7 +20104,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -20104,7 +20116,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -20176,7 +20188,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 15044
+     i32.const 15068
      i32.lt_s
      br_if $folding-inner2
      global.get $~lib/memory/__stack_pointer
@@ -20250,7 +20262,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -20277,7 +20289,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -20297,7 +20309,7 @@
     i32.sub
     global.set $~lib/memory/__stack_pointer
     global.get $~lib/memory/__stack_pointer
-    i32.const 15044
+    i32.const 15068
     i32.lt_s
     br_if $folding-inner2
     global.get $~lib/memory/__stack_pointer
@@ -20384,7 +20396,7 @@
     i32.sub
     global.set $~lib/memory/__stack_pointer
     global.get $~lib/memory/__stack_pointer
-    i32.const 15044
+    i32.const 15068
     i32.lt_s
     br_if $folding-inner2
     global.get $~lib/memory/__stack_pointer
@@ -20466,7 +20478,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -20496,7 +20508,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 15044
+     i32.const 15068
      i32.lt_s
      br_if $folding-inner2
      global.get $~lib/memory/__stack_pointer
@@ -20539,7 +20551,7 @@
        i32.sub
        global.set $~lib/memory/__stack_pointer
        global.get $~lib/memory/__stack_pointer
-       i32.const 15044
+       i32.const 15068
        i32.lt_s
        br_if $folding-inner2
        global.get $~lib/memory/__stack_pointer
@@ -20630,7 +20642,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -20687,7 +20699,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -21283,7 +21295,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -21308,7 +21320,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -21472,7 +21484,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -21497,7 +21509,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -21665,7 +21677,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -21690,7 +21702,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -21725,7 +21737,7 @@
        i32.sub
        global.set $~lib/memory/__stack_pointer
        global.get $~lib/memory/__stack_pointer
-       i32.const 15044
+       i32.const 15068
        i32.lt_s
        br_if $folding-inner2
        global.get $~lib/memory/__stack_pointer
@@ -22015,7 +22027,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -22040,7 +22052,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -22076,7 +22088,7 @@
       i32.sub
       global.set $~lib/memory/__stack_pointer
       global.get $~lib/memory/__stack_pointer
-      i32.const 15044
+      i32.const 15068
       i32.lt_s
       br_if $folding-inner2
       global.get $~lib/memory/__stack_pointer
@@ -22469,7 +22481,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -22492,7 +22504,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -22684,7 +22696,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -22707,7 +22719,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -22908,7 +22920,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -22931,7 +22943,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -23238,7 +23250,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
@@ -23486,7 +23498,7 @@
    end
    i32.const 0
    global.set $std/array/arr
-   i32.const 31428
+   i32.const 31452
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/rt/itcms/state
    i32.const 0
@@ -23527,8 +23539,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -23542,11 +23554,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -23636,11 +23648,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -23678,7 +23690,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23730,11 +23742,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -23768,11 +23780,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -23833,11 +23845,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -23873,11 +23885,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -23902,7 +23914,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 229
+   i32.const 245
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -23947,11 +23959,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24050,11 +24062,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24166,11 +24178,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24277,11 +24289,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24297,7 +24309,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -24317,7 +24329,7 @@
   if
    i32.const 5696
    i32.const 1104
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -24335,11 +24347,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24355,7 +24367,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -24388,11 +24400,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24470,11 +24482,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24555,11 +24567,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24721,11 +24733,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24774,11 +24786,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -24834,7 +24846,7 @@
    global.set $~lib/memory/__stack_pointer
    block $folding-inner1
     global.get $~lib/memory/__stack_pointer
-    i32.const 15044
+    i32.const 15068
     i32.lt_s
     br_if $folding-inner1
     global.get $~lib/memory/__stack_pointer
@@ -24891,7 +24903,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 15044
+     i32.const 15068
      i32.lt_s
      br_if $folding-inner1
      global.get $~lib/memory/__stack_pointer
@@ -24982,8 +24994,8 @@
     end
     br $folding-inner2
    end
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -25003,11 +25015,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -25048,7 +25060,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -25102,11 +25114,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -25211,11 +25223,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -25324,11 +25336,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -25425,7 +25437,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -25457,7 +25469,7 @@
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     i32.const 15044
+     i32.const 15068
      i32.lt_s
      br_if $folding-inner1
      global.get $~lib/memory/__stack_pointer
@@ -25631,8 +25643,8 @@
    local.get $0
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -25650,11 +25662,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -25777,11 +25789,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -25808,7 +25820,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -25830,7 +25842,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -25852,7 +25864,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -25890,7 +25902,7 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -25947,8 +25959,8 @@
    local.get $0
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -25961,11 +25973,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -25988,11 +26000,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26023,11 +26035,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26101,11 +26113,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26174,11 +26186,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26203,7 +26215,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 132
+   i32.const 148
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -26229,11 +26241,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26344,11 +26356,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26441,11 +26453,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26537,11 +26549,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26630,11 +26642,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26662,7 +26674,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -26677,7 +26689,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -26699,7 +26711,7 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 229
+    i32.const 245
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -26742,8 +26754,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -26755,11 +26767,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26799,11 +26811,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26820,7 +26832,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 276
+   i32.const 292
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -26852,11 +26864,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -26923,7 +26935,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -26938,7 +26950,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -27008,8 +27020,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -27025,11 +27037,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27046,7 +27058,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 335
+   i32.const 351
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -27089,11 +27101,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27163,11 +27175,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27192,7 +27204,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -27218,7 +27230,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -27309,8 +27321,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -27327,7 +27339,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -27351,7 +27363,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -27454,8 +27466,8 @@
    local.get $3
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -27470,11 +27482,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27539,11 +27551,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27572,7 +27584,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -27587,7 +27599,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -27620,8 +27632,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -27633,11 +27645,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27648,7 +27660,7 @@
   i32.store
   i32.const 14576
   i32.const 1104
-  i32.const 477
+  i32.const 493
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -27659,11 +27671,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27689,7 +27701,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -27711,7 +27723,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -27722,7 +27734,7 @@
    if
     global.get $~lib/memory/__stack_pointer
     i32.const 16
-    i32.const 41
+    i32.const 42
     call $~lib/rt/itcms/__new
     local.tee $0
     i32.store
@@ -27733,7 +27745,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
@@ -27771,7 +27783,7 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -27826,8 +27838,8 @@
    local.get $0
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -27839,11 +27851,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27874,11 +27886,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27950,11 +27962,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28021,11 +28033,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28050,7 +28062,7 @@
   if
    i32.const 1344
    i32.const 1104
-   i32.const 132
+   i32.const 148
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -28071,11 +28083,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28118,11 +28130,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28215,11 +28227,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28311,11 +28323,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28404,11 +28416,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28436,7 +28448,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -28451,7 +28463,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -28473,7 +28485,7 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 229
+    i32.const 245
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -28511,8 +28523,8 @@
    local.get $3
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -28527,11 +28539,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28660,11 +28672,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28681,7 +28693,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 276
+   i32.const 292
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -28711,11 +28723,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28780,7 +28792,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -28795,7 +28807,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -28863,8 +28875,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -28879,11 +28891,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -28900,7 +28912,7 @@
   if
    i32.const 2176
    i32.const 1104
-   i32.const 335
+   i32.const 351
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -28940,11 +28952,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -29014,11 +29026,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -29066,7 +29078,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29092,7 +29104,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29179,8 +29191,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -29197,7 +29209,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29221,7 +29233,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29316,8 +29328,8 @@
    local.get $3
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -29332,11 +29344,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -29406,7 +29418,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29421,7 +29433,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29569,8 +29581,8 @@
    local.get $0
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -29584,7 +29596,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29599,7 +29611,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29632,8 +29644,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -29645,11 +29657,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -29672,7 +29684,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29694,7 +29706,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29705,7 +29717,7 @@
    if
     global.get $~lib/memory/__stack_pointer
     i32.const 16
-    i32.const 42
+    i32.const 44
     call $~lib/rt/itcms/__new
     local.tee $0
     i32.store
@@ -29727,8 +29739,8 @@
    local.get $0
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -29744,7 +29756,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29760,7 +29772,7 @@
     i32.sub
     global.set $~lib/memory/__stack_pointer
     global.get $~lib/memory/__stack_pointer
-    i32.const 15044
+    i32.const 15068
     i32.lt_s
     br_if $folding-inner0
     global.get $~lib/memory/__stack_pointer
@@ -29827,8 +29839,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -29844,7 +29856,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29859,7 +29871,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29927,8 +29939,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -29942,7 +29954,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29954,7 +29966,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -29976,7 +29988,7 @@
    if
     i32.const 1344
     i32.const 1104
-    i32.const 132
+    i32.const 148
     i32.const 33
     call $~lib/builtins/abort
     unreachable
@@ -29996,7 +30008,7 @@
    if
     i32.const 5696
     i32.const 1104
-    i32.const 136
+    i32.const 152
     i32.const 40
     call $~lib/builtins/abort
     unreachable
@@ -30012,8 +30024,8 @@
    local.get $0
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -30027,11 +30039,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -30147,11 +30159,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -30195,11 +30207,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -30242,7 +30254,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30271,7 +30283,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30355,8 +30367,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -30369,11 +30381,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -30407,7 +30419,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30422,7 +30434,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30444,7 +30456,7 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 229
+    i32.const 245
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -30541,8 +30553,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -30558,7 +30570,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30570,7 +30582,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30584,7 +30596,7 @@
    if
     i32.const 2176
     i32.const 1104
-    i32.const 276
+    i32.const 292
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -30617,8 +30629,8 @@
    local.get $3
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -30634,7 +30646,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30649,7 +30661,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30705,8 +30717,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -30723,7 +30735,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30738,7 +30750,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30810,8 +30822,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -30828,7 +30840,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30840,7 +30852,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30854,7 +30866,7 @@
    if
     i32.const 2176
     i32.const 1104
-    i32.const 335
+    i32.const 351
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -30897,8 +30909,8 @@
    local.get $3
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -30914,7 +30926,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -30930,7 +30942,7 @@
     i32.sub
     global.set $~lib/memory/__stack_pointer
     global.get $~lib/memory/__stack_pointer
-    i32.const 15044
+    i32.const 15068
     i32.lt_s
     br_if $folding-inner0
     global.get $~lib/memory/__stack_pointer
@@ -30996,8 +31008,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -31011,11 +31023,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -31075,7 +31087,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31101,7 +31113,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31221,8 +31233,8 @@
    local.get $2
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -31239,7 +31251,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31263,7 +31275,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31366,8 +31378,8 @@
    local.get $3
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -31383,7 +31395,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31395,7 +31407,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31457,8 +31469,8 @@
    local.get $0
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -31472,7 +31484,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31487,7 +31499,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31520,8 +31532,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -31535,7 +31547,7 @@
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31550,7 +31562,7 @@
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 15044
+   i32.const 15068
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
@@ -31583,8 +31595,8 @@
    global.set $~lib/memory/__stack_pointer
    return
   end
-  i32.const 31456
-  i32.const 31504
+  i32.const 31472
+  i32.const 31520
   i32.const 1
   i32.const 1
   call $~lib/builtins/abort
@@ -31596,11 +31608,11 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 15044
+  i32.const 15068
   i32.lt_s
   if
-   i32.const 31456
-   i32.const 31504
+   i32.const 31472
+   i32.const 31520
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -63,12 +63,12 @@
  (global $~lib/builtins/u32.MAX_VALUE i32 (i32.const -1))
  (global $~lib/builtins/i64.MAX_VALUE i64 (i64.const 9223372036854775807))
  (global $std/array/ArrayU32 i32 (i32.const 40))
- (global $std/array/ArrayU8 i32 (i32.const 41))
- (global $std/array/ArrayStr i32 (i32.const 42))
+ (global $std/array/ArrayU8 i32 (i32.const 42))
+ (global $std/array/ArrayStr i32 (i32.const 44))
  (global $~lib/rt/__rtti_base i32 (i32.const 13664))
- (global $~lib/memory/__data_end i32 (i32.const 14020))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 30404))
- (global $~lib/memory/__heap_base i32 (i32.const 30404))
+ (global $~lib/memory/__data_end i32 (i32.const 14044))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 30428))
+ (global $~lib/memory/__heap_base i32 (i32.const 30428))
  (global $~started (mut i32) (i32.const 0))
  (memory $0 1)
  (data (i32.const 12) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
@@ -340,9 +340,9 @@
  (data (i32.const 13468) "\1c\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 13500) "\1c\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 13532) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00(\00\00\00I\00l\00l\00e\00g\00a\00l\00 \00g\00e\00n\00e\00r\00i\00c\00 \00t\00y\00p\00e\00\00\00\00\00")
- (data (i32.const 13596) "\1c\00\00\00\00\00\00\00\00\00\00\00+\00\00\00\08\00\00\009\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 13596) "\1c\00\00\00\00\00\00\00\00\00\00\00.\00\00\00\08\00\00\009\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 13628) "\1c\00\00\00\00\00\00\00\00\00\00\00\1e\00\00\00\08\00\00\00:\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 13664) ",\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02\t\00\00\00\00\00\00 \00\00\00\00\00\00\00A\00\00\00\02\00\00\00B\00\00\00\00\00\00\00\02\01\00\00\00\00\00\00\02A\00\00\00\00\00\00\02\19\00\00\00\00\00\00\02\1a\00\00\00\00\00\00\02a\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02A\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00\02A\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02a\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02A\00\00\00\00\00\00\00\00\00\00\00\00\00\00B\00\00\00\00\00\00\00B\08\00\00\00\00\00\00\82\00\00\00\00\00\00\00\02\02\00\00\00\00\00\00\02\n\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02\01\00\00\07\00\00\00B\00\00\00\06\00\00\00\02A\00\00\1d\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 13664) "/\00\00\00 \00\00\00\00\00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02\t\00\00\00\00\00\00 \00\00\00\00\00\00\00A\00\00\00\02\00\00\00B\00\00\00\00\00\00\00\02\01\00\00\00\00\00\00\02A\00\00\00\00\00\00\02\19\00\00\00\00\00\00\02\1a\00\00\00\00\00\00\02a\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02A\00\00\00\00\00\00\00\00\00\00\00\00\00\00 \00\00\00\00\00\00\00\02A\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02a\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02A\00\00\00\00\00\00\00\00\00\00\00\00\00\00B\00\00\00\00\00\00\00B\08\00\00\00\00\00\00\82\00\00\00\00\00\00\00\02\02\00\00\00\00\00\00\02\n\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02A\00\00\00\00\00\00\02\01\00\00\07\00\00\00\00\00\00\00\00\00\00\00B\00\00\00\06\00\00\00\00\00\00\00\00\00\00\00\02A\00\00\1d\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (table $0 59 funcref)
  (elem $0 (i32.const 1) $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|4 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|18 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|30 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|34 $start:std/array~anonymous|35 $start:std/array~anonymous|36 $start:std/array~anonymous|37 $start:std/array~anonymous|38 $start:std/array~anonymous|39 $start:std/array~anonymous|40 $start:std/array~anonymous|41 $start:std/array~anonymous|42 $~lib/util/sort/COMPARATOR<f32>~anonymous|0 $~lib/util/sort/COMPARATOR<f64>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $~lib/util/sort/COMPARATOR<u32>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|1 $start:std/array~anonymous|43 $start:std/array~anonymous|44 $start:std/array~anonymous|45 $start:std/array~anonymous|46 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/util/sort/COMPARATOR<~lib/string/String|null>~anonymous|0 $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 $~lib/util/sort/COMPARATOR<u8>~anonymous|0 $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|1)
  (export "ArrayU32" (global $std/array/ArrayU32))
@@ -4269,7 +4269,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4445,7 +4445,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4707,7 +4707,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4736,7 +4736,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 276
+   i32.const 292
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -4813,7 +4813,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 132
+   i32.const 148
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -5064,7 +5064,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 335
+   i32.const 351
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -5676,7 +5676,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6160,7 +6160,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7725,7 +7725,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8915,7 +8915,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9115,7 +9115,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9703,7 +9703,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13097,7 +13097,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13120,6 +13120,25 @@
   local.get $2
   call $~lib/array/Array<u32>#__uset
  )
+ (func $~lib/array/ArrayIterator<u32>#set:i (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+ )
+ (func $~lib/array/ArrayIterator<u32>#set:arr (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/rt/itcms/__link
+ )
+ (func $~lib/array/Array<u32>#__iter (param $0 i32) (result i32)
+  i32.const 0
+  local.get $0
+  call $~lib/array/ArrayIterator<u32>#constructor
+ )
  (func $~lib/array/Array<u32>#at (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -13141,7 +13160,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 132
+   i32.const 148
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -13472,7 +13491,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 276
+   i32.const 292
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13554,7 +13573,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 335
+   i32.const 351
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -13739,7 +13758,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 477
+  i32.const 493
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -13940,7 +13959,7 @@
    if
     i32.const 320
     i32.const 80
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13963,6 +13982,25 @@
   local.get $2
   call $~lib/array/Array<u8>#__uset
  )
+ (func $~lib/array/ArrayIterator<u8>#set:i (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+ )
+ (func $~lib/array/ArrayIterator<u8>#set:arr (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/rt/itcms/__link
+ )
+ (func $~lib/array/Array<u8>#__iter (param $0 i32) (result i32)
+  i32.const 0
+  local.get $0
+  call $~lib/array/ArrayIterator<u8>#constructor
+ )
  (func $~lib/array/Array<u8>#at (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -13984,7 +14022,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 132
+   i32.const 148
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -14319,7 +14357,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 276
+   i32.const 292
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -14401,7 +14439,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 335
+   i32.const 351
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -15040,7 +15078,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 477
+  i32.const 493
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -15087,6 +15125,25 @@
   i32.shl
   i32.add
   i32.load
+ )
+ (func $~lib/array/ArrayIterator<~lib/string/String>#set:i (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+ )
+ (func $~lib/array/ArrayIterator<~lib/string/String>#set:arr (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/rt/itcms/__link
+ )
+ (func $~lib/array/Array<~lib/string/String>#__iter (param $0 i32) (result i32)
+  i32.const 0
+  local.get $0
+  call $~lib/array/ArrayIterator<~lib/string/String>#constructor
  )
  (func $~lib/array/Array<~lib/string/String>#fill (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
@@ -15424,7 +15481,7 @@
   drop
   i32.const 13552
   i32.const 80
-  i32.const 477
+  i32.const 493
   i32.const 7
   call $~lib/builtins/abort
   unreachable
@@ -16825,15 +16882,48 @@
   local.get $1
   call $~lib/array/Array<u32>~visit
  )
+ (func $~lib/array/ArrayIterator<u32>~visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/itcms/__visit
+  end
+ )
  (func $std/array/ArrayU8~visit (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<u8>~visit
  )
+ (func $~lib/array/ArrayIterator<u8>~visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/itcms/__visit
+  end
+ )
  (func $std/array/ArrayStr~visit (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String>~visit
+ )
+ (func $~lib/array/ArrayIterator<~lib/string/String>~visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/itcms/__visit
+  end
  )
  (func $~lib/function/Function<%28u8%2Cu8%29=>i32>#__visit (param $0 i32) (param $1 i32)
   local.get $0
@@ -16849,256 +16939,274 @@
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid
    block $~lib/function/Function<%28u8%2Cu8%29=>i32>
-    block $std/array/ArrayStr
-     block $std/array/ArrayU8
-      block $std/array/ArrayU32
-       block $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>
-        block $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>
-         block $~lib/array/Array<~lib/array/Array<u32>>
-          block $~lib/array/Array<~lib/array/Array<u8>>
-           block $~lib/array/Array<i64>
-            block $~lib/array/Array<u64>
-             block $~lib/array/Array<u16>
-              block $~lib/array/Array<i8>
-               block $~lib/array/Array<bool>
-                block $~lib/function/Function<%28~lib/string/String%2C~lib/string/String%29=>i32>
-                 block $~lib/array/Array<~lib/string/String>
-                  block $~lib/function/Function<%28~lib/string/String|null%2C~lib/string/String|null%29=>i32>
-                   block $~lib/array/Array<~lib/string/String|null>
-                    block $~lib/function/Function<%28std/array/Proxy<i32>%2Cstd/array/Proxy<i32>%29=>i32>
-                     block $~lib/array/Array<std/array/Proxy<i32>>
-                      block $std/array/Proxy<i32>
-                       block $~lib/function/Function<%28~lib/array/Array<i32>%2C~lib/array/Array<i32>%29=>i32>
-                        block $~lib/array/Array<~lib/array/Array<i32>>
-                         block $~lib/function/Function<%28u32%2Cu32%29=>i32>
-                          block $~lib/function/Function<%28i32%2Ci32%29=>i32>
-                           block $~lib/function/Function<%28f64%2Cf64%29=>i32>
-                            block $~lib/function/Function<%28f32%2Cf32%29=>i32>
-                             block $~lib/function/Function<%28bool%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>bool>
-                              block $~lib/function/Function<%28i32%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>i32>
-                               block $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>i32>
-                                block $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>f32>
-                                 block $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>void>
-                                  block $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>bool>
-                                   block $~lib/array/Array<std/array/Ref|null>
-                                    block $~lib/array/Array<f64>
-                                     block $~lib/array/Array<f32>
-                                      block $~lib/array/Array<std/array/Ref>
-                                       block $~lib/array/Array<u32>
-                                        block $~lib/array/Array<u8>
-                                         block $~lib/typedarray/Uint8Array
-                                          block $std/array/Ref
-                                           block $~lib/array/Array<i32>
-                                            block $~lib/arraybuffer/ArrayBufferView
-                                             block $~lib/string/String
-                                              block $~lib/arraybuffer/ArrayBuffer
+    block $~lib/array/ArrayIterator<~lib/string/String>
+     block $std/array/ArrayStr
+      block $~lib/array/ArrayIterator<u8>
+       block $std/array/ArrayU8
+        block $~lib/array/ArrayIterator<u32>
+         block $std/array/ArrayU32
+          block $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>
+           block $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>
+            block $~lib/array/Array<~lib/array/Array<u32>>
+             block $~lib/array/Array<~lib/array/Array<u8>>
+              block $~lib/array/Array<i64>
+               block $~lib/array/Array<u64>
+                block $~lib/array/Array<u16>
+                 block $~lib/array/Array<i8>
+                  block $~lib/array/Array<bool>
+                   block $~lib/function/Function<%28~lib/string/String%2C~lib/string/String%29=>i32>
+                    block $~lib/array/Array<~lib/string/String>
+                     block $~lib/function/Function<%28~lib/string/String|null%2C~lib/string/String|null%29=>i32>
+                      block $~lib/array/Array<~lib/string/String|null>
+                       block $~lib/function/Function<%28std/array/Proxy<i32>%2Cstd/array/Proxy<i32>%29=>i32>
+                        block $~lib/array/Array<std/array/Proxy<i32>>
+                         block $std/array/Proxy<i32>
+                          block $~lib/function/Function<%28~lib/array/Array<i32>%2C~lib/array/Array<i32>%29=>i32>
+                           block $~lib/array/Array<~lib/array/Array<i32>>
+                            block $~lib/function/Function<%28u32%2Cu32%29=>i32>
+                             block $~lib/function/Function<%28i32%2Ci32%29=>i32>
+                              block $~lib/function/Function<%28f64%2Cf64%29=>i32>
+                               block $~lib/function/Function<%28f32%2Cf32%29=>i32>
+                                block $~lib/function/Function<%28bool%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>bool>
+                                 block $~lib/function/Function<%28i32%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>i32>
+                                  block $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>i32>
+                                   block $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>f32>
+                                    block $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>void>
+                                     block $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>bool>
+                                      block $~lib/array/Array<std/array/Ref|null>
+                                       block $~lib/array/Array<f64>
+                                        block $~lib/array/Array<f32>
+                                         block $~lib/array/Array<std/array/Ref>
+                                          block $~lib/array/Array<u32>
+                                           block $~lib/array/Array<u8>
+                                            block $~lib/typedarray/Uint8Array
+                                             block $std/array/Ref
+                                              block $~lib/array/Array<i32>
+                                               block $~lib/arraybuffer/ArrayBufferView
+                                                block $~lib/string/String
+                                                 block $~lib/arraybuffer/ArrayBuffer
+                                                  local.get $0
+                                                  i32.const 8
+                                                  i32.sub
+                                                  i32.load
+                                                  br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/array/Array<i32> $std/array/Ref $~lib/typedarray/Uint8Array $~lib/array/Array<u8> $~lib/array/Array<u32> $~lib/array/Array<std/array/Ref> $~lib/array/Array<f32> $~lib/array/Array<f64> $~lib/array/Array<std/array/Ref|null> $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>bool> $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>void> $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>f32> $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>i32> $~lib/function/Function<%28i32%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>i32> $~lib/function/Function<%28bool%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>bool> $~lib/function/Function<%28f32%2Cf32%29=>i32> $~lib/function/Function<%28f64%2Cf64%29=>i32> $~lib/function/Function<%28i32%2Ci32%29=>i32> $~lib/function/Function<%28u32%2Cu32%29=>i32> $~lib/array/Array<~lib/array/Array<i32>> $~lib/function/Function<%28~lib/array/Array<i32>%2C~lib/array/Array<i32>%29=>i32> $std/array/Proxy<i32> $~lib/array/Array<std/array/Proxy<i32>> $~lib/function/Function<%28std/array/Proxy<i32>%2Cstd/array/Proxy<i32>%29=>i32> $~lib/array/Array<~lib/string/String|null> $~lib/function/Function<%28~lib/string/String|null%2C~lib/string/String|null%29=>i32> $~lib/array/Array<~lib/string/String> $~lib/function/Function<%28~lib/string/String%2C~lib/string/String%29=>i32> $~lib/array/Array<bool> $~lib/array/Array<i8> $~lib/array/Array<u16> $~lib/array/Array<u64> $~lib/array/Array<i64> $~lib/array/Array<~lib/array/Array<u8>> $~lib/array/Array<~lib/array/Array<u32>> $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>> $~lib/array/Array<~lib/array/Array<~lib/string/String|null>> $std/array/ArrayU32 $~lib/array/ArrayIterator<u32> $std/array/ArrayU8 $~lib/array/ArrayIterator<u8> $std/array/ArrayStr $~lib/array/ArrayIterator<~lib/string/String> $~lib/function/Function<%28u8%2Cu8%29=>i32> $invalid
+                                                 end
+                                                 return
+                                                end
+                                                return
+                                               end
                                                local.get $0
-                                               i32.const 8
-                                               i32.sub
-                                               i32.load
-                                               br_table $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/array/Array<i32> $std/array/Ref $~lib/typedarray/Uint8Array $~lib/array/Array<u8> $~lib/array/Array<u32> $~lib/array/Array<std/array/Ref> $~lib/array/Array<f32> $~lib/array/Array<f64> $~lib/array/Array<std/array/Ref|null> $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>bool> $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>void> $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>f32> $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>i32> $~lib/function/Function<%28i32%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>i32> $~lib/function/Function<%28bool%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>bool> $~lib/function/Function<%28f32%2Cf32%29=>i32> $~lib/function/Function<%28f64%2Cf64%29=>i32> $~lib/function/Function<%28i32%2Ci32%29=>i32> $~lib/function/Function<%28u32%2Cu32%29=>i32> $~lib/array/Array<~lib/array/Array<i32>> $~lib/function/Function<%28~lib/array/Array<i32>%2C~lib/array/Array<i32>%29=>i32> $std/array/Proxy<i32> $~lib/array/Array<std/array/Proxy<i32>> $~lib/function/Function<%28std/array/Proxy<i32>%2Cstd/array/Proxy<i32>%29=>i32> $~lib/array/Array<~lib/string/String|null> $~lib/function/Function<%28~lib/string/String|null%2C~lib/string/String|null%29=>i32> $~lib/array/Array<~lib/string/String> $~lib/function/Function<%28~lib/string/String%2C~lib/string/String%29=>i32> $~lib/array/Array<bool> $~lib/array/Array<i8> $~lib/array/Array<u16> $~lib/array/Array<u64> $~lib/array/Array<i64> $~lib/array/Array<~lib/array/Array<u8>> $~lib/array/Array<~lib/array/Array<u32>> $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>> $~lib/array/Array<~lib/array/Array<~lib/string/String|null>> $std/array/ArrayU32 $std/array/ArrayU8 $std/array/ArrayStr $~lib/function/Function<%28u8%2Cu8%29=>i32> $invalid
+                                               local.get $1
+                                               call $~lib/arraybuffer/ArrayBufferView~visit
+                                               return
                                               end
+                                              local.get $0
+                                              local.get $1
+                                              call $~lib/array/Array<i32>~visit
                                               return
                                              end
                                              return
                                             end
                                             local.get $0
                                             local.get $1
-                                            call $~lib/arraybuffer/ArrayBufferView~visit
+                                            call $~lib/typedarray/Uint8Array~visit
                                             return
                                            end
                                            local.get $0
                                            local.get $1
-                                           call $~lib/array/Array<i32>~visit
+                                           call $~lib/array/Array<u8>~visit
                                            return
                                           end
+                                          local.get $0
+                                          local.get $1
+                                          call $~lib/array/Array<u32>~visit
                                           return
                                          end
                                          local.get $0
                                          local.get $1
-                                         call $~lib/typedarray/Uint8Array~visit
+                                         call $~lib/array/Array<std/array/Ref>~visit
                                          return
                                         end
                                         local.get $0
                                         local.get $1
-                                        call $~lib/array/Array<u8>~visit
+                                        call $~lib/array/Array<f32>~visit
                                         return
                                        end
                                        local.get $0
                                        local.get $1
-                                       call $~lib/array/Array<u32>~visit
+                                       call $~lib/array/Array<f64>~visit
                                        return
                                       end
                                       local.get $0
                                       local.get $1
-                                      call $~lib/array/Array<std/array/Ref>~visit
+                                      call $~lib/array/Array<std/array/Ref|null>~visit
                                       return
                                      end
                                      local.get $0
                                      local.get $1
-                                     call $~lib/array/Array<f32>~visit
+                                     call $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>bool>~visit
                                      return
                                     end
                                     local.get $0
                                     local.get $1
-                                    call $~lib/array/Array<f64>~visit
+                                    call $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>void>~visit
                                     return
                                    end
                                    local.get $0
                                    local.get $1
-                                   call $~lib/array/Array<std/array/Ref|null>~visit
+                                   call $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>f32>~visit
                                    return
                                   end
                                   local.get $0
                                   local.get $1
-                                  call $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>bool>~visit
+                                  call $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>i32>~visit
                                   return
                                  end
                                  local.get $0
                                  local.get $1
-                                 call $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>void>~visit
+                                 call $~lib/function/Function<%28i32%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>i32>~visit
                                  return
                                 end
                                 local.get $0
                                 local.get $1
-                                call $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>f32>~visit
+                                call $~lib/function/Function<%28bool%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>bool>~visit
                                 return
                                end
                                local.get $0
                                local.get $1
-                               call $~lib/function/Function<%28i32%2Ci32%2C~lib/array/Array<i32>%29=>i32>~visit
+                               call $~lib/function/Function<%28f32%2Cf32%29=>i32>~visit
                                return
                               end
                               local.get $0
                               local.get $1
-                              call $~lib/function/Function<%28i32%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>i32>~visit
+                              call $~lib/function/Function<%28f64%2Cf64%29=>i32>~visit
                               return
                              end
                              local.get $0
                              local.get $1
-                             call $~lib/function/Function<%28bool%2Ci32%2Ci32%2C~lib/array/Array<i32>%29=>bool>~visit
+                             call $~lib/function/Function<%28i32%2Ci32%29=>i32>~visit
                              return
                             end
                             local.get $0
                             local.get $1
-                            call $~lib/function/Function<%28f32%2Cf32%29=>i32>~visit
+                            call $~lib/function/Function<%28u32%2Cu32%29=>i32>~visit
                             return
                            end
                            local.get $0
                            local.get $1
-                           call $~lib/function/Function<%28f64%2Cf64%29=>i32>~visit
+                           call $~lib/array/Array<~lib/array/Array<i32>>~visit
                            return
                           end
                           local.get $0
                           local.get $1
-                          call $~lib/function/Function<%28i32%2Ci32%29=>i32>~visit
+                          call $~lib/function/Function<%28~lib/array/Array<i32>%2C~lib/array/Array<i32>%29=>i32>~visit
                           return
                          end
-                         local.get $0
-                         local.get $1
-                         call $~lib/function/Function<%28u32%2Cu32%29=>i32>~visit
                          return
                         end
                         local.get $0
                         local.get $1
-                        call $~lib/array/Array<~lib/array/Array<i32>>~visit
+                        call $~lib/array/Array<std/array/Proxy<i32>>~visit
                         return
                        end
                        local.get $0
                        local.get $1
-                       call $~lib/function/Function<%28~lib/array/Array<i32>%2C~lib/array/Array<i32>%29=>i32>~visit
+                       call $~lib/function/Function<%28std/array/Proxy<i32>%2Cstd/array/Proxy<i32>%29=>i32>~visit
                        return
                       end
+                      local.get $0
+                      local.get $1
+                      call $~lib/array/Array<~lib/string/String|null>~visit
                       return
                      end
                      local.get $0
                      local.get $1
-                     call $~lib/array/Array<std/array/Proxy<i32>>~visit
+                     call $~lib/function/Function<%28~lib/string/String|null%2C~lib/string/String|null%29=>i32>~visit
                      return
                     end
                     local.get $0
                     local.get $1
-                    call $~lib/function/Function<%28std/array/Proxy<i32>%2Cstd/array/Proxy<i32>%29=>i32>~visit
+                    call $~lib/array/Array<~lib/string/String>~visit
                     return
                    end
                    local.get $0
                    local.get $1
-                   call $~lib/array/Array<~lib/string/String|null>~visit
+                   call $~lib/function/Function<%28~lib/string/String%2C~lib/string/String%29=>i32>~visit
                    return
                   end
                   local.get $0
                   local.get $1
-                  call $~lib/function/Function<%28~lib/string/String|null%2C~lib/string/String|null%29=>i32>~visit
+                  call $~lib/array/Array<bool>~visit
                   return
                  end
                  local.get $0
                  local.get $1
-                 call $~lib/array/Array<~lib/string/String>~visit
+                 call $~lib/array/Array<i8>~visit
                  return
                 end
                 local.get $0
                 local.get $1
-                call $~lib/function/Function<%28~lib/string/String%2C~lib/string/String%29=>i32>~visit
+                call $~lib/array/Array<u16>~visit
                 return
                end
                local.get $0
                local.get $1
-               call $~lib/array/Array<bool>~visit
+               call $~lib/array/Array<u64>~visit
                return
               end
               local.get $0
               local.get $1
-              call $~lib/array/Array<i8>~visit
+              call $~lib/array/Array<i64>~visit
               return
              end
              local.get $0
              local.get $1
-             call $~lib/array/Array<u16>~visit
+             call $~lib/array/Array<~lib/array/Array<u8>>~visit
              return
             end
             local.get $0
             local.get $1
-            call $~lib/array/Array<u64>~visit
+            call $~lib/array/Array<~lib/array/Array<u32>>~visit
             return
            end
            local.get $0
            local.get $1
-           call $~lib/array/Array<i64>~visit
+           call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>~visit
            return
           end
           local.get $0
           local.get $1
-          call $~lib/array/Array<~lib/array/Array<u8>>~visit
+          call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>~visit
           return
          end
          local.get $0
          local.get $1
-         call $~lib/array/Array<~lib/array/Array<u32>>~visit
+         call $std/array/ArrayU32~visit
          return
         end
         local.get $0
         local.get $1
-        call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>~visit
+        call $~lib/array/ArrayIterator<u32>~visit
         return
        end
        local.get $0
        local.get $1
-       call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>~visit
+       call $std/array/ArrayU8~visit
        return
       end
       local.get $0
       local.get $1
-      call $std/array/ArrayU32~visit
+      call $~lib/array/ArrayIterator<u8>~visit
       return
      end
      local.get $0
      local.get $1
-     call $std/array/ArrayU8~visit
+     call $std/array/ArrayStr~visit
      return
     end
     local.get $0
     local.get $1
-    call $std/array/ArrayStr~visit
+    call $~lib/array/ArrayIterator<~lib/string/String>~visit
     return
    end
    local.get $0
@@ -17126,8 +17234,8 @@
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 30432
-   i32.const 30480
+   i32.const 30448
+   i32.const 30496
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
@@ -27836,7 +27944,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28139,7 +28247,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 229
+   i32.const 245
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -28563,7 +28671,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -28588,7 +28696,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -28743,7 +28851,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29352,7 +29460,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29572,7 +29680,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29597,7 +29705,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29654,7 +29762,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -29843,7 +29951,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -29868,7 +29976,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -29993,7 +30101,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30065,7 +30173,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -30335,7 +30443,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -30360,7 +30468,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -33417,7 +33525,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33497,6 +33605,40 @@
   global.set $~lib/memory/__stack_pointer
   local.get $2
  )
+ (func $~lib/array/ArrayIterator<u32>#constructor (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.const 41
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/array/ArrayIterator<u32>#set:i
+  local.get $0
+  local.get $1
+  call $~lib/array/ArrayIterator<u32>#set:arr
+  local.get $0
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
  (func $~lib/array/Array<u32>#concat (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -33536,7 +33678,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 229
+   i32.const 245
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -33942,7 +34084,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34003,7 +34145,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
-   i32.const 41
+   i32.const 42
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
@@ -34014,6 +34156,40 @@
   call $~lib/array/Array<u8>#constructor
   local.tee $0
   i32.store
+  local.get $0
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
+ (func $~lib/array/ArrayIterator<u8>#constructor (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.const 43
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/array/ArrayIterator<u8>#set:i
+  local.get $0
+  local.get $1
+  call $~lib/array/ArrayIterator<u8>#set:arr
   local.get $0
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -34061,7 +34237,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 229
+   i32.const 245
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34438,7 +34614,7 @@
   if
    global.get $~lib/memory/__stack_pointer
    i32.const 16
-   i32.const 42
+   i32.const 44
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
@@ -34449,6 +34625,40 @@
   call $~lib/array/Array<~lib/string/String>#constructor
   local.tee $0
   i32.store
+  local.get $0
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $2
+ )
+ (func $~lib/array/ArrayIterator<~lib/string/String>#constructor (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.const 45
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/array/ArrayIterator<~lib/string/String>#set:i
+  local.get $0
+  local.get $1
+  call $~lib/array/ArrayIterator<~lib/string/String>#set:arr
   local.get $0
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -34487,7 +34697,7 @@
   if
    i32.const 320
    i32.const 80
-   i32.const 132
+   i32.const 148
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -34512,7 +34722,7 @@
   if
    i32.const 4672
    i32.const 80
-   i32.const 136
+   i32.const 152
    i32.const 40
    call $~lib/builtins/abort
    unreachable
@@ -34570,7 +34780,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 229
+   i32.const 245
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -34695,7 +34905,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 276
+   i32.const 292
    i32.const 21
    call $~lib/builtins/abort
    unreachable
@@ -34829,7 +35039,7 @@
   if
    i32.const 1152
    i32.const 80
-   i32.const 335
+   i32.const 351
    i32.const 21
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -9908,7 +9908,7 @@
   if
    i32.const 1392
    i32.const 6496
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9928,7 +9928,7 @@
   if
    i32.const 6544
    i32.const 6496
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -11342,7 +11342,7 @@
   if
    i32.const 368
    i32.const 5472
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11367,7 +11367,7 @@
   if
    i32.const 5520
    i32.const 5472
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -3120,7 +3120,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3157,7 +3157,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3191,7 +3191,7 @@
   if
    i32.const 1248
    i32.const 1728
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4099,7 +4099,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -4266,7 +4266,7 @@
      if
       i32.const 1248
       i32.const 1728
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable
@@ -6254,7 +6254,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -6421,7 +6421,7 @@
      if
       i32.const 1248
       i32.const 1728
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable
@@ -7718,7 +7718,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8448,7 +8448,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -8617,7 +8617,7 @@
      if
       i32.const 1248
       i32.const 1728
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable
@@ -10607,7 +10607,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -10776,7 +10776,7 @@
      if
       i32.const 1248
       i32.const 1728
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable
@@ -14166,7 +14166,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -14335,7 +14335,7 @@
      if
       i32.const 1248
       i32.const 1728
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable
@@ -15696,7 +15696,7 @@
    if
     i32.const 1248
     i32.const 1728
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -16194,7 +16194,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -16362,7 +16362,7 @@
      if
       i32.const 1248
       i32.const 1728
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable
@@ -17730,7 +17730,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -17898,7 +17898,7 @@
      if
       i32.const 1248
       i32.const 1728
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable
@@ -19411,7 +19411,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -19490,7 +19490,7 @@
        if
         i32.const 1248
         i32.const 1728
-        i32.const 115
+        i32.const 126
         i32.const 22
         call $~lib/builtins/abort
         unreachable
@@ -19615,7 +19615,7 @@
      if
       i32.const 1248
       i32.const 1728
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable
@@ -21430,7 +21430,7 @@
    if
     i32.const 1456
     i32.const 1728
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -21509,7 +21509,7 @@
        if
         i32.const 1248
         i32.const 1728
-        i32.const 115
+        i32.const 126
         i32.const 22
         call $~lib/builtins/abort
         unreachable
@@ -21633,7 +21633,7 @@
      if
       i32.const 1248
       i32.const 1728
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable
@@ -22606,7 +22606,7 @@
   if
    i32.const 1456
    i32.const 1728
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -4222,7 +4222,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4303,7 +4303,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4425,7 +4425,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4451,7 +4451,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5931,7 +5931,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6015,7 +6015,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7233,7 +7233,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7317,7 +7317,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8525,7 +8525,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8609,7 +8609,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10437,7 +10437,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10521,7 +10521,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11728,7 +11728,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11812,7 +11812,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13027,7 +13027,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13111,7 +13111,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14310,7 +14310,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -14394,7 +14394,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -15610,7 +15610,7 @@
    if
     i32.const 224
     i32.const 704
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -15694,7 +15694,7 @@
   if
    i32.const 224
    i32.const 704
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -17691,7 +17691,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -17863,7 +17863,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -18560,7 +18560,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19164,7 +19164,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -19768,7 +19768,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -20536,7 +20536,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21140,7 +21140,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -21744,7 +21744,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22348,7 +22348,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -22952,7 +22952,7 @@
   if
    i32.const 432
    i32.const 704
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -3171,7 +3171,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3203,7 +3203,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3837,7 +3837,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -4838,7 +4838,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5448,7 +5448,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -6460,7 +6460,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6494,7 +6494,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7099,7 +7099,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -8102,7 +8102,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8714,7 +8714,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -9724,7 +9724,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9758,7 +9758,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10346,7 +10346,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -11323,7 +11323,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11911,7 +11911,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -13002,7 +13002,7 @@
    if
     i32.const 1248
     i32.const 1616
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13036,7 +13036,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13409,7 +13409,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -14109,7 +14109,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14451,7 +14451,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -15045,7 +15045,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -15636,7 +15636,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -15715,7 +15715,7 @@
        if
         i32.const 1248
         i32.const 1616
-        i32.const 115
+        i32.const 126
         i32.const 22
         call $~lib/builtins/abort
         unreachable
@@ -16772,7 +16772,7 @@
   if
    i32.const 1248
    i32.const 1616
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -17117,7 +17117,7 @@
    if
     i32.const 1456
     i32.const 1616
-    i32.const 64
+    i32.const 75
     i32.const 60
     call $~lib/builtins/abort
     unreachable
@@ -17196,7 +17196,7 @@
        if
         i32.const 1248
         i32.const 1616
-        i32.const 115
+        i32.const 126
         i32.const 22
         call $~lib/builtins/abort
         unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -4276,7 +4276,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4322,7 +4322,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5246,7 +5246,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -5292,7 +5292,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -6218,7 +6218,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -6264,7 +6264,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -7188,7 +7188,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -7234,7 +7234,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -8158,7 +8158,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -8204,7 +8204,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -9116,7 +9116,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -9162,7 +9162,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -10091,7 +10091,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -10137,7 +10137,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -11067,7 +11067,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -11113,7 +11113,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -12027,7 +12027,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -12073,7 +12073,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -13004,7 +13004,7 @@
    if
     i32.const 224
     i32.const 592
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -13050,7 +13050,7 @@
   if
    i32.const 224
    i32.const 592
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -14252,7 +14252,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14480,7 +14480,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14708,7 +14708,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -14936,7 +14936,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15164,7 +15164,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15392,7 +15392,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15620,7 +15620,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -15848,7 +15848,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16076,7 +16076,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable
@@ -16304,7 +16304,7 @@
   if
    i32.const 432
    i32.const 592
-   i32.const 64
+   i32.const 75
    i32.const 60
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -68,7 +68,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2885,7 +2885,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2906,7 +2906,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -2927,7 +2927,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -73,7 +73,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3885,7 +3885,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -3921,7 +3921,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -3967,7 +3967,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4003,7 +4003,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4049,7 +4049,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable
@@ -4085,7 +4085,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -4131,7 +4131,7 @@
    if
     i32.const 448
     i32.const 512
-    i32.const 115
+    i32.const 126
     i32.const 22
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -3886,7 +3886,7 @@
      if
       i32.const 1088
       i32.const 1776
-      i32.const 99
+      i32.const 110
       i32.const 42
       call $~lib/builtins/abort
       unreachable

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -3827,7 +3827,7 @@
   if
    i32.const 64
    i32.const 752
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -23910,7 +23910,7 @@
   if
    i32.const 1264
    i32.const 15248
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -23930,7 +23930,7 @@
   if
    i32.const 15296
    i32.const 15248
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -27012,7 +27012,7 @@
   if
    i32.const 240
    i32.const 14224
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -27037,7 +27037,7 @@
   if
    i32.const 14272
    i32.const 14224
-   i32.const 103
+   i32.const 114
    i32.const 40
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -4610,7 +4610,7 @@
     if
      i32.const 1360
      i32.const 1760
-     i32.const 99
+     i32.const 110
      i32.const 42
      call $~lib/builtins/abort
      unreachable
@@ -4642,7 +4642,7 @@
   if
    i32.const 1360
    i32.const 1760
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5454,7 +5454,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable
@@ -5629,7 +5629,7 @@
   if
    i32.const 336
    i32.const 736
-   i32.const 99
+   i32.const 110
    i32.const 42
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION

- [x] I've read the contributing guidelines

This PR implements for..of loops as well as iterators, which are important (convenience) features when writing code in assemblyscript.

The optimal solution would be to use `Symbol.iterator`, however symbols (and the api itself) are not yet implemented by the compiler.

Instead, this PR uses a different approach: a new decorator, `@iterator`.

TODO:
 - [ ] Add tests
 - [x] Run `npm check` and `npm test` to make sure the code is fine