### PR TITLE
SDK: Update long.js CDN path

### DIFF
--- a/lib/sdk/index.js
+++ b/lib/sdk/index.js
@@ -6,7 +6,7 @@ const ASSEMBLYSCRIPT_VERSION = "latest";
 if (typeof define === "function" && define.amd) {
   const paths = {
     "binaryen": "https://cdn.jsdelivr.net/npm/binaryen@" + BINARYEN_VERSION + "/index",
-    "long": "https://cdn.jsdelivr.net/npm/long@" + LONG_VERSION + "/dist/long",
+    "long": "https://cdn.jsdelivr.net/npm/long@" + LONG_VERSION + "/umd/index",
     "assemblyscript": "https://cdn.jsdelivr.net/npm/assemblyscript@" + ASSEMBLYSCRIPT_VERSION + "/dist/assemblyscript",
     "assemblyscript/cli/asc": "https://cdn.jsdelivr.net/npm/assemblyscript@" + ASSEMBLYSCRIPT_VERSION + "/dist/asc",
   };


### PR DESCRIPTION
We've recently switched to long.js 5.1, which has a slightly different directory structure.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
