### PR TITLE
fix: transform cannot find module

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -43,6 +43,7 @@ under the licensing terms detailed in LICENSE:
 * Joe Pea <trusktr@gmail.com>
 * Felipe Gasper <FGasper@users.noreply.github.com>
 * Congcong Cai <77575210+HerrCai0907@users.noreply.github.com>
+* mooooooi <emwings@outlook.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -237,17 +237,27 @@ function merge(config, currentOptions, parentOptions, parentBaseDir) {
 
 exports.merge = merge;
 
+function normalizePath(p) {
+  const parsed = path.parse(p);
+  if (!parsed.root) {
+    parsed.root = "./";
+  }
+  return path.format(parsed);
+}
+
+exports.normalizePath = normalizePath;
+
 const dynrequire = typeof __webpack_require__ === "function"
   ? __non_webpack_require__
   : require;
 
 /** Resolves a single possibly relative path. Keeps absolute paths, otherwise prepends baseDir. */
 function resolvePath(p, baseDir, useNodeResolution = false) {
-  if (path.isAbsolute(p) || (baseDir == "." && p.startsWith("./"))) return p;
+  if (path.isAbsolute(p)) return p;
   if (useNodeResolution && !p.startsWith(".")) {
     return dynrequire.resolve(p, { paths: [ baseDir ] });
   }
-  return path.resolve(baseDir, p);
+  return normalizePath(path.join(baseDir, p));
 }
 
 exports.resolvePath = resolvePath;

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -247,7 +247,7 @@ function resolvePath(p, baseDir, useNodeResolution = false) {
   if (useNodeResolution && !p.startsWith(".")) {
     return dynrequire.resolve(p, { paths: [ baseDir ] });
   }
-  return path.join(baseDir, p);
+  return path.resolve(baseDir, p);
 }
 
 exports.resolvePath = resolvePath;

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -243,7 +243,7 @@ const dynrequire = typeof __webpack_require__ === "function"
 
 /** Resolves a single possibly relative path. Keeps absolute paths, otherwise prepends baseDir. */
 function resolvePath(p, baseDir, useNodeResolution = false) {
-  if (path.isAbsolute(p)) return p;
+  if (path.isAbsolute(p) || (baseDir == "." && p.startsWith("./"))) return p;
   if (useNodeResolution && !p.startsWith(".")) {
     return dynrequire.resolve(p, { paths: [ baseDir ] });
   }


### PR DESCRIPTION
Environment:
assemblyscript: 0.19.17
platform: macos
cmd: yarn asbuild
asconfig: 
```js
{
    // ...someting not important
    options: {
        "transform": "./transform.ts"
    }
}
```

The segment of options.js
```javascript
function resolvePath(p, baseDir, useNodeResolution = false) {
  if (path.isAbsolute(p)) return p;
  if (useNodeResolution && !p.startsWith(".")) {
    return dynrequire.resolve(p, { paths: [ baseDir ] });
  }
  return path.join(baseDir, p);
}
```
The default value of `baseDir` is `.`. When p is relative path, then ...
```typescript
path.join(".", "./transform.ts"); // The result is 'transform.ts'. It lost the information about relative
```

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file