### PR TITLE
Skip "type" keyword during import declarations

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2601,13 +2601,16 @@ export class Parser extends DiagnosticEmitter {
   ): ImportStatement | null {
 
     // at 'import':
-    //  ('{' (ImportMember (',' ImportMember)* '}') | ('*' 'as' Identifier)?
+    //  'type'? ('{' (ImportMember (',' ImportMember)* '}') | ('*' 'as' Identifier)?
     //  'from' StringLiteral ';'?
 
     var startPos = tn.tokenPos;
     var members: ImportDeclaration[] | null = null;
     var namespaceName: IdentifierExpression | null = null;
     var skipFrom = false;
+
+    tn.skip(Token.TYPE);
+
     if (tn.skip(Token.OPENBRACE)) { // import { ... } from "file"
       members = new Array();
       while (!tn.skip(Token.CLOSEBRACE)) {
@@ -2703,7 +2706,8 @@ export class Parser extends DiagnosticEmitter {
     tn: Tokenizer
   ): ImportDeclaration | null {
 
-    // before: Identifier ('as' Identifier)?
+    // before: 'type'? Identifier ('as' Identifier)?
+    tn.skip(Token.TYPE);
 
     if (tn.skipIdentifier(IdentifierHandling.ALWAYS)) {
       let identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());

--- a/tests/parser/import.ts
+++ b/tests/parser/import.ts
@@ -14,3 +14,8 @@ import {
 } from "./other";
 import * as A from "./other";
 import "./other";
+
+import type { A } from "./other";
+import { type B } from "./other";
+import { A, type C } from "./other";
+import type * as T from "./other";

--- a/tests/parser/import.ts.fixture.ts
+++ b/tests/parser/import.ts.fixture.ts
@@ -14,3 +14,14 @@ import {
 } from "./other";
 import * as A from "./other";
 import "./other";
+import {
+  A
+} from "./other";
+import {
+  B
+} from "./other";
+import {
+  A,
+  C
+} from "./other";
+import * as T from "./other";


### PR DESCRIPTION
Support following declarations:
```ts
import type { Foo } from "./foo";
import type * as Foo from "./foo";
```
This will introduced in TS 4.5 so support this as well:
```ts
import { type Foo, Boo } from "./foo";
import { Boo, type Foo } from "./foo";
```

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
