### PR TITLE
Statically eliminate logical expression branches

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -10057,17 +10057,15 @@ export class Compiler extends DiagnosticEmitter {
     return supported;
   }
 
-  /** Evaluates a (boolean) condition, determining whether it is TRUE, FALSE or UNKNOWN. */
+  /** Evaluates a boolean condition, determining whether it is TRUE, FALSE or UNKNOWN. */
   evaluateCondition(expr: ExpressionRef): ConditionKind {
+    assert(getExpressionType(expr) == TypeRef.I32);
     var module = this.module;
     var evaled = module.runExpression(expr, ExpressionRunnerFlags.Default);
     if (evaled) {
-      switch (getExpressionType(evaled)) {
-        case TypeRef.I32: return getConstValueI32(evaled) ? ConditionKind.TRUE : ConditionKind.FALSE;
-        case TypeRef.I64: return getConstValueI64Low(evaled) || getConstValueI64High(evaled) ? ConditionKind.TRUE : ConditionKind.FALSE;
-        case TypeRef.F32: return getConstValueF32(evaled) ? ConditionKind.TRUE : ConditionKind.FALSE;
-        case TypeRef.F64: return getConstValueF64(evaled) ? ConditionKind.TRUE : ConditionKind.FALSE;
-      }
+      return getConstValueI32(evaled)
+        ? ConditionKind.TRUE
+        : ConditionKind.FALSE;
     }
     return ConditionKind.UNKNOWN;
   }

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -2949,11 +2949,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $start:do

--- a/tests/compiler/empty-exportruntime.untouched.wat
+++ b/tests/compiler/empty-exportruntime.untouched.wat
@@ -2466,11 +2466,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -2974,11 +2974,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $start:for

--- a/tests/compiler/issues/1225.untouched.wat
+++ b/tests/compiler/issues/1225.untouched.wat
@@ -2419,11 +2419,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $start:issues/1225

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -2434,11 +2434,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
@@ -2515,11 +2510,6 @@
   i32.const 0
   i32.store
   i32.const 0
-  if (result i32)
-   unreachable
-  else
-   i32.const 0
-  end
   drop
   f64.const 0
   i64.reinterpret_f64
@@ -2529,18 +2519,8 @@
   i64.sub
   i64.const -9007199254740994
   i64.le_u
-  if (result i32)
-   unreachable
-  else
-   i32.const 0
-  end
   drop
   i32.const 1
-  if (result i32)
-   i32.const 1
-  else
-   unreachable
-  end
   drop
   f64.const 1
   i64.reinterpret_f64
@@ -2550,22 +2530,12 @@
   i64.sub
   i64.const -9007199254740994
   i64.le_u
-  if (result i32)
-   i32.const 1
-  else
-   unreachable
-  end
   drop
   i32.const 1
   if (result i32)
    i32.const 2
   else
    i32.const 1
-  end
-  if (result i32)
-   i32.const 1
-  else
-   unreachable
   end
   drop
   f64.const 1
@@ -2588,11 +2558,6 @@
   i64.sub
   i64.const -9007199254740994
   i64.le_u
-  if (result i32)
-   i32.const 1
-  else
-   unreachable
-  end
   drop
   i32.const 1
   if (result i32)

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -2541,11 +2541,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -4278,11 +4278,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -2416,11 +2416,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $start:rt/finalize

--- a/tests/compiler/rt/runtime-incremental-export.untouched.wat
+++ b/tests/compiler/rt/runtime-incremental-export.untouched.wat
@@ -2466,11 +2466,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/std-wasi/console.untouched.wat
+++ b/tests/compiler/std-wasi/console.untouched.wat
@@ -5317,11 +5317,6 @@
   i32.load offset=8
   local.set $2
   i32.const 1
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.set $3

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -6985,11 +6985,6 @@
   i32.load offset=8
   local.set $2
   i32.const 1
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 1
-  end
   drop
   local.get $2
   local.set $3

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -3872,11 +3872,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -13489,7 +13489,7 @@
     local.get $2
     i32.load offset=4
     local.set $2
-    loop $while-continue|024
+    loop $while-continue|02528
      local.get $1
      local.get $4
      i32.lt_s
@@ -13508,7 +13508,7 @@
       i32.const 1
       i32.add
       local.set $1
-      br $while-continue|024
+      br $while-continue|02528
      end
     end
     i32.const -1
@@ -13551,7 +13551,7 @@
     local.get $2
     i32.load offset=4
     local.set $2
-    loop $while-continue|02528
+    loop $while-continue|026
      local.get $1
      local.get $4
      i32.lt_s
@@ -13570,7 +13570,7 @@
       i32.const 1
       i32.add
       local.set $1
-      br $while-continue|02528
+      br $while-continue|026
      end
     end
     i32.const -1
@@ -14209,7 +14209,7 @@
     local.get $1
     i32.load offset=4
     local.set $1
-    loop $while-continue|026
+    loop $while-continue|028
      local.get $0
      local.get $2
      i32.lt_s
@@ -14227,7 +14227,7 @@
       i32.const 1
       i32.add
       local.set $0
-      br $while-continue|026
+      br $while-continue|028
      end
     end
     i32.const -1
@@ -14248,7 +14248,7 @@
    global.get $std/array/arr
    local.tee $1
    i32.store
-   block $__inlined_func$~lib/array/Array<i32>#indexOf28
+   block $__inlined_func$~lib/array/Array<i32>#indexOf30
     local.get $1
     i32.load offset=12
     local.tee $2
@@ -14260,7 +14260,7 @@
     if
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/array/Array<i32>#indexOf28
+     br $__inlined_func$~lib/array/Array<i32>#indexOf30
     end
     local.get $2
     i32.const 2
@@ -14275,7 +14275,7 @@
     local.get $1
     i32.load offset=4
     local.set $1
-    loop $while-continue|030
+    loop $while-continue|032
      local.get $0
      local.get $2
      i32.lt_s
@@ -14288,12 +14288,12 @@
       i32.load
       i32.const 43
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf28
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf30
       local.get $0
       i32.const 1
       i32.add
       local.set $0
-      br $while-continue|030
+      br $while-continue|032
      end
     end
     i32.const -1
@@ -14314,7 +14314,7 @@
    global.get $std/array/arr
    local.tee $1
    i32.store
-   block $__inlined_func$~lib/array/Array<i32>#indexOf32
+   block $__inlined_func$~lib/array/Array<i32>#indexOf34
     local.get $1
     i32.load offset=12
     local.tee $2
@@ -14326,7 +14326,7 @@
     if
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/array/Array<i32>#indexOf32
+     br $__inlined_func$~lib/array/Array<i32>#indexOf34
     end
     local.get $2
     i32.const 4
@@ -14341,7 +14341,7 @@
     local.get $1
     i32.load offset=4
     local.set $1
-    loop $while-continue|034
+    loop $while-continue|036
      local.get $0
      local.get $2
      i32.lt_s
@@ -14354,12 +14354,12 @@
       i32.load
       i32.const 43
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf32
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf34
       local.get $0
       i32.const 1
       i32.add
       local.set $0
-      br $while-continue|034
+      br $while-continue|036
      end
     end
     i32.const -1
@@ -14382,7 +14382,7 @@
    i32.store
    i32.const 0
    local.set $2
-   block $__inlined_func$~lib/array/Array<i32>#indexOf36
+   block $__inlined_func$~lib/array/Array<i32>#indexOf38
     local.get $1
     i32.load offset=12
     local.tee $0
@@ -14394,12 +14394,12 @@
     if
      i32.const -1
      local.set $2
