### PR TITLE
fix: use shrinkLevel: 0 for asinit default config

### DIFF
--- a/bin/asinit
+++ b/bin/asinit
@@ -257,7 +257,7 @@ function ensureAsconfigJson() {
           textFile: "build/optimized.wat",
           sourceMap: true,
           optimizeLevel: 3,
-          shrinkLevel: 1,
+          shrinkLevel: 0,
           converge: false,
           noAssert: false
         }


### PR DESCRIPTION
After landing #1776 we forget make same changes for asinit.

- [x] I've read the contributing guidelines