### PR TITLE
Diagnose better error when using generic function by value

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7832,10 +7832,10 @@ export class Compiler extends DiagnosticEmitter {
 
         if (typeParameterNodes !== null && typeParameterNodes.length != 0) {
           this.error(
-            DiagnosticCode.Expected_0_arguments_but_got_1,
-            expression.range, typeParameterNodes.length.toString(), "0"
+            DiagnosticCode.Type_argument_expected,
+            expression.range
           );
-          return module.unreachable();
+          break; // also diagnose 'not a value at runtime'
         }
 
         let functionInstance = this.resolver.resolveFunction(
@@ -7856,10 +7856,10 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
     this.error(
-      DiagnosticCode.Expression_refers_to_a_static_element_that_does_not_compile_to_a_value_at_runtime,
+      DiagnosticCode.Expression_does_not_compile_to_a_value_at_runtime,
       expression.range
     );
-    return this.module.unreachable();
+    return module.unreachable();
   }
 
   private compileInstanceOfExpression(
@@ -9207,7 +9207,7 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
     this.error(
-      DiagnosticCode.Expression_refers_to_a_static_element_that_does_not_compile_to_a_value_at_runtime,
+      DiagnosticCode.Expression_does_not_compile_to_a_value_at_runtime,
       expression.range
     );
     return this.module.unreachable();

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -48,7 +48,7 @@ export enum DiagnosticCode {
   _0_keyword_cannot_be_used_here = 230,
   A_class_with_a_constructor_explicitly_returning_something_else_than_this_must_be_final = 231,
   Property_0_is_always_assigned_before_being_used = 233,
-  Expression_refers_to_a_static_element_that_does_not_compile_to_a_value_at_runtime = 234,
+  Expression_does_not_compile_to_a_value_at_runtime = 234,
   Importing_the_table_disables_some_indirect_call_optimizations = 901,
   Exporting_the_table_disables_some_indirect_call_optimizations = 902,
   Expression_compiles_to_a_dynamic_check_at_runtime = 903,
@@ -237,7 +237,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 230: return "'{0}' keyword cannot be used here.";
     case 231: return "A class with a constructor explicitly returning something else than 'this' must be '@final'.";
     case 233: return "Property '{0}' is always assigned before being used.";
-    case 234: return "Expression refers to a static element that does not compile to a value at runtime.";
+    case 234: return "Expression does not compile to a value at runtime.";
     case 901: return "Importing the table disables some indirect call optimizations.";
     case 902: return "Exporting the table disables some indirect call optimizations.";
     case 903: return "Expression compiles to a dynamic check at runtime.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -43,7 +43,7 @@
   "'{0}' keyword cannot be used here.": 230,
   "A class with a constructor explicitly returning something else than 'this' must be '@final'.": 231,
   "Property '{0}' is always assigned before being used.": 233,
-  "Expression refers to a static element that does not compile to a value at runtime.": 234,
+  "Expression does not compile to a value at runtime.": 234,
 
   "Importing the table disables some indirect call optimizations.": 901,
   "Exporting the table disables some indirect call optimizations.": 902,


### PR DESCRIPTION
Passing a generic function by value previously diagnosed a mismatch in argument count, which was not very helpful. Now diagnoses that a **type** argument was expected, *and* that the expression does not compile to a value at runtime.

See #2081.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
