### PR TITLE
Optimize loader string encoding routine

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -141,10 +141,14 @@ function postInstantiate(extendedExports, instance) {
   /** Allocates a new string in the module's memory and returns its pointer. */
   function __newString(str) {
     if (str == null) return 0;
-    const length = str.length;
-    const ptr = __new(length << 1, STRING_ID);
-    const U16 = new Uint16Array(memory.buffer);
-    for (var i = 0, p = ptr >>> 1; i < length; ++i) U16[p + i] = str.charCodeAt(i);
+    const size = str.length << 1;
+    const ptr = __new(size, STRING_ID);
+    const buf = new Uint8Array(memory.buffer, ptr, size);
+    for (let i = 0; i < size; i += 2) {
+      let c = str.charCodeAt(i >>> 1);
+      buf[i    ] = c;
+      buf[i + 1] = c >>> 8;
+    }
     return ptr;
   }
 

--- a/lib/loader/tests/index.js
+++ b/lib/loader/tests/index.js
@@ -50,6 +50,22 @@ function test(file) {
     assert.strictEqual(exports.strlen(ref), str.length);
   }
 
+  // should be able to allocate and work with a string containing an isolated lead surrogate
+  {
+    let str = "𝄞".substring(0, 1);
+    let ref = exports.__newString(str);
+    assert.strictEqual(exports.__getString(ref), str);
+    assert.strictEqual(exports.strlen(ref), str.length);
+  }
+
+  // should be able to allocate and work with a string containing an isolated trail surrogate
+  {
+    let str = "𝄞".substring(1);
+    let ref = exports.__newString(str);
+    assert.strictEqual(exports.__getString(ref), str);
+    assert.strictEqual(exports.strlen(ref), str.length);
+  }
+
   // should be able to allocate a typed array
   {
     let arr = [1, 2, 3, 4, 5, 0x80000000 | 0];

--- a/lib/loader/umd/index.js
+++ b/lib/loader/umd/index.js
@@ -173,13 +173,17 @@ var loader = (function(exports) {
   
     function __newString(str) {
       if (str == null) return 0;
-      const length = str.length;
+      const size = str.length << 1;
   
-      const ptr = __new(length << 1, STRING_ID);
+      const ptr = __new(size, STRING_ID);
   
-      const U16 = new Uint16Array(memory.buffer);
+      const buf = new Uint8Array(memory.buffer, ptr, size);
   
-      for (var i = 0, p = ptr >>> 1; i < length; ++i) U16[p + i] = str.charCodeAt(i);
+      for (let i = 0; i < size; i += 2) {
+        let c = str.charCodeAt(i >>> 1);
+        buf[i] = c;
+        buf[i + 1] = c >>> 8;
+      }
   
       return ptr;
     }


### PR DESCRIPTION
For some reason, using an `Uint8Array` when encoding a string is up to [5x faster](https://esbench.com/bench/60ca650f6c89f600a5700dfd). Speedup depends on the browser a bit, but seems to be universal across major engines.

- [x] I've read the contributing guidelines