-     br $__inlined_func$~lib/array/Array<i32>#indexOf36
+     br $__inlined_func$~lib/array/Array<i32>#indexOf38
     end
     local.get $1
     i32.load offset=4
     local.set $1
-    loop $while-continue|037
+    loop $while-continue|039
      local.get $0
      local.get $2
      i32.gt_s
@@ -14412,12 +14412,12 @@
       i32.load
       i32.const 43
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf36
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf38
       local.get $2
       i32.const 1
       i32.add
       local.set $2
-      br $while-continue|037
+      br $while-continue|039
      end
     end
     i32.const -1
@@ -14440,7 +14440,7 @@
    i32.store
    i32.const 1
    local.set $2
-   block $__inlined_func$~lib/array/Array<i32>#indexOf39
+   block $__inlined_func$~lib/array/Array<i32>#indexOf41
     local.get $1
     i32.load offset=12
     local.tee $0
@@ -14452,12 +14452,12 @@
     if
      i32.const -1
      local.set $2
-     br $__inlined_func$~lib/array/Array<i32>#indexOf39
+     br $__inlined_func$~lib/array/Array<i32>#indexOf41
     end
     local.get $1
     i32.load offset=4
     local.set $1
-    loop $while-continue|040
+    loop $while-continue|042
      local.get $0
      local.get $2
      i32.gt_s
@@ -14470,12 +14470,12 @@
       i32.load
       i32.const 43
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf39
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf41
       local.get $2
       i32.const 1
       i32.add
       local.set $2
-      br $while-continue|040
+      br $while-continue|042
      end
     end
     i32.const -1
@@ -14498,7 +14498,7 @@
    i32.store
    i32.const 2
    local.set $2
-   block $__inlined_func$~lib/array/Array<i32>#indexOf42
+   block $__inlined_func$~lib/array/Array<i32>#indexOf44
     local.get $1
     i32.load offset=12
     local.tee $0
@@ -14510,12 +14510,12 @@
     if
      i32.const -1
      local.set $2
-     br $__inlined_func$~lib/array/Array<i32>#indexOf42
+     br $__inlined_func$~lib/array/Array<i32>#indexOf44
     end
     local.get $1
     i32.load offset=4
     local.set $1
-    loop $while-continue|043
+    loop $while-continue|045
      local.get $0
      local.get $2
      i32.gt_s
@@ -14528,12 +14528,12 @@
       i32.load
       i32.const 43
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf42
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf44
       local.get $2
       i32.const 1
       i32.add
       local.set $2
-      br $while-continue|043
+      br $while-continue|045
      end
     end
     i32.const -1
@@ -14576,7 +14576,7 @@
     local.get $0
     i32.load offset=4
     local.set $0
-    loop $while-continue|02644
+    loop $while-continue|02736
      local.get $1
      local.get $2
      i32.lt_s
@@ -14602,7 +14602,7 @@
       i32.const 1
       i32.add
       local.set $1
-      br $while-continue|02644
+      br $while-continue|02736
      end
     end
     i32.const 0
@@ -14642,7 +14642,7 @@
     local.get $0
     i32.load offset=4
     local.set $0
-    loop $while-continue|02736
+    loop $while-continue|02846
      local.get $1
      local.get $2
      i32.lt_s
@@ -14668,7 +14668,7 @@
       i32.const 1
       i32.add
       local.set $1
-      br $while-continue|02736
+      br $while-continue|02846
      end
     end
     i32.const 0
@@ -17718,7 +17718,7 @@
    local.get $3
    i32.load offset=4
    local.set $4
-   loop $for-loop|044
+   loop $for-loop|04577
     local.get $6
     local.get $5
     local.get $7
@@ -17755,7 +17755,7 @@
      i32.const 1
      i32.add
      local.set $6
-     br $for-loop|044
+     br $for-loop|04577
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -18137,7 +18137,7 @@
    local.get $4
    i32.load offset=12
    local.set $2
-   loop $for-loop|077
+   loop $for-loop|078
     local.get $0
     local.get $2
     local.get $4
@@ -18171,7 +18171,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|077
+     br $for-loop|078
     end
    end
    local.get $6
@@ -18202,7 +18202,7 @@
    local.get $4
    i32.load offset=12
    local.set $2
-   loop $for-loop|079
+   loop $for-loop|080
     local.get $0
     local.get $2
     local.get $4
@@ -18236,7 +18236,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|079
+     br $for-loop|080
     end
    end
    local.get $6
@@ -18267,7 +18267,7 @@
    local.get $4
    i32.load offset=12
    local.set $2
-   loop $for-loop|081
+   loop $for-loop|082
     local.get $0
     local.get $2
     local.get $4
@@ -18301,7 +18301,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|081
+     br $for-loop|082
     end
    end
    local.get $6
@@ -18329,7 +18329,7 @@
    local.get $4
    i32.load offset=12
    local.set $2
-   loop $for-loop|083
+   loop $for-loop|084
     local.get $0
     local.get $2
     local.get $4
@@ -18363,7 +18363,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|083
+     br $for-loop|084
     end
    end
    local.get $6
@@ -18390,7 +18390,7 @@
    local.get $4
    i32.load offset=12
    local.set $2
-   loop $for-loop|085
+   loop $for-loop|086
     local.get $0
     local.get $2
     local.get $4
@@ -18424,7 +18424,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|085
+     br $for-loop|086
     end
    end
    local.get $6
@@ -18471,7 +18471,7 @@
    local.get $4
    i32.load offset=12
    local.set $2
-   loop $for-loop|087
+   loop $for-loop|088
     local.get $0
     local.get $2
     local.get $4
@@ -18505,7 +18505,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|087
+     br $for-loop|088
     end
    end
    local.get $6
@@ -18564,7 +18564,7 @@
    local.get $4
    i32.load offset=12
    local.set $2
-   loop $for-loop|089
+   loop $for-loop|090
     local.get $0
     local.get $2
     local.get $4
@@ -18598,7 +18598,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|089
+     br $for-loop|090
     end
    end
    local.get $6
@@ -18661,7 +18661,7 @@
    i32.const 1
    i32.sub
    local.set $0
-   loop $for-loop|090
+   loop $for-loop|091
     local.get $0
     i32.const 0
     i32.ge_s
@@ -18688,7 +18688,7 @@
      i32.const 1
      i32.sub
      local.set $0
-     br $for-loop|090
+     br $for-loop|091
     end
    end
    local.get $6
@@ -18719,7 +18719,7 @@
    i32.const 1
    i32.sub
    local.set $0
-   loop $for-loop|092
+   loop $for-loop|093
     local.get $0
     i32.const 0
     i32.ge_s
@@ -18746,7 +18746,7 @@
      i32.const 1
      i32.sub
      local.set $0
-     br $for-loop|092
+     br $for-loop|093
     end
    end
    local.get $6
@@ -18777,7 +18777,7 @@
    i32.const 1
    i32.sub
    local.set $0
-   loop $for-loop|094
+   loop $for-loop|095
     local.get $0
     i32.const 0
     i32.ge_s
@@ -18804,7 +18804,7 @@
      i32.const 1
      i32.sub
      local.set $0
-     br $for-loop|094
+     br $for-loop|095
     end
    end
    local.get $6
@@ -18832,7 +18832,7 @@
    i32.const 1
    i32.sub
    local.set $0
-   loop $for-loop|096
+   loop $for-loop|097
     local.get $0
     i32.const 0
     i32.ge_s
@@ -18859,7 +18859,7 @@
      i32.const 1
      i32.sub
      local.set $0
