### PR TITLE
Properly handle conditional continue in do loops

### DIFF
--- a/tests/compiler/NonNullable.optimized.wat
+++ b/tests/compiler/NonNullable.optimized.wat
@@ -74,7 +74,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -95,7 +95,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/NonNullable.untouched.wat
+++ b/tests/compiler/NonNullable.untouched.wat
@@ -69,7 +69,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -93,9 +93,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -130,7 +130,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -151,7 +151,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -147,7 +147,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -171,9 +171,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -1246,7 +1246,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1269,7 +1269,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -1510,7 +1510,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1521,7 +1520,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1549,9 +1548,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/class-implements.optimized.wat
+++ b/tests/compiler/class-implements.optimized.wat
@@ -1184,7 +1184,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1207,7 +1207,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/class-implements.untouched.wat
+++ b/tests/compiler/class-implements.untouched.wat
@@ -1520,7 +1520,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1531,7 +1530,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1559,9 +1558,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/class-overloading-cast.optimized.wat
+++ b/tests/compiler/class-overloading-cast.optimized.wat
@@ -1198,7 +1198,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1221,7 +1221,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1
@@ -1469,7 +1469,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -1490,7 +1490,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/class-overloading-cast.untouched.wat
+++ b/tests/compiler/class-overloading-cast.untouched.wat
@@ -1520,7 +1520,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1531,7 +1530,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1559,9 +1558,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2405,7 +2402,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2429,9 +2426,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/class-overloading.optimized.wat
+++ b/tests/compiler/class-overloading.optimized.wat
@@ -1222,7 +1222,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1245,7 +1245,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1
@@ -1493,7 +1493,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -1514,7 +1514,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -1526,7 +1526,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1537,7 +1536,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1565,9 +1564,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2412,7 +2409,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2436,9 +2433,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -1434,7 +1434,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1457,7 +1457,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -1622,7 +1622,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1633,7 +1632,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1661,9 +1660,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/constructor.optimized.wat
+++ b/tests/compiler/constructor.optimized.wat
@@ -1323,7 +1323,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1346,7 +1346,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -1522,7 +1522,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1533,7 +1532,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1561,9 +1560,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -1157,7 +1157,7 @@
   (local $3 i32)
   i32.const 10
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $2
    i32.const 1
    i32.add
@@ -1166,7 +1166,7 @@
    i32.const 1
    i32.sub
    local.tee $0
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   if
@@ -1190,14 +1190,14 @@
   end
   i32.const 10
   local.set $0
-  loop $do-continue|00
+  loop $do-loop|00
    local.get $0
    local.tee $1
    i32.const 1
    i32.sub
    local.set $0
    local.get $1
-   br_if $do-continue|00
+   br_if $do-loop|00
   end
   local.get $0
   i32.const -1
@@ -1214,7 +1214,7 @@
   local.set $2
   i32.const 10
   local.set $0
-  loop $do-continue|01
+  loop $do-loop|01
    local.get $0
    i32.const 1
    i32.sub
@@ -1223,7 +1223,7 @@
    i32.const 1
    i32.add
    local.set $3
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.add
@@ -1232,7 +1232,7 @@
     i32.const 1
     i32.sub
     local.tee $0
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
    local.get $0
    if
@@ -1255,7 +1255,7 @@
     unreachable
    end
    local.get $0
-   br_if $do-continue|01
+   br_if $do-loop|01
   end
   local.get $0
   if
@@ -1290,14 +1290,14 @@
   end
   i32.const 0
   local.set $0
-  loop $do-continue|02
+  loop $do-loop|02
    local.get $0
    i32.const 1
    i32.add
    local.tee $0
    i32.const 10
    i32.ne
-   br_if $do-continue|02
+   br_if $do-loop|02
   end
   local.get $0
   i32.const 10
@@ -1312,14 +1312,14 @@
   end
   i32.const 0
   local.set $0
-  loop $do-continue|03
+  loop $do-loop|03
    local.get $0
    i32.const 1
    i32.add
    local.tee $0
    i32.const 10
    i32.ne
-   br_if $do-continue|03
+   br_if $do-loop|03
   end
   local.get $0
   i32.const 10
@@ -1334,14 +1334,17 @@
   end
   i32.const 0
   local.set $0
-  loop $do-continue|04
+  loop $do-loop|04
    local.get $0
    i32.const 1
    i32.add
    local.tee $0
    i32.const 10
    i32.ne
-   br_if $do-continue|04
+   i32.const 0
+   local.get $0
+   select
+   br_if $do-loop|04
   end
   local.get $0
   i32.const 10
@@ -1358,7 +1361,7 @@
   local.set $0
   i32.const 0
   local.set $2
-  loop $do-continue|05
+  loop $do-loop|06
    local.get $0
    i32.const 1
    i32.add
@@ -1366,16 +1369,20 @@
    i32.const 10
    i32.ne
    if
-    loop $do-continue|17
+    loop $do-loop|18
      local.get $2
      i32.const 1
      i32.add
      local.tee $2
      i32.const 10
      i32.rem_s
-     br_if $do-continue|17
+     i32.const 0
+     local.get $2
+     select
+     br_if $do-loop|18
     end
-    br $do-continue|05
+    local.get $0
+    br_if $do-loop|06
    end
   end
   local.get $0
@@ -1450,7 +1457,7 @@
    local.get $1
    call $do/Ref#constructor
    i32.store
-   loop $do-continue|08
+   loop $do-loop|09
     local.get $2
     i32.const 1
     i32.add
@@ -1467,7 +1474,7 @@
      i32.store
     end
     local.get $0
-    br_if $do-continue|08
+    br_if $do-loop|09
    end
    local.get $2
    i32.const 10
@@ -1511,8 +1518,8 @@
    call $do/Ref#constructor
    local.tee $0
    i32.store
-   loop $do-continue|06
-    block $do-break|07
+   loop $do-loop|07
+    block $do-break|08
      local.get $2
      i32.const 1
      i32.add
@@ -1522,10 +1529,10 @@
      if
       i32.const 0
       local.set $0
-      br $do-break|07
+      br $do-break|08
      end
      call $do/Ref#constructor
-     br_if $do-continue|06
+     br_if $do-loop|07
     end
    end
    local.get $2
@@ -1658,7 +1665,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1681,7 +1688,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -44,12 +44,11 @@
  (func $do/testSimple
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   i32.const 10
   local.set $0
   i32.const 0
   local.set $1
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 1
    i32.sub
@@ -59,9 +58,7 @@
    i32.add
    local.set $1
    local.get $0
-   local.set $2
-   local.get $2
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   i32.const 0
@@ -95,7 +92,7 @@
   (local $1 i32)
   i32.const 10
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    nop
    local.get $0
    local.tee $1
@@ -103,9 +100,7 @@
    i32.sub
    local.set $0
    local.get $1
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   i32.const -1
@@ -126,14 +121,13 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
   i32.const 10
   local.set $0
   i32.const 0
   local.set $1
   i32.const 0
   local.set $2
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 1
    i32.sub
@@ -142,7 +136,7 @@
    i32.const 1
    i32.add
    local.set $1
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $0
     i32.const 1
     i32.sub
@@ -152,9 +146,7 @@
     i32.add
     local.set $2
     local.get $0
-    local.set $3
-    local.get $3
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
    local.get $0
    i32.const 0
@@ -181,9 +173,7 @@
     unreachable
    end
    local.get $0
-   local.set $3
-   local.get $3
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   i32.const 0
@@ -226,11 +216,10 @@
  )
  (func $do/testAlwaysTrue
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   local.set $0
   block $do-break|0
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $0
     i32.const 1
     i32.add
@@ -241,9 +230,7 @@
      br $do-break|0
     end
     i32.const 1
-    local.set $1
-    local.get $1
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
   local.get $0
@@ -265,7 +252,7 @@
   (local $0 i32)
   i32.const 0
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 1
    i32.add
@@ -278,7 +265,7 @@
    end
    i32.const 1
    drop
-   br $do-continue|0
+   br $do-loop|0
   end
   unreachable
  )
