### PR TITLE
Properly skip duplicate class id exports

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -951,7 +951,7 @@ export class Compiler extends DiagnosticEmitter {
 
           let exportName = prefix + name;
           if (!module.hasExport(exportName)) {
-            module.addGlobalExport(internalName, prefix + name);
+            module.addGlobalExport(internalName, exportName);
           }
         }
         break;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -948,7 +948,11 @@ export class Compiler extends DiagnosticEmitter {
             module.addGlobal(internalName, TypeRef.I32, false, module.i32(classInstance.id));
             this.doneModuleExports.add(element);
           }
-          module.addGlobalExport(internalName, prefix + name);
+
+          let exportName = prefix + name;
+          if (!module.hasExport(exportName)) {
+            module.addGlobalExport(internalName, prefix + name);
+          }
         }
         break;
       }


### PR DESCRIPTION
Fixes #1731 by making sure that class id exports aren't added twice, which can happen when an imported file is also a yet unprocessed entry file.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