-     br $for-loop|096
+     br $for-loop|097
     end
    end
    local.get $6
@@ -18886,7 +18886,7 @@
    i32.const 1
    i32.sub
    local.set $0
-   loop $for-loop|098
+   loop $for-loop|099
     local.get $0
     i32.const 0
     i32.ge_s
@@ -18913,7 +18913,7 @@
      i32.const 1
      i32.sub
      local.set $0
-     br $for-loop|098
+     br $for-loop|099
     end
    end
    local.get $6
@@ -18960,7 +18960,7 @@
    i32.const 1
    i32.sub
    local.set $0
-   loop $for-loop|0100
+   loop $for-loop|0101
     local.get $0
     i32.const 0
     i32.ge_s
@@ -18987,7 +18987,7 @@
      i32.const 1
      i32.sub
      local.set $0
-     br $for-loop|0100
+     br $for-loop|0101
     end
    end
    local.get $6
@@ -19046,7 +19046,7 @@
    i32.const 1
    i32.sub
    local.set $0
-   loop $for-loop|0102
+   loop $for-loop|0103
     local.get $0
     i32.const 0
     i32.ge_s
@@ -19073,7 +19073,7 @@
      i32.const 1
      i32.sub
      local.set $0
-     br $for-loop|0102
+     br $for-loop|0103
     end
    end
    local.get $6
@@ -19161,11 +19161,11 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   block $1of146
-    block $0of147
-     block $outOfRange48
+   block $1of148
+    block $0of149
+     block $outOfRange50
       global.get $~argumentsLength
-      br_table $0of147 $1of146 $outOfRange48
+      br_table $0of149 $1of148 $outOfRange50
      end
      unreachable
     end
@@ -19223,7 +19223,7 @@
     if
      local.get $1
      local.set $2
-     loop $for-loop|0104
+     loop $for-loop|0105
       local.get $5
       local.get $7
       i32.gt_s
@@ -19293,7 +19293,7 @@
        i32.const 1
        i32.add
        local.set $7
-       br $for-loop|0104
+       br $for-loop|0105
       end
      end
     else
@@ -19334,7 +19334,7 @@
     i32.eq
     br_if $__inlined_func$std/array/isArraysEqual<f32>
     drop
-    loop $for-loop|025
+    loop $for-loop|026
      local.get $0
      local.get $1
      i32.gt_s
@@ -19372,7 +19372,7 @@
       i32.const 1
       i32.add
       local.set $1
-      br $for-loop|025
+      br $for-loop|026
      end
     end
     i32.const 1
@@ -19409,11 +19409,11 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   block $1of155
-    block $0of156
-     block $outOfRange57
+   block $1of156
+    block $0of157
+     block $outOfRange58
       global.get $~argumentsLength
-      br_table $0of156 $1of155 $outOfRange57
+      br_table $0of157 $1of156 $outOfRange58
      end
      unreachable
     end
@@ -19471,7 +19471,7 @@
     if
      local.get $1
      local.set $2
-     loop $for-loop|0106
+     loop $for-loop|0107
       local.get $5
       local.get $7
       i32.gt_s
@@ -19487,12 +19487,12 @@
        i32.const 1
        i32.sub
        local.set $1
-       loop $while-continue|1107
+       loop $while-continue|1108
         local.get $1
         i32.const 0
         i32.ge_s
         if
-         block $while-break|1108
+         block $while-break|1109
           local.get $3
           local.get $1
           i32.const 3
@@ -19509,7 +19509,7 @@
           call_indirect $0 (type $f64_f64_=>_i32)
           i32.const 0
           i32.ge_s
-          br_if $while-break|1108
+          br_if $while-break|1109
           local.get $1
           local.tee $0
           i32.const 1
@@ -19524,7 +19524,7 @@
           i32.add
           local.get $12
           f64.store
-          br $while-continue|1107
+          br $while-continue|1108
          end
         end
        end
@@ -19541,7 +19541,7 @@
        i32.const 1
        i32.add
        local.set $7
-       br $for-loop|0106
+       br $for-loop|0107
       end
      end
     else
@@ -19582,7 +19582,7 @@
     i32.eq
     br_if $__inlined_func$std/array/isArraysEqual<f64>
     drop
-    loop $for-loop|028
+    loop $for-loop|029
      local.get $0
      local.get $1
      i32.gt_s
@@ -19620,7 +19620,7 @@
       i32.const 1
       i32.add
       local.set $1
-      br $for-loop|028
+      br $for-loop|029
      end
     end
     i32.const 1
@@ -19657,11 +19657,11 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   block $1of158
-    block $0of159
-     block $outOfRange60
+   block $1of159
+    block $0of160
+     block $outOfRange61
       global.get $~argumentsLength
-      br_table $0of159 $1of158 $outOfRange60
+      br_table $0of160 $1of159 $outOfRange61
      end
      unreachable
     end
@@ -20044,7 +20044,7 @@
    local.get $4
    local.get $5
    i32.store
-   loop $for-loop|061111
+   loop $for-loop|062
     local.get $0
     i32.const 2
     i32.lt_s
@@ -20068,7 +20068,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|061111
+     br $for-loop|062
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -20166,7 +20166,7 @@
    local.get $0
    local.get $1
    i32.store
-   loop $for-loop|053
+   loop $for-loop|055
     local.get $5
     i32.const 512
     i32.lt_s
@@ -20209,7 +20209,7 @@
      i32.const 1
      i32.add
      local.set $5
-     br $for-loop|053
+     br $for-loop|055
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -20256,13 +20256,13 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   block $1of156
-    block $0of157
-     block $outOfRange58
+   block $1of157
+    block $0of158
+     block $outOfRange59
       global.get $~argumentsLength
       i32.const 1
       i32.sub
-      br_table $0of157 $1of156 $outOfRange58
+      br_table $0of158 $1of157 $outOfRange59
      end
      unreachable
     end
@@ -20479,7 +20479,7 @@
    call $~lib/array/Array<~lib/string/String>#constructor
    local.tee $10
    i32.store
-   loop $for-loop|062
+   loop $for-loop|063113
     local.get $0
     i32.const 400
     i32.lt_s
@@ -20611,7 +20611,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|062
+     br $for-loop|063113
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -20636,13 +20636,13 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   block $1of163
-    block $0of164
-     block $outOfRange65
+   block $1of164
+    block $0of165
+     block $outOfRange66
       global.get $~argumentsLength
       i32.const 1
       i32.sub
-      br_table $0of164 $1of163 $outOfRange65
+      br_table $0of165 $1of164 $outOfRange66
      end
      unreachable
     end
@@ -21330,7 +21330,7 @@
      local.set $1
      br $__inlined_func$~lib/util/string/joinIntegerArray<i8>
     end
-    block $folding-inner0115
+    block $folding-inner0116
      local.get $3
      i32.eqz
      if
@@ -21338,7 +21338,7 @@
       i32.load8_s
       call $~lib/util/number/itoa32
       local.set $1
-      br $folding-inner0115
+      br $folding-inner0116
      end
      global.get $~lib/memory/__stack_pointer
      local.get $3
@@ -21359,7 +21359,7 @@
      call $~lib/rt/itcms/__new
      local.tee $1
      i32.store
-     loop $for-loop|0116
+     loop $for-loop|0117
       local.get $3
       local.get $6
       i32.gt_s
@@ -21398,7 +21398,7 @@
        i32.const 1
        i32.add
        local.set $6
-       br $for-loop|0116
+       br $for-loop|0117
       end
      end
      local.get $2