@@ -286,7 +273,7 @@
   (local $0 i32)
   i32.const 0
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 1
    i32.add
@@ -314,7 +301,7 @@
   i32.const 0
   local.set $0
   block $do-break|0
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $0
     i32.const 1
     i32.add
@@ -342,7 +329,7 @@
   (local $0 i32)
   i32.const 0
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 1
    i32.add
@@ -358,19 +345,22 @@
   i32.const 0
   local.set $0
   block $do-break|0
-   loop $do-continue|0
-    local.get $0
-    i32.const 1
-    i32.add
-    local.tee $0
-    i32.const 10
-    i32.eq
-    if
-     br $do-break|0
+   loop $do-loop|0
+    block $do-continue|0
+     local.get $0
+     i32.const 1
+     i32.add
+     local.tee $0
+     i32.const 10
+     i32.eq
+     if
+      br $do-break|0
+     end
+     br $do-continue|0
     end
-    br $do-continue|0
+    local.get $0
+    br_if $do-loop|0
    end
-   unreachable
   end
   local.get $0
   i32.const 10
@@ -395,36 +385,42 @@
   i32.const 0
   local.set $1
   block $do-break|0
-   loop $do-continue|0
-    local.get $0
-    i32.const 1
-    i32.add
-    local.tee $0
-    i32.const 10
-    i32.eq
-    if
-     br $do-break|0
-    end
-    block $do-break|1
-     loop $do-continue|1
-      local.get $1
-      i32.const 1
-      i32.add
-      local.tee $1
-      i32.const 10
-      i32.rem_s
-      i32.const 0
-      i32.eq
-      if
-       br $do-break|1
-      end
-      br $do-continue|1
+   loop $do-loop|0
+    block $do-continue|0
+     local.get $0
+     i32.const 1
+     i32.add
+     local.tee $0
+     i32.const 10
+     i32.eq
+     if
+      br $do-break|0
      end
-     unreachable
+     block $do-break|1
+      loop $do-loop|1
+       block $do-continue|1
+        local.get $1
+        i32.const 1
+        i32.add
+        local.tee $1
+        i32.const 10
+        i32.rem_s
+        i32.const 0
+        i32.eq
+        if
+         br $do-break|1
+        end
+        br $do-continue|1
+       end
+       local.get $1
+       br_if $do-loop|1
+      end
+     end
+     br $do-continue|0
     end
-    br $do-continue|0
+    local.get $0
+    br_if $do-loop|0
    end
-   unreachable
   end
   local.get $0
   i32.const 10
