### PR TITLE
Fix bindings on Node.js 18

### DIFF
--- a/src/bindings/js.ts
+++ b/src/bindings/js.ts
@@ -871,9 +871,9 @@ export class JSBuilder extends ExportsWalker {
       sb.push(`
 } = await (async url => instantiate(
   await (
-    typeof globalThis.fetch === "function"
-      ? WebAssembly.compileStreaming(globalThis.fetch(url))
-      : WebAssembly.compile(await (await import("node:fs/promises")).readFile(url))
+    globalThis.fetch && globalThis.WebAssembly.compileStreaming
+      ? globalThis.WebAssembly.compileStreaming(globalThis.fetch(url))
+      : globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url))
   ), {
 `);
       let needsMaybeDefault = false;

--- a/tests/compiler/bindings/esm.debug.js
+++ b/tests/compiler/bindings/esm.debug.js
@@ -371,9 +371,9 @@ export const {
   internrefFunction
 } = await (async url => instantiate(
   await (
-    typeof globalThis.fetch === "function"
-      ? WebAssembly.compileStreaming(globalThis.fetch(url))
-      : WebAssembly.compile(await (await import("node:fs/promises")).readFile(url))
+    globalThis.fetch && globalThis.WebAssembly.compileStreaming
+      ? globalThis.WebAssembly.compileStreaming(globalThis.fetch(url))
+      : globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url))
   ), {
   }
 ))(new URL("esm.debug.wasm", import.meta.url));

--- a/tests/compiler/bindings/esm.release.js
+++ b/tests/compiler/bindings/esm.release.js
@@ -371,9 +371,9 @@ export const {
   internrefFunction
 } = await (async url => instantiate(
   await (
-    typeof globalThis.fetch === "function"
-      ? WebAssembly.compileStreaming(globalThis.fetch(url))
-      : WebAssembly.compile(await (await import("node:fs/promises")).readFile(url))
+    globalThis.fetch && globalThis.WebAssembly.compileStreaming
+      ? globalThis.WebAssembly.compileStreaming(globalThis.fetch(url))
+      : globalThis.WebAssembly.compile(await (await import("node:fs/promises")).readFile(url))
   ), {
   }
 ))(new URL("esm.release.wasm", import.meta.url));


### PR DESCRIPTION
Node.js 18 introduces `fetch` but not (yet) `WebAssembly.compileStreaming`.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
