### PR TITLE
Fix: Cannot find global type 'Number'

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -46,6 +46,7 @@ under the licensing terms detailed in LICENSE:
 * mooooooi <emwings@outlook.com>
 * Yasushi Ando <andyjpn@gmail.com>
 * Syed Jafri <syed@metalpay.co>
+* Peter Hayman <peteyhayman@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1406,6 +1406,7 @@ declare const F64: typeof _Float;
 /** Alias of F64. */
 declare const Number: typeof F64;
 declare type Number = typeof F64;
+
 // User-defined diagnostic macros
 
 /** Emits a user-defined diagnostic error when encountered. */

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1405,7 +1405,7 @@ declare const F32: typeof _Float;
 declare const F64: typeof _Float;
 /** Alias of F64. */
 declare const Number: typeof F64;
-
+declare type Number = typeof F64;
 // User-defined diagnostic macros
 
 /** Emits a user-defined diagnostic error when encountered. */


### PR DESCRIPTION
This PR is to fix the red squigglies that I've noticed appearing in the `tsconfig.json` when upgrading from version `0.19.23` to `0.20.4`. 

The error is `Cannot find global type 'Number'`.

![Screenshot 2022-04-13 143750](https://user-images.githubusercontent.com/25616826/163103219-b908d220-a7b1-43c4-9efb-abf67f027508.png)





<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈
⯈
⯈

- [ x] I've read the contributing guidelines
- [ x] I've added my name and email to the NOTICE file
