### PR TITLE
Allow inlining the original function into its varargs stub

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6872,7 +6872,8 @@ export class Compiler extends DiagnosticEmitter {
       table
     );
     stmts.push(
-      module.call(original.internalName, forwardedOperands, returnType.toRef())
+      // assume this will always succeed (can just use name as the reportNode)
+      this.makeCallDirect(original, forwardedOperands, original.declaration.name)
     );
     flow.freeScopedLocals();
     this.currentFlow = previousFlow;


### PR DESCRIPTION
If constructors of exported classes are inlined and require a varargs stub, we were missing to make sure that the varargs stub has something to call. This change simply allows inlining the original function into the stub.

fixes #1820

- [x] I've read the contributing guidelines