@@ -1923,7 +1919,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1934,7 +1929,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1962,9 +1957,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2761,7 +2754,6 @@
  (func $do/testRef
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -2777,7 +2769,7 @@
   call $do/Ref#constructor
   local.tee $1
   i32.store
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 1
    i32.add
@@ -2795,9 +2787,7 @@
     i32.store
    end
    local.get $1
-   local.set $2
-   local.get $2
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   i32.const 10
@@ -2836,7 +2826,6 @@
  (func $do/testRefAutorelease
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -2853,7 +2842,7 @@
   local.tee $1
   i32.store
   block $do-break|0
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $0
     i32.const 1
     i32.add
@@ -2866,9 +2855,7 @@
      br $do-break|0
     end
     call $do/getRef
-    local.set $2
-    local.get $2
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
   local.get $0

--- a/tests/compiler/empty-exportruntime.optimized.wat
+++ b/tests/compiler/empty-exportruntime.optimized.wat
@@ -1264,7 +1264,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1287,7 +1287,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/empty-exportruntime.untouched.wat
+++ b/tests/compiler/empty-exportruntime.untouched.wat
@@ -1516,7 +1516,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1527,7 +1526,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1555,9 +1554,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/empty-new.optimized.wat
+++ b/tests/compiler/empty-new.optimized.wat
@@ -1216,7 +1216,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1239,7 +1239,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/empty-new.untouched.wat
+++ b/tests/compiler/empty-new.untouched.wat
@@ -1509,7 +1509,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1520,7 +1519,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1548,9 +1547,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -1212,7 +1212,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1235,7 +1235,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -1573,7 +1573,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1584,7 +1583,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1612,9 +1611,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/exportstar-rereexport.optimized.wat
+++ b/tests/compiler/exportstar-rereexport.optimized.wat
@@ -1401,7 +1401,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1424,7 +1424,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/exportstar-rereexport.untouched.wat
+++ b/tests/compiler/exportstar-rereexport.untouched.wat
@@ -1554,7 +1554,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1565,7 +1564,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1593,9 +1592,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -1440,7 +1440,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1463,7 +1463,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -1518,7 +1518,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1529,7 +1528,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1557,9 +1556,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/extends-recursive.optimized.wat
+++ b/tests/compiler/extends-recursive.optimized.wat
@@ -1169,7 +1169,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1192,7 +1192,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -1514,7 +1514,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1525,7 +1524,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1553,9 +1552,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/field-initialization.optimized.wat
+++ b/tests/compiler/field-initialization.optimized.wat
@@ -1447,7 +1447,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1470,7 +1470,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -1842,7 +1842,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -1863,7 +1863,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/field-initialization.untouched.wat
+++ b/tests/compiler/field-initialization.untouched.wat
@@ -1518,7 +1518,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1529,7 +1528,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1557,9 +1556,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2597,7 +2594,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2621,9 +2618,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -1660,7 +1660,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1683,7 +1683,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -1936,7 +1936,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1947,7 +1946,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1975,9 +1974,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/function-call.optimized.wat
+++ b/tests/compiler/function-call.optimized.wat
@@ -1349,7 +1349,7 @@
     block $__inlined_func$~lib/rt/itcms/interrupt
      i32.const 2048
      local.set $0
-     loop $do-continue|0
+     loop $do-loop|0
       local.get $0
       call $~lib/rt/itcms/step
       i32.sub
@@ -1372,7 +1372,7 @@
       local.get $0
       i32.const 0
       i32.gt_s
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
      global.get $~lib/rt/itcms/total
      local.tee $0

--- a/tests/compiler/function-call.untouched.wat
+++ b/tests/compiler/function-call.untouched.wat
@@ -1544,7 +1544,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1555,7 +1554,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1583,9 +1582,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -1332,7 +1332,7 @@
     block $__inlined_func$~lib/rt/itcms/interrupt
      i32.const 2048
      local.set $0
-     loop $do-continue|0
+     loop $do-loop|0
       local.get $0
       call $~lib/rt/itcms/step
       i32.sub
@@ -1355,7 +1355,7 @@
       local.get $0
       i32.const 0
       i32.gt_s
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
      global.get $~lib/rt/itcms/total
      local.tee $0

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -1700,7 +1700,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1711,7 +1710,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1739,9 +1738,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/getter-call.optimized.wat
+++ b/tests/compiler/getter-call.optimized.wat
@@ -1264,7 +1264,7 @@
     block $__inlined_func$~lib/rt/itcms/interrupt
      i32.const 2048
      local.set $0
-     loop $do-continue|0
+     loop $do-loop|0
       local.get $0
       call $~lib/rt/itcms/step
       i32.sub
@@ -1287,7 +1287,7 @@
       local.get $0
       i32.const 0
       i32.gt_s
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
      global.get $~lib/rt/itcms/total
      local.tee $0

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -1512,7 +1512,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1523,7 +1522,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1551,9 +1550,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/implicit-getter-setter.optimized.wat
+++ b/tests/compiler/implicit-getter-setter.optimized.wat
@@ -1175,7 +1175,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1198,7 +1198,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/implicit-getter-setter.untouched.wat
+++ b/tests/compiler/implicit-getter-setter.untouched.wat
@@ -1519,7 +1519,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1530,7 +1529,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1558,9 +1557,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -1285,7 +1285,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1308,7 +1308,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -1528,7 +1528,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1539,7 +1538,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1567,9 +1566,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/infer-generic.optimized.wat
+++ b/tests/compiler/infer-generic.optimized.wat
@@ -1336,7 +1336,7 @@
     block $__inlined_func$~lib/rt/itcms/interrupt
      i32.const 2048
      local.set $2
-     loop $do-continue|0
+     loop $do-loop|0
       local.get $2
       call $~lib/rt/itcms/step
       i32.sub
@@ -1359,7 +1359,7 @@
       local.get $2
       i32.const 0
       i32.gt_s
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
      global.get $~lib/rt/itcms/total
      local.tee $0

--- a/tests/compiler/infer-generic.untouched.wat
+++ b/tests/compiler/infer-generic.untouched.wat
@@ -1598,7 +1598,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1609,7 +1608,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1637,9 +1636,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -1258,7 +1258,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1281,7 +1281,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -1718,7 +1718,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1729,7 +1728,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1757,9 +1756,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/instanceof-class.optimized.wat
+++ b/tests/compiler/instanceof-class.optimized.wat
@@ -1176,7 +1176,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1199,7 +1199,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1
@@ -1546,7 +1546,7 @@
      i32.load
      i32.le_u
      if
-      loop $do-continue|0
+      loop $do-loop|0
        i32.const 1
        local.get $0
        i32.const 3
@@ -1560,7 +1560,7 @@
        i32.add
        i32.load offset=4
        local.tee $0
-       br_if $do-continue|0
+       br_if $do-loop|0
       end
      end
      i32.const 0
@@ -1578,7 +1578,7 @@
      i32.load
      i32.le_u
      if
-      loop $do-continue|07
+      loop $do-loop|07
        i32.const 1
        local.get $0
        i32.const 6
@@ -1592,7 +1592,7 @@
        i32.add
        i32.load offset=4
        local.tee $0
-       br_if $do-continue|07
+       br_if $do-loop|07
       end
      end
      i32.const 0

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -1512,7 +1512,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1523,7 +1522,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1551,9 +1550,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2398,7 +2395,6 @@
  (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   i32.const 20
   i32.sub
@@ -2411,7 +2407,7 @@
   i32.load
   i32.le_u
   if
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     local.get $1
     i32.eq
@@ -2428,9 +2424,7 @@
     i32.add
     i32.load offset=4
     local.tee $2
-    local.set $4
-    local.get $4
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
   i32.const 0

--- a/tests/compiler/issues/1095.optimized.wat
+++ b/tests/compiler/issues/1095.optimized.wat
@@ -1308,7 +1308,7 @@
     block $__inlined_func$~lib/rt/itcms/interrupt
      i32.const 2048
      local.set $0
-     loop $do-continue|0
+     loop $do-loop|0
       local.get $0
       call $~lib/rt/itcms/step
       i32.sub
@@ -1331,7 +1331,7 @@
       local.get $0
       i32.const 0
       i32.gt_s
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
      global.get $~lib/rt/itcms/total
      local.tee $0

--- a/tests/compiler/issues/1095.untouched.wat
+++ b/tests/compiler/issues/1095.untouched.wat
@@ -1512,7 +1512,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1523,7 +1522,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1551,9 +1550,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/issues/1225.optimized.wat
+++ b/tests/compiler/issues/1225.optimized.wat
@@ -1171,7 +1171,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1194,7 +1194,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/issues/1225.untouched.wat
+++ b/tests/compiler/issues/1225.untouched.wat
@@ -1523,7 +1523,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1534,7 +1533,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1562,9 +1561,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/issues/1699.optimized.wat
+++ b/tests/compiler/issues/1699.optimized.wat
@@ -1436,7 +1436,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1459,7 +1459,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2

--- a/tests/compiler/issues/1699.untouched.wat
+++ b/tests/compiler/issues/1699.untouched.wat
@@ -1513,7 +1513,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1524,7 +1523,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1552,9 +1551,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1333,7 +1333,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1356,7 +1356,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -1535,7 +1535,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1546,7 +1545,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1574,9 +1573,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/loop-flow.optimized.wat
+++ b/tests/compiler/loop-flow.optimized.wat
@@ -70,21 +70,23 @@
   end
  )
  (func $loop-flow/doAny (param $0 i32) (result i32)
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 1
    i32.ne
    if
     local.get $0
     i32.const 2
-    i32.ne
-    br_if $do-continue|0
-    i32.const 1104
-    i32.const 1056
-    i32.const 78
-    i32.const 22
-    call $~lib/builtins/abort
-    unreachable
+    i32.eq
+    if
+     i32.const 1104
+     i32.const 1056
+     i32.const 78
+     i32.const 22
+     call $~lib/builtins/abort
+     unreachable
+    end
+    br $do-loop|0
    end
   end
   i32.const 1

--- a/tests/compiler/loop-flow.untouched.wat
+++ b/tests/compiler/loop-flow.untouched.wat
@@ -123,37 +123,42 @@
   unreachable
  )
  (func $loop-flow/doReturn (result i32)
-  loop $do-continue|0
+  loop $do-loop|0
    i32.const 1
    return
   end
   unreachable
  )
  (func $loop-flow/doAny (param $0 i32) (result i32)
-  loop $do-continue|0
-   local.get $0
-   i32.const 1
-   i32.eq
-   if
-    i32.const 1
-    return
-   else
+  loop $do-loop|0
+   block $do-continue|0
     local.get $0
-    i32.const 2
+    i32.const 1
     i32.eq
     if
-     i32.const 80
-     i32.const 32
-     i32.const 78
-     i32.const 22
-     call $~lib/builtins/abort
-     unreachable
+     i32.const 1
+     return
     else
-     br $do-continue|0
+     local.get $0
+     i32.const 2
+     i32.eq
+     if
+      i32.const 80
+      i32.const 32
+      i32.const 78
+      i32.const 22
+      call $~lib/builtins/abort
+      unreachable
+     else
+      br $do-continue|0
+     end
+     unreachable
     end
     unreachable
    end
-   unreachable
+   i32.const 1
+   drop
+   br $do-loop|0
   end
   unreachable
  )
@@ -296,7 +301,7 @@
   unreachable
  )
  (func $loop-flow/doThrow (result i32)
-  loop $do-continue|0
+  loop $do-loop|0
    i32.const 80
    i32.const 32
    i32.const 71

--- a/tests/compiler/loop-wrap.optimized.wat
+++ b/tests/compiler/loop-wrap.optimized.wat
@@ -8,7 +8,7 @@
  (export "memory" (memory $0))
  (func $loop-wrap/testAlwaysWrapped
   (local $0 i32)
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 10
    i32.ne
@@ -19,13 +19,13 @@
     i32.const 255
     i32.and
     local.tee $0
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
  )
  (func $loop-wrap/testFirstWrapped
   (local $0 i32)
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $0
    i32.const 255
    i32.and
@@ -38,12 +38,12 @@
     local.tee $0
     i32.const 255
     i32.and
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )
  (func $loop-wrap/testSubsequentWrapped (param $0 i32)
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 255
    i32.and
@@ -56,7 +56,7 @@
     i32.const 255
     i32.and
     local.tee $0
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
  )

--- a/tests/compiler/loop-wrap.untouched.wat
+++ b/tests/compiler/loop-wrap.untouched.wat
@@ -13,11 +13,10 @@
  (export "memory" (memory $0))
  (func $loop-wrap/testAlwaysWrapped
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   local.set $0
   block $do-break|0
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $0
     i32.const 10
     i32.eq
@@ -30,19 +29,16 @@
     i32.const 255
     i32.and
     local.tee $0
-    local.set $1
-    local.get $1
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
  )
  (func $loop-wrap/testFirstWrapped
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   local.set $0
   block $do-break|1
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $0
     i32.const 255
     i32.and
@@ -57,19 +53,16 @@
     local.tee $0
     i32.const 255
     i32.and
-    local.set $1
-    local.get $1
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )
  (func $loop-wrap/testSubsequentWrapped (param $0 i32)
   (local $1 i32)
-  (local $2 i32)
   local.get $0
   local.set $1
   block $do-break|0
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $1
     i32.const 255
     i32.and
@@ -84,9 +77,7 @@
     i32.const 255
     i32.and
     local.tee $1
-    local.set $2
-    local.get $2
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
  )

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -1166,7 +1166,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1189,7 +1189,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1
@@ -1537,7 +1537,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|0
+     loop $do-loop|0
       i32.const 1
       local.get $2
       i32.const 3
@@ -1551,7 +1551,7 @@
       i32.add
       i32.load offset=4
       local.tee $2
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
     i32.const 0
@@ -1614,7 +1614,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|012
+     loop $do-loop|012
       i32.const 1
       local.get $1
       i32.const 3
@@ -1628,7 +1628,7 @@
       i32.add
       i32.load offset=4
       local.tee $1
-      br_if $do-continue|012
+      br_if $do-loop|012
      end
     end
     i32.const 0
@@ -1678,7 +1678,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|015
+     loop $do-loop|015
       i32.const 1
       local.get $2
       i32.const 3
@@ -1692,7 +1692,7 @@
       i32.add
       i32.load offset=4
       local.tee $2
-      br_if $do-continue|015
+      br_if $do-loop|015
      end
     end
     i32.const 0
@@ -1743,7 +1743,7 @@
      i32.load
      i32.le_u
      if
-      loop $do-continue|018
+      loop $do-loop|018
        i32.const 1
        local.get $2
        i32.const 3
@@ -1757,7 +1757,7 @@
        i32.add
        i32.load offset=4
        local.tee $2
-       br_if $do-continue|018
+       br_if $do-loop|018
       end
      end
      i32.const 0

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -1512,7 +1512,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1523,7 +1522,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1551,9 +1550,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2377,7 +2374,6 @@
  (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   i32.const 20
   i32.sub
@@ -2390,7 +2386,7 @@
   i32.load
   i32.le_u
   if
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     local.get $1
     i32.eq
@@ -2407,9 +2403,7 @@
     i32.add
     i32.load offset=4
     local.tee $2
-    local.set $4
-    local.get $4
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
   i32.const 0

--- a/tests/compiler/new.optimized.wat
+++ b/tests/compiler/new.optimized.wat
@@ -1202,7 +1202,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1225,7 +1225,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/new.untouched.wat
+++ b/tests/compiler/new.untouched.wat
@@ -1515,7 +1515,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1526,7 +1525,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1554,9 +1553,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -1293,7 +1293,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1316,7 +1316,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -2025,7 +2025,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -2046,7 +2046,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -1613,7 +1613,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1624,7 +1623,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1652,9 +1651,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2719,7 +2716,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -2741,7 +2737,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -2768,12 +2764,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -2804,9 +2798,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )
@@ -2862,7 +2854,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2886,9 +2878,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -1526,7 +1526,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1549,7 +1549,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -1843,7 +1843,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -1864,7 +1864,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -1602,7 +1602,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1613,7 +1612,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1641,9 +1640,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2484,7 +2481,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2508,9 +2505,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/optional-typeparameters.optimized.wat
+++ b/tests/compiler/optional-typeparameters.optimized.wat
@@ -1174,7 +1174,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1197,7 +1197,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -1518,7 +1518,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1529,7 +1528,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1557,9 +1556,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -1251,7 +1251,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1274,7 +1274,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -1602,7 +1602,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1613,7 +1612,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1641,9 +1640,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/rereexport.optimized.wat
+++ b/tests/compiler/rereexport.optimized.wat
@@ -1399,7 +1399,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1422,7 +1422,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -1554,7 +1554,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1565,7 +1564,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1593,9 +1592,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -1271,7 +1271,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1294,7 +1294,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -1528,7 +1528,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1539,7 +1538,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1567,9 +1566,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -4233,7 +4230,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -4255,7 +4251,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -4282,12 +4278,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -4318,9 +4312,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -293,7 +293,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -314,7 +314,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end
@@ -1587,7 +1587,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1610,7 +1610,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -153,7 +153,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -177,9 +177,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -1788,7 +1786,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1799,7 +1796,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1827,9 +1824,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2894,7 +2889,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -2916,7 +2910,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -2943,12 +2937,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -2979,9 +2971,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -1499,7 +1499,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1522,7 +1522,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -4089,7 +4089,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -4110,7 +4110,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -1551,7 +1551,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1562,7 +1561,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1590,9 +1589,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -5271,7 +5268,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -5295,9 +5292,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -5551,7 +5546,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -5573,7 +5567,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -5600,12 +5594,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -5636,9 +5628,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -1286,7 +1286,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1309,7 +1309,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -2106,7 +2106,7 @@
      select
      i32.eqz
      if
-      loop $do-continue|0
+      loop $do-loop|0
        local.get $2
        i64.load
        local.get $3
@@ -2127,7 +2127,7 @@
         local.tee $0
         i32.const 4
         i32.ge_u
-        br_if $do-continue|0
+        br_if $do-loop|0
        end
       end
      end

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -1595,7 +1595,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1606,7 +1605,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1634,9 +1633,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2701,7 +2698,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -2723,7 +2719,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -2750,12 +2746,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -2786,9 +2780,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )
@@ -2844,7 +2836,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2868,9 +2860,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/resolve-nested.optimized.wat
+++ b/tests/compiler/resolve-nested.optimized.wat
@@ -1171,7 +1171,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1194,7 +1194,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/resolve-nested.untouched.wat
+++ b/tests/compiler/resolve-nested.untouched.wat
@@ -1534,7 +1534,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1545,7 +1544,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1573,9 +1572,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/resolve-new.optimized.wat
+++ b/tests/compiler/resolve-new.optimized.wat
@@ -1280,7 +1280,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1303,7 +1303,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/resolve-new.untouched.wat
+++ b/tests/compiler/resolve-new.untouched.wat
@@ -1510,7 +1510,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1521,7 +1520,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1549,9 +1548,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -1286,7 +1286,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1309,7 +1309,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3
@@ -2014,7 +2014,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -2035,7 +2035,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -1596,7 +1596,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1607,7 +1606,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1635,9 +1634,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2702,7 +2699,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -2724,7 +2720,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -2751,12 +2747,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -2787,9 +2781,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )
@@ -2845,7 +2837,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2869,9 +2861,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -1290,7 +1290,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1313,7 +1313,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -1906,7 +1906,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -1927,7 +1927,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -1603,7 +1603,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1614,7 +1613,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1642,9 +1641,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2709,7 +2706,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -2731,7 +2727,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -2758,12 +2754,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -2794,9 +2788,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )
@@ -2852,7 +2844,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2876,9 +2868,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -1306,7 +1306,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1329,7 +1329,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3
@@ -2034,7 +2034,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -2055,7 +2055,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -1593,7 +1593,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1604,7 +1603,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1632,9 +1631,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2699,7 +2696,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -2721,7 +2717,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -2748,12 +2744,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -2784,9 +2778,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )
@@ -2842,7 +2834,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2866,9 +2858,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/rt/finalize.optimized.wat
+++ b/tests/compiler/rt/finalize.optimized.wat
@@ -1232,7 +1232,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1255,7 +1255,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/rt/finalize.untouched.wat
+++ b/tests/compiler/rt/finalize.untouched.wat
@@ -1533,7 +1533,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1544,7 +1543,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1572,9 +1571,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/rt/instanceof.optimized.wat
+++ b/tests/compiler/rt/instanceof.optimized.wat
@@ -1205,7 +1205,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1228,7 +1228,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1
@@ -1497,7 +1497,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|0
+     loop $do-loop|0
       i32.const 1
       local.get $0
       i32.const 4