@@ -21421,7 +21421,7 @@
       local.get $0
       call $~lib/string/String#substring
       local.set $1
-      br $folding-inner0115
+      br $folding-inner0116
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -21519,7 +21519,7 @@
      local.set $1
      br $__inlined_func$~lib/util/string/joinIntegerArray<u16>
     end
-    block $folding-inner0118
+    block $folding-inner0119
      local.get $3
      i32.eqz
      if
@@ -21527,7 +21527,7 @@
       i32.load16_u
       call $~lib/util/number/utoa32
       local.set $1
-      br $folding-inner0118
+      br $folding-inner0119
      end
      global.get $~lib/memory/__stack_pointer
      local.get $3
@@ -21548,7 +21548,7 @@
      call $~lib/rt/itcms/__new
      local.tee $1
      i32.store
-     loop $for-loop|0119
+     loop $for-loop|0120
       local.get $3
       local.get $6
       i32.gt_s
@@ -21589,7 +21589,7 @@
        i32.const 1
        i32.add
        local.set $6
-       br $for-loop|0119
+       br $for-loop|0120
       end
      end
      local.get $2
@@ -21614,7 +21614,7 @@
       local.get $0
       call $~lib/string/String#substring
       local.set $1
-      br $folding-inner0118
+      br $folding-inner0119
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -21712,7 +21712,7 @@
      local.set $1
      br $__inlined_func$~lib/util/string/joinIntegerArray<u64>
     end
-    block $folding-inner0121
+    block $folding-inner0122
      local.get $3
      i32.eqz
      if
@@ -21877,7 +21877,7 @@
        local.get $0
       end
       local.set $1
-      br $folding-inner0121
+      br $folding-inner0122
      end
      global.get $~lib/memory/__stack_pointer
      local.get $3
@@ -21898,7 +21898,7 @@
      call $~lib/rt/itcms/__new
      local.tee $1
      i32.store
-     loop $for-loop|0122
+     loop $for-loop|0123
       local.get $3
       local.get $6
       i32.gt_s
@@ -21939,7 +21939,7 @@
        i32.const 1
        i32.add
        local.set $6
-       br $for-loop|0122
+       br $for-loop|0123
       end
      end
      local.get $2
@@ -21964,7 +21964,7 @@
       local.get $0
       call $~lib/string/String#substring
       local.set $1
-      br $folding-inner0121
+      br $folding-inner0122
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -22062,7 +22062,7 @@
      local.set $1
      br $__inlined_func$~lib/util/string/joinIntegerArray<i64>
     end
-    block $folding-inner0124
+    block $folding-inner0125
      local.get $3
      i32.eqz
      if
@@ -22248,7 +22248,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
       end
-      br $folding-inner0124
+      br $folding-inner0125
      end
      global.get $~lib/memory/__stack_pointer
      local.get $3
@@ -22269,7 +22269,7 @@
      call $~lib/rt/itcms/__new
      local.tee $1
      i32.store
-     loop $for-loop|0125
+     loop $for-loop|0126
       local.get $3
       local.get $6
       i32.gt_s
@@ -22310,7 +22310,7 @@
        i32.const 1
        i32.add
        local.set $6
-       br $for-loop|0125
+       br $for-loop|0126
       end
      end
      local.get $2
@@ -22335,7 +22335,7 @@
       local.get $0
       call $~lib/string/String#substring
       local.set $1
-      br $folding-inner0124
+      br $folding-inner0125
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -22765,7 +22765,7 @@
     i32.const 1
     i32.shr_u
     local.set $2
-    loop $for-loop|078
+    loop $for-loop|077
      local.get $5
      local.get $7
      i32.gt_s
@@ -22807,7 +22807,7 @@
       i32.const 1
       i32.add
       local.set $7
-      br $for-loop|078
+      br $for-loop|077
      end
     end
     global.get $~lib/memory/__stack_pointer
@@ -22989,7 +22989,7 @@
     i32.const 1
     i32.shr_u
     local.set $2
-    loop $for-loop|080
+    loop $for-loop|079
      local.get $5
      local.get $7
      i32.gt_s
@@ -23031,7 +23031,7 @@
       i32.const 1
       i32.add
       local.set $7
-      br $for-loop|080
+      br $for-loop|079
      end
     end
     global.get $~lib/memory/__stack_pointer
@@ -23153,7 +23153,7 @@
    end
    i32.const 0
    local.set $0
-   loop $for-loop|1129
+   loop $for-loop|1130
     local.get $0
     i32.const 10
     i32.lt_s
@@ -23175,7 +23175,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|1129
+     br $for-loop|1130
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -23250,7 +23250,7 @@
    local.get $4
    i32.load offset=4
    local.set $4
-   loop $for-loop|0130
+   loop $for-loop|0131
     local.get $0
     local.get $5
     i32.lt_s
@@ -23275,7 +23275,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|0130
+     br $for-loop|0131
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -23311,7 +23311,7 @@
    call $~lib/rt/itcms/__link
    i32.const 0
    local.set $0
-   loop $for-loop|1131
+   loop $for-loop|1132
     local.get $0
     local.get $5
     i32.lt_s
@@ -23342,7 +23342,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|1131
+     br $for-loop|1132
     end
    end
    i32.const 0
@@ -23397,7 +23397,7 @@
    end
    i32.const 0
    local.set $0
-   loop $for-loop|2132
+   loop $for-loop|2133
     local.get $0
     local.get $4
     i32.load offset=12
@@ -23433,7 +23433,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|2132
+     br $for-loop|2133
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -23492,23 +23492,23 @@
    i32.const 0
    i32.gt_s
    if
-    loop $while-continue|070
+    loop $while-continue|071
      global.get $~lib/rt/itcms/state
      if
       call $~lib/rt/itcms/step
       drop
-      br $while-continue|070
+      br $while-continue|071
      end
     end
    end
    call $~lib/rt/itcms/step
    drop
-   loop $while-continue|1133
+   loop $while-continue|1134
     global.get $~lib/rt/itcms/state
     if
      call $~lib/rt/itcms/step
      drop
