### PR TITLE
Simplify stringLengthUTF8 more

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3107,7 +3107,6 @@ function stringLengthUTF8(str: string): usize {
     } else if (u <= 0x7FF) {
       len += 2;
     } else if (u >= 0xD800 && u <= 0xDFFF && i + 1 < k) {
-      u = 0x10000 + ((u & 0x3FF) << 10) | (str.charCodeAt(++i) & 0x3FF);
       len += 4;
     } else {
       len += 3;

--- a/src/module.ts
+++ b/src/module.ts
@@ -3107,6 +3107,7 @@ function stringLengthUTF8(str: string): usize {
     } else if (u <= 0x7FF) {
       len += 2;
     } else if (u >= 0xD800 && u <= 0xDFFF && i + 1 < k) {
+      i++;
       len += 4;
     } else {
       len += 3;


### PR DESCRIPTION
`u = 0x10000 + ((u & 0x3FF) << 10) | (str.charCodeAt(++i) & 0x3FF);`
don't need anymore

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