@@ -1511,7 +1511,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
     i32.const 0
@@ -1543,7 +1543,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|01
+     loop $do-loop|01
       i32.const 1
       local.get $0
       i32.const 5
@@ -1557,7 +1557,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|01
+      br_if $do-loop|01
      end
     end
     i32.const 0
@@ -1589,7 +1589,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|03
+     loop $do-loop|03
       i32.const 1
       local.get $0
       i32.const 4
@@ -1603,7 +1603,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|03
+      br_if $do-loop|03
      end
     end
     i32.const 0
@@ -1636,7 +1636,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|05
+     loop $do-loop|05
       i32.const 1
       local.get $0
       i32.const 5
@@ -1650,7 +1650,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|05
+      br_if $do-loop|05
      end
     end
     i32.const 0
@@ -1682,7 +1682,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|07
+     loop $do-loop|07
       i32.const 1
       local.get $0
       i32.const 4
@@ -1696,7 +1696,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|07
+      br_if $do-loop|07
      end
     end
     i32.const 0
@@ -1729,7 +1729,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|09
+     loop $do-loop|09
       i32.const 1
       local.get $0
       i32.const 5
@@ -1743,7 +1743,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|09
+      br_if $do-loop|09
      end
     end
     i32.const 0
@@ -1794,7 +1794,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|011
+     loop $do-loop|011
       i32.const 1
       local.get $0
       i32.const 4
