### PR TITLE
Annotate that the ERROR macro terminates execution

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1393,7 +1393,7 @@ declare const F64: typeof _Float;
 // User-defined diagnostic macros
 
 /** Emits a user-defined diagnostic error when encountered. */
-declare function ERROR(message?: any): void;
+declare function ERROR(message?: any): never;
 /** Emits a user-defined diagnostic warning when encountered. */
 declare function WARNING(message?: any): void;
 /** Emits a user-defined diagnostic info when encountered. */


### PR DESCRIPTION
fixes #1951

- [x] I've read the contributing guidelines