### PR TITLE
Fix: Incorrect type declaration about 'Number'

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1425,6 +1425,7 @@ declare const F32: typeof _Float;
 declare const F64: typeof _Float;
 /** Alias of F64. */
 declare const Number: typeof F64;
+declare type Number = _Float;
 
 // User-defined diagnostic macros
 
@@ -1953,11 +1954,6 @@ declare class SyntaxError extends Error { }
 
 /** Class for indicating an error when a global URI handling function was used in a wrong way. */
 declare class URIError extends Error { }
-
-interface Number {
-  /** Returns the respective basic value converted to a string. */
-  toString(radix?: number): string;
-}
 
 interface Function {
   /** Function table index. */

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1425,7 +1425,6 @@ declare const F32: typeof _Float;
 declare const F64: typeof _Float;
 /** Alias of F64. */
 declare const Number: typeof F64;
-declare type Number = typeof F64;
 
 // User-defined diagnostic macros
 
@@ -1954,6 +1953,11 @@ declare class SyntaxError extends Error { }
 
 /** Class for indicating an error when a global URI handling function was used in a wrong way. */
 declare class URIError extends Error { }
+
+interface Number {
+  /** Returns the respective basic value converted to a string. */
+  toString(radix?: number): string;
+}
 
 interface Function {
   /** Function table index. */


### PR DESCRIPTION
In #2260 , `Number` was declared as `typeof F64` (equivalent to `typeof _Float`), which causes all numbers to be considered as a `Class` with some methods that don't belong to it, just like:

![image](https://user-images.githubusercontent.com/30105266/165989202-e3291b3a-4458-4866-9025-51efc5e7d389.png)

I updated the declaration of `Number` according to the [document](https://www.assemblyscript.org/stdlib/number.html#instance-members). I think this is a small change, so I submit PR directly.

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈
⯈
⯈

- [x] I've read the contributing guidelines
- [ ] I've added my name and email to the NOTICE file
