### PR TITLE
Remove automatic type detection when emitting a select

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1554,7 +1554,8 @@ function builtin_max(ctx: BuiltinContext): ExpressionRef {
         module.binary(op,
           module.local_get(temp1.index, typeRef),
           module.local_get(temp2.index, typeRef)
-        )
+        ),
+        typeRef
       );
       flow.freeTempLocal(temp2);
       flow.freeTempLocal(temp1);
@@ -1633,7 +1634,8 @@ function builtin_min(ctx: BuiltinContext): ExpressionRef {
         module.binary(op,
           module.local_get(temp1.index, typeRef),
           module.local_get(temp2.index, typeRef)
-        )
+        ),
+        typeRef
       );
       flow.freeTempLocal(temp2);
       flow.freeTempLocal(temp1);
@@ -2770,7 +2772,7 @@ function builtin_select(ctx: BuiltinContext): ExpressionRef {
     operands[2]
   );
   compiler.currentType = type;
-  return module.select(arg0, arg1, arg2);
+  return module.select(arg0, arg1, arg2, type.toRef());
 }
 builtins.set(BuiltinNames.select, builtin_select);
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5245,7 +5245,8 @@ export class Compiler extends DiagnosticEmitter {
         return module.select(
           module.i32(1),
           module.binary(BinaryOp.EqI32, rightExpr, module.i32(0)),
-          leftExpr
+          leftExpr,
+          TypeRef.I32
         );
       }
       case TypeKind.I8:

--- a/src/module.ts
+++ b/src/module.ts
@@ -1479,7 +1479,7 @@ export class Module {
   ): ExpressionRef {
     if (type == TypeRef.Auto) {
       type = binaryen._BinaryenExpressionGetType(ifTrue);
-      assert(type == binaryen._BinaryenExpressionGetType(ifFalse) || type == TypeRef.Unreachable);
+      if (type == TypeRef.Unreachable) type = binaryen._BinaryenExpressionGetType(ifFalse);
     }
     return binaryen._BinaryenSelect(this.ref, condition, ifTrue, ifFalse, type);
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1479,7 +1479,7 @@ export class Module {
   ): ExpressionRef {
     if (type == TypeRef.Auto) {
       type = binaryen._BinaryenExpressionGetType(ifTrue);
-      assert(type == binaryen._BinaryenExpressionGetType(ifFalse));
+      assert(type == binaryen._BinaryenExpressionGetType(ifFalse) || type == TypeRef.Unreachable);
     }
     return binaryen._BinaryenSelect(this.ref, condition, ifTrue, ifFalse, type);
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1475,12 +1475,8 @@ export class Module {
     ifTrue: ExpressionRef,
     ifFalse: ExpressionRef,
     condition: ExpressionRef,
-    type: TypeRef = TypeRef.Auto
+    type: TypeRef
   ): ExpressionRef {
-    if (type == TypeRef.Auto) {
-      type = binaryen._BinaryenExpressionGetType(ifTrue);
-      if (type == TypeRef.Unreachable) type = binaryen._BinaryenExpressionGetType(ifFalse);
-    }
     return binaryen._BinaryenSelect(this.ref, condition, ifTrue, ifFalse, type);
   }
 

--- a/tests/compiler/closure.json
+++ b/tests/compiler/closure.json
@@ -8,8 +8,6 @@
     "$local0; // closure 2",
     "AS100: Not implemented: Closures",
     "$local0; // closure 3",
-    "AS100: Not implemented: Closures",
-    "select($local0, $arg0, $arg1); // closure 4",
     "EOF"
   ]
 }

--- a/tests/compiler/closure.json
+++ b/tests/compiler/closure.json
@@ -9,7 +9,7 @@
     "AS100: Not implemented: Closures",
     "$local0; // closure 3",
     "AS100: Not implemented: Closures",
-    "max($local0, $arg0); // closure 4",
+    "select($local0, $arg0, $arg1); // closure 4",
     "EOF"
   ]
 }

--- a/tests/compiler/closure.json
+++ b/tests/compiler/closure.json
@@ -8,6 +8,8 @@
     "$local0; // closure 2",
     "AS100: Not implemented: Closures",
     "$local0; // closure 3",
+    "AS100: Not implemented: Closures",
+    "max($local0, $arg0); // closure 4",
     "EOF"
   ]
 }

--- a/tests/compiler/closure.ts
+++ b/tests/compiler/closure.ts
@@ -15,10 +15,20 @@ testVar();
 
 function testLet(): (value: i32) => i32 {
   let $local0 = 0;
-  return function inner(value: i32) {
+  return function inner(value: i32): i32 {
     return $local0; // closure 3
   };
 }
 testLet();
+
+// see: https://github.com/AssemblyScript/assemblyscript/issues/2073
+
+function testSelect(): (value: i32) => i32 {
+  let $local0 = 0;
+  return function inner($arg0: i32): i32 {
+    return max($local0, $arg0); // closure 4
+  };
+}
+testSelect();
 
 ERROR("EOF");

--- a/tests/compiler/closure.ts
+++ b/tests/compiler/closure.ts
@@ -21,14 +21,4 @@ function testLet(): (value: i32) => i32 {
 }
 testLet();
 
-// see: https://github.com/AssemblyScript/assemblyscript/issues/2073
-
-function testSelect(): (value: i32, cond: bool) => i32 {
-  let $local0 = 0;
-  return function inner($arg0: i32, $arg1: bool): i32 {
-    return select($local0, $arg0, $arg1); // closure 4
-  };
-}
-testSelect();
-
 ERROR("EOF");

--- a/tests/compiler/closure.ts
+++ b/tests/compiler/closure.ts
@@ -23,10 +23,10 @@ testLet();
 
 // see: https://github.com/AssemblyScript/assemblyscript/issues/2073
 
-function testSelect(): (value: i32) => i32 {
+function testSelect(): (value: i32, cond: bool) => i32 {
   let $local0 = 0;
-  return function inner($arg0: i32): i32 {
-    return max($local0, $arg0); // closure 4
+  return function inner($arg0: i32, $arg1: bool): i32 {
+    return select($local0, $arg0, $arg1); // closure 4
   };
 }
 testSelect();


### PR DESCRIPTION
Fixes #2073 by removing error-prone automatic type detection when emitting a select expression. Was a legacy option anyway, from a time where `select`s didn't specify a type.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
