### PR TITLE
fix: support windows format path (#2262)

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -643,17 +643,18 @@ export async function main(argv, options) {
 
   // Include entry files
   for (let i = 0, k = argv.length; i < k; ++i) {
-    const filename = argv[i];
-    let sourcePath = String(filename)
-      .replace(/\\/g, "/")
-      .replace(extension_re, "")
-      .replace(/[\\/]$/, "");
+    const filename = String(argv[i]);
 
     // Setting the path to relative path
-    sourcePath = path.isAbsolute(sourcePath)
-      ? path.relative(baseDir, sourcePath).replace(/\\/g, "/")
-      : sourcePath;
+    let sourcePath = path.isAbsolute(filename)
+      ? path.relative(baseDir, filename)
+      : path.normalize(filename);
 
+    sourcePath = sourcePath
+      .replace(/\\/g, "/")
+      .replace(extension_re, "")
+      .replace(/\/$/, "");
+    
     // Try entryPath.ext, then entryPath/index.ext
     let sourceText = await readFile(sourcePath + extension, baseDir);
     if (sourceText == null) {


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈using `npx asc` will transform the path from `a\b` to `a\\b`, so the entry path replace reg should be changed from `/\\/g` to `/\\+/g`

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
