### PR TITLE
fix(astBuilder): fix export statment

### DIFF
--- a/src/extra/ast.ts
+++ b/src/extra/ast.ts
@@ -1071,7 +1071,9 @@ export class ASTBuilder {
       sb.push("declare ");
     }
     var members = node.members;
-    if (members != null && members.length > 0) {
+    if (members == null) {
+      sb.push("export *");
+    } else if (members.length > 0) {
       let numMembers = members.length;
       sb.push("export {\n");
       let indentLevel = ++this.indentLevel;
@@ -1084,8 +1086,6 @@ export class ASTBuilder {
       }
       --this.indentLevel;
       sb.push("\n}");
-    } else if (members == null) {
-      sb.push("export *");
     } else {
       sb.push("export {}");
     }

--- a/src/extra/ast.ts
+++ b/src/extra/ast.ts
@@ -1084,6 +1084,8 @@ export class ASTBuilder {
       }
       --this.indentLevel;
       sb.push("\n}");
+    } else if (members == null) {
+      sb.push("export *");
     } else {
       sb.push("export {}");
     }


### PR DESCRIPTION
Now `export * from "xx"` will be built to `export {} from "xx"`.

@willemneal  visitor-as also has this problem.

It makes the behavior of the compiler plug-in difficult to understand, because there may be many files that are modified.