### PR TITLE
Compile virtual dependencies before finalizing stubs

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -538,8 +538,7 @@ export class Compiler extends DiagnosticEmitter {
       let instance = functionTable[i];
       if (instance.is(CommonFlags.VIRTUAL)) {
         assert(instance.is(CommonFlags.INSTANCE));
-        functionTable[i] = this.ensureVirtualStub(instance); // incl. varargs
-        virtualStubs.add(instance);
+        functionTable[i] = this.ensureVirtualStub(instance); // includes varargs stub
       } else if (instance.signature.requiredParameters < instance.signature.parameterTypes.length) {
         functionTable[i] = this.ensureVarargsStub(instance);
       }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7056,13 +7056,7 @@ export class Compiler extends DiagnosticEmitter {
       let classInstance = assert(overloadInstance.getClassOrInterface());
       builder.addCase(classInstance.id, stmts);
       // Also alias each extendee inheriting this exact overload
-      let extendees = classInstance.getAllExtendees(
-        overloadInstance.isAccessor
-          // FIXME: Parent is not the property, but should be, so we don't need
-          // to use a substring here but can trivially use the property name.
-          ? instance.prototype.name.substring(GETTER_PREFIX.length)
-          : instance.prototype.name
-      );
+      let extendees = classInstance.getAllExtendees(instance.declaration.name.text); // without get:/set:
       for (let _values = Set_values(extendees), a = 0, b = _values.length; a < b; ++a) {
         let extendee = _values[a];
         builder.addCase(extendee.id, stmts);

--- a/src/program.ts
+++ b/src/program.ts
@@ -3456,7 +3456,7 @@ export class FunctionPrototype extends DeclaredElement {
   /** Methods overloading this one, if any. These are unbound. */
   overloads: Set<FunctionPrototype> | null = null;
 
-  /** Clones of this prototype that are bounds to specific classes. */
+  /** Clones of this prototype that are bound to specific classes. */
   private boundPrototypes: Map<Class,FunctionPrototype> | null = null;
 
   /** Constructs a new function prototype. */
@@ -3504,11 +3504,9 @@ export class FunctionPrototype extends DeclaredElement {
   /** Tests if this prototype is bound to a class. */
   get isBound(): bool {
     var parent = this.parent;
-    return parent.kind == ElementKind.CLASS ||
-           parent.kind == ElementKind.PROPERTY_PROTOTYPE && (
-             parent.parent.kind == ElementKind.CLASS ||
-             parent.parent.kind == ElementKind.INTERFACE
-           );
+    var parentKind = parent.kind;
+    if (parentKind == ElementKind.PROPERTY_PROTOTYPE) parentKind = parent.parent.kind;
+    return parentKind == ElementKind.CLASS || parentKind == ElementKind.INTERFACE;
   }
 
   /** Creates a clone of this prototype that is bound to a concrete class instead. */

--- a/src/program.ts
+++ b/src/program.ts
@@ -3651,11 +3651,6 @@ export class Function extends TypedElement {
     registerConcreteElement(program, this);
   }
 
-  /** Gets whether this is an accessor method of a property. */
-  get isAccessor(): bool {
-    return this.isAny(CommonFlags.GET | CommonFlags.SET);
-  }
-
   /** Gets the name of the parameter at the specified index. */
   getParameterName(index: i32): string {
     var parameters = (<FunctionDeclaration>this.declaration).signature.parameters;

--- a/src/program.ts
+++ b/src/program.ts
@@ -3653,12 +3653,27 @@ export class Function extends TypedElement {
     registerConcreteElement(program, this);
   }
 
+  /** Gets whether this is an accessor method of a property. */
+  get isAccessor(): bool {
+    return this.isAny(CommonFlags.GET | CommonFlags.SET);
+  }
+
   /** Gets the name of the parameter at the specified index. */
   getParameterName(index: i32): string {
     var parameters = (<FunctionDeclaration>this.declaration).signature.parameters;
     return parameters.length > index
       ? parameters[index].name.text
       : getDefaultParameterName(index);
+  }
+
+  /** Gets the class or interface this function belongs to, if an instance method. */
+  getClassOrInterface(): Class | null {
+    var parent = this.parent;
+    if (parent.kind == ElementKind.PROPERTY) parent = parent.parent;
+    if (parent.kind == ElementKind.CLASS || parent.kind == ElementKind.INTERFACE) {
+      return <Class>parent;
+    }
+    return null;
   }
 
   /** Creates a stub for use with this function, i.e. for varargs or virtual calls. */

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -126,6 +126,8 @@ export class Resolver extends DiagnosticEmitter {
   currentThisExpression: Expression | null = null;
   /** Element expression of the previously resolved element access. */
   currentElementExpression : Expression | null = null;
+  /** Whether a new overload has been discovered. */
+  discoveredOverload: bool = false;
 
   /** Constructs the resolver for the specified program. */
   constructor(
@@ -2757,6 +2759,20 @@ export class Resolver extends DiagnosticEmitter {
       ctxTypes
     );
     prototype.setResolvedInstance(instanceKey, instance);
+
+    // remember discovered overloads for virtual stub finalization
+    if (classInstance) {
+      let methodOrPropertyName = instance.declaration.name.text;
+      let baseClass = classInstance.base;
+      while (baseClass) {
+        let baseMembers = baseClass.members;
+        if (baseMembers && baseMembers.has(methodOrPropertyName)) {
+          this.discoveredOverload = true;
+          break;
+        }
+        baseClass = baseClass.base;
+      }
+    }
     return instance;
   }
 

--- a/tests/compiler/class-overloading-cast.untouched.wat
+++ b/tests/compiler/class-overloading-cast.untouched.wat
@@ -2527,6 +2527,9 @@
  (func $class-overloading-cast/B<i32,f64>#foo (param $0 i32) (param $1 i32) (result i32)
   i32.const 464
  )
+ (func $class-overloading-cast/B<f64,~lib/string/String>#foo (param $0 i32) (param $1 f64) (result i32)
+  i32.const 464
+ )
  (func $class-overloading-cast/A<i32>#foo@virtual (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $default
@@ -2560,9 +2563,6 @@
   local.get $0
   local.get $1
   call $class-overloading-cast/A<i32>#foo
- )
- (func $class-overloading-cast/B<f64,~lib/string/String>#foo (param $0 i32) (param $1 f64) (result i32)
-  i32.const 464
  )
  (func $class-overloading-cast/A<f64>#foo@virtual (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -2567,6 +2567,55 @@
   i32.const 624
   global.set $class-overloading/which
  )
+ (func $class-overloading/B#b (param $0 i32) (param $1 i32)
+  i32.const 496
+  global.set $class-overloading/which
+ )
+ (func $class-overloading/F#b (param $0 i32) (param $1 i32)
+  i32.const 624
+  global.set $class-overloading/which
+ )
+ (func $class-overloading/B#get:c (param $0 i32) (result i32)
+  i32.const 496
+  global.set $class-overloading/which
+  i32.const 0
+ )
+ (func $class-overloading/F#get:c (param $0 i32) (result i32)
+  i32.const 624
+  global.set $class-overloading/which
+  i32.const 0
+ )
+ (func $class-overloading/B#set:c (param $0 i32) (param $1 i32)
+  i32.const 496
+  global.set $class-overloading/which
+ )
+ (func $class-overloading/F#set:c (param $0 i32) (param $1 i32)
+  i32.const 624
+  global.set $class-overloading/which
+ )
+ (func $class-overloading/CA#foo (param $0 i32)
+  i32.const 656
+  global.set $class-overloading/which
+ )
+ (func $class-overloading/CC#foo (param $0 i32)
+  i32.const 688
+  global.set $class-overloading/which
+ )
+ (func $class-overloading/A1#baz (param $0 i32) (result i32)
+  i32.const 720
+  i32.const 528
+  i32.const 186
+  i32.const 5
+  call $~lib/builtins/abort
+  unreachable
+ )
+ (func $class-overloading/A1#bar (param $0 i32) (result i32)
+  local.get $0
+  call $class-overloading/A1#baz@virtual
+ )
+ (func $class-overloading/B1#baz (param $0 i32) (result i32)
+  i32.const 3
+ )
  (func $class-overloading/A#a<i32>@virtual (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $default
@@ -2618,14 +2667,6 @@
   local.get $0
   local.get $1
   call $class-overloading/A#a<i32>
- )
- (func $class-overloading/B#b (param $0 i32) (param $1 i32)
-  i32.const 496
-  global.set $class-overloading/which
- )
- (func $class-overloading/F#b (param $0 i32) (param $1 i32)
-  i32.const 624
-  global.set $class-overloading/which
  )
  (func $class-overloading/A#b@virtual (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2679,16 +2720,6 @@
   local.get $1
   call $class-overloading/A#b
  )
- (func $class-overloading/B#get:c (param $0 i32) (result i32)
-  i32.const 496
-  global.set $class-overloading/which
-  i32.const 0
- )
- (func $class-overloading/F#get:c (param $0 i32) (result i32)
-  i32.const 624
-  global.set $class-overloading/which
-  i32.const 0
- )
  (func $class-overloading/A#get:c@virtual (param $0 i32) (result i32)
   (local $1 i32)
   block $default
@@ -2736,14 +2767,6 @@
   end
   local.get $0
   call $class-overloading/A#get:c
- )
- (func $class-overloading/B#set:c (param $0 i32) (param $1 i32)
-  i32.const 496
-  global.set $class-overloading/which
- )
- (func $class-overloading/F#set:c (param $0 i32) (param $1 i32)
-  i32.const 624
-  global.set $class-overloading/which
  )
  (func $class-overloading/A#set:c@virtual (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -2797,14 +2820,6 @@
   local.get $1
   call $class-overloading/A#set:c
  )
- (func $class-overloading/CA#foo (param $0 i32)
-  i32.const 656
-  global.set $class-overloading/which
- )
- (func $class-overloading/CC#foo (param $0 i32)
-  i32.const 688
-  global.set $class-overloading/which
- )
  (func $class-overloading/IA#foo@virtual (param $0 i32)
   (local $1 i32)
   block $default
@@ -2835,18 +2850,6 @@
   end
   unreachable
  )
- (func $class-overloading/A1#baz (param $0 i32) (result i32)
-  i32.const 720
-  i32.const 528
-  i32.const 186
-  i32.const 5
-  call $~lib/builtins/abort
-  unreachable
- )
- (func $class-overloading/A1#bar (param $0 i32) (result i32)
-  local.get $0
-  call $class-overloading/A1#baz@virtual
- )
  (func $class-overloading/A2#foo@virtual (param $0 i32) (result i32)
   (local $1 i32)
   block $default
@@ -2868,9 +2871,6 @@
   end
   local.get $0
   call $class-overloading/A2#foo
- )
- (func $class-overloading/B1#baz (param $0 i32) (result i32)
-  i32.const 3
  )
  (func $class-overloading/A1#baz@virtual (param $0 i32) (result i32)
   (local $1 i32)


### PR DESCRIPTION
Should fix #2034 by first compiling virtual overload dependencies so late cross-dependencies are not missed during stub finalization.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
