### PR TITLE
Use shared temporary buffer for WASI out values

### DIFF
--- a/std/assembly/bindings/wasi.ts
+++ b/std/assembly/bindings/wasi.ts
@@ -1,1 +1,6 @@
 export * from "./wasi_snapshot_preview1";
+
+// A WASI-wide reusable temporary buffer to store and work with out values. Must
+// be large enough to fit any operation it is used in, i.e. process/writeString.
+// @ts-ignore: decorator
+@lazy export const tempbuf = memory.data(4 * sizeof<usize>());

--- a/std/assembly/wasi/index.ts
+++ b/std/assembly/wasi/index.ts
@@ -2,7 +2,8 @@ import {
   proc_exit,
   fd_write,
   iovec,
-  random_get
+  random_get,
+  tempbuf
 } from "bindings/wasi";
 
 import {
@@ -108,13 +109,11 @@ function trace( // eslint-disable-line @typescript-eslint/no-unused-vars
 }
 
 function seed(): f64 { // eslint-disable-line @typescript-eslint/no-unused-vars
-  var temp = load<u64>(0);
   var rand: u64;
   do {
-    random_get(0, 8); // to be sure
-    rand = load<u64>(0);
+    random_get(tempbuf, 8);
+    rand = load<u64>(tempbuf);
   } while (!rand);
-  store<u64>(0, temp);
   return reinterpret<f64>(rand);
 }
 

--- a/tests/compiler/std-wasi/console.optimized.wat
+++ b/tests/compiler/std-wasi/console.optimized.wat
@@ -2065,7 +2065,7 @@
      local.get $0
      call $~lib/bindings/wasi_snapshot_preview1/errnoToString
      i32.const 4272
-     i32.const 180
+     i32.const 178
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -2168,7 +2168,7 @@
   if
    i32.const 0
    i32.const 4272
-   i32.const 186
+   i32.const 184
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
@@ -2194,7 +2194,7 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 4272
-   i32.const 191
+   i32.const 189
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable
@@ -3190,7 +3190,7 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 4272
-   i32.const 59
+   i32.const 57
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/console.untouched.wat
+++ b/tests/compiler/std-wasi/console.untouched.wat
@@ -23,7 +23,7 @@
  (import "wasi_snapshot_preview1" "proc_exit" (func $~lib/bindings/wasi_snapshot_preview1/proc_exit (param i32)))
  (import "wasi_snapshot_preview1" "clock_time_get" (func $~lib/bindings/wasi_snapshot_preview1/clock_time_get (param i32 i64 i32) (result i32)))
  (global $~lib/process/process.stderr i32 (i32.const 2))
- (global $~lib/process/iobuf i32 (i32.const 112))
+ (global $~lib/bindings/wasi/tempbuf i32 (i32.const 112))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
@@ -2920,17 +2920,17 @@
     if
      br $break|0
     end
-    global.get $~lib/process/iobuf
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
+    global.get $~lib/bindings/wasi/tempbuf
     i32.const 2
     i32.const 4
     i32.mul
     i32.add
     i32.store
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     local.get $2
     i32.store offset=4
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     local.get $6
     local.get $3
     i32.const 8
@@ -2946,9 +2946,9 @@
     i32.or
     i32.store offset=8
     local.get $0
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     i32.const 1
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     i32.const 3
     i32.const 4
     i32.mul
@@ -2962,7 +2962,7 @@
      local.get $7
      call $~lib/bindings/wasi_snapshot_preview1/errnoToString
      i32.const 3248
-     i32.const 180
+     i32.const 178
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -2991,21 +2991,21 @@
   if
    i32.const 0
    i32.const 3248
-   i32.const 186
+   i32.const 184
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   local.get $9
   i32.store
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   local.get $8
   i32.store offset=4
   local.get $0
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 1
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 2
   i32.const 4
   i32.mul
@@ -3021,7 +3021,7 @@
    local.get $10
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3248
-   i32.const 191
+   i32.const 189
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable
@@ -4427,7 +4427,7 @@
   (local $0 i32)
   i32.const 1
   i64.const 0
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   call $~lib/bindings/wasi_snapshot_preview1/clock_time_get
   local.set $0
   local.get $0
@@ -4437,12 +4437,12 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3248
-   i32.const 59
+   i32.const 57
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i64.load
  )
  (func $~lib/map/MapEntry<~lib/string/String,u64>#set:value (param $0 i32) (param $1 i64)

--- a/tests/compiler/std-wasi/crypto.optimized.wat
+++ b/tests/compiler/std-wasi/crypto.optimized.wat
@@ -4340,7 +4340,7 @@
      local.get $0
      call $~lib/bindings/wasi_snapshot_preview1/errnoToString
      i32.const 6720
-     i32.const 180
+     i32.const 178
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -4440,7 +4440,7 @@
   if
    i32.const 0
    i32.const 6720
-   i32.const 186
+   i32.const 184
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
@@ -4466,7 +4466,7 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 6720
-   i32.const 191
+   i32.const 189
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/crypto.untouched.wat
+++ b/tests/compiler/std-wasi/crypto.untouched.wat
@@ -32,7 +32,7 @@
  (global $std-wasi/crypto/ab (mut i32) (i32.const 0))
  (global $std-wasi/crypto/buf (mut i32) (i32.const 0))
  (global $~lib/process/process.stdout i32 (i32.const 1))
- (global $~lib/process/iobuf i32 (i32.const 5648))
+ (global $~lib/bindings/wasi/tempbuf i32 (i32.const 5648))
  (global $~lib/builtins/i32.MAX_VALUE i32 (i32.const 2147483647))
  (global $std-wasi/crypto/b1 (mut i32) (i32.const 0))
  (global $std-wasi/crypto/b2 (mut i32) (i32.const 0))
@@ -5562,17 +5562,17 @@
     if
      br $break|0
     end
-    global.get $~lib/process/iobuf
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
+    global.get $~lib/bindings/wasi/tempbuf
     i32.const 2
     i32.const 4
     i32.mul
     i32.add
     i32.store
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     local.get $2
     i32.store offset=4
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     local.get $6
     local.get $3
     i32.const 8
@@ -5588,9 +5588,9 @@
     i32.or
     i32.store offset=8
     local.get $0
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     i32.const 1
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     i32.const 3
     i32.const 4
     i32.mul
@@ -5604,7 +5604,7 @@
      local.get $7
      call $~lib/bindings/wasi_snapshot_preview1/errnoToString
      i32.const 5696
-     i32.const 180
+     i32.const 178
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -5633,21 +5633,21 @@
   if
    i32.const 0
    i32.const 5696
-   i32.const 186
+   i32.const 184
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   local.get $9
   i32.store
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   local.get $8
   i32.store offset=4
   local.get $0
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 1
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 2
   i32.const 4
   i32.mul
@@ -5663,7 +5663,7 @@
    local.get $10
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 5696
-   i32.const 191
+   i32.const 189
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/std-wasi/process.optimized.wat
+++ b/tests/compiler/std-wasi/process.optimized.wat
@@ -2051,7 +2051,7 @@
      local.get $0
      call $~lib/bindings/wasi_snapshot_preview1/errnoToString
      i32.const 4224
-     i32.const 180
+     i32.const 178
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -2151,7 +2151,7 @@
   if
    i32.const 0
    i32.const 4224
-   i32.const 186
+   i32.const 184
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
@@ -2177,7 +2177,7 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 4224
-   i32.const 191
+   i32.const 189
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable
@@ -4817,7 +4817,7 @@
     local.get $0
     call $~lib/bindings/wasi_snapshot_preview1/errnoToString
     i32.const 4224
-    i32.const 87
+    i32.const 85
     i32.const 12
     call $~lib/wasi/index/abort
     unreachable
@@ -4845,7 +4845,7 @@
     local.get $0
     call $~lib/bindings/wasi_snapshot_preview1/errnoToString
     i32.const 4224
-    i32.const 94
+    i32.const 92
     i32.const 12
     call $~lib/wasi/index/abort
     unreachable
@@ -5139,7 +5139,7 @@
     local.get $1
     call $~lib/bindings/wasi_snapshot_preview1/errnoToString
     i32.const 4224
-    i32.const 66
+    i32.const 64
     i32.const 12
     call $~lib/wasi/index/abort
     unreachable
@@ -5167,7 +5167,7 @@
     local.get $5
     call $~lib/bindings/wasi_snapshot_preview1/errnoToString
     i32.const 4224
-    i32.const 73
+    i32.const 71
     i32.const 12
     call $~lib/wasi/index/abort
     unreachable
@@ -5432,7 +5432,7 @@
     local.get $0
     call $~lib/bindings/wasi_snapshot_preview1/errnoToString
     i32.const 4224
-    i32.const 53
+    i32.const 51
     i32.const 14
     call $~lib/wasi/index/abort
     unreachable
@@ -5640,7 +5640,7 @@
     local.get $0
     call $~lib/bindings/wasi_snapshot_preview1/errnoToString
     i32.const 4224
-    i32.const 59
+    i32.const 57
     i32.const 14
     call $~lib/wasi/index/abort
     unreachable
@@ -5846,7 +5846,7 @@
     local.get $0
     call $~lib/bindings/wasi_snapshot_preview1/errnoToString
     i32.const 4224
-    i32.const 142
+    i32.const 140
     i32.const 14
     call $~lib/wasi/index/abort
     unreachable

--- a/tests/compiler/std-wasi/process.untouched.wat
+++ b/tests/compiler/std-wasi/process.untouched.wat
@@ -25,7 +25,7 @@
  (import "wasi_snapshot_preview1" "clock_time_get" (func $~lib/bindings/wasi_snapshot_preview1/clock_time_get (param i32 i64 i32) (result i32)))
  (import "wasi_snapshot_preview1" "fd_read" (func $~lib/bindings/wasi_snapshot_preview1/fd_read (param i32 i32 i32 i32) (result i32)))
  (global $~lib/process/process.stdout i32 (i32.const 1))
- (global $~lib/process/iobuf i32 (i32.const 64))
+ (global $~lib/bindings/wasi/tempbuf i32 (i32.const 64))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
@@ -2918,17 +2918,17 @@
     if
      br $break|0
     end
-    global.get $~lib/process/iobuf
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
+    global.get $~lib/bindings/wasi/tempbuf
     i32.const 2
     i32.const 4
     i32.mul
     i32.add
     i32.store
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     local.get $2
     i32.store offset=4
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     local.get $6
     local.get $3
     i32.const 8
@@ -2944,9 +2944,9 @@
     i32.or
     i32.store offset=8
     local.get $0
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     i32.const 1
-    global.get $~lib/process/iobuf
+    global.get $~lib/bindings/wasi/tempbuf
     i32.const 3
     i32.const 4
     i32.mul
@@ -2960,7 +2960,7 @@
      local.get $7
      call $~lib/bindings/wasi_snapshot_preview1/errnoToString
      i32.const 3200
-     i32.const 180
+     i32.const 178
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -2989,21 +2989,21 @@
   if
    i32.const 0
    i32.const 3200
-   i32.const 186
+   i32.const 184
    i32.const 3
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   local.get $9
   i32.store
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   local.get $8
   i32.store offset=4
   local.get $0
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 1
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 2
   i32.const 4
   i32.mul
@@ -3019,7 +3019,7 @@
    local.get $10
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3200
-   i32.const 191
+   i32.const 189
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable
@@ -6148,7 +6148,7 @@
   (local $0 i32)
   i32.const 0
   i64.const 1000000
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   call $~lib/bindings/wasi_snapshot_preview1/clock_time_get
   local.set $0
   local.get $0
@@ -6158,12 +6158,12 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3200
-   i32.const 53
+   i32.const 51
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i64.load
   i64.const 1000000
   i64.div_u
@@ -6716,7 +6716,7 @@
   (local $0 i32)
   i32.const 1
   i64.const 0
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   call $~lib/bindings/wasi_snapshot_preview1/clock_time_get
   local.set $0
   local.get $0
@@ -6726,12 +6726,12 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3200
-   i32.const 59
+   i32.const 57
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i64.load
  )
  (func $~lib/number/U64#toString (param $0 i64) (param $1 i32) (result i32)
@@ -6768,25 +6768,25 @@
   if
    i32.const 3760
    i32.const 3200
-   i32.const 137
+   i32.const 135
    i32.const 7
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   local.get $1
   local.get $2
   i32.add
   i32.store
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   local.get $3
   local.get $2
   i32.sub
   i32.store offset=4
   local.get $0
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 1
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 2
   i32.const 4
   i32.mul
@@ -6800,12 +6800,12 @@
    local.get $4
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3200
-   i32.const 142
+   i32.const 140
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.load offset=8
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
@@ -7208,8 +7208,8 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store offset=8
-  global.get $~lib/process/iobuf
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 4
   i32.add
   call $~lib/bindings/wasi_snapshot_preview1/environ_sizes_get
@@ -7221,19 +7221,19 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3200
-   i32.const 87
+   i32.const 85
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.load
   local.set $1
   local.get $1
   i32.const 4
   i32.mul
   local.set $2
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.load offset=4
   local.set $3
   local.get $2
@@ -7256,7 +7256,7 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3200
-   i32.const 94
+   i32.const 92
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable
@@ -8045,8 +8045,8 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/process/iobuf
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.const 4
   i32.add
   call $~lib/bindings/wasi_snapshot_preview1/args_sizes_get
@@ -8058,19 +8058,19 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3200
-   i32.const 66
+   i32.const 64
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable
   end
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.load
   local.set $1
   local.get $1
   i32.const 4
   i32.mul
   local.set $2
-  global.get $~lib/process/iobuf
+  global.get $~lib/bindings/wasi/tempbuf
   i32.load offset=4
   local.set $3
   local.get $2
@@ -8093,7 +8093,7 @@
    local.get $0
    call $~lib/bindings/wasi_snapshot_preview1/errnoToString
    i32.const 3200
-   i32.const 73
+   i32.const 71
    i32.const 12
    call $~lib/wasi/index/abort
    unreachable

--- a/tests/compiler/wasi/seed.optimized.wat
+++ b/tests/compiler/wasi/seed.optimized.wat
@@ -13,12 +13,12 @@
  (global $~lib/math/random_state0_32 (mut i32) (i32.const 0))
  (global $~lib/math/random_state1_32 (mut i32) (i32.const 0))
  (memory $0 1)
- (data (i32.const 1036) "<")
- (data (i32.const 1048) "\01\00\00\00$\00\00\00U\00n\00p\00a\00i\00r\00e\00d\00 \00s\00u\00r\00r\00o\00g\00a\00t\00e")
- (data (i32.const 1100) ",")
- (data (i32.const 1112) "\01\00\00\00\1c\00\00\00~\00l\00i\00b\00/\00s\00t\00r\00i\00n\00g\00.\00t\00s")
- (data (i32.const 1148) ",")
- (data (i32.const 1160) "\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00m\00a\00t\00h\00.\00t\00s")
+ (data (i32.const 1052) "<")
+ (data (i32.const 1064) "\01\00\00\00$\00\00\00U\00n\00p\00a\00i\00r\00e\00d\00 \00s\00u\00r\00r\00o\00g\00a\00t\00e")
+ (data (i32.const 1116) ",")
+ (data (i32.const 1128) "\01\00\00\00\1c\00\00\00~\00l\00i\00b\00/\00s\00t\00r\00i\00n\00g\00.\00t\00s")
+ (data (i32.const 1164) ",")
+ (data (i32.const 1176) "\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00m\00a\00t\00h\00.\00t\00s")
  (export "test" (func $wasi/seed/test))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
@@ -43,15 +43,15 @@
   i32.const 19
   i32.const 544106784
   i32.store
-  i32.const 1168
+  i32.const 1184
   local.set $2
-  i32.const 1164
+  i32.const 1180
   i32.load
   i32.const 1
   i32.shr_u
   i32.const 1
   i32.shl
-  i32.const 1168
+  i32.const 1184
   i32.add
   local.set $5
   i32.const 23
@@ -297,23 +297,17 @@
   global.get $~lib/math/random_seeded
   i32.eqz
   if
-   i32.const 0
-   i64.load
-   local.set $1
    loop $do-loop|0
-    i32.const 0
+    i32.const 1024
     i32.const 8
     call $~lib/bindings/wasi_snapshot_preview1/random_get
     drop
-    i32.const 0
+    i32.const 1024
     i64.load
     local.tee $2
     i64.eqz
     br_if $do-loop|0
    end
-   i32.const 0
-   local.get $1
-   i64.store
    i32.const 1
    global.set $~lib/math/random_seeded
    local.get $2

--- a/tests/compiler/wasi/seed.untouched.wat
+++ b/tests/compiler/wasi/seed.untouched.wat
@@ -14,18 +14,20 @@
  (import "wasi_snapshot_preview1" "fd_write" (func $~lib/bindings/wasi_snapshot_preview1/fd_write (param i32 i32 i32 i32) (result i32)))
  (import "wasi_snapshot_preview1" "proc_exit" (func $~lib/bindings/wasi_snapshot_preview1/proc_exit (param i32)))
  (global $~lib/math/random_seeded (mut i32) (i32.const 0))
+ (global $~lib/bindings/wasi/tempbuf i32 (i32.const 16))
  (global $~lib/math/random_state0_64 (mut i64) (i64.const 0))
  (global $~lib/math/random_state1_64 (mut i64) (i64.const 0))
  (global $~lib/math/random_state0_32 (mut i32) (i32.const 0))
  (global $~lib/math/random_state1_32 (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
- (global $~lib/memory/__data_end i32 (i32.const 172))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 16556))
- (global $~lib/memory/__heap_base i32 (i32.const 16556))
+ (global $~lib/memory/__data_end i32 (i32.const 204))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 16588))
+ (global $~lib/memory/__heap_base i32 (i32.const 16588))
  (memory $0 1)
