### PR TITLE
Try to work around an issue when polyfilling import maps

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -416,7 +416,10 @@ export async function main(argv, options) {
         }
       } else {
         try {
-          transform = await import(new URL(filename, import.meta.url));
+          // FIXME: see https://github.com/guybedford/es-module-shims/issues/275
+          const baseUrl = import.meta.url;
+          baseUrl.hash = baseUrl.hash; // eslint-disable-line
+          transform = await import(new URL(filename, baseUrl));
           if (transform.default) transform = transform.default;
         } catch (e) {
           return prepareResult(e);


### PR DESCRIPTION
The website's editor is currently not working when import maps must be polyfilled (any non-Chromium browser, e.g. Firefox) which happens due to an issue in the utilized polyfill's implementation. This is an attempt to work around the problem for now by suppressing generation of the code pattern in distribution files that would trigger the issue.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
