### PR TITLE
Skip leading bar during type's declaration

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3417,7 +3417,7 @@ export class Parser extends DiagnosticEmitter {
     startPos: i32
   ): TypeDeclaration | null {
 
-    // at 'type': Identifier ('<' TypeParameters '>')? '=' Type ';'?
+    // at 'type': Identifier ('<' TypeParameters '>')? '=' '|'? Type ';'?
 
     if (tn.skipIdentifier()) {
       let name = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
@@ -3428,6 +3428,7 @@ export class Parser extends DiagnosticEmitter {
         flags |= CommonFlags.GENERIC;
       }
       if (tn.skip(Token.EQUALS)) {
+        tn.skip(Token.BAR);
         let type = this.parseType(tn);
         if (!type) return null;
         let ret = Node.createTypeDeclaration(

--- a/tests/parser/type.ts
+++ b/tests/parser/type.ts
@@ -1,3 +1,8 @@
 type int32_t = i32;
 @nonportable()
 export type uint64_t = u64;
+
+// with leading `|`
+export type T1 = | int32_t;
+export type T2 =
+  | int32_t;

--- a/tests/parser/type.ts.fixture.ts
+++ b/tests/parser/type.ts.fixture.ts
@@ -1,3 +1,5 @@
 type int32_t = i32;
 @nonportable()
 export type uint64_t = u64;
+export type T1 = int32_t;
+export type T2 = int32_t;


### PR DESCRIPTION
Add parsing this valid TS syntax:
```ts
type Maybe<T> = | T | null;
```
or
```ts
type Maybe<T> = 
  | T 
  | null;
```

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
