### PR TITLE
Add global types recognition for advanced developers

### DIFF
--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig-base.json",
   "include": [
-    "./**/*.ts",
-    "../node_modules/**/assembly/global.d.ts"
+    "./**/*.ts"
   ]
 }

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig-base.json",
   "include": [
-    "./**/*.ts"
+    "./**/*.ts",
+    "../node_modules/**/assembly/global.d.ts"
   ]
 }

--- a/std/assembly.json
+++ b/std/assembly.json
@@ -13,5 +13,8 @@
         "./assembly/*"
       ]
     }
-  }
+  },
+  "include": [
+    "../../../node_modules/**/assembly/global.d.ts"
+  ]
 }


### PR DESCRIPTION
When dealing with adding global types for end users, as-pect and cli tools have always relied on adding something like this to an end user's project:

```ts
/// <reference path="../path/to/types.d.ts" />
```

I instead propose standardizing recognizing types that follow the `../node_modules/**/assembly/global.d.ts` pattern out of the box. This of course is not a perfect solution, and I am amenable to other solutions in the same vein as this one, however, this one seems like the simplest way to fix a long standing problem for cli developers using the compiler programmatically.

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈
⯈
⯈

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
