### PR TITLE
std(sort): reduce INSERTION_SORT_THRESHOLD constant to 48

### DIFF
--- a/std/assembly/util/sort.ts
+++ b/std/assembly/util/sort.ts
@@ -5,7 +5,7 @@ type Comparator<T> = (a: T, b: T) => i32;
 // @ts-ignore: decorator
 @lazy @inline const EMPTY = u32.MAX_VALUE;
 // @ts-ignore: decorator
-@inline const INSERTION_SORT_THRESHOLD = 128;
+@inline const INSERTION_SORT_THRESHOLD = 48;
 // @ts-ignore: decorator
 @inline const MIN_RUN_LENGTH = 32;
 

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -5019,7 +5019,7 @@
   (local $15 i32)
   (local $16 f32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -5927,7 +5927,7 @@
   (local $15 i32)
   (local $16 f64)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -6785,7 +6785,7 @@
   (local $12 i64)
   (local $13 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -7598,7 +7598,7 @@
   (local $12 i64)
   (local $13 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -8405,7 +8405,7 @@
   i32.store offset=8
   block $folding-inner0
    local.get $1
-   i32.const 128
+   i32.const 48
    i32.le_s
    if
     local.get $1
@@ -12455,7 +12455,7 @@
   (local $12 i64)
   (local $13 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -7225,7 +7225,7 @@
   (local $21 i32)
   (local $22 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -8248,7 +8248,7 @@
   (local $21 i32)
   (local $22 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -9299,7 +9299,7 @@
   (local $19 i32)
   (local $20 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -10214,7 +10214,7 @@
   (local $19 i32)
   (local $20 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -11127,7 +11127,7 @@
   i32.const 0
   i32.store offset=8
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -12059,7 +12059,7 @@
   i32.const 0
   i32.store offset=8
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -12974,7 +12974,7 @@
   i32.const 0
   i32.store offset=8
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -13802,7 +13802,7 @@
   i32.const 0
   i32.store offset=8
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -14989,7 +14989,7 @@
   i32.const 0
   i32.store offset=8
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -20669,7 +20669,7 @@
   (local $19 i32)
   (local $20 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3468,7 +3468,7 @@
   (local $15 i32)
   (local $16 f64)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -29643,7 +29643,7 @@
   (local $12 i64)
   (local $13 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -30427,7 +30427,7 @@
   (local $12 i64)
   (local $13 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -31261,7 +31261,7 @@
   (local $12 i64)
   (local $13 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -32089,7 +32089,7 @@
   (local $12 i64)
   (local $13 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -32927,7 +32927,7 @@
   (local $12 i64)
   (local $13 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -33749,7 +33749,7 @@
   (local $12 i64)
   (local $13 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -34580,7 +34580,7 @@
   (local $14 i32)
   (local $15 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -35411,7 +35411,7 @@
   (local $14 i32)
   (local $15 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -36243,7 +36243,7 @@
   (local $15 i32)
   (local $16 f32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -4040,7 +4040,7 @@
   (local $21 i32)
   (local $22 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -31802,7 +31802,7 @@
   (local $19 i32)
   (local $20 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -32732,7 +32732,7 @@
   (local $19 i32)
   (local $20 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -33719,7 +33719,7 @@
   (local $19 i32)
   (local $20 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -34649,7 +34649,7 @@
   (local $19 i32)
   (local $20 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -35593,7 +35593,7 @@
   (local $19 i32)
   (local $20 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -36517,7 +36517,7 @@
   (local $19 i32)
   (local $20 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -37447,7 +37447,7 @@
   (local $21 i32)
   (local $22 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -38377,7 +38377,7 @@
   (local $21 i32)
   (local $22 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1
@@ -39307,7 +39307,7 @@
   (local $21 i32)
   (local $22 i32)
   local.get $1
-  i32.const 128
+  i32.const 48
   i32.le_s
   if
    local.get $1


### PR DESCRIPTION
After some new changes in algo (optimize memory usage), I decided to recheck boundary for insertion sort and found (Chrome baseline) that it had moved down.

- [x] I've read the contributing guidelines