### PR TITLE
feat: add afterEmit transform stage

### DIFF
--- a/cli/transform.d.ts
+++ b/cli/transform.d.ts
@@ -40,4 +40,16 @@ export abstract class Transform {
 
   /** Called when compilation is complete, before the module is being validated. */
   afterCompile?(module: Module): void;
+
+  /** Called after all files emitted, before asc exit. Users can output some customized files according to the emitted files */
+  afterEmit?(files: OutputFiles): void;
+}
+
+export interface OutputFiles {
+  binaryFile?: Uint8Array | null;
+  jsFile?: string | null;
+  tsdFile?: string | null;
+  idlFile?: string | null;
+  textFile?: string | null;
+  sourceMap?: string | null;
 }


### PR DESCRIPTION
Support #1873. 

I found that the most convenient implementation at present is to implement it as `AfterEmit`. The transform author can generate some custom files based on the output files, such as some metadata files (in my personal case, it is mainly based on code analysis and wasm files. Other files do not used).