### PR TITLE
Refactor cloneExpression to reuse copyExpression

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4646,7 +4646,7 @@ export class Compiler extends DiagnosticEmitter {
           this.currentFlow = flow;
 
           // simplify if copying left is trivial
-          if (expr = module.tryCopySimpleExpression(leftExpr)) {
+          if (expr = module.tryCopyTrivialExpression(leftExpr)) {
             expr = module.if(
               this.makeIsTrueish(leftExpr, this.currentType, left),
               rightExpr,
@@ -4710,7 +4710,7 @@ export class Compiler extends DiagnosticEmitter {
           this.currentFlow = flow;
 
           // simplify if copying left is trivial
-          if (expr = module.tryCopySimpleExpression(leftExpr)) {
+          if (expr = module.tryCopyTrivialExpression(leftExpr)) {
             expr = module.if(
               this.makeIsTrueish(leftExpr, leftType, left),
               expr,

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4645,8 +4645,8 @@ export class Compiler extends DiagnosticEmitter {
           rightFlow.freeScopedLocals();
           this.currentFlow = flow;
 
-          // simplify if cloning left without side effects is possible
-          if (expr = module.cloneExpression(leftExpr, true, 0)) {
+          // simplify if copying left is trivial
+          if (expr = module.tryCopySimpleExpression(leftExpr)) {
             expr = module.if(
               this.makeIsTrueish(leftExpr, this.currentType, left),
               rightExpr,
@@ -4709,8 +4709,8 @@ export class Compiler extends DiagnosticEmitter {
           rightFlow.freeScopedLocals();
           this.currentFlow = flow;
 
-          // simplify if cloning left without side effects is possible
-          if (expr = module.cloneExpression(leftExpr, true, 0)) {
+          // simplify if copying left is trivial
+          if (expr = module.tryCopySimpleExpression(leftExpr)) {
             expr = module.if(
               this.makeIsTrueish(leftExpr, leftType, left),
               expr,

--- a/src/module.ts
+++ b/src/module.ts
@@ -2496,6 +2496,7 @@ export class Module {
   }
 
   copyExpression(expr: ExpressionRef): ExpressionRef {
+    // TODO: Copy debug location as well (needs Binaryen support)
     return binaryen._BinaryenExpressionCopy(expr, this.ref);
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -2484,7 +2484,8 @@ export class Module {
     return Relooper.create(this);
   }
 
-  tryCopySimpleExpression(expr: ExpressionRef): ExpressionRef {
+  /** Makes a copy of a trivial expression (doesn't contain subexpressions). Returns `0` if non-trivial. */
+  tryCopyTrivialExpression(expr: ExpressionRef): ExpressionRef {
     switch (binaryen._BinaryenExpressionGetId(expr)) {
       case ExpressionId.LocalGet:
       case ExpressionId.GlobalGet:
@@ -2495,6 +2496,7 @@ export class Module {
     return 0;
   }
 
+  /** Makes a copy of any expression including all subexpressions. */
   copyExpression(expr: ExpressionRef): ExpressionRef {
     // TODO: Copy debug location as well (needs Binaryen support)
     return binaryen._BinaryenExpressionCopy(expr, this.ref);

--- a/src/module.ts
+++ b/src/module.ts
@@ -2484,110 +2484,13 @@ export class Module {
     return Relooper.create(this);
   }
 
-  cloneExpression(
-    expr: ExpressionRef,
-    noSideEffects: bool = false,
-    maxDepth: i32 = i32.MAX_VALUE
-  ): ExpressionRef { // currently supports side effect free expressions only
-    if (maxDepth < 0) return 0;
-    maxDepth -= 1;
-
-    var nested1: ExpressionRef,
-        nested2: ExpressionRef;
-
+  tryCopySimpleExpression(expr: ExpressionRef): ExpressionRef {
     switch (binaryen._BinaryenExpressionGetId(expr)) {
-      case ExpressionId.Const: {
-        switch (<u32>binaryen._BinaryenExpressionGetType(expr)) {
-          case <u32>TypeRef.I32: {
-            return this.i32(binaryen._BinaryenConstGetValueI32(expr));
-          }
-          case <u32>TypeRef.I64: {
-            return this.i64(
-              binaryen._BinaryenConstGetValueI64Low(expr),
-              binaryen._BinaryenConstGetValueI64High(expr)
-            );
-          }
-          case <u32>TypeRef.F32: {
-            return this.f32(binaryen._BinaryenConstGetValueF32(expr));
-          }
-          case <u32>TypeRef.F64: {
-            return this.f64(binaryen._BinaryenConstGetValueF64(expr));
-          }
-          case <u32>TypeRef.V128: {
-            // TODO
-            return 0;
-          }
-          // Not possible to clone an externref as it is opaque
-          case <u32>TypeRef.Externref: {
-            return 0;
-          }
-          default: {
-            throw new Error("concrete type expected");
-          }
-        }
-      }
-      case ExpressionId.LocalGet: {
-        return binaryen._BinaryenLocalGet(this.ref,
-          binaryen._BinaryenLocalGetGetIndex(expr),
-          binaryen._BinaryenExpressionGetType(expr)
-        );
-      }
-      case ExpressionId.GlobalGet: {
-        let globalName = binaryen._BinaryenGlobalGetGetName(expr);
-        if (!globalName) break;
-        return binaryen._BinaryenGlobalGet(
-          this.ref, globalName, binaryen._BinaryenExpressionGetType(expr)
-        );
-      }
-      case ExpressionId.Load: {
-        if (!(nested1 = this.cloneExpression(
-          binaryen._BinaryenLoadGetPtr(expr), noSideEffects, maxDepth)
-        )) {
-          break;
-        }
-        return (
-          binaryen._BinaryenLoadIsAtomic(expr)
-            ? binaryen._BinaryenAtomicLoad(this.ref,
-                binaryen._BinaryenLoadGetBytes(expr),
-                binaryen._BinaryenLoadGetOffset(expr),
-                binaryen._BinaryenExpressionGetType(expr),
-                nested1
-              )
-            : binaryen._BinaryenLoad(this.ref,
-                binaryen._BinaryenLoadGetBytes(expr),
-                binaryen._BinaryenLoadIsSigned(expr),
-                binaryen._BinaryenLoadGetOffset(expr),
-                binaryen._BinaryenLoadGetAlign(expr),
-                binaryen._BinaryenExpressionGetType(expr),
-                nested1
-              )
-        );
-      }
-      case ExpressionId.Unary: {
-        if (!(nested1 = this.cloneExpression(
-          binaryen._BinaryenUnaryGetValue(expr), noSideEffects, maxDepth)
-        )) {
-          break;
-        }
-        return binaryen._BinaryenUnary(
-          this.ref, binaryen._BinaryenUnaryGetOp(expr), nested1
-        );
-      }
-      case ExpressionId.Binary: {
-        if (!(nested1 = this.cloneExpression(
-          binaryen._BinaryenBinaryGetLeft(expr), noSideEffects, maxDepth)
-        )) {
-          break;
-        }
-        if (!(nested2 = this.cloneExpression(
-          binaryen._BinaryenBinaryGetRight(expr), noSideEffects, maxDepth)
-        )) {
-          break;
-        }
-        return binaryen._BinaryenBinary(
-          this.ref, binaryen._BinaryenBinaryGetOp(expr), nested1, nested2
-        );
-      }
+      case ExpressionId.LocalGet:
+      case ExpressionId.GlobalGet:
+      case ExpressionId.Const:
+      case ExpressionId.Unreachable:
+      case ExpressionId.RefNull: return this.copyExpression(expr);
     }
     return 0;
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -2490,8 +2490,12 @@ export class Module {
       case ExpressionId.LocalGet:
       case ExpressionId.GlobalGet:
       case ExpressionId.Const:
+      case ExpressionId.MemorySize:
+      case ExpressionId.Nop:
       case ExpressionId.Unreachable:
-      case ExpressionId.RefNull: return this.copyExpression(expr);
+      case ExpressionId.DataDrop:
+      case ExpressionId.RefNull:
+      case ExpressionId.RttCanon: return this.copyExpression(expr);
     }
     return 0;
   }


### PR DESCRIPTION
A while ago Binaryen introduced a `copyExpression` helper that we can reuse. The previous `cloneExpression` now is merely a special case of it, `tryCopySimpleExpression`.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
