### PR TITLE
fix: compileSwitchStatement will hide inner conditional flags

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2970,7 +2970,7 @@ export class Compiler extends DiagnosticEmitter {
         commonCategorical &= innerFlow.flags;
       }
 
-      commonConditional |= innerFlow.getConditionFlags();
+      commonConditional |= innerFlow.deriveConditionalFlags();
 
       // Switch back to the parent flow
       innerFlow.unset(

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2969,7 +2969,8 @@ export class Compiler extends DiagnosticEmitter {
       if (terminates || isLast || innerFlow.isAny(FlowFlags.BREAKS | FlowFlags.CONDITIONALLY_BREAKS)) {
         commonCategorical &= innerFlow.flags;
       }
-      commonConditional |= innerFlow.flags & FlowFlags.ANY_CONDITIONAL;
+
+      commonConditional |= innerFlow.getConditionFlags();
 
       // Switch back to the parent flow
       innerFlow.unset(

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -266,7 +266,7 @@ export class Flow {
   /** Unsets the specified flag or flags. */
   unset(flag: FlowFlags): void { this.flags &= ~flag; }
 
-  getConditionFlags(): FlowFlags {
+  deriveConditionalFlags(): FlowFlags {
     let condiFlags = this.flags & FlowFlags.ANY_CONDITIONAL;
     if (this.is(FlowFlags.RETURNS)) {
       condiFlags |= FlowFlags.CONDITIONALLY_RETURNS;

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -266,6 +266,26 @@ export class Flow {
   /** Unsets the specified flag or flags. */
   unset(flag: FlowFlags): void { this.flags &= ~flag; }
 
+  getConditionFlags(): FlowFlags {
+    let condiFlags = this.flags & FlowFlags.ANY_CONDITIONAL;
+    if (this.is(FlowFlags.RETURNS)) {
+      condiFlags |= FlowFlags.CONDITIONALLY_RETURNS;
+    }
+    if (this.is(FlowFlags.THROWS)) {
+      condiFlags |= FlowFlags.CONDITIONALLY_THROWS;
+    }
+    if (this.is(FlowFlags.BREAKS)) {
+      condiFlags |= FlowFlags.CONDITIONALLY_BREAKS;
+    }
+    if (this.is(FlowFlags.CONTINUES)) {
+      condiFlags |= FlowFlags.CONDITIONALLY_CONTINUES;
+    }
+    if (this.is(FlowFlags.ACCESSES_THIS)) {
+      condiFlags |= FlowFlags.CONDITIONALLY_ACCESSES_THIS;
+    }
+    return condiFlags;
+  }
+
   /** Forks this flow to a child flow. */
   fork(resetBreakContext: bool = false): Flow {
     var branch = new Flow(this.parentFunction);


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈fix issue: do-while + switch + continue cause compiler crash #2101
⯈when `compileSwitchStatement`, `commonConditional` don't consider the situations that `CONTINUES` should change to `CONDITIONALLY_CONTINUES` in `FlowFlags`.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
