### PR TITLE
fix: Make warning 232 pedantic

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -798,11 +798,6 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
-        } else if (functionPrototype.is(CommonFlags.GENERIC)) {
-          this.warning(
-            DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
-            functionPrototype.identifierNode.range
-          );
         }
         break;
       }
@@ -820,11 +815,6 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
-        } else if (classPrototype.is(CommonFlags.GENERIC)) {
-          this.warning(
-            DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
-            classPrototype.identifierNode.range
-          );
         }
         break;
       }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -798,8 +798,8 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
-        } else if (functionPrototype.is(CommonFlags.GENERIC)) {
-          this.pedantic(
+        } else if (functionPrototype.is(CommonFlags.GENERIC) && this.options.pedantic) {
+            this.pedantic(
             DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
             functionPrototype.identifierNode.range
           );
@@ -820,7 +820,7 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
-        } else if (classPrototype.is(CommonFlags.GENERIC)) {
+        } else if (classPrototype.is(CommonFlags.GENERIC) && this.options.pedantic) {
           this.pedantic(
             DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
             classPrototype.identifierNode.range

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -799,7 +799,7 @@ export class Compiler extends DiagnosticEmitter {
             this.ensureModuleExport(instanceName, instance, prefix);
           }
         } else if (functionPrototype.is(CommonFlags.GENERIC) && this.options.pedantic) {
-            this.pedantic(
+          this.pedantic(
             DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
             functionPrototype.identifierNode.range
           );

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -798,11 +798,13 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
-        } else if (functionPrototype.is(CommonFlags.GENERIC) && this.options.pedantic) {
-          this.pedantic(
-            DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
-            functionPrototype.identifierNode.range
-          );
+        } else if (functionPrototype.is(CommonFlags.GENERIC)) {
+          if (this.options.pedantic) {
+            this.pedantic(
+              DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
+              functionPrototype.identifierNode.range
+            );
+          }
         }
         break;
       }
@@ -820,11 +822,13 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
-        } else if (classPrototype.is(CommonFlags.GENERIC) && this.options.pedantic) {
-          this.pedantic(
-            DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
-            classPrototype.identifierNode.range
-          );
+        } else if (classPrototype.is(CommonFlags.GENERIC)) {
+          if (this.options.pedantic) {
+            this.pedantic(
+              DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
+              classPrototype.identifierNode.range
+            );
+          }
         }
         break;
       }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -799,7 +799,7 @@ export class Compiler extends DiagnosticEmitter {
             this.ensureModuleExport(instanceName, instance, prefix);
           }
         } else if (functionPrototype.is(CommonFlags.GENERIC)) {
-          this.warning(
+          this.pedantic(
             DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
             functionPrototype.identifierNode.range
           );
@@ -821,7 +821,7 @@ export class Compiler extends DiagnosticEmitter {
             this.ensureModuleExport(instanceName, instance, prefix);
           }
         } else if (classPrototype.is(CommonFlags.GENERIC)) {
-          this.warning(
+          this.pedantic(
             DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
             classPrototype.identifierNode.range
           );

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -798,6 +798,11 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
+        } else if (functionPrototype.is(CommonFlags.GENERIC)) {
+          this.warning(
+            DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
+            functionPrototype.identifierNode.range
+          );
         }
         break;
       }
@@ -815,6 +820,11 @@ export class Compiler extends DiagnosticEmitter {
             }
             this.ensureModuleExport(instanceName, instance, prefix);
           }
+        } else if (classPrototype.is(CommonFlags.GENERIC)) {
+          this.warning(
+            DiagnosticCode.Exported_generic_function_or_class_has_no_concrete_instances,
+            classPrototype.identifierNode.range
+          );
         }
         break;
       }

--- a/tests/compiler/export-generic.json
+++ b/tests/compiler/export-generic.json
@@ -1,5 +1,6 @@
 {
   "asc_flags": [
+    "--pedantic"
   ],
   "stderr": [
     "AS232: Exported generic function or class has no concrete instances.",


### PR DESCRIPTION
Because of tree shaking unused methods or class aren't compiled so there is no need to warn about unimplemented instances.
