### PR TITLE
Disable CI on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,29 +48,30 @@ jobs:
       run: npm test
     - name: Test browser build
       run: node tests/browser-asc
-  test-windows:
-    name: "Compiler (Windows, node current)"
-    runs-on: windows-latest
-    needs: check
-    steps:
-    - uses: actions/checkout@v1.0.0
-    - uses: dcodeIO/setup-node-nvm@master
-      with:
-        node-version: current
-    - name: Install dependencies
-      run: npm ci --no-audit
-    - name: Clean distribution files
-      run: npm run clean
-    - name: Test sources
-      run: npm test
-    - name: Build distribution files
-      run: npm run build
-    - name: Update entry file
-      run: npm run prepare-ci
-    - name: Test distribution
-      run: npm test
-    - name: Test browser build
-      run: node tests/browser-asc
+  # see: https://github.com/npm/cli/issues/4234
+  # test-windows:
+  #   name: "Compiler (Windows, node current)"
+  #   runs-on: windows-latest
+  #   needs: check
+  #   steps:
+  #   - uses: actions/checkout@v1.0.0
+  #   - uses: dcodeIO/setup-node-nvm@master
+  #     with:
+  #       node-version: current
+  #   - name: Install dependencies
+  #     run: npm ci --no-audit
+  #   - name: Clean distribution files
+  #     run: npm run clean
+  #   - name: Test sources
+  #     run: npm test
+  #   - name: Build distribution files
+  #     run: npm run build
+  #   - name: Update entry file
+  #     run: npm run prepare-ci
+  #   - name: Test distribution
+  #     run: npm test
+  #   - name: Test browser build
+  #     run: node tests/browser-asc
   test-macos:
     name: "Compiler (MacOS, node current)"
     runs-on: macos-latest


### PR DESCRIPTION
CI on Windows hosts is currently broken due to an [npm bug](https://github.com/npm/cli/issues/4234), but seems to be fixed in newer npm versions. Right now, however, the Node install coming with Node on Windows hosts comes with a broken version. Can be enabled again once that's not the case anymore.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