@@ -1808,7 +1808,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|011
+      br_if $do-loop|011
      end
     end
     i32.const 0
@@ -1840,7 +1840,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|013
+     loop $do-loop|013
       i32.const 1
       local.get $0
       i32.const 5
@@ -1854,7 +1854,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|013
+      br_if $do-loop|013
      end
     end
     i32.const 0
@@ -1896,7 +1896,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|015
+     loop $do-loop|015
       i32.const 1
       local.get $0
       i32.const 4
@@ -1910,7 +1910,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|015
+      br_if $do-loop|015
      end
     end
     i32.const 0
@@ -1943,7 +1943,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|017
+     loop $do-loop|017
       i32.const 1
       local.get $0
       i32.const 5
@@ -1957,7 +1957,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|017
+      br_if $do-loop|017
      end
     end
     i32.const 0
@@ -1999,7 +1999,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|019
+     loop $do-loop|019
       i32.const 1
       local.get $0
       i32.const 4
@@ -2013,7 +2013,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|019
+      br_if $do-loop|019
      end
     end
     i32.const 0
@@ -2046,7 +2046,7 @@
     i32.load
     i32.le_u
     if
-     loop $do-continue|021
+     loop $do-loop|021
       i32.const 1
       local.get $0
       i32.const 5
@@ -2060,7 +2060,7 @@
       i32.add
       i32.load offset=4
       local.tee $0
