### PR TITLE
fix: when parser error, infinite loop in skipStatement (#1999)

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4296,8 +4296,16 @@ export class Parser extends DiagnosticEmitter {
           tn.readIdentifier();
           break;
         }
-        case Token.STRINGLITERAL: {
+        case Token.STRINGLITERAL:{
           tn.readString();
+          break;
+        }
+        case Token.TEMPLATELITERAL: {
+          tn.readString();
+          while(tn.readingTemplateString){
+            this.skipBlock(tn);
+            tn.readString(CharCode.BACKTICK);
+          }
           break;
         }
         case Token.INTEGERLITERAL: {


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

Fixes #1999, where in ```skipBlock(tn: Tokenizer): void```,  the condition of  ```Token.TEMPLATELITERAL``` is missing and ```tn.next()``` also don't go to the next token. It causes infinite loop.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