-     br $while-continue|1133
+     br $while-continue|1134
     end
    end
    global.get $~lib/rt/itcms/total

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -2830,14 +2830,9 @@
   i32.store offset=12
  )
  (func $~lib/array/Array.isArray<~lib/array/Array<i32>|null> (param $0 i32) (result i32)
-  i32.const 1
-  if (result i32)
-   local.get $0
-   i32.const 0
-   i32.ne
-  else
-   i32.const 0
-  end
+  local.get $0
+  i32.const 0
+  i32.ne
  )
  (func $std/array/Ref#set:v (param $0 i32) (param $1 i32)
   local.get $0
@@ -2846,13 +2841,6 @@
  )
  (func $~lib/array/Array.isArray<std/array/Ref> (param $0 i32) (result i32)
   i32.const 0
-  if (result i32)
-   local.get $0
-   i32.const 0
-   i32.ne
-  else
-   i32.const 0
-  end
  )
  (func $~lib/arraybuffer/ArrayBufferView#set:buffer (param $0 i32) (param $1 i32)
   local.get $0
@@ -2875,36 +2863,17 @@
  )
  (func $~lib/array/Array.isArray<~lib/typedarray/Uint8Array> (param $0 i32) (result i32)
   i32.const 0
-  if (result i32)
-   local.get $0
-   i32.const 0
-   i32.ne
-  else
-   i32.const 0
-  end
  )
  (func $~lib/array/Array.isArray<i32> (param $0 i32) (result i32)
   i32.const 0
  )
  (func $~lib/array/Array.isArray<~lib/string/String> (param $0 i32) (result i32)
   i32.const 0
-  if (result i32)
-   local.get $0
-   i32.const 0
-   i32.ne
-  else
-   i32.const 0
-  end
  )
  (func $~lib/array/Array.isArray<~lib/array/Array<i32>> (param $0 i32) (result i32)
-  i32.const 1
-  if (result i32)
-   local.get $0
-   i32.const 0
-   i32.ne
-  else
-   i32.const 0
-  end
+  local.get $0
+  i32.const 0
+  i32.ne
  )
  (func $~lib/util/memory/memcpy (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -12902,11 +12871,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/array/Array<u32>#set:buffer (param $0 i32) (param $1 i32)
@@ -17182,14 +17146,9 @@
   block $~lib/util/sort/COMPARATOR<i32>|inlined.1 (result i32)
    i32.const 1
    drop
-   i32.const 1
-   if (result i32)
-    i32.const 4
-    i32.const 4
-    i32.le_u
-   else
-    i32.const 0
-   end
+   i32.const 4
+   i32.const 4
+   i32.le_u
    drop
    i32.const 7312
    br $~lib/util/sort/COMPARATOR<i32>|inlined.1
@@ -29134,14 +29093,9 @@
    block $~lib/util/sort/COMPARATOR<i32>|inlined.0 (result i32)
     i32.const 1
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 4
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
+    i32.const 4
+    i32.const 4
+    i32.le_u
     drop
     i32.const 6912
     br $~lib/util/sort/COMPARATOR<i32>|inlined.0
@@ -29182,13 +29136,6 @@
     i32.const 1
     drop
     i32.const 0
-    if (result i32)
-     i32.const 4
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
     drop
     i32.const 7040
     br $~lib/util/sort/COMPARATOR<u32>|inlined.0
@@ -35269,13 +35216,6 @@
     i32.const 1
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
     drop
     i32.const 13616
     br $~lib/util/sort/COMPARATOR<u8>|inlined.0

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -4035,11 +4035,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -3300,11 +3300,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -16552,11 +16552,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $start:std/map
@@ -16625,11 +16620,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16676,11 +16666,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16701,11 +16686,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16726,11 +16706,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16764,11 +16739,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16789,11 +16759,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16827,11 +16792,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16852,11 +16812,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16890,11 +16845,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16915,11 +16865,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16953,11 +16898,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -16978,11 +16918,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -17016,11 +16951,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -17041,11 +16971,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -17079,11 +17004,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -17104,11 +17024,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -17142,11 +17057,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -17167,11 +17077,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1
@@ -17205,11 +17110,6 @@
   i32.load offset=8
   local.set $2
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.get $1

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -616,18 +616,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/abs
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/abs
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -852,18 +846,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/acos
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/acos
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -1702,18 +1690,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/acosh
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/acosh
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -2339,18 +2321,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/asin
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/asin
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -2545,18 +2521,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/asinh
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/asinh
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -2916,18 +2886,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/atan
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/atan
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -3241,18 +3205,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/atanh
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/atanh
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -3636,19 +3594,13 @@
   local.get $4
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/atan2
-    local.get $2
-    local.get $3
-    local.get $4
-    call $std/math/check<f64>
-   end
+   local.get $0
+   local.get $1
+   call $~lib/bindings/Math/atan2
+   local.get $2
+   local.get $3
+   local.get $4
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -4090,18 +4042,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/cbrt
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/cbrt
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -4241,18 +4187,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/ceil
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/ceil
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -5196,18 +5136,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/cos
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/cos
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -6539,18 +6473,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/cosh
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/cosh
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -7087,18 +7015,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/exp
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/exp
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -7119,18 +7041,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/expm1
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/expm1
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -7418,19 +7334,13 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    f64.const 2
-    local.get $0
-    call $~lib/bindings/Math/pow
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   f64.const 2
+   local.get $0
+   call $~lib/bindings/Math/pow
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -7577,18 +7487,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/floor
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/floor
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -7960,18 +7864,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/log
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/log
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -8252,18 +8150,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/log10
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/log10
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -8484,18 +8376,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/log1p
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/log1p
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -8867,18 +8753,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/log2
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/log2
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -9081,19 +8961,13 @@
   local.get $4
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/max
-    local.get $2
-    local.get $3
-    local.get $4
-    call $std/math/check<f64>
-   end
+   local.get $0
+   local.get $1
+   call $~lib/bindings/Math/max
+   local.get $2
+   local.get $3
+   local.get $4
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -9128,19 +9002,13 @@
   local.get $4
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/min
-    local.get $2
-    local.get $3
-    local.get $4
-    call $std/math/check<f64>
-   end
+   local.get $0
+   local.get $1
+   call $~lib/bindings/Math/min
+   local.get $2
+   local.get $3
+   local.get $4
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -9426,19 +9294,13 @@
   local.get $4
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    local.get $1
-    call $std/math/mod
-    local.get $2
-    local.get $3
-    local.get $4
-    call $std/math/check<f64>
-   end
+   local.get $0
+   local.get $1
+   call $std/math/mod
+   local.get $2
+   local.get $3
+   local.get $4
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -10692,19 +10554,13 @@
   local.get $4
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/pow
-    local.get $2
-    local.get $3
-    local.get $4
-    call $std/math/check<f64>
-   end
+   local.get $0
+   local.get $1
+   call $~lib/bindings/Math/pow
+   local.get $2
+   local.get $3
+   local.get $4
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -11632,18 +11488,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/sign
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/sign
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -12859,18 +12709,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/sin
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/sin
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -13603,18 +13447,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/sinh
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/sinh
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -13731,18 +13569,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/sqrt
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/sqrt
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -14295,18 +14127,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/tan
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/tan
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -15070,18 +14896,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/tanh
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/tanh
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
@@ -15191,18 +15011,12 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    call $~lib/bindings/Math/trunc
-    local.get $1
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   end
+   local.get $0
+   call $~lib/bindings/Math/trunc
+   local.get $1
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -312,17 +312,11 @@
   local.get $2
   call $std/mod/check<f64>
   if (result i32)
-   global.get $std/mod/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    local.get $1
-    call $std/mod/mod
-    local.get $2
-    call $std/mod/check<f64>
-   end
+   local.get $0
+   local.get $1
+   call $std/mod/mod
+   local.get $2
+   call $std/mod/check<f64>
   else
    i32.const 0
   end

--- a/tests/compiler/std/polyfills.untouched.wat
+++ b/tests/compiler/std/polyfills.untouched.wat
@@ -300,13 +300,8 @@
  )
  (func $~lib/polyfills/bswap16<u8> (param $0 i32) (result i32)
   i32.const 1
-  if (result i32)
-   i32.const 1
-   i32.const 4
-   i32.le_u
-  else
-   i32.const 0
-  end
+  i32.const 4
+  i32.le_u
   drop
   i32.const 1
   i32.const 2
@@ -321,13 +316,8 @@
  )
  (func $~lib/polyfills/bswap16<i8> (param $0 i32) (result i32)
   i32.const 1
-  if (result i32)
-   i32.const 1
-   i32.const 4
-   i32.le_u
-  else
-   i32.const 0
-  end
+  i32.const 4
+  i32.le_u
   drop
   i32.const 1
   i32.const 2
@@ -341,14 +331,9 @@
   return
  )
  (func $~lib/polyfills/bswap16<u16> (param $0 i32) (result i32)
-  i32.const 1
-  if (result i32)
-   i32.const 2
-   i32.const 4
-   i32.le_u
-  else
-   i32.const 0
-  end
+  i32.const 2
+  i32.const 4
+  i32.le_u
   drop
   i32.const 2
   i32.const 2
@@ -372,14 +357,9 @@
   return
  )
  (func $~lib/polyfills/bswap16<i16> (param $0 i32) (result i32)
-  i32.const 1
-  if (result i32)
-   i32.const 2
-   i32.const 4
-   i32.le_u
-  else
-   i32.const 0
-  end
+  i32.const 2
+  i32.const 4
+  i32.le_u
   drop
   i32.const 2
   i32.const 2
@@ -402,14 +382,9 @@
   return
  )
  (func $~lib/polyfills/bswap16<u32> (param $0 i32) (result i32)
-  i32.const 1
-  if (result i32)
-   i32.const 4
-   i32.const 4
-   i32.le_u
-  else
-   i32.const 0
-  end
+  i32.const 4
+  i32.const 4
+  i32.le_u
   drop
   i32.const 4
   i32.const 2
@@ -437,14 +412,9 @@
   return
  )
  (func $~lib/polyfills/bswap16<i32> (param $0 i32) (result i32)
-  i32.const 1
-  if (result i32)
-   i32.const 4
-   i32.const 4
-   i32.le_u
-  else
-   i32.const 0
-  end
+  i32.const 4
+  i32.const 4
+  i32.le_u
   drop
   i32.const 4
   i32.const 2

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -13564,11 +13564,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $start:std/set

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -4428,11 +4428,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -4270,11 +4270,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -9291,11 +9291,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $std/string/getString (result i32)

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -4785,11 +4785,6 @@
   i32.load offset=8
   local.set $2
   i32.const 1
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
   local.get $2
   local.set $3
@@ -4858,12 +4853,7 @@
   local.get $0
   i32.load offset=8
   local.set $2
-  i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 1
-  end
+  i32.const 1
   drop
   local.get $2
   local.set $3

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -28319,9 +28319,22 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (param $0 i32)
-  i32.const 10316
-  i32.load
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   i32.const 1360
+   i32.const 1632
+   i32.const 1864
+   i32.const 19
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  local.get $1
+  i32.load offset=12
+  i32.add
   local.get $0
   i32.load offset=8
   i32.const 2
@@ -28337,10 +28350,14 @@
   end
   local.get $0
   i32.load offset=4
-  i32.const 10308
-  i32.load
-  i32.const 10312
-  i32.load
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $1
+  i32.load offset=4
+  local.get $1
+  i32.load offset=8
   call $~lib/memory/memory.copy
  )
  (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (param $0 i32) (param $1 i32)
@@ -39487,29 +39504,29 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  local.tee $0
+  local.tee $1
   i64.const 0
   i64.store
-  local.get $0
+  local.get $1
   i64.const 0
   i64.store offset=8
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store offset=16
-  local.get $0
+  local.get $1
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
-  local.tee $4
+  local.tee $3
   i32.store
-  local.get $4
+  local.get $3
   i32.const 0
   i64.const 7
   call $~lib/typedarray/Int64Array#__set
-  local.get $4
+  local.get $3
   i32.const 1
   i64.const 8
   call $~lib/typedarray/Int64Array#__set
-  local.get $4
+  local.get $3
   i32.const 2
   i64.const 9
   call $~lib/typedarray/Int64Array#__set
@@ -39537,76 +39554,76 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
-  local.tee $8
+  local.tee $4
   i32.store offset=8
-  local.get $8
+  local.get $4
   i32.const 0
   i32.const 1000
   call $~lib/typedarray/Int16Array#__set
-  local.get $8
+  local.get $4
   i32.const 1
   i32.const 1001
   call $~lib/typedarray/Int16Array#__set
-  local.get $8
+  local.get $4
   i32.const 2
   i32.const 1002
   call $~lib/typedarray/Int16Array#__set
   global.get $~lib/memory/__stack_pointer
   i32.const 10
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.tee $0
+  local.tee $1
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   i32.const 10304
   i32.store offset=16
   block $folding-inner0
-   local.get $0
+   local.get $1
    i32.load offset=8
    i32.const 10316
    i32.load
    i32.lt_s
    br_if $folding-inner0
-   local.get $0
+   local.get $1
    i32.load offset=4
-   local.set $5
+   local.set $6
    i32.const 10308
    i32.load
-   local.set $6
+   local.set $7
    i32.const 10316
    i32.load
-   local.set $1
+   local.set $8
    loop $for-loop|0
-    local.get $1
-    local.get $7
-    i32.gt_s
+    local.get $0
+    local.get $8
+    i32.lt_s
     if
-     local.get $5
-     local.get $7
-     i32.add
+     local.get $0
      local.get $6
+     i32.add
      local.get $7
+     local.get $0
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.tee $3
+     local.tee $5
      i32.const 31
      i32.shr_s
      i32.const -1
      i32.xor
-     local.get $3
+     local.get $5
      i32.const 255
-     local.get $3
+     local.get $5
      i32.sub
      i32.const 31
      i32.shr_s
      i32.or
      i32.and
      i32.store8
-     local.get $7
+     local.get $0
      i32.const 1
      i32.add
-     local.set $7
+     local.set $0
      br $for-loop|0
     end
    end
@@ -39615,19 +39632,19 @@
    i32.const 63
    i32.const 11024
    call $~lib/rt/__newArray
-   local.set $1
+   local.set $0
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=16
    local.get $0
+   i32.store offset=16
    local.get $1
+   local.get $0
    call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
    global.get $~lib/memory/__stack_pointer
    i32.const 10384
    i32.store offset=16
    i32.const 0
-   local.set $1
-   local.get $0
+   local.set $0
+   local.get $1
    i32.load offset=8
    i32.const 10396
    i32.load
@@ -39635,27 +39652,27 @@
    i32.add
    i32.lt_s
    br_if $folding-inner0
-   local.get $0
+   local.get $1
    i32.load offset=4
    i32.const 3
    i32.add
-   local.set $3
+   local.set $6
    i32.const 10388
    i32.load
-   local.set $5
+   local.set $7
    i32.const 10396
    i32.load
-   local.set $6
+   local.set $8
    loop $for-loop|00
-    local.get $1
-    local.get $6
+    local.get $0
+    local.get $8
     i32.lt_s
     if
-     local.get $1
-     local.get $3
+     local.get $0
+     local.get $6
      i32.add
-     local.get $5
-     local.get $1
+     local.get $7
+     local.get $0
      i32.const 2
      i32.shl
      i32.add
@@ -39676,10 +39693,10 @@
       i32.const 0
      end
      i32.store8
-     local.get $1
+     local.get $0
      i32.const 1
      i32.add
-     local.set $1
+     local.set $0
      br $for-loop|00
     end
    end
@@ -39688,15 +39705,15 @@
    i32.const 63
    i32.const 11120
    call $~lib/rt/__newArray
-   local.set $1
+   local.set $0
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=16
-   local.get $0
    local.get $1
-   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
    local.get $0
-   local.get $4
+   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
+   local.get $1
+   local.get $3
    i32.const 6
    call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
    i32.const 10
@@ -39704,19 +39721,19 @@
    i32.const 63
    i32.const 11152
    call $~lib/rt/__newArray
-   local.set $1
+   local.set $0
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=16
    local.get $0
+   i32.store offset=16
    local.get $1
+   local.get $0
    call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
    global.get $~lib/memory/__stack_pointer
    i32.const 10480
    i32.store offset=16
    i32.const 0
-   local.set $4
-   local.get $0
+   local.set $0
+   local.get $1
    i32.load offset=8
    i32.const 10492
    i32.load
@@ -39724,27 +39741,27 @@
    i32.add
    i32.lt_s
    br_if $folding-inner0
-   local.get $0
+   local.get $1
    i32.load offset=4
    i32.const 2
    i32.add
-   local.set $3
+   local.set $5
    i32.const 10484
    i32.load
-   local.set $5
+   local.set $6
    i32.const 10492
    i32.load
-   local.set $6
+   local.set $7
    loop $for-loop|01
-    local.get $4
-    local.get $6
+    local.get $0
+    local.get $7
     i32.lt_s
     if
-     local.get $3
-     local.get $4
-     i32.add
+     local.get $0
      local.get $5
-     local.get $4
+     i32.add
+     local.get $6
+     local.get $0
      i32.const 3
      i32.shl
      i32.add
@@ -39765,10 +39782,10 @@
       i32.const 0
      end
      i32.store8
-     local.get $4
+     local.get $0
      i32.const 1
      i32.add
-     local.set $4
+     local.set $0
      br $for-loop|01
     end
    end
@@ -39777,36 +39794,26 @@
    i32.const 63
    i32.const 11184
    call $~lib/rt/__newArray
-   local.set $1
+   local.set $0
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=16
-   local.get $0
    local.get $1
+   local.get $0
    call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
+   local.get $1
    local.get $2
-   i32.load offset=8
-   local.get $0
-   i32.load offset=8
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $0
-   i32.load offset=4
-   local.get $2
-   i32.load offset=4
-   local.get $2
-   i32.load offset=8
-   call $~lib/memory/memory.copy
-   local.get $0
-   local.get $8
+   call $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array>
+   local.get $1
+   local.get $4
    i32.const 4
    call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
    global.get $~lib/memory/__stack_pointer
    i32.const 10560
    i32.store offset=16
    i32.const 0
-   local.set $3
-   local.get $0
+   local.set $2
+   local.get $1
    i32.load offset=8
    i32.const 10572
    i32.load
@@ -39814,47 +39821,47 @@
    i32.add
    i32.lt_s
    br_if $folding-inner0
-   local.get $0
+   local.get $1
    i32.load offset=4
    i32.const 7
    i32.add
-   local.set $6
+   local.set $3
    i32.const 10564
    i32.load
-   local.set $1
+   local.set $4
    i32.const 10572
    i32.load
-   local.set $2
+   local.set $5
    loop $for-loop|02
     local.get $2
-    local.get $3
-    i32.gt_s
+    local.get $5
+    i32.lt_s
     if
+     local.get $2
      local.get $3
-     local.get $6
      i32.add
-     local.get $1
-     local.get $3
+     local.get $2
+     local.get $4
      i32.add
      i32.load8_s
-     local.tee $5
+     local.tee $0
      i32.const 31
      i32.shr_s
      i32.const -1
      i32.xor
-     local.get $5
+     local.get $0
      i32.const 255
-     local.get $5
+     local.get $0
      i32.sub
      i32.const 31
      i32.shr_s
      i32.or
      i32.and
      i32.store8
-     local.get $3
+     local.get $2
      i32.const 1
      i32.add
-     local.set $3
+     local.set $2
      br $for-loop|02
     end
    end
@@ -39867,7 +39874,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=16
-   local.get $0
+   local.get $1
    local.get $2
    call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
    global.get $~lib/memory/__stack_pointer
@@ -40888,6 +40895,8 @@
   i32.const 10304
   i32.store offset=16
   local.get $0
+  i32.const 10304
+  i32.const 0
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>>
   i32.const 10
   i32.const 2
@@ -41293,6 +41302,8 @@
   i32.const 10304
   i32.store offset=16
   local.get $0
+  i32.const 10304
+  i32.const 0
   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>>
   i32.const 10
   i32.const 2
@@ -42563,25 +42574,10 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 10384
    i32.store offset=16
-   i32.const 10396
-   i32.load
+   local.get $3
+   i32.const 10384
    i32.const 3
-   i32.add
-   local.get $3
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-   i32.gt_s
-   br_if $folding-inner0
-   local.get $3
-   i32.load offset=4
-   i32.const 12
-   i32.add
-   i32.const 10388
-   i32.load
-   i32.const 10392
-   i32.load
-   call $~lib/memory/memory.copy
+   call $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>>
    i32.const 10
    i32.const 2
    i32.const 61
@@ -42677,7 +42673,7 @@
    local.get $0
    i32.load offset=8
    local.set $0
-   loop $for-loop|04
+   loop $for-loop|01
     local.get $0
     local.get $1
     i32.gt_s
@@ -42697,7 +42693,7 @@
      i32.const 1
      i32.add
      local.set $1
-     br $for-loop|04
+     br $for-loop|01
     end
    end
    i32.const 0
@@ -42727,7 +42723,7 @@
    i32.const 1
    i32.shr_u
    local.set $4
-   loop $for-loop|01
+   loop $for-loop|02
     local.get $0
     local.get $4
     i32.lt_s
@@ -42749,7 +42745,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|01
+     br $for-loop|02
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -42778,7 +42774,7 @@
    i32.const 10572
    i32.load
    local.set $2
-   loop $for-loop|08
+   loop $for-loop|05
     local.get $0
     local.get $2
     i32.lt_s
@@ -42798,7 +42794,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $for-loop|08
+     br $for-loop|05
     end
    end
    i32.const 10

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -23333,27 +23333,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 0
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -23380,20 +23362,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -23482,24 +23452,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -23525,13 +23477,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -23608,27 +23555,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 0
+  i32.const 3
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -23655,20 +23584,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -23741,24 +23658,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -23784,13 +23683,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -23862,27 +23756,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -23939,27 +23814,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -23986,20 +23843,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -24059,27 +23904,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -24136,27 +23962,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 0
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -24183,20 +23991,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -24285,24 +24081,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -24328,13 +24106,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -24411,27 +24184,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 0
+  i32.const 3
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -24458,20 +24213,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -24540,24 +24283,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -24583,13 +24308,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -24661,27 +24381,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -24738,27 +24439,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -24785,20 +24468,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -24858,27 +24529,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -24936,27 +24588,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 0
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -25079,24 +24713,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -25204,27 +24820,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 0
+  i32.const 3
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -25344,24 +24942,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -25463,27 +25043,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -25541,27 +25102,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -25675,26 +25218,7 @@
    unreachable
   end
   i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -25807,26 +25331,8 @@
    unreachable
   end
   i32.const 1
-  i32.const 1
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -25853,20 +25359,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -25957,24 +25451,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -26000,13 +25476,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -26084,26 +25555,8 @@
    unreachable
   end
   i32.const 1
-  i32.const 1
+  i32.const 3
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -26130,20 +25583,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -26212,24 +25653,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -26255,13 +25678,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -26339,26 +25757,8 @@
    unreachable
   end
   i32.const 1
-  i32.const 1
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -26385,20 +25785,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -26458,27 +25846,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -26536,26 +25905,8 @@
    unreachable
   end
   i32.const 1
-  i32.const 1
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -26582,20 +25933,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -26661,26 +26000,8 @@
    unreachable
   end
   i32.const 1
-  i32.const 1
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -26707,20 +26028,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -26811,24 +26120,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -26854,13 +26145,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -26938,26 +26224,8 @@
    unreachable
   end
   i32.const 1
-  i32.const 1
+  i32.const 3
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -26984,20 +26252,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -27066,24 +26322,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -27109,13 +26347,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -27193,26 +26426,8 @@
    unreachable
   end
   i32.const 1
-  i32.const 1
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -27239,20 +26454,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -27312,27 +26515,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -27390,26 +26574,8 @@
    unreachable
   end
   i32.const 1
-  i32.const 1
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 1
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -27436,20 +26602,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -27509,27 +26663,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -27608,24 +26743,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -27651,13 +26768,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -27734,27 +26846,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 2
+  i32.const 3
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -27781,20 +26875,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -27863,24 +26945,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -27906,13 +26970,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -27989,27 +27048,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 2
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -28036,20 +27077,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -28114,27 +27143,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 2
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -28161,20 +27172,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -28239,27 +27238,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 2
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -28286,20 +27267,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -28359,27 +27328,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -28462,24 +27412,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -28505,13 +27437,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -28588,27 +27515,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 2
+  i32.const 3
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -28635,20 +27544,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -28717,24 +27614,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -28760,13 +27639,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -28843,27 +27717,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 2
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -28890,20 +27746,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -28968,27 +27812,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 2
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -29015,20 +27841,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -29093,27 +27907,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 2
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -29140,20 +27936,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -29218,27 +28002,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 3
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -29265,20 +28031,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -29369,24 +28123,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -29412,13 +28148,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -29490,27 +28221,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -29571,24 +28283,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -29614,13 +28308,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -29697,27 +28386,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 3
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -29744,20 +28415,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -29822,27 +28481,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 3
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -29869,20 +28510,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -29947,27 +28576,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 3
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -29994,20 +28605,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -30072,27 +28671,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 3
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -30119,20 +28700,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -30223,24 +28792,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -30266,13 +28817,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -30344,27 +28890,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
-  i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.const 0
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -30425,24 +28952,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -30468,13 +28977,8 @@
    if
     i32.const 0
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $7
     local.get $9
@@ -30551,27 +29055,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 3
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -30598,20 +29084,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -30676,27 +29150,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
+  i32.const 3
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -30723,20 +29179,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -30801,27 +29245,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 3
+  i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -30848,20 +29274,8 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     i32.const 0
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
     local.get $6
     local.get $9
@@ -30929,24 +29343,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -30973,20 +29369,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -31066,26 +29451,7 @@
    unreachable
   end
   i32.const 0
-  i32.const 0
-  i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
+  i32.eqz
   drop
   local.get $5
   i32.load offset=4
@@ -31145,24 +29511,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -31189,20 +29537,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -31271,24 +29608,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -31315,20 +29634,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -31397,24 +29705,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -31441,20 +29731,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -31523,24 +29802,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 2
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -31567,20 +29828,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -31649,24 +29899,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -31693,20 +29925,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -31790,27 +30011,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  i32.const 0
+  i32.const 3
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -31837,20 +30040,10 @@
     i32.const 0
     drop
     i32.const 1
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.eqz
     drop
     i32.const 1
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -31919,24 +30112,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 3
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -31963,20 +30138,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -32045,24 +30209,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -32089,20 +30235,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -32171,24 +30306,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 1
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -32215,20 +30332,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -32297,24 +30403,6 @@
   i32.const 0
   i32.const 1
   i32.eq
-  if (result i32)
-   i32.const 3
-   i32.const 0
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 0
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -32341,20 +30429,9 @@
     i32.const 0
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.eqz
-    else
-     i32.const 0
-    end
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 0
-     i32.eqz
-    else
-     i32.const 0
-    end
+    i32.const 0
+    i32.eqz
     drop
     local.get $6
     local.get $9
@@ -32424,24 +30501,6 @@
   i32.const 1
   i32.const 0
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -32549,27 +30608,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 0
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -32684,27 +30725,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  i32.const 1
+  i32.const 0
+  i32.const 2
   i32.eq
-  if (result i32)
-   i32.const 0
-   i32.const 2
-   i32.eq
-  else
-   i32.const 0
-  end
-  if (result i32)
-   i32.const 1
-   if (result i32)
-    i32.const 0
-   else
-    i32.const 0
-   end
-   i32.eqz
-  else
-   i32.const 0
-  end
   drop
   local.get $5
   i32.load offset=4
@@ -37318,11 +35341,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
@@ -67068,13 +65086,8 @@
     i32.const 1
     drop
     i32.const 1
-    if (result i32)
-     i32.const 1
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
+    i32.const 4
+    i32.le_u
     drop
     i32.const 13616
     br $~lib/util/sort/COMPARATOR<i8>|inlined.0
@@ -67115,13 +65128,6 @@
     i32.const 1
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
     drop
     i32.const 13680
     br $~lib/util/sort/COMPARATOR<u8>|inlined.0
@@ -67162,13 +65168,6 @@
     i32.const 1
     drop
     i32.const 0
-    if (result i32)
-     i32.const 1
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
     drop
     i32.const 13744
     br $~lib/util/sort/COMPARATOR<u8>|inlined.1
@@ -67208,14 +65207,9 @@
    block $~lib/util/sort/COMPARATOR<i16>|inlined.0 (result i32)
     i32.const 1
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 2
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
+    i32.const 2
+    i32.const 4
+    i32.le_u
     drop
     i32.const 13808
     br $~lib/util/sort/COMPARATOR<i16>|inlined.0
@@ -67256,13 +65250,6 @@
     i32.const 1
     drop
     i32.const 0
-    if (result i32)
-     i32.const 2
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
     drop
     i32.const 13872
     br $~lib/util/sort/COMPARATOR<u16>|inlined.0
@@ -67302,14 +65289,9 @@
    block $~lib/util/sort/COMPARATOR<i32>|inlined.0 (result i32)
     i32.const 1
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 4
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
+    i32.const 4
+    i32.const 4
+    i32.le_u
     drop
     i32.const 13936
     br $~lib/util/sort/COMPARATOR<i32>|inlined.0
@@ -67350,13 +65332,6 @@
     i32.const 1
     drop
     i32.const 0
-    if (result i32)
-     i32.const 4
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
     drop
     i32.const 14000
     br $~lib/util/sort/COMPARATOR<u32>|inlined.0
@@ -67396,14 +65371,9 @@
    block $~lib/util/sort/COMPARATOR<i64>|inlined.0 (result i32)
     i32.const 1
     drop
-    i32.const 1
-    if (result i32)
-     i32.const 8
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
+    i32.const 8
+    i32.const 4
+    i32.le_u
     drop
     i32.const 14064
     br $~lib/util/sort/COMPARATOR<i64>|inlined.0
@@ -67444,13 +65414,6 @@
     i32.const 1
     drop
     i32.const 0
-    if (result i32)
-     i32.const 8
-     i32.const 4
-     i32.le_u
-    else
-     i32.const 0
-    end
     drop
     i32.const 14128
     br $~lib/util/sort/COMPARATOR<u64>|inlined.0

--- a/tests/compiler/std/uri.untouched.wat
+++ b/tests/compiler/std/uri.untouched.wat
@@ -4800,11 +4800,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $~lib/rt/__visit_globals (param $0 i32)

--- a/tests/compiler/throw.untouched.wat
+++ b/tests/compiler/throw.untouched.wat
@@ -1672,11 +1672,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $start:throw

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -3055,11 +3055,6 @@
   i32.const 0
   drop
   i32.const 0
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
   drop
  )
  (func $start:while


### PR DESCRIPTION
As brought up in Discord, we currently do not statically eliminate expressions like `isNullable<T>() && value === null`, which may be surprising since we do this for normal `if`s. This PR also applies it for logical expressions when interested in `bool` returns. Question is: Is this always safe?

- [x] I've read the contributing guidelines