-      br_if $do-continue|021
+      br_if $do-loop|021
      end
     end
     i32.const 0

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -1520,7 +1520,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1531,7 +1530,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1559,9 +1558,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2358,7 +2355,6 @@
  (func $~lib/rt/__instanceof (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   i32.const 20
   i32.sub
@@ -2371,7 +2367,7 @@
   i32.load
   i32.le_u
   if
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     local.get $1
     i32.eq
@@ -2388,9 +2384,7 @@
     i32.add
     i32.load offset=4
     local.tee $2
-    local.set $4
-    local.get $4
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
   i32.const 0

--- a/tests/compiler/rt/runtime-incremental-export.optimized.wat
+++ b/tests/compiler/rt/runtime-incremental-export.optimized.wat
@@ -1264,7 +1264,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1287,7 +1287,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/rt/runtime-incremental-export.untouched.wat
+++ b/tests/compiler/rt/runtime-incremental-export.untouched.wat
@@ -1516,7 +1516,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1527,7 +1526,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1555,9 +1554,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/std-wasi/console.optimized.wat
+++ b/tests/compiler/std-wasi/console.optimized.wat
@@ -574,7 +574,7 @@
   i32.add
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $4
    i32.const 1
    i32.sub
@@ -589,7 +589,7 @@
    i32.const 10
    i32.div_u
    local.tee $2
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   local.get $4
@@ -649,7 +649,7 @@
   i32.add
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $4
    i32.const 1
    i32.sub
@@ -664,7 +664,7 @@
    i32.const 10
    i32.div_u
    local.tee $3
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $0
   local.get $4
@@ -2834,7 +2834,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -2857,7 +2857,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -3948,7 +3948,7 @@
        select
        i32.eqz
        if
-        loop $do-continue|0
+        loop $do-loop|0
          local.get $4
          i64.load
          local.get $2
@@ -3969,7 +3969,7 @@
           local.tee $0
           i32.const 4
           i32.ge_u
-          br_if $do-continue|0
+          br_if $do-loop|0
          end
         end
        end

--- a/tests/compiler/std-wasi/console.untouched.wat
+++ b/tests/compiler/std-wasi/console.untouched.wat
@@ -520,7 +520,6 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 0
   i32.const 12
   call $~lib/bindings/wasi_snapshot_preview1/iovec#set:buf
@@ -589,7 +588,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $2
    i32.const 10
    i32.div_u
@@ -607,9 +606,7 @@
    local.get $5
    local.set $2
    local.get $2
-   local.set $7
-   local.get $7
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $4
   local.get $6
@@ -630,7 +627,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $3
    i32.const 10
    i32.div_u
@@ -648,9 +645,7 @@
    local.get $7
    local.set $3
    local.get $3
-   local.set $8
-   local.get $8
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $4
   local.get $6
@@ -3564,7 +3559,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -3575,7 +3569,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -3603,9 +3597,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -4314,7 +4306,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -4338,9 +4330,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -5087,7 +5077,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -5109,7 +5098,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -5136,12 +5125,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -5172,9 +5159,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/std-wasi/crypto.optimized.wat
+++ b/tests/compiler/std-wasi/crypto.optimized.wat
@@ -530,7 +530,7 @@
   i32.add
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $4
    i32.const 1
    i32.sub
@@ -545,7 +545,7 @@
    i32.const 10
    i32.div_u
    local.tee $2
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   local.get $4
@@ -605,7 +605,7 @@
   i32.add
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $4
    i32.const 1
    i32.sub
@@ -620,7 +620,7 @@
    i32.const 10
    i32.div_u
    local.tee $3
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $0
   local.get $4
@@ -2273,7 +2273,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -2296,7 +2296,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2

--- a/tests/compiler/std-wasi/crypto.untouched.wat
+++ b/tests/compiler/std-wasi/crypto.untouched.wat
@@ -494,7 +494,6 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 0
   i32.const 12
   call $~lib/bindings/wasi_snapshot_preview1/iovec#set:buf
@@ -563,7 +562,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $2
    i32.const 10
    i32.div_u
@@ -581,9 +580,7 @@
    local.get $5
    local.set $2
    local.get $2
-   local.set $7
-   local.get $7
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $4
   local.get $6
@@ -604,7 +601,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $3
    i32.const 10
    i32.div_u
@@ -622,9 +619,7 @@
    local.get $7
    local.set $3
    local.get $3
-   local.set $8
-   local.get $8
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $4
   local.get $6
@@ -2121,7 +2116,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -2132,7 +2126,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -2160,9 +2154,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -3963,7 +3955,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -3985,7 +3976,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -4012,12 +4003,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -4048,9 +4037,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -560,7 +560,7 @@
   i32.add
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $4
    i32.const 1
    i32.sub
@@ -575,7 +575,7 @@
    i32.const 10
    i32.div_u
    local.tee $2
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   local.get $4
@@ -635,7 +635,7 @@
   i32.add
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $4
    i32.const 1
    i32.sub
@@ -650,7 +650,7 @@
    i32.const 10
    i32.div_u
    local.tee $3
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $0
   local.get $4
@@ -2847,7 +2847,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -2870,7 +2870,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -4081,7 +4081,7 @@
   select
   i32.eqz
   if
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $1
     i64.load
     local.get $2
@@ -4102,7 +4102,7 @@
      local.tee $3
      i32.const 4
      i32.ge_u
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -518,7 +518,6 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 0
   i32.const 12
   call $~lib/bindings/wasi_snapshot_preview1/iovec#set:buf
@@ -587,7 +586,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $2
    i32.const 10
    i32.div_u
@@ -605,9 +604,7 @@
    local.get $5
    local.set $2
    local.get $2
-   local.set $7
-   local.get $7
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $4
   local.get $6
@@ -628,7 +625,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $3
    i32.const 10
    i32.div_u
@@ -646,9 +643,7 @@
    local.get $7
    local.set $3
    local.get $3
-   local.set $8
-   local.get $8
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $4
   local.get $6
@@ -3562,7 +3557,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -3573,7 +3567,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -3601,9 +3595,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -5530,7 +5522,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -5554,9 +5546,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -6631,7 +6621,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -6653,7 +6642,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -6680,12 +6669,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -6716,9 +6703,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -67,7 +67,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $4
@@ -88,7 +88,7 @@
       local.tee $1
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -96,7 +96,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -120,9 +120,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -1344,7 +1344,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1367,7 +1367,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -1586,7 +1586,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1597,7 +1596,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1625,9 +1624,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2354,7 +2354,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -2377,7 +2377,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -9074,7 +9074,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      i64.load
      local.get $1
@@ -9095,7 +9095,7 @@
       local.tee $3
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end
@@ -9195,7 +9195,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -9216,7 +9216,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -1923,7 +1923,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1934,7 +1933,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1962,9 +1961,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -14726,7 +14723,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -14750,9 +14747,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -16325,7 +16320,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -16347,7 +16341,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -16374,12 +16368,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -16410,9 +16402,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1437,7 +1437,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1460,7 +1460,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1516,7 +1516,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1527,7 +1526,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1555,9 +1554,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -1443,7 +1443,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1466,7 +1466,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -1523,7 +1523,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1534,7 +1533,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1562,9 +1561,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -1804,7 +1804,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1827,7 +1827,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -3718,7 +3718,7 @@
   select
   i32.eqz
   if
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $1
     i64.load
     local.get $2
@@ -3739,7 +3739,7 @@
      local.tee $3
      i32.const 4
      i32.ge_u
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -1866,7 +1866,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1877,7 +1876,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1905,9 +1904,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -3492,7 +3489,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -3514,7 +3510,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -3541,12 +3537,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -3577,9 +3571,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )
@@ -4924,7 +4916,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -4948,9 +4940,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1451,7 +1451,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1474,7 +1474,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -1536,7 +1536,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1547,7 +1546,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1575,9 +1574,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -11671,7 +11671,7 @@
   i32.const 0
   local.set $9
   block $do-break|0
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $4
     local.get $5
     i64.lt_s
@@ -11987,7 +11987,7 @@
   i32.const 0
   local.set $8
   block $do-break|0
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $4
     local.get $5
     i32.lt_s

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -1219,7 +1219,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1242,7 +1242,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -1523,7 +1523,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1534,7 +1533,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1562,9 +1561,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/std/object.optimized.wat
+++ b/tests/compiler/std/object.optimized.wat
@@ -72,7 +72,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -93,7 +93,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/std/object.untouched.wat
+++ b/tests/compiler/std/object.untouched.wat
@@ -140,7 +140,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -164,9 +164,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -1226,7 +1226,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1249,7 +1249,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -1577,7 +1577,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1588,7 +1587,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1616,9 +1615,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1444,7 +1444,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1467,7 +1467,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -1531,7 +1531,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1542,7 +1541,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1570,9 +1569,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -2216,7 +2216,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -2239,7 +2239,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -1565,7 +1565,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1576,7 +1575,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1604,9 +1603,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/std/staticarray.optimized.wat
+++ b/tests/compiler/std/staticarray.optimized.wat
@@ -1572,7 +1572,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1595,7 +1595,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -2873,7 +2873,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -2894,7 +2894,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/std/staticarray.untouched.wat
+++ b/tests/compiler/std/staticarray.untouched.wat
@@ -1621,7 +1621,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1632,7 +1631,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1660,9 +1659,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -3899,7 +3896,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -3923,9 +3920,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/std/string-casemapping.optimized.wat
+++ b/tests/compiler/std/string-casemapping.optimized.wat
@@ -1699,7 +1699,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1722,7 +1722,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3
@@ -3313,7 +3313,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -3334,7 +3334,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/std/string-casemapping.untouched.wat
+++ b/tests/compiler/std/string-casemapping.untouched.wat
@@ -1698,7 +1698,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1709,7 +1708,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1737,9 +1736,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -4068,7 +4065,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -4092,9 +4089,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -4778,7 +4773,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -4800,7 +4794,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -4827,12 +4821,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -4863,9 +4855,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -1284,7 +1284,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1307,7 +1307,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3
@@ -2697,7 +2697,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -2718,7 +2718,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -1535,7 +1535,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1546,7 +1545,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1574,9 +1573,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -3694,7 +3691,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -3718,9 +3715,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -963,7 +963,7 @@
   select
   i32.eqz
   if
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $1
     i64.load
     local.get $2
@@ -984,7 +984,7 @@
      local.tee $3
      i32.const 4
      i32.ge_u
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -2470,7 +2470,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -2493,7 +2493,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -6274,7 +6274,7 @@
   local.get $3
   i32.and
   if
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -6302,7 +6302,7 @@
     local.tee $1
     i64.const 0
     i64.ne
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   else
    local.get $3
@@ -6315,7 +6315,7 @@
    i64.const 1
    i64.sub
    local.set $5
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -6340,7 +6340,7 @@
     local.tee $1
     i64.const 0
     i64.ne
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   end
  )

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -571,7 +571,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -595,9 +595,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -2234,7 +2232,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -2245,7 +2242,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -2273,9 +2270,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -7719,7 +7714,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -7741,7 +7735,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -7768,12 +7762,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -7804,9 +7796,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -1528,7 +1528,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -1551,7 +1551,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -2121,7 +2121,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -2142,7 +2142,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -1568,7 +1568,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1579,7 +1578,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1607,9 +1606,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -2848,7 +2845,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -2872,9 +2869,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -2311,7 +2311,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $2
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $2
      call $~lib/rt/itcms/step
      i32.sub
