### PR TITLE
NEW token should not participate in non-starting precedence

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4395,7 +4395,6 @@ function determinePrecedence(kind: Token): Precedence {
     case Token.PLUS_PLUS:
     case Token.MINUS_MINUS: return Precedence.UNARY_POSTFIX;
     case Token.DOT:
-    case Token.NEW:
     case Token.OPENBRACKET:
     case Token.EXCLAMATION: return Precedence.MEMBERACCESS;
   }


### PR DESCRIPTION
Fixes #2082 where it was discovered that the `new` token is incorrectly handled as a non-starting token.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
