### PR TITLE
WIP loader uses FinalizationRegistry

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -43,6 +43,7 @@ under the licensing terms detailed in LICENSE:
 * Joe Pea <trusktr@gmail.com>
 * Felipe Gasper <FGasper@users.noreply.github.com>
 * Congcong Cai <77575210+HerrCai0907@users.noreply.github.com>
+* Sebastian Krüger <2pi_r2@gmx.de>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -98,16 +98,57 @@ function postInstantiate(extendedExports, instance) {
   const memory = exports.memory;
   const table = exports.table;
   const __new = exports.__new || F_NO_EXPORT_RUNTIME;
-  const __pin = exports.__pin || F_NO_EXPORT_RUNTIME;
-  const __unpin = exports.__unpin || F_NO_EXPORT_RUNTIME;
+  const __pin = (ptr) => {
+    if(gcMap.has(ptr)) {
+      gcMap.set(ptr, gcMap.get(ptr) + 1)
+    } else {
+      (exports.__pin || F_NO_EXPORT_RUNTIME)(ptr)
+      gcMap.set(ptr, 1)
+    }
+  };
+  const __unpin = (ptr) => {
+    if(gcMap.has(ptr)) {
+      const val = gcMap.get(ptr)
+      if(val === 1) {
+        (exports.__unpin || F_NO_EXPORT_RUNTIME)(ptr)
+      } else {
+        gcMap.set(ptr, val - 1)
+      }
+    }
+    // TODO: throw? unpin something that is not pined?
+  };
   const __collect = exports.__collect || F_NO_EXPORT_RUNTIME;
   const __rtti_base = exports.__rtti_base;
   const getRttiCount = __rtti_base ? arr => arr[__rtti_base >>> 2] : F_NO_EXPORT_RUNTIME;
+
+
+  const gcMap = new Map()
+  const valuePtr = new WeakMap()
+
+  const __registry = FinalizationRegistry ? new FinalizationRegistry(ptr => __unpin(ptr)) : {register() {}, unregister() {}};
+
+  
+  const __registryPin = (value, ptr) => {
+    __pin(ptr)
+    valuePtr.set(value, ptr)
+    __registry.register(value, ptr, value)
+  }
+
+  const __registryUnpin = (value) => {
+    if(valuePtr.has(value)) {
+      __unpin(valuePtr.get(value))
+      __registry.unregister(value)
+    }
+  }
 
   extendedExports.__new = __new;
   extendedExports.__pin = __pin;
   extendedExports.__unpin = __unpin;
   extendedExports.__collect = __collect;
+  extendedExports.__registry = __registry;
+  extendedExports.__registryPin = __registryPin;
+  extendedExports.__registryUnpin = __registryUnpin;
+
 
   /** Gets the runtime type info for the given id. */
   function getRttInfo(id) {
@@ -244,13 +285,15 @@ function postInstantiate(extendedExports, instance) {
     const length = info & ARRAY
       ? U32[arr + ARRAY_LENGTH_OFFSET >>> 2]
       : U32[buf + SIZE_OFFSET >>> 2] >>> align;
-    return getView(align, info & VAL_SIGNED, info & VAL_FLOAT).subarray(buf >>>= align, buf + length);
+    const view = getView(align, info & VAL_SIGNED, info & VAL_FLOAT).subarray(buf >>>= align, buf + length);
+    __registryPin(view, arr);
+    return view;
   }
 
   extendedExports.__getArrayView = __getArrayView;
 
   /** Copies an array's values from the module's memory. Infers the array type from RTTI. */
-  function __getArray(arr) {
+  function __getArray(arr) { 
     const input = __getArrayView(arr);
     const len = input.length;
     const out = new Array(len);
@@ -273,7 +316,9 @@ function postInstantiate(extendedExports, instance) {
   function __getFunction(ptr) {
     if (!table) throw Error(E_NO_EXPORT_TABLE);
     const index = new Uint32Array(memory.buffer)[ptr >>> 2];
-    return table.get(index);
+    const fn = table.get(index);
+    __registryPin(fn, ptr)
+    return fn;
   }
 
   extendedExports.__getFunction = __getFunction;
@@ -288,7 +333,9 @@ function postInstantiate(extendedExports, instance) {
     const buffer = memory.buffer;
     const U32 = new Uint32Array(buffer);
     const bufPtr = U32[ptr + ARRAYBUFFERVIEW_DATASTART_OFFSET >>> 2];
-    return new Type(buffer, bufPtr, U32[bufPtr + SIZE_OFFSET >>> 2] >>> alignLog2);
+    const view = new Type(buffer, bufPtr, U32[bufPtr + SIZE_OFFSET >>> 2] >>> alignLog2);
+    __registryPin(view, ptr);
+    return view;
   }
 
   /** Attach a set of get TypedArray and View functions to the exports. */


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

Draft PR.

Loader uses FinalizationRegistry so you don't need to __unpin anything.
I had to wrap __pin and __unpin to work properly.

TODO:
- [ ] typedef
- [ ] classes

Note I export 2 new functions and the FinalizationRegistry this is so that other libs (like as-bind) can build ontop of this. 

I currently work on the implementation for as-bind and @trusktr said I should PR to the loader :D - so here is the PR.


- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