@@ -2334,7 +2334,7 @@
      local.get $2
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $2
@@ -24481,7 +24481,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -24502,7 +24502,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -1879,7 +1879,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1890,7 +1889,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1918,9 +1917,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -21786,7 +21783,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -21808,7 +21804,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -21835,12 +21831,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -21871,9 +21865,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )
@@ -22016,7 +22008,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -22040,9 +22032,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/std/uri.optimized.wat
+++ b/tests/compiler/std/uri.optimized.wat
@@ -1365,7 +1365,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1388,7 +1388,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3
@@ -2790,7 +2790,7 @@
     block $while-break|0
      local.get $7
      local.set $5
-     loop $do-continue|1
+     loop $do-loop|1
       block $do-break|1
        local.get $7
        i32.const 1
@@ -2817,7 +2817,7 @@
        i32.add
        local.tee $7
        i32.gt_u
-       br_if $do-continue|1
+       br_if $do-loop|1
       end
      end
      local.get $5
@@ -3278,7 +3278,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -3299,7 +3299,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end

--- a/tests/compiler/std/uri.untouched.wat
+++ b/tests/compiler/std/uri.untouched.wat
@@ -1579,7 +1579,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1590,7 +1589,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1618,9 +1617,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -3779,7 +3776,7 @@
      local.get $3
      local.set $8
      block $do-break|1
-      loop $do-continue|1
+      loop $do-loop|1
        local.get $0
        local.get $3
        i32.const 1
@@ -3811,9 +3808,7 @@
        local.tee $3
        local.get $1
        i32.lt_u
-       local.set $11
-       local.get $11
-       br_if $do-continue|1
+       br_if $do-loop|1
       end
      end
      local.get $3
@@ -4143,7 +4138,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -4167,9 +4162,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end

--- a/tests/compiler/super-inline.optimized.wat
+++ b/tests/compiler/super-inline.optimized.wat
@@ -1174,7 +1174,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $1
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $1
      call $~lib/rt/itcms/step
      i32.sub
@@ -1197,7 +1197,7 @@
      local.get $1
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $1

--- a/tests/compiler/super-inline.untouched.wat
+++ b/tests/compiler/super-inline.untouched.wat
@@ -1511,7 +1511,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1522,7 +1521,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1550,9 +1549,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/templateliteral.optimized.wat
+++ b/tests/compiler/templateliteral.optimized.wat
@@ -183,7 +183,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -204,7 +204,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end
@@ -1463,7 +1463,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $3
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      call $~lib/rt/itcms/step
      i32.sub
@@ -1486,7 +1486,7 @@
      local.get $3
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $3

--- a/tests/compiler/templateliteral.untouched.wat
+++ b/tests/compiler/templateliteral.untouched.wat
@@ -146,7 +146,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -170,9 +170,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -1726,7 +1724,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1737,7 +1734,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1765,9 +1762,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -4251,7 +4246,6 @@
   (local $4 i64)
   (local $5 i64)
   (local $6 i64)
-  (local $7 i32)
   local.get $3
   i64.extend_i32_s
   local.set $4
@@ -4273,7 +4267,7 @@
    i64.const 1
    i64.sub
    local.set $6
-   loop $do-continue|0
+   loop $do-loop|0
     local.get $2
     i32.const 1
     i32.sub
@@ -4300,12 +4294,10 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
   else
-   loop $do-continue|1
+   loop $do-loop|1
     local.get $2
     i32.const 1
     i32.sub
@@ -4336,9 +4328,7 @@
     local.get $1
     i64.const 0
     i64.ne
-    local.set $7
-    local.get $7
-    br_if $do-continue|1
+    br_if $do-loop|1
    end
   end
  )

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -109,7 +109,7 @@
    select
    i32.eqz
    if
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $3
      i64.load
      local.get $1
@@ -130,7 +130,7 @@
       local.tee $0
       i32.const 4
       i32.ge_u
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
     end
    end
@@ -1748,7 +1748,7 @@
     block $__inlined_func$~lib/rt/itcms/interrupt
      i32.const 2048
      local.set $1
-     loop $do-continue|0
+     loop $do-loop|0
       local.get $1
       call $~lib/rt/itcms/step
       i32.sub
@@ -1771,7 +1771,7 @@
       local.get $1
       i32.const 0
       i32.gt_s
-      br_if $do-continue|0
+      br_if $do-loop|0
      end
      global.get $~lib/rt/itcms/total
      local.tee $1

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -106,7 +106,7 @@
   end
   if
    block $do-break|0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $5
      i64.load
      local.get $6
@@ -130,9 +130,7 @@
      local.get $4
      i32.const 4
      i32.ge_u
-     local.set $7
-     local.get $7
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
    end
   end
@@ -1689,7 +1687,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1700,7 +1697,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -1728,9 +1725,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop

--- a/tests/compiler/unify-local-flags.optimized.wat
+++ b/tests/compiler/unify-local-flags.optimized.wat
@@ -24,7 +24,7 @@
  )
  (func $unify-local-flags/testDo
   (local $0 i32)
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $0
    i32.const 1
    i32.add
@@ -33,7 +33,7 @@
    i32.and
    i32.const 255
    i32.lt_u
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
  )
 )

--- a/tests/compiler/unify-local-flags.untouched.wat
+++ b/tests/compiler/unify-local-flags.untouched.wat
@@ -69,12 +69,11 @@
  (func $unify-local-flags/testDo
   (local $0 i32)
   (local $1 i32)
-  (local $2 i32)
   i32.const 0
   local.set $0
   i32.const 0
   local.set $1
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $1
    local.set $0
    local.get $1
@@ -85,9 +84,7 @@
    i32.and
    i32.const 255
    i32.lt_u
-   local.set $2
-   local.get $2
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
  )
 )

--- a/tests/compiler/wasi/abort.optimized.wat
+++ b/tests/compiler/wasi/abort.optimized.wat
@@ -258,7 +258,7 @@
   i32.const 2
   i32.add
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 1
    i32.sub
@@ -273,7 +273,7 @@
    i32.const 10
    i32.div_u
    local.tee $2
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   i32.const 1
@@ -285,7 +285,7 @@
   i32.const 2
   i32.add
   local.set $0
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $0
    i32.const 1
    i32.sub
@@ -300,7 +300,7 @@
    i32.const 10
    i32.div_u
    local.tee $1
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $0
   i32.const 1

--- a/tests/compiler/wasi/abort.untouched.wat
+++ b/tests/compiler/wasi/abort.untouched.wat
@@ -364,7 +364,6 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 0
   i32.const 12
   call $~lib/bindings/wasi_snapshot_preview1/iovec#set:buf