- (data (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00U\00n\00p\00a\00i\00r\00e\00d\00 \00s\00u\00r\00r\00o\00g\00a\00t\00e\00\00\00\00\00\00\00\00\00")
- (data (i32.const 76) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1c\00\00\00~\00l\00i\00b\00/\00s\00t\00r\00i\00n\00g\00.\00t\00s\00")
- (data (i32.const 124) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00m\00a\00t\00h\00.\00t\00s\00\00\00\00\00")
+ (data (i32.const 16) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 44) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00U\00n\00p\00a\00i\00r\00e\00d\00 \00s\00u\00r\00r\00o\00g\00a\00t\00e\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 108) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1c\00\00\00~\00l\00i\00b\00/\00s\00t\00r\00i\00n\00g\00.\00t\00s\00")
+ (data (i32.const 156) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00m\00a\00t\00h\00.\00t\00s\00\00\00\00\00")
  (table $0 1 funcref)
  (elem $0 (i32.const 1))
  (export "test" (func $wasi/seed/test))
@@ -33,28 +35,21 @@
  (export "_start" (func $~start))
  (func $~lib/wasi/index/seed (result f64)
   (local $0 i64)
-  (local $1 i64)
-  i32.const 0
-  i64.load
-  local.set $0
   loop $do-loop|0
-   i32.const 0
+   global.get $~lib/bindings/wasi/tempbuf
    i32.const 8
    call $~lib/bindings/wasi_snapshot_preview1/random_get
    drop
-   i32.const 0
+   global.get $~lib/bindings/wasi/tempbuf
    i64.load
-   local.set $1
-   local.get $1
+   local.set $0
+   local.get $0
    i64.const 0
    i64.ne
    i32.eqz
    br_if $do-loop|0
   end
-  i32.const 0
   local.get $0
-  i64.store
-  local.get $1
   f64.reinterpret_i64
  )
  (func $~lib/math/murmurHash3 (param $0 i64) (result i64)
@@ -304,8 +299,8 @@
         i32.const 2
         i32.eq
         if
-         i32.const 32
-         i32.const 96
+         i32.const 64
+         i32.const 128
          i32.const 739
          i32.const 49
          call $~lib/wasi/index/abort
@@ -660,7 +655,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 144
+   i32.const 176
    i32.const 1421
    i32.const 5
    call $~lib/wasi/index/abort


### PR DESCRIPTION
This fixes an issue with wasi/seed where if all memory is optimized away there can be an OOB access at offset 0 (unlikely in real programs), while moving the previous shared `iobuf` up to become a general shared buffer for these kinds of tasks.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
