### PR TITLE
Defuse assertion when mixing managed and unmanaged classes

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -9614,7 +9614,10 @@ function ensureVisitMembersOf(compiler: Compiler, instance: Class): void {
   );
 
   // And make sure the base visitor function exists
-  if (base) ensureVisitMembersOf(compiler, base);
+  if (base && base.type.isManaged) {
+    // errored earlier if not managed
+    ensureVisitMembersOf(compiler, base);
+  }
 }
 
 /** Compiles the `__visit_members` function. */

--- a/tests/compiler/unmanaged-errors.json
+++ b/tests/compiler/unmanaged-errors.json
@@ -1,0 +1,8 @@
+{
+  "asc_flags": [
+  ],
+  "stderr": [
+    "AS207: Unmanaged classes cannot extend managed classes", "Foo extends Base",
+    "EOF"
+  ]
+}

--- a/tests/compiler/unmanaged-errors.json
+++ b/tests/compiler/unmanaged-errors.json
@@ -2,7 +2,8 @@
   "asc_flags": [
   ],
   "stderr": [
-    "AS207: Unmanaged classes cannot extend managed classes", "Foo extends Base",
+    "AS207: Unmanaged classes cannot extend managed classes and vice-versa.", "UnmanagedFoo extends ManagedBase",
+    "AS207: Unmanaged classes cannot extend managed classes and vice-versa.", "ManagedFoo extends UnmanagedBase",
     "EOF"
   ]
 }

--- a/tests/compiler/unmanaged-errors.ts
+++ b/tests/compiler/unmanaged-errors.ts
@@ -1,0 +1,9 @@
+// see: https://github.com/AssemblyScript/assemblyscript/issues/2067
+
+@unmanaged export class Base {}
+export class Baz {}
+export class Foo extends Base {
+  constructor(public baz: Baz) { super(); }
+}
+
+ERROR("EOF");

--- a/tests/compiler/unmanaged-errors.ts
+++ b/tests/compiler/unmanaged-errors.ts
@@ -1,9 +1,12 @@
+export class ManagedBase {}
+@unmanaged export class UnmanagedFoo extends ManagedBase {} // AS207
+
 // see: https://github.com/AssemblyScript/assemblyscript/issues/2067
 
-@unmanaged export class Base {}
-export class Baz {}
-export class Foo extends Base {
-  constructor(public baz: Baz) { super(); }
+@unmanaged export class UnmanagedBase {}
+export class ManagedBaz {}
+export class ManagedFoo extends UnmanagedBase { // AS207
+  constructor(public baz: ManagedBaz) { super(); }
 }
 
 ERROR("EOF");


### PR DESCRIPTION
Fixes #2067 where a managed / unmanaged mismatch is diagnosed but before it is reported triggers an assertion in runtime visitor logic.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