@@ -433,7 +432,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $2
    i32.const 10
    i32.div_u
@@ -451,9 +450,7 @@
    local.get $5
    local.set $2
    local.get $2
-   local.set $7
-   local.get $7
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $4
   local.get $6
@@ -474,7 +471,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $3
    i32.const 10
    i32.div_u
@@ -492,9 +489,7 @@
    local.get $7
    local.set $3
    local.get $3
-   local.set $8
-   local.get $8
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $4
   local.get $6

--- a/tests/compiler/wasi/seed.optimized.wat
+++ b/tests/compiler/wasi/seed.optimized.wat
@@ -224,7 +224,7 @@
   i32.const 5
   i32.add
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    i32.const 1
    i32.sub
@@ -239,7 +239,7 @@
    i32.const 10
    i32.div_u
    local.tee $4
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   i32.const 4
@@ -251,7 +251,7 @@
   i32.const 2
   i32.add
   local.set $0
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $0
    i32.const 1
    i32.sub
@@ -266,7 +266,7 @@
    i32.const 10
    i32.div_u
    local.tee $3
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $0
   i32.const 1
@@ -300,7 +300,7 @@
    i32.const 0
    i64.load
    local.set $1
-   loop $do-continue|0
+   loop $do-loop|0
     i32.const 0
     i32.const 8
     call $~lib/bindings/wasi_snapshot_preview1/random_get
@@ -309,7 +309,7 @@
     i64.load
     local.tee $2
     i64.eqz
-    br_if $do-continue|0
+    br_if $do-loop|0
    end
    i32.const 0
    local.get $1

--- a/tests/compiler/wasi/seed.untouched.wat
+++ b/tests/compiler/wasi/seed.untouched.wat
@@ -34,11 +34,10 @@
  (func $~lib/wasi/index/seed (result f64)
   (local $0 i64)
   (local $1 i64)
-  (local $2 i32)
   i32.const 0
   i64.load
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    i32.const 0
    i32.const 8
    call $~lib/bindings/wasi_snapshot_preview1/random_get
@@ -50,9 +49,7 @@
    i64.const 0
    i64.ne
    i32.eqz
-   local.set $2
-   local.get $2
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   local.get $0
@@ -466,7 +463,6 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 0
   i32.const 12
   call $~lib/bindings/wasi_snapshot_preview1/iovec#set:buf
@@ -535,7 +531,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $2
    i32.const 10
    i32.div_u
@@ -553,9 +549,7 @@
    local.get $5
    local.set $2
    local.get $2
-   local.set $7
-   local.get $7
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $4
   local.get $6
@@ -576,7 +570,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $3
    i32.const 10
    i32.div_u
@@ -594,9 +588,7 @@
    local.get $7
    local.set $3
    local.get $3
-   local.set $8
-   local.get $8
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $4
   local.get $6

--- a/tests/compiler/wasi/trace.optimized.wat
+++ b/tests/compiler/wasi/trace.optimized.wat
@@ -334,7 +334,7 @@
   i32.add
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $4
    i32.const 1
    i32.sub
@@ -349,7 +349,7 @@
    i32.const 10
    i32.div_u
    local.tee $2
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $0
   local.get $4
@@ -409,7 +409,7 @@
   i32.add
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $4
    i32.const 1
    i32.sub
@@ -424,7 +424,7 @@
    i32.const 10
    i32.div_u
    local.tee $3
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $0
   local.get $4

--- a/tests/compiler/wasi/trace.untouched.wat
+++ b/tests/compiler/wasi/trace.untouched.wat
@@ -493,7 +493,6 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
   i32.const 0
   i32.const 12
   call $~lib/bindings/wasi_snapshot_preview1/iovec#set:buf
@@ -562,7 +561,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $2
    i32.const 10
    i32.div_u
@@ -580,9 +579,7 @@
    local.get $5
    local.set $2
    local.get $2
-   local.set $7
-   local.get $7
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   local.get $4
   local.get $6
@@ -603,7 +600,7 @@
   local.get $6
   i32.add
   local.set $4
-  loop $do-continue|1
+  loop $do-loop|1
    local.get $3
    i32.const 10
    i32.div_u
@@ -621,9 +618,7 @@
    local.get $7
    local.set $3
    local.get $3
-   local.set $8
-   local.get $8
-   br_if $do-continue|1
+   br_if $do-loop|1
   end
   local.get $4
   local.get $6

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -1602,6 +1602,28 @@
     i32.lt_s
     br_if $while-continue|010
    end
+   i32.const 0
+   local.set $0
+   loop $do-loop|0
+    local.get $0
+    i32.const 1
+    i32.add
+    local.tee $0
+    i32.const 3
+    i32.lt_s
+    br_if $do-loop|0
+   end
+   local.get $0
+   i32.const 3
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1056
+    i32.const 217
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
    global.get $~lib/rt/itcms/state
    i32.const 0
    i32.gt_s
@@ -1708,7 +1730,7 @@
    block $__inlined_func$~lib/rt/itcms/interrupt
     i32.const 2048
     local.set $0
-    loop $do-continue|0
+    loop $do-loop|0
      local.get $0
      call $~lib/rt/itcms/step
      i32.sub
@@ -1731,7 +1753,7 @@
      local.get $0
      i32.const 0
      i32.gt_s
-     br_if $do-continue|0
+     br_if $do-loop|0
     end
     global.get $~lib/rt/itcms/total
     local.tee $0

--- a/tests/compiler/while.ts
+++ b/tests/compiler/while.ts
@@ -208,4 +208,17 @@ ran = false;
 testIfImplicitContinueElse();
 assert(ran);
 
+function testConditionalContinue(): void {
+  let i = 0;
+  do {
+    i++;
+    continue;
+  } while (i < 3);
+  assert(i == 3);
+  ran = true;
+}
+ran = false;
+testConditionalContinue();
+assert(ran);
+
 __collect();

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -1965,7 +1965,6 @@
  )
  (func $~lib/rt/itcms/interrupt
   (local $0 i32)
-  (local $1 i32)
   i32.const 0
   drop
   i32.const 0
@@ -1976,7 +1975,7 @@
   i32.const 100
   i32.div_u
   local.set $0
-  loop $do-continue|0
+  loop $do-loop|0
    local.get $0
    call $~lib/rt/itcms/step
    i32.sub
@@ -2004,9 +2003,7 @@
    local.get $0
    i32.const 0
    i32.gt_s
-   local.set $1
-   local.get $1
-   br_if $do-continue|0
+   br_if $do-loop|0
   end
   i32.const 0
   drop
@@ -3007,6 +3004,38 @@
   i32.const 1
   global.set $while/ran
  )
+ (func $while/testConditionalContinue
+  (local $0 i32)
+  i32.const 0
+  local.set $0
+  loop $do-loop|0
+   block $do-continue|0
+    local.get $0
+    i32.const 1
+    i32.add
+    local.set $0
+    br $do-continue|0
+   end
+   local.get $0
+   i32.const 3
+   i32.lt_s
+   br_if $do-loop|0
+  end
+  local.get $0
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 217
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  global.set $while/ran
+ )
  (func $~lib/rt/itcms/__collect
   (local $0 i32)
   i32.const 0
@@ -3252,6 +3281,19 @@
    i32.const 0
    i32.const 32
    i32.const 209
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  global.set $while/ran
+  call $while/testConditionalContinue
+  global.get $while/ran
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 222
    i32.const 1
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
Fixes #2030 by wrapping the loop body in a continue block and detaching the loop condition.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
