### PR TITLE
Support Node.js v12.0.0 in @assemblyscript/loader

### DIFF
--- a/lib/loader/package.json
+++ b/lib/loader/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/AssemblyScript/assemblyscript/issues"
   },
   "type": "module",
-  "main": "index.js",
+  "main": "./umd/index.js",
   "types": "index.d.ts",
   "exports": {
     "import": "./index.js",


### PR DESCRIPTION
Node.js v12.0.0 doesn't support conditional exports, so when it sees that `main` (`index.js`) is using ESM syntax it will throw a `SyntaxError` and prevent loading the module.

This PR sets `main` to use the UMD module so that old runtimes will be able to load the most compatible version. This will have no effect on ESM users since they can support conditional exports and will load `exports.import` (`./index.js`).

The earliest version of Node.js that can use this module in its current state is v12.20.0.