### PR TITLE
feat(CLI): ignore a specific warning

### DIFF
--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -214,7 +214,7 @@ export function main(argv: string[], options: APIOptions, callback?: (err: Error
 export function main(argv: string[], callback?: (err: Error | null) => number): number;
 
 /** Checks diagnostics emitted so far for errors. */
-export function checkDiagnostics(emitter: Record<string,unknown>, stderr?: OutputStream, reportDiagnostic?: DiagnosticReporter): boolean;
+export function checkDiagnostics(emitter: Record<string,unknown>, stderr?: OutputStream, reportDiagnostic?: DiagnosticReporter, ignoreWarning?: number[]): boolean;
 
 /** An object of stats for the current task. */
 export interface Stats {

--- a/cli/asc.json
+++ b/cli/asc.json
@@ -342,6 +342,10 @@
     "type": "b",
     "default": false
   },
+  "ignoreWarning": {
+    "description": "Ignore a specific warning. E.g. 232",
+    "type": "I"
+  },
   "lib": {
     "description": [
       "Adds one or multiple paths to custom library components and",


### PR DESCRIPTION
`--ignoreWarning` will suppress a specific warning or list of warnings.

This is useful in cases where the warning is known by the author and is okay. For example, in my work on adding a generic encoder interface I add generic methods to a class and if that class isn't used I get 232, which can be ignored.

- [x]  I've read the contributing guidelines