### PR TITLE
Fix compiler crash on declarations of type 'void'

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3052,6 +3052,13 @@ export class Compiler extends DiagnosticEmitter {
           uniqueMap(flow.contextualTypeArguments)
         );
         if (!type) continue;
+        if (type.kind == TypeKind.VOID) {
+          this.error(
+            DiagnosticCode.Variable_declarations_of_type_void_are_forbidden,
+            typeNode.range
+          );
+          continue;
+        }
         this.checkTypeSupported(type, typeNode);
 
         if (initializerNode) {

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -49,6 +49,7 @@ export enum DiagnosticCode {
   A_class_with_a_constructor_explicitly_returning_something_else_than_this_must_be_final = 231,
   Property_0_is_always_assigned_before_being_used = 233,
   Expression_refers_to_a_static_element_that_does_not_compile_to_a_value_at_runtime = 234,
+  Variable_declarations_of_type_void_are_forbidden = 235,
   Importing_the_table_disables_some_indirect_call_optimizations = 901,
   Exporting_the_table_disables_some_indirect_call_optimizations = 902,
   Expression_compiles_to_a_dynamic_check_at_runtime = 903,
@@ -233,6 +234,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 231: return "A class with a constructor explicitly returning something else than 'this' must be '@final'.";
     case 233: return "Property '{0}' is always assigned before being used.";
     case 234: return "Expression refers to a static element that does not compile to a value at runtime.";
+    case 235: return "Variable declarations of type 'void' are forbidden.";
     case 901: return "Importing the table disables some indirect call optimizations.";
     case 902: return "Exporting the table disables some indirect call optimizations.";
     case 903: return "Expression compiles to a dynamic check at runtime.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -44,6 +44,7 @@
   "A class with a constructor explicitly returning something else than 'this' must be '@final'.": 231,
   "Property '{0}' is always assigned before being used.": 233,
   "Expression refers to a static element that does not compile to a value at runtime.": 234,
+  "Variable declarations of type 'void' are forbidden.": 235,
 
   "Importing the table disables some indirect call optimizations.": 901,
   "Exporting the table disables some indirect call optimizations.": 902,

--- a/tests/compiler/void-assign-error.json
+++ b/tests/compiler/void-assign-error.json
@@ -1,0 +1,9 @@
+{
+  "asc_flags": [
+   ],
+  "stderr": [
+    "AS235: Variable declarations of type 'void' are forbidden.",
+    "AS235: Variable declarations of type 'void' are forbidden.",
+    "EOF"
+  ]
+}

--- a/tests/compiler/void-assign-error.ts
+++ b/tests/compiler/void-assign-error.ts
@@ -1,0 +1,7 @@
+function foo(): void {
+  let bar: void;
+  let baz: void = 1;
+}
+
+foo();
+ERROR("EOF");


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file

## The issue
Variable declarations of the form
```ts
let foo: void;
let foo: void = 1;
```
both currently crash the compiler. This PR introduces an error that occurs when users attempt to declare variables with a void type.

### More on this
```ts
let foo: void; // TS actually allows this declaration
let bar = void 0; // AS complains here that the `void` keyword doesn't actually resolve to a runtime type
```
In conclusion, I think disallowing declarations of type `void` altogether is the way to go, since `void` expressions are not assignable even in inferred contexts.
