### PR TITLE
fix: proper error for block scoped class expressions

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3519,7 +3519,7 @@ export class Compiler extends DiagnosticEmitter {
         this.error(
           DiagnosticCode.Not_implemented_0,
           expression.range,
-          "Class expressions"
+          "Block-scoped class declarations or expressions"
         );
         expr = this.module.unreachable();
         break;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3514,6 +3514,16 @@ export class Compiler extends DiagnosticEmitter {
         this.currentType = compiled.type;
         break;
       }
+      case NodeKind.CLASS: {
+        // TODO: compile as class expression
+        this.error(
+          DiagnosticCode.Not_implemented_0,
+          expression.range,
+          "Class expressions"
+        );
+        expr = this.module.unreachable();
+        break;
+      }
       default: {
         assert(false);
         expr = this.module.unreachable();


### PR DESCRIPTION
example:
```ts
{ class InnerClass {} }
```
Output:
```
ERROR AS100: Not implemented: Block-scoped class declarations or expressions

   { class InnerClass {} }
     ~~~~~~~~~~~~~~~~~~~
```

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
