### PR TITLE
Throw unimplemented error when using spread operator

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -39,7 +39,7 @@ under the licensing terms detailed in LICENSE:
 * bnbarak <bn.barak@gmail.com>
 * Colin Eberhardt <colin.eberhardt@gmail.com>
 * Ryan Pivovar <ryanpivovar@gmail.com>
-* Roman F. <romdotdog@users.noreply.github.com>
+* Roman F. <70765447+romdotdog@users.noreply.github.com>
 * Joe Pea <trusktr@gmail.com>
 
 Portions of this software are derived from third-party works licensed under

--- a/NOTICE
+++ b/NOTICE
@@ -39,6 +39,7 @@ under the licensing terms detailed in LICENSE:
 * bnbarak <bn.barak@gmail.com>
 * Colin Eberhardt <colin.eberhardt@gmail.com>
 * Ryan Pivovar <ryanpivovar@gmail.com>
+* Roman F. <romdotdog@users.noreply.github.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -9745,6 +9745,13 @@ export class Compiler extends DiagnosticEmitter {
       case Token.TYPEOF: {
         return this.compileTypeof(expression, contextualType, constraints);
       }
+      case Token.DOT_DOT_DOT: {
+        this.error(
+          DiagnosticCode.Not_implemented_0,
+          expression.range, "Spread operator"
+        );
+        return module.unreachable();
+      }
       default: {
         assert(false);
         return module.unreachable();

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1769,10 +1769,12 @@ export class Resolver extends DiagnosticEmitter {
         return type.intType;
       }
       case Token.DOT_DOT_DOT: {
-        this.error(
-          DiagnosticCode.Not_implemented_0,
-          node.range, "Spread operator"
-        );
+        if (reportMode == ReportMode.REPORT) {
+          this.error(
+            DiagnosticCode.Not_implemented_0,
+            node.range, "Spread operator"
+          );
+        }
         return null;
       }
       default: assert(false);

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1768,6 +1768,13 @@ export class Resolver extends DiagnosticEmitter {
         }
         return type.intType;
       }
+      case Token.DOT_DOT_DOT: {
+        this.error(
+          DiagnosticCode.Not_implemented_0,
+          node.range, "Spread operator"
+        );
+        return null;
+      }
       default: assert(false);
     }
     return null;


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

I'm not exactly sure what the current status of the spread operator is, but I noticed that the compiler crashes when using it
fixes #1853
all tests passed in my fork

- [x] I've read the contributing guidelines