### PR TITLE
fix: Make a patch release for #1894

### DIFF
--- a/tests/compiler/rereexport.ts
+++ b/tests/compiler/rereexport.ts
@@ -11,13 +11,13 @@ import { exportstar } from "./reexport";
 export { exportstar };
 
 import * as ReexportsNamespace from "./reexport";
-// Test our import * as namespace works with different types
+// Test our import * as namespace works with different types.
 assert(ReexportsNamespace.add(2, 2) == 4);
 assert(ReexportsNamespace.rerenamed_mul(2, 2) == 4);
 let car: ReexportsNamespace.Car = new ReexportsNamespace.Car();
 assert(car.numDoors == 2);
 
-// Test our imported namespace with the exported import * as namespace
+// Test our imported namespace with the exported import * as namespace.
 assert(ReexportsNamespace.ExportsNamespace.add(2, 2) == 4);
 assert(ReexportsNamespace.ExportsNamespace.renamed_mul(2, 2) == 4);
 let exportsNamespaceCar: ReexportsNamespace.Car = new ReexportsNamespace.ExportsNamespace.Car();


### PR DESCRIPTION
relates to #1894 

Per our discussion in the meeting: https://github.com/AssemblyScript/core/issues/65 , this just cuts a release for #1894 , by adding some periods to comments I wrote in a test 😄 