### PR TITLE
fix: Expression passed to `evaluateCondition` asserted to be valid

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -10069,7 +10069,7 @@ export class Compiler extends DiagnosticEmitter {
   evaluateCondition(expr: ExpressionRef): ConditionKind {
     let type = getExpressionType(expr);
     if (type == TypeRef.Unreachable)
-      return ConditionKind.UNKNOWN; // invalid expression given
+      return ConditionKind.UNKNOWN;
 
     assert(type == TypeRef.I32);
     var module = this.module;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -10067,7 +10067,11 @@ export class Compiler extends DiagnosticEmitter {
 
   /** Evaluates a boolean condition, determining whether it is TRUE, FALSE or UNKNOWN. */
   evaluateCondition(expr: ExpressionRef): ConditionKind {
-    assert(getExpressionType(expr) == TypeRef.I32);
+    let type = getExpressionType(expr);
+    if (type == TypeRef.Unreachable)
+      return ConditionKind.UNKNOWN; // invalid expression given
+
+    assert(type == TypeRef.I32);
     var module = this.module;
     var evaled = module.runExpression(expr, ExpressionRunnerFlags.Default);
     if (evaled) {

--- a/tests/compiler/unknown-bool-ident.json
+++ b/tests/compiler/unknown-bool-ident.json
@@ -2,6 +2,7 @@
   "asc_flags": [
   ],
   "stderr": [
-    "TS2304: Cannot find name 'unknown_var'."
+    "TS2304: Cannot find name 'unknown_var'.",
+    "EOF"
   ]
 }

--- a/tests/compiler/unknown-bool-ident.json
+++ b/tests/compiler/unknown-bool-ident.json
@@ -1,0 +1,7 @@
+{
+  "asc_flags": [
+  ],
+  "stderr": [
+    "TS2304: Cannot find name 'unknown_var'."
+  ]
+}

--- a/tests/compiler/unknown-bool-ident.ts
+++ b/tests/compiler/unknown-bool-ident.ts
@@ -1,0 +1,1 @@
+if (1 <= unknown_var) {}

--- a/tests/compiler/unknown-bool-ident.ts
+++ b/tests/compiler/unknown-bool-ident.ts
@@ -1,1 +1,2 @@
 if (1 <= unknown_var) {}
+ERROR("EOF");


### PR DESCRIPTION
`getExpressionType` can return Unreachable type if expression passed is invalid
fixes #1990 

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
