### PR TITLE
Handle compiler crash where there is no stack trace

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -1478,7 +1478,7 @@ function crash(stage, e) {
     EOL,
     BAR, "Whoops, the AssemblyScript compiler has crashed during ", stage, " :-(", EOL,
     BAR, EOL,
-    (e.stack != null
+    (typeof e.stack === "string"
       ? [
           BAR, "Here is a stack trace that may or may not be useful:", EOL,
           BAR, EOL,

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -1488,7 +1488,9 @@ function crash(stage, e) {
           BAR, "run again, which should then show the actual code location in the sources.", EOL,
         ]
       : [
-          BAR, "There is no stack trace. Perhaps a Binaryen exception above / in console?", EOL
+          BAR, "There is no stack trace. Perhaps a Binaryen exception above / in console?", EOL,
+          BAR, EOL,
+          BAR, "> " + e.stack, EOL
         ]
     ).join(""),
     BAR, EOL,

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -1488,7 +1488,7 @@ function crash(stage, e) {
           BAR, "run again, which should then show the actual code location in the sources.", EOL,
         ]
       : [
-          BAR, "Sadly, there is no stack trace. Perhaps a Binaryen exception above?", EOL
+          BAR, "There is no stack trace. Perhaps a Binaryen exception above / in console?", EOL
         ]
     ).join(""),
     BAR, EOL,

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -1478,12 +1478,19 @@ function crash(stage, e) {
     EOL,
     BAR, "Whoops, the AssemblyScript compiler has crashed during ", stage, " :-(", EOL,
     BAR, EOL,
-    BAR, "Here is a stack trace that may or may not be useful:", EOL,
-    BAR, EOL,
-    e.stack.replace(/^/mg, BAR), EOL,
-    BAR, EOL,
-    BAR, "If it refers to the dist files, try to 'npm install source-map-support' and", EOL,
-    BAR, "run again, which should then show the actual code location in the sources.", EOL,
+    (e.stack != null
+      ? [
+          BAR, "Here is a stack trace that may or may not be useful:", EOL,
+          BAR, EOL,
+          e.stack.replace(/^/mg, BAR), EOL,
+          BAR, EOL,
+          BAR, "If it refers to the dist files, try to 'npm install source-map-support' and", EOL,
+          BAR, "run again, which should then show the actual code location in the sources.", EOL,
+        ]
+      : [
+          BAR, "Sadly, there is no stack trace. Perhaps a Binaryen exception above?", EOL
+        ]
+    ).join(""),
     BAR, EOL,
     BAR, "If you see where the error is, feel free to send us a pull request. If not,", EOL,
     BAR, "please let us know: https://github.com/AssemblyScript/assemblyscript/issues", EOL,

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -1480,7 +1480,7 @@ function crash(stage, e) {
     BAR, EOL,
     (typeof e.stack === "string"
       ? [
-          BAR, "Here is a stack trace that may or may not be useful:", EOL,
+          BAR, "Here is the stack trace hinting at the problem, perhaps it's useful?", EOL,
           BAR, EOL,
           e.stack.replace(/^/mg, BAR), EOL,
           BAR, EOL,


### PR DESCRIPTION
Related to #1731 where a Binaryen exception suppresses the stack trace, then crashing the crash handler. Now prints a half-way meaningful message hinting at what to look for.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
