### PR TITLE
 Fix makeGray misuse in GC (#2178)

### DIFF
--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -103,7 +103,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1488,7 +1488,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2071,7 +2071,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -62,7 +62,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -846,7 +846,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1073,7 +1073,7 @@
   if
    i32.const 1104
    i32.const 1168
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -105,7 +105,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1490,7 +1490,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2073,7 +2073,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -76,7 +76,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -860,7 +860,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -114,7 +114,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1499,7 +1499,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2082,7 +2082,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -98,7 +98,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -882,7 +882,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -120,7 +120,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1505,7 +1505,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2088,7 +2088,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -122,7 +122,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -906,7 +906,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -216,7 +216,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1601,7 +1601,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2184,7 +2184,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2227,6 +2227,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2243,7 +2259,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2272,10 +2288,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -70,7 +70,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -87,6 +87,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 17972
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1120
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -111,61 +162,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 17972
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -173,7 +176,7 @@
   else
    i32.const 1536
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1248
@@ -183,7 +186,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1540
@@ -193,11 +196,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -206,17 +209,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -986,7 +989,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1213,7 +1216,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1747,12 +1750,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1120
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1778,8 +1782,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -115,7 +115,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1500,7 +1500,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2083,7 +2083,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -125,7 +125,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -909,7 +909,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1136,7 +1136,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -512,7 +512,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1897,7 +1897,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2480,7 +2480,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -62,7 +62,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -846,7 +846,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -110,7 +110,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1495,7 +1495,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2078,7 +2078,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2126,6 +2126,22 @@
   local.get $1
   i32.store
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2142,7 +2158,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2171,10 +2187,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -1,6 +1,6 @@
 (module
- (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
@@ -78,7 +78,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -95,6 +95,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 17980
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1120
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -119,61 +170,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 17980
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -181,7 +184,7 @@
   else
    i32.const 1504
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1248
@@ -191,7 +194,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1508
@@ -201,11 +204,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -214,17 +217,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -994,7 +997,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1221,7 +1224,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1953,12 +1956,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1120
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1984,8 +1988,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -109,7 +109,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1494,7 +1494,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2077,7 +2077,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2135,7 +2135,7 @@
    if
     i32.const 432
     i32.const 96
-    i32.const 337
+    i32.const 347
     i32.const 7
     call $~lib/builtins/abort
     unreachable
@@ -2148,6 +2148,22 @@
    call $~lib/rt/itcms/Object#linkTo
   end
   local.get $0
+ )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
  )
  (func $~lib/rt/itcms/__unpin (param $0 i32)
   (local $1 i32)
@@ -2167,25 +2183,13 @@
   if
    i32.const 496
    i32.const 96
-   i32.const 351
+   i32.const 361
    i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/rt/itcms/state
-  i32.const 1
-  i32.eq
-  if
-   local.get $1
-   call $~lib/rt/itcms/Object#makeGray
-  else
-   local.get $1
-   call $~lib/rt/itcms/Object#unlink
-   local.get $1
-   global.get $~lib/rt/itcms/fromSpace
-   global.get $~lib/rt/itcms/white
-   call $~lib/rt/itcms/Object#linkTo
-  end
+  local.get $1
+  call $~lib/rt/itcms/Object#needScan
  )
  (func $~lib/rt/itcms/__collect
   (local $0 i32)

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -73,7 +73,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -992,7 +992,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1219,7 +1219,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1531,7 +1531,7 @@
    if
     i32.const 1456
     i32.const 1120
-    i32.const 337
+    i32.const 347
     i32.const 7
     call $~lib/builtins/abort
     unreachable
@@ -1584,7 +1584,7 @@
   if
    i32.const 1520
    i32.const 1120
-   i32.const 351
+   i32.const 361
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -102,7 +102,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1487,7 +1487,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2070,7 +2070,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/empty-new.release.wat
+++ b/tests/compiler/empty-new.release.wat
@@ -58,7 +58,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -842,7 +842,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -139,7 +139,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1524,7 +1524,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2107,7 +2107,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/exportstar-rereexport.release.wat
+++ b/tests/compiler/exportstar-rereexport.release.wat
@@ -93,7 +93,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -877,7 +877,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -112,7 +112,7 @@
     if
      i32.const 0
      i32.const 256
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1497,7 +1497,7 @@
     if
      i32.const 0
      i32.const 256
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2080,7 +2080,7 @@
   if
    i32.const 192
    i32.const 256
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2133,6 +2133,22 @@
   local.get $1
   f64.store offset=8
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2149,7 +2165,7 @@
   if
    i32.const 0
    i32.const 256
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2178,10 +2194,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -76,7 +76,7 @@
     if
      i32.const 0
      i32.const 1280
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -93,6 +93,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18156
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1280
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1280
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -117,61 +168,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18156
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1280
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1280
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -179,7 +182,7 @@
   else
    i32.const 1696
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1408
@@ -189,7 +192,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1700
@@ -199,11 +202,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -212,17 +215,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -992,7 +995,7 @@
     if
      i32.const 0
      i32.const 1280
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1219,7 +1222,7 @@
   if
    i32.const 1216
    i32.const 1280
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1897,7 +1900,40 @@
     local.get $0
     local.get $1
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -102,7 +102,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1487,7 +1487,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2070,7 +2070,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2113,6 +2113,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2129,7 +2145,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2158,10 +2174,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -1,8 +1,8 @@
 (module
+ (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -60,7 +60,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -77,6 +77,141 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 17868
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1120
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
+ )
+ (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/rt/itcms/iter
+  local.get $0
+  i32.eq
+  if
+   local.get $0
+   i32.load offset=8
+   local.tee $1
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 147
+    i32.const 30
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   global.set $~lib/rt/itcms/iter
+  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
+  global.get $~lib/rt/itcms/toSpace
+  local.set $1
+  local.get $0
+  i32.load offset=12
+  local.tee $2
+  i32.const 1
+  i32.le_u
+  if (result i32)
+   i32.const 1
+  else
+   i32.const 1440
+   i32.load
+   local.get $2
+   i32.lt_u
+   if
+    i32.const 1248
+    i32.const 1312
+    i32.const 22
+    i32.const 28
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $2
+   i32.const 3
+   i32.shl
+   i32.const 1444
+   i32.add
+   i32.load
+   i32.const 32
+   i32.and
+  end
+  local.set $3
+  local.get $1
+  i32.load offset=8
+  local.set $2
+  local.get $0
+  local.get $1
+  global.get $~lib/rt/itcms/white
+  i32.eqz
+  i32.const 2
+  local.get $3
+  select
+  i32.or
+  i32.store offset=4
+  local.get $0
+  local.get $2
+  i32.store offset=8
+  local.get $2
+  local.get $2
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $0
+  i32.or
+  i32.store offset=4
+  local.get $1
+  local.get $0
+  i32.store offset=8
  )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -844,7 +979,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1347,9 +1482,6 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__visit (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
   global.get $~lib/rt/itcms/white
   local.get $0
   i32.const 20
@@ -1360,133 +1492,8 @@
   i32.and
   i32.eq
   if
-   global.get $~lib/rt/itcms/iter
    local.get $0
-   i32.eq
-   if
-    local.get $0
-    i32.load offset=8
-    local.tee $1
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 147
-     i32.const 30
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    global.set $~lib/rt/itcms/iter
-   end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink
-    local.get $0
-    i32.load offset=4
-    i32.const -4
-    i32.and
-    local.tee $1
-    i32.eqz
-    if
-     i32.const 0
-     local.get $0
-     i32.const 17868
-     i32.lt_u
-     local.get $0
-     i32.load offset=8
-     select
-     i32.eqz
-     if
-      i32.const 0
-      i32.const 1120
-      i32.const 127
-      i32.const 18
-      call $~lib/builtins/abort
-      unreachable
-     end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink
-    end
-    local.get $0
-    i32.load offset=8
-    local.tee $2
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 131
-     i32.const 16
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $2
-    i32.store offset=8
-    local.get $2
-    local.get $2
-    i32.load offset=4
-    i32.const 3
-    i32.and
-    local.get $1
-    i32.or
-    i32.store offset=4
-   end
-   global.get $~lib/rt/itcms/toSpace
-   local.set $2
-   local.get $0
-   i32.load offset=12
-   local.tee $1
-   i32.const 1
-   i32.le_u
-   if (result i32)
-    i32.const 1
-   else
-    i32.const 1440
-    i32.load
-    local.get $1
-    i32.lt_u
-    if
-     i32.const 1248
-     i32.const 1312
-     i32.const 22
-     i32.const 28
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i32.const 3
-    i32.shl
-    i32.const 1444
-    i32.add
-    i32.load
-    i32.const 32
-    i32.and
-   end
-   local.set $3
-   local.get $2
-   i32.load offset=8
-   local.set $1
-   local.get $0
-   local.get $2
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.const 2
-   local.get $3
-   select
-   i32.or
-   i32.store offset=4
-   local.get $0
-   local.get $1
-   i32.store offset=8
-   local.get $1
-   local.get $1
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $0
-   i32.or
-   i32.store offset=4
-   local.get $2
-   local.get $0
-   i32.store offset=8
+   call $~lib/rt/itcms/Object#makeGray
    global.get $~lib/rt/itcms/visitCount
    i32.const 1
    i32.add

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -113,7 +113,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1498,7 +1498,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2081,7 +2081,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2134,6 +2134,22 @@
   local.get $1
   i32.store
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2150,7 +2166,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2179,10 +2195,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -83,7 +83,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -100,6 +100,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18380
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1120
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -124,61 +175,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18380
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -186,7 +189,7 @@
   else
    i32.const 1792
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1248
@@ -196,7 +199,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1796
@@ -206,11 +209,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -219,17 +222,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -999,7 +1002,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1226,7 +1229,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3111,12 +3114,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1120
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -3142,8 +3146,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -104,7 +104,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1489,7 +1489,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2072,7 +2072,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2115,6 +2115,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2131,7 +2147,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2160,10 +2176,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -1,6 +1,6 @@
 (module
- (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
@@ -61,7 +61,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -78,6 +78,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 17908
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1120
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -102,61 +153,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 17908
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -164,7 +167,7 @@
   else
    i32.const 1472
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1248
@@ -174,7 +177,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1476
@@ -184,11 +187,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -197,17 +200,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -977,7 +980,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1204,7 +1207,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1766,12 +1769,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1120
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1797,8 +1801,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -529,7 +529,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1914,7 +1914,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2497,7 +2497,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -62,7 +62,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -846,7 +846,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -137,7 +137,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1522,7 +1522,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2105,7 +2105,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -100,7 +100,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -884,7 +884,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -293,7 +293,7 @@
     if
      i32.const 0
      i32.const 640
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1678,7 +1678,7 @@
     if
      i32.const 0
      i32.const 640
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2261,7 +2261,7 @@
   if
    i32.const 576
    i32.const 640
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2304,6 +2304,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2320,7 +2336,7 @@
   if
    i32.const 0
    i32.const 640
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2349,10 +2365,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/function-expression.release.wat
+++ b/tests/compiler/function-expression.release.wat
@@ -129,7 +129,7 @@
     if
      i32.const 0
      i32.const 1664
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -146,6 +146,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18580
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1664
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1664
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -170,61 +221,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18580
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1664
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1664
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -232,7 +235,7 @@
   else
    i32.const 2112
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1792
@@ -242,7 +245,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 2116
@@ -252,11 +255,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -265,17 +268,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1045,7 +1048,7 @@
     if
      i32.const 0
      i32.const 1664
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1535,7 +1538,7 @@
    if
     i32.const 0
     i32.const 1664
-    i32.const 294
+    i32.const 304
     i32.const 14
     call $~lib/builtins/abort
     unreachable
@@ -1558,8 +1561,39 @@
     i32.eqz
     i32.eq
     if
-     i32.const 2012
-     call $~lib/rt/itcms/Object#makeGray
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+     if
+      i32.const 2012
+      call $~lib/rt/itcms/Object#makeGray
+     else
+      i32.const 2012
+      call $~lib/rt/itcms/Object#unlink
+      global.get $~lib/rt/itcms/fromSpace
+      local.tee $1
+      i32.load offset=8
+      local.set $2
+      i32.const 2016
+      global.get $~lib/rt/itcms/white
+      local.get $1
+      i32.or
+      i32.store
+      i32.const 2020
+      local.get $2
+      i32.store
+      local.get $2
+      local.get $2
+      i32.load offset=4
+      i32.const 3
+      i32.and
+      i32.const 2012
+      i32.or
+      i32.store offset=4
+      local.get $1
+      i32.const 2012
+      i32.store offset=8
+     end
     else
      global.get $~lib/rt/itcms/state
      i32.const 1

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -105,7 +105,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1490,7 +1490,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2073,7 +2073,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -65,7 +65,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -849,7 +849,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -121,7 +121,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1506,7 +1506,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2089,7 +2089,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2147,6 +2147,22 @@
   end
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2163,7 +2179,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2192,10 +2208,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -97,7 +97,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -114,6 +114,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18596
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1152
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -138,61 +189,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18596
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1152
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -200,7 +203,7 @@
   else
    i32.const 2112
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1280
@@ -210,7 +213,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 2116
@@ -220,11 +223,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -233,17 +236,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1013,7 +1016,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1240,7 +1243,7 @@
   if
    i32.const 1088
    i32.const 1152
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2252,7 +2255,7 @@
   if
    i32.const 0
    i32.const 1152
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2283,7 +2286,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -191,7 +191,7 @@
     if
      i32.const 0
      i32.const 272
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1576,7 +1576,7 @@
     if
      i32.const 0
      i32.const 272
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2159,7 +2159,7 @@
   if
    i32.const 208
    i32.const 272
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -87,7 +87,7 @@
     if
      i32.const 0
      i32.const 1296
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -871,7 +871,7 @@
     if
      i32.const 0
      i32.const 1296
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -311,7 +311,7 @@
     if
      i32.const 0
      i32.const 176
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1696,7 +1696,7 @@
     if
      i32.const 0
      i32.const 176
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2279,7 +2279,7 @@
   if
    i32.const 112
    i32.const 176
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -74,7 +74,7 @@
     if
      i32.const 0
      i32.const 1200
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -858,7 +858,7 @@
     if
      i32.const 0
      i32.const 1200
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1085,7 +1085,7 @@
   if
    i32.const 1136
    i32.const 1200
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof-class.debug.wat
+++ b/tests/compiler/instanceof-class.debug.wat
@@ -105,7 +105,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1490,7 +1490,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2073,7 +2073,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/instanceof-class.release.wat
+++ b/tests/compiler/instanceof-class.release.wat
@@ -76,7 +76,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -860,7 +860,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -105,7 +105,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1490,7 +1490,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2073,7 +2073,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2116,6 +2116,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2132,7 +2148,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2161,10 +2177,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -1,6 +1,6 @@
 (module
- (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
@@ -65,7 +65,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -82,6 +82,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18004
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1120
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -106,61 +157,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18004
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -168,7 +171,7 @@
   else
    i32.const 1584
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1248
@@ -178,7 +181,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1588
@@ -188,11 +191,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -201,17 +204,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -981,7 +984,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1534,12 +1537,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1120
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -1565,8 +1569,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -116,7 +116,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1501,7 +1501,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2084,7 +2084,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -71,7 +71,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -855,7 +855,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -107,7 +107,7 @@
     if
      i32.const 0
      i32.const 192
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1492,7 +1492,7 @@
     if
      i32.const 0
      i32.const 192
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2075,7 +2075,7 @@
   if
    i32.const 128
    i32.const 192
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2118,6 +2118,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2134,7 +2150,7 @@
   if
    i32.const 0
    i32.const 192
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2163,10 +2179,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -1,6 +1,6 @@
 (module
- (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
@@ -72,7 +72,7 @@
     if
      i32.const 0
      i32.const 1216
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -89,6 +89,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18140
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1216
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -113,61 +164,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18140
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1216
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1216
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -175,7 +178,7 @@
   else
    i32.const 1712
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1344
@@ -185,7 +188,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1716
@@ -195,11 +198,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -208,17 +211,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -988,7 +991,7 @@
     if
      i32.const 0
      i32.const 1216
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1215,7 +1218,7 @@
   if
    i32.const 1152
    i32.const 1216
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2044,7 +2047,7 @@
   if
    i32.const 0
    i32.const 1216
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2075,7 +2078,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -109,7 +109,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1494,7 +1494,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2077,7 +2077,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -71,7 +71,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -855,7 +855,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -128,7 +128,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1513,7 +1513,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2096,7 +2096,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -62,7 +62,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -846,7 +846,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -105,7 +105,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1490,7 +1490,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2073,7 +2073,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.release.wat
+++ b/tests/compiler/managed-cast.release.wat
@@ -66,7 +66,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -850,7 +850,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -108,7 +108,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1493,7 +1493,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2076,7 +2076,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -102,7 +102,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -886,7 +886,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/number.debug.wat
+++ b/tests/compiler/number.debug.wat
@@ -207,7 +207,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1592,7 +1592,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2175,7 +2175,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/number.release.wat
+++ b/tests/compiler/number.release.wat
@@ -109,7 +109,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -893,7 +893,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1120,7 +1120,7 @@
   if
    i32.const 1280
    i32.const 1344
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -14,17 +14,17 @@
  (type $i32_f32_=>_none (func (param i32 f32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/iter (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/toSpace (mut i32) (i32.const 0))
  (global $~lib/shared/runtime/Runtime.Stub i32 (i32.const 0))
  (global $~lib/shared/runtime/Runtime.Minimal i32 (i32.const 1))
  (global $~lib/shared/runtime/Runtime.Incremental i32 (i32.const 2))
- (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/visitCount (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/pinSpace (mut i32) (i32.const 0))
- (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $~lib/native/ASC_SHRINK_LEVEL i32 (i32.const 0))
@@ -38,8 +38,8 @@
  (data (i32.const 128) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 156) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00\00\00\00\00\00\00\00\00")
  (data (i32.const 220) ",\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
- (data (i32.const 268) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
- (data (i32.const 336) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 272) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 300) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
  (data (i32.const 368) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 396) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (data (i32.const 460) "<\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\"\00\00\00o\00b\00j\00e\00c\00t\00-\00l\00i\00t\00e\00r\00a\00l\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00")
@@ -257,6 +257,22 @@
   end
   call $~lib/rt/itcms/Object#linkTo
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -273,7 +289,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -302,10 +318,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5
@@ -362,7 +378,7 @@
     if
      i32.const 0
      i32.const 80
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1581,7 +1597,7 @@
     if
      i32.const 0
      i32.const 80
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1686,7 +1702,7 @@
   i32.const 1073741820
   i32.gt_u
   if
-   i32.const 288
+   i32.const 320
    i32.const 416
    i32.const 458
    i32.const 29
@@ -2162,9 +2178,9 @@
   i32.const 1073741804
   i32.ge_u
   if
-   i32.const 288
+   i32.const 320
    i32.const 80
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2801,7 +2817,7 @@
   i32.const 176
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 288
+  i32.const 320
   local.get $0
   call $~lib/rt/itcms/__visit
  )
@@ -3345,6 +3361,9 @@
   i32.const 128
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/toSpace
+  i32.const 272
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/fromSpace
   memory.size
   i32.const 16
   i32.shl
@@ -3353,12 +3372,9 @@
   i32.const 1
   i32.shr_u
   global.set $~lib/rt/itcms/threshold
-  i32.const 336
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/pinSpace
   i32.const 368
   call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/fromSpace
+  global.set $~lib/rt/itcms/pinSpace
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $object-literal/Managed#constructor

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -8,14 +8,14 @@
  (type $none_=>_i32 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/iter (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/toSpace (mut i32) (i32.const 0))
- (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/visitCount (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/pinSpace (mut i32) (i32.const 0))
- (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/memory/__stack_pointer (mut i32) (i32.const 18156))
  (memory $0 1)
@@ -27,8 +27,8 @@
  (data (i32.const 1192) "\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
  (data (i32.const 1244) ",")
  (data (i32.const 1256) "\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
- (data (i32.const 1292) "<")
- (data (i32.const 1304) "\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 1324) "<")
+ (data (i32.const 1336) "\01\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
  (data (i32.const 1420) "<")
  (data (i32.const 1432) "\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
  (data (i32.const 1484) "<")
@@ -47,6 +47,57 @@
  (data (i32.const 1748) " ")
  (export "memory" (memory $0))
  (start $~start)
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18156
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1104
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1104
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
+ )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -70,61 +121,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18156
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1104
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1104
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -132,7 +135,7 @@
   else
    i32.const 1712
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1200
@@ -142,7 +145,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1716
@@ -152,11 +155,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -165,17 +168,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -184,7 +187,7 @@
   (local $1 i32)
   i32.const 1200
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
-  i32.const 1312
+  i32.const 1344
   call $byn-split-outlined-A$~lib/rt/itcms/__visit
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
@@ -206,7 +209,7 @@
     if
      i32.const 0
      i32.const 1104
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1040,7 +1043,7 @@
     if
      i32.const 0
      i32.const 1104
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1219,7 +1222,7 @@
   i32.const 1073741820
   i32.gt_u
   if
-   i32.const 1312
+   i32.const 1344
    i32.const 1440
    i32.const 458
    i32.const 29
@@ -1411,9 +1414,9 @@
   i32.const 1073741804
   i32.ge_u
   if
-   i32.const 1312
+   i32.const 1344
    i32.const 1104
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1764,6 +1767,14 @@
     i32.store
     i32.const 1152
     global.set $~lib/rt/itcms/toSpace
+    i32.const 1300
+    i32.const 1296
+    i32.store
+    i32.const 1304
+    i32.const 1296
+    i32.store
+    i32.const 1296
+    global.set $~lib/rt/itcms/fromSpace
     memory.size
     i32.const 16
     i32.shl
@@ -1772,14 +1783,6 @@
     i32.const 1
     i32.shr_u
     global.set $~lib/rt/itcms/threshold
-    i32.const 1364
-    i32.const 1360
-    i32.store
-    i32.const 1368
-    i32.const 1360
-    i32.store
-    i32.const 1360
-    global.set $~lib/rt/itcms/pinSpace
     i32.const 1396
     i32.const 1392
     i32.store
@@ -1787,7 +1790,7 @@
     i32.const 1392
     i32.store
     i32.const 1392
-    global.set $~lib/rt/itcms/fromSpace
+    global.set $~lib/rt/itcms/pinSpace
     local.get $0
     i32.const 4
     i32.sub
@@ -2749,12 +2752,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1104
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2780,8 +2784,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -111,7 +111,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1496,7 +1496,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2079,7 +2079,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -74,7 +74,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -858,7 +858,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -146,7 +146,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1531,7 +1531,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2114,7 +2114,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/reexport.release.wat
+++ b/tests/compiler/reexport.release.wat
@@ -95,7 +95,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -879,7 +879,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -139,7 +139,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1524,7 +1524,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2107,7 +2107,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rereexport.release.wat
+++ b/tests/compiler/rereexport.release.wat
@@ -93,7 +93,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -877,7 +877,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -122,7 +122,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1507,7 +1507,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2090,7 +2090,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2148,6 +2148,22 @@
   end
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2164,7 +2180,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2193,10 +2209,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -1,7 +1,7 @@
 (module
  (type $none_=>_i32 (func (result i32)))
- (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $none_=>_none (func))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
@@ -83,7 +83,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -100,6 +100,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 19732
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1152
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -124,61 +175,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 19732
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1152
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -186,7 +189,7 @@
   else
    i32.const 3296
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1280
@@ -196,7 +199,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 3300
@@ -206,11 +209,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -219,17 +222,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -999,7 +1002,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1226,7 +1229,7 @@
   if
    i32.const 1088
    i32.const 1152
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1942,6 +1945,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -1952,10 +1956,10 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   local.tee $0
+   local.tee $1
    i32.const 0
    i32.store
-   local.get $0
+   local.get $1
    i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -1964,92 +1968,123 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   local.tee $1
+   local.tee $2
    i32.const 0
    i32.store
    i32.const 8
    i32.const 0
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $0
    i32.const 1056
    i64.load align=1
    i64.store align=1
-   local.get $1
-   local.get $3
+   local.get $2
+   local.get $0
    i32.store
    i32.const 16
    i32.const 3
    call $~lib/rt/itcms/__new
-   local.tee $2
-   local.get $3
+   local.tee $4
+   local.get $0
    i32.store
-   local.get $3
+   local.get $0
    if
-    local.get $2
+    local.get $4
     i32.eqz
     if
      i32.const 0
      i32.const 1152
-     i32.const 294
+     i32.const 304
      i32.const 14
      call $~lib/builtins/abort
      unreachable
     end
     global.get $~lib/rt/itcms/white
-    local.get $3
+    local.get $0
     i32.const 20
     i32.sub
-    local.tee $4
+    local.tee $2
     i32.load offset=4
     i32.const 3
     i32.and
     i32.eq
     if
-     local.get $2
+     local.get $4
      i32.const 20
      i32.sub
      i32.load offset=4
      i32.const 3
      i32.and
-     local.tee $1
+     local.tee $3
      global.get $~lib/rt/itcms/white
      i32.eqz
      i32.eq
      if
-      local.get $4
-      call $~lib/rt/itcms/Object#makeGray
+      global.get $~lib/rt/itcms/state
+      i32.const 1
+      i32.eq
+      if
+       local.get $2
+       call $~lib/rt/itcms/Object#makeGray
+      else
+       local.get $2
+       call $~lib/rt/itcms/Object#unlink
+       global.get $~lib/rt/itcms/fromSpace
+       local.tee $3
+       i32.load offset=8
+       local.set $5
+       local.get $2
+       global.get $~lib/rt/itcms/white
+       local.get $3
+       i32.or
+       i32.store offset=4
+       local.get $2
+       local.get $5
+       i32.store offset=8
+       local.get $5
+       local.get $5
+       i32.load offset=4
+       i32.const 3
+       i32.and
+       local.get $2
+       i32.or
+       i32.store offset=4
+       local.get $3
+       local.get $2
+       i32.store offset=8
+      end
      else
       global.get $~lib/rt/itcms/state
       i32.const 1
       i32.eq
-      local.get $1
+      local.get $3
       i32.const 3
       i32.eq
       i32.and
       if
-       local.get $4
+       local.get $2
        call $~lib/rt/itcms/Object#makeGray
       end
      end
     end
    end
-   local.get $2
-   local.get $3
+   local.get $4
+   local.get $0
    i32.store offset=4
-   local.get $2
+   local.get $4
    i32.const 8
    i32.store offset=8
-   local.get $2
+   local.get $4
    i32.const 1
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $0
-   local.get $2
+   local.get $1
+   local.get $4
    i32.store
-   local.get $2
+   local.get $4
    i32.load offset=12
    i32.eqz
    if
@@ -2060,7 +2095,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $2
+   local.get $4
    i32.load offset=4
    i64.load
    call $~lib/number/U64#toString

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -380,7 +380,7 @@
     if
      i32.const 0
      i32.const 448
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1765,7 +1765,7 @@
     if
      i32.const 0
      i32.const 448
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2348,7 +2348,7 @@
   if
    i32.const 384
    i32.const 448
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -266,7 +266,7 @@
     if
      i32.const 0
      i32.const 1472
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1050,7 +1050,7 @@
     if
      i32.const 0
      i32.const 1472
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1277,7 +1277,7 @@
   if
    i32.const 1408
    i32.const 1472
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -146,7 +146,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1531,7 +1531,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2114,7 +2114,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2157,6 +2157,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2173,7 +2189,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2202,10 +2218,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -135,7 +135,7 @@
     if
      i32.const 0
      i32.const 1232
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -152,6 +152,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 21236
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1232
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1232
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -176,61 +227,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 21236
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1232
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1232
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -238,7 +241,7 @@
   else
    i32.const 4800
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1360
@@ -248,7 +251,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 4804
@@ -258,11 +261,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -271,17 +274,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1051,7 +1054,7 @@
     if
      i32.const 0
      i32.const 1232
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1278,7 +1281,7 @@
   if
    i32.const 1168
    i32.const 1232
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3581,6 +3584,7 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -3638,25 +3642,25 @@
   local.tee $1
   i32.const 0
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $2
   i32.store offset=4
   local.get $0
-  local.get $3
+  local.get $2
   i32.store
-  local.get $3
+  local.get $2
   if
    local.get $0
    i32.eqz
    if
     i32.const 0
     i32.const 1232
-    i32.const 294
+    i32.const 304
     i32.const 14
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/rt/itcms/white
-   local.get $3
+   local.get $2
    i32.const 20
    i32.sub
    local.tee $4
@@ -3671,18 +3675,49 @@
     i32.load offset=4
     i32.const 3
     i32.and
-    local.tee $2
+    local.tee $3
     global.get $~lib/rt/itcms/white
     i32.eqz
     i32.eq
     if
-     local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+     if
+      local.get $4
+      call $~lib/rt/itcms/Object#makeGray
+     else
+      local.get $4
+      call $~lib/rt/itcms/Object#unlink
+      global.get $~lib/rt/itcms/fromSpace
+      local.tee $5
+      i32.load offset=8
+      local.set $3
+      local.get $4
+      global.get $~lib/rt/itcms/white
+      local.get $5
+      i32.or
+      i32.store offset=4
+      local.get $4
+      local.get $3
+      i32.store offset=8
+      local.get $3
+      local.get $3
+      i32.load offset=4
+      i32.const 3
+      i32.and
+      local.get $4
+      i32.or
+      i32.store offset=4
+      local.get $5
+      local.get $4
+      i32.store offset=8
+     end
     else
      global.get $~lib/rt/itcms/state
      i32.const 1
      i32.eq
-     local.get $2
+     local.get $3
      i32.const 3
      i32.eq
      i32.and
@@ -3694,7 +3729,7 @@
    end
   end
   local.get $0
-  local.get $3
+  local.get $2
   i32.store offset=4
   local.get $0
   local.get $1

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -189,7 +189,7 @@
     if
      i32.const 0
      i32.const 496
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1574,7 +1574,7 @@
     if
      i32.const 0
      i32.const 496
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2157,7 +2157,7 @@
   if
    i32.const 432
    i32.const 496
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -102,7 +102,7 @@
     if
      i32.const 0
      i32.const 1520
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -886,7 +886,7 @@
     if
      i32.const 0
      i32.const 1520
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1208,7 +1208,7 @@
    if
     i32.const 1456
     i32.const 1520
-    i32.const 260
+    i32.const 270
     i32.const 31
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -103,7 +103,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1488,7 +1488,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2071,7 +2071,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -67,7 +67,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -851,7 +851,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -190,7 +190,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1575,7 +1575,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2158,7 +2158,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -102,7 +102,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -886,7 +886,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1113,7 +1113,7 @@
   if
    i32.const 1280
    i32.const 1344
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -197,7 +197,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1582,7 +1582,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2165,7 +2165,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -106,7 +106,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -890,7 +890,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1117,7 +1117,7 @@
   if
    i32.const 1280
    i32.const 1344
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -187,7 +187,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1572,7 +1572,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2155,7 +2155,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -122,7 +122,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -906,7 +906,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1133,7 +1133,7 @@
   if
    i32.const 1280
    i32.const 1344
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -106,7 +106,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1511,7 +1511,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2094,7 +2094,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -65,7 +65,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -849,7 +849,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/rt/instanceof.debug.wat
+++ b/tests/compiler/rt/instanceof.debug.wat
@@ -113,7 +113,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1498,7 +1498,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2081,7 +2081,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rt/instanceof.release.wat
+++ b/tests/compiler/rt/instanceof.release.wat
@@ -105,7 +105,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -889,7 +889,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -109,7 +109,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1494,7 +1494,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2077,7 +2077,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2135,7 +2135,7 @@
    if
     i32.const 432
     i32.const 96
-    i32.const 337
+    i32.const 347
     i32.const 7
     call $~lib/builtins/abort
     unreachable
@@ -2148,6 +2148,22 @@
    call $~lib/rt/itcms/Object#linkTo
   end
   local.get $0
+ )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
  )
  (func $~lib/rt/itcms/__unpin (param $0 i32)
   (local $1 i32)
@@ -2167,25 +2183,13 @@
   if
    i32.const 496
    i32.const 96
-   i32.const 351
+   i32.const 361
    i32.const 5
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/rt/itcms/state
-  i32.const 1
-  i32.eq
-  if
-   local.get $1
-   call $~lib/rt/itcms/Object#makeGray
-  else
-   local.get $1
-   call $~lib/rt/itcms/Object#unlink
-   local.get $1
-   global.get $~lib/rt/itcms/fromSpace
-   global.get $~lib/rt/itcms/white
-   call $~lib/rt/itcms/Object#linkTo
-  end
+  local.get $1
+  call $~lib/rt/itcms/Object#needScan
  )
  (func $~lib/rt/itcms/__collect
   (local $0 i32)

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -73,7 +73,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -992,7 +992,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1219,7 +1219,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1531,7 +1531,7 @@
    if
     i32.const 1456
     i32.const 1120
-    i32.const 337
+    i32.const 347
     i32.const 7
     call $~lib/builtins/abort
     unreachable
@@ -1584,7 +1584,7 @@
   if
    i32.const 1520
    i32.const 1120
-   i32.const 351
+   i32.const 361
    i32.const 5
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std-wasi/console.debug.wat
+++ b/tests/compiler/std-wasi/console.debug.wat
@@ -3262,7 +3262,7 @@
     if
      i32.const 0
      i32.const 3968
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -3702,7 +3702,7 @@
     if
      i32.const 0
      i32.const 3968
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/wasi/index/abort
      unreachable
@@ -3801,7 +3801,7 @@
   if
    i32.const 3376
    i32.const 3968
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -3844,6 +3844,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3860,7 +3876,7 @@
   if
    i32.const 0
    i32.const 3968
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -3889,10 +3905,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std-wasi/console.release.wat
+++ b/tests/compiler/std-wasi/console.release.wat
@@ -2220,7 +2220,7 @@
     if
      i32.const 0
      i32.const 4992
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -2237,6 +2237,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 24356
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 4992
+    i32.const 127
+    i32.const 18
+    call $~lib/wasi/index/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 4992
+   i32.const 131
+   i32.const 16
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -2261,61 +2312,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 24356
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 4992
-     i32.const 127
-     i32.const 18
-     call $~lib/wasi/index/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4992
-    i32.const 131
-    i32.const 16
-    call $~lib/wasi/index/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -2323,7 +2326,7 @@
   else
    i32.const 7936
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 5120
@@ -2333,7 +2336,7 @@
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 7940
@@ -2343,11 +2346,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -2356,17 +2359,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -2546,7 +2549,7 @@
     if
      i32.const 0
      i32.const 4992
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/wasi/index/abort
      unreachable
@@ -2600,7 +2603,7 @@
   if
    i32.const 4400
    i32.const 4992
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -4492,7 +4495,7 @@
   if
    i32.const 0
    i32.const 4992
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -4523,7 +4526,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std-wasi/crypto.debug.wat
+++ b/tests/compiler/std-wasi/crypto.debug.wat
@@ -874,7 +874,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -2259,7 +2259,7 @@
     if
      i32.const 0
      i32.const 320
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/wasi/index/abort
      unreachable
@@ -2842,7 +2842,7 @@
   if
    i32.const 256
    i32.const 320
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -2891,6 +2891,22 @@
   i32.sub
   i32.load offset=16
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2907,7 +2923,7 @@
   if
    i32.const 0
    i32.const 320
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -2936,10 +2952,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std-wasi/crypto.release.wat
+++ b/tests/compiler/std-wasi/crypto.release.wat
@@ -609,7 +609,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -626,6 +626,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 23284
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1344
+    i32.const 127
+    i32.const 18
+    call $~lib/wasi/index/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1344
+   i32.const 131
+   i32.const 16
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -650,61 +701,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 23284
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1344
-     i32.const 127
-     i32.const 18
-     call $~lib/wasi/index/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1344
-    i32.const 131
-    i32.const 16
-    call $~lib/wasi/index/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -712,7 +715,7 @@
   else
    i32.const 6864
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1472
@@ -722,7 +725,7 @@
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 6868
@@ -732,11 +735,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -745,17 +748,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1575,7 +1578,7 @@
     if
      i32.const 0
      i32.const 1344
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/wasi/index/abort
      unreachable
@@ -1948,7 +1951,7 @@
   if
    i32.const 1280
    i32.const 1344
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -3699,32 +3702,31 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   local.tee $4
+   local.tee $1
    i32.const 0
    i32.store
    i32.const 0
    local.get $0
-   local.tee $1
    i32.load offset=8
-   local.tee $0
-   local.get $0
+   local.tee $3
+   local.get $3
    i32.const 0
    i32.gt_s
    select
    local.set $2
-   local.get $4
+   local.get $1
    block $__inlined_func$~lib/typedarray/Uint8Array#constructor (result i32)
-    local.get $0
+    local.get $3
     local.get $2
     i32.sub
-    local.tee $0
+    local.tee $3
     i32.const 0
-    local.get $0
+    local.get $3
     i32.const 0
     i32.gt_s
     select
     local.set $3
-    local.get $4
+    local.get $1
     i32.const 4
     i32.sub
     global.set $~lib/memory/__stack_pointer
@@ -3734,14 +3736,14 @@
      i32.lt_s
      br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
-     local.tee $0
+     local.tee $1
      i32.const 0
      i32.store
-     local.get $0
+     local.get $1
      i32.const 12
      i32.const 3
      call $~lib/rt/itcms/__new
-     local.tee $0
+     local.tee $1
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.tee $5
@@ -3755,23 +3757,23 @@
      global.get $~lib/memory/__stack_pointer
      i64.const 0
      i64.store
-     local.get $0
+     local.get $1
      i32.eqz
      if
       global.get $~lib/memory/__stack_pointer
       i32.const 12
       i32.const 2
       call $~lib/rt/itcms/__new
-      local.tee $0
+      local.tee $1
       i32.store
      end
-     local.get $0
+     local.get $1
      i32.const 0
      i32.store
-     local.get $0
+     local.get $1
      i32.const 0
      i32.store offset=4
-     local.get $0
+     local.get $1
      i32.const 0
      i32.store offset=8
      local.get $3
@@ -3791,19 +3793,19 @@
      call $~lib/rt/itcms/__new
      local.tee $4
      i32.store offset=4
-     local.get $0
+     local.get $1
      local.get $4
      i32.store
      local.get $4
      if
-      local.get $0
+      local.get $1
       local.get $4
       call $byn-split-outlined-A$~lib/rt/itcms/__link
      end
-     local.get $0
+     local.get $1
      local.get $4
      i32.store offset=4
-     local.get $0
+     local.get $1
      local.get $3
      i32.store offset=8
      global.get $~lib/memory/__stack_pointer
@@ -3811,23 +3813,23 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $5
-     local.get $0
+     local.get $1
      i32.store
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $1
      br $__inlined_func$~lib/typedarray/Uint8Array#constructor
     end
     br $folding-inner1
    end
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=4
    local.get $2
-   local.get $1
+   local.get $0
    i32.load offset=4
    i32.add
    local.get $3
@@ -3836,7 +3838,7 @@
    i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    return
   end
   i32.const 23312
@@ -3866,12 +3868,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1344
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -3897,8 +3900,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std-wasi/process.debug.wat
+++ b/tests/compiler/std-wasi/process.debug.wat
@@ -3260,7 +3260,7 @@
     if
      i32.const 0
      i32.const 3632
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -3700,7 +3700,7 @@
     if
      i32.const 0
      i32.const 3632
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/wasi/index/abort
      unreachable
@@ -3799,7 +3799,7 @@
   if
    i32.const 3328
    i32.const 3632
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -3842,6 +3842,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3858,7 +3874,7 @@
   if
    i32.const 0
    i32.const 3632
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -3887,10 +3903,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std-wasi/process.release.wat
+++ b/tests/compiler/std-wasi/process.release.wat
@@ -2252,7 +2252,7 @@
     if
      i32.const 0
      i32.const 4656
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/wasi/index/abort
      unreachable
@@ -2269,6 +2269,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 23788
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 4656
+    i32.const 127
+    i32.const 18
+    call $~lib/wasi/index/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 4656
+   i32.const 131
+   i32.const 16
+   call $~lib/wasi/index/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -2293,61 +2344,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 23788
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 4656
-     i32.const 127
-     i32.const 18
-     call $~lib/wasi/index/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4656
-    i32.const 131
-    i32.const 16
-    call $~lib/wasi/index/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -2355,7 +2358,7 @@
   else
    i32.const 7360
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 4784
@@ -2365,7 +2368,7 @@
     call $~lib/wasi/index/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 7364
@@ -2375,11 +2378,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -2388,17 +2391,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -2578,7 +2581,7 @@
     if
      i32.const 0
      i32.const 4656
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/wasi/index/abort
      unreachable
@@ -2632,7 +2635,7 @@
   if
    i32.const 4352
    i32.const 4656
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/wasi/index/abort
    unreachable
@@ -5437,7 +5440,7 @@
   if
    i32.const 0
    i32.const 4656
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/wasi/index/abort
    unreachable
@@ -5468,7 +5471,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -179,7 +179,7 @@
     if
      i32.const 0
      i32.const 512
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1564,7 +1564,7 @@
     if
      i32.const 0
      i32.const 512
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2147,7 +2147,7 @@
   if
    i32.const 448
    i32.const 512
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2205,6 +2205,22 @@
   end
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2221,7 +2237,7 @@
   if
    i32.const 0
    i32.const 512
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2250,10 +2266,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -1,7 +1,7 @@
 (module
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
@@ -156,7 +156,7 @@
     if
      i32.const 0
      i32.const 1536
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -173,6 +173,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18252
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1536
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -197,61 +248,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18252
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1536
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1536
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -259,7 +262,7 @@
   else
    i32.const 1792
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1200
@@ -269,7 +272,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1796
@@ -279,11 +282,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -292,17 +295,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1072,7 +1075,7 @@
     if
      i32.const 0
      i32.const 1536
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1299,7 +1302,7 @@
   if
    i32.const 1472
    i32.const 1536
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2387,7 +2390,7 @@
   if
    i32.const 0
    i32.const 1536
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2418,7 +2421,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -7,9 +7,9 @@
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $f32_f32_=>_i32 (func (param f32 f32) (result i32)))
  (type $f64_f64_=>_i32 (func (param f64 f64) (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32)))
  (type $i32_i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32 i32)))
- (type $i32_=>_none (func (param i32)))
  (type $none_=>_none (func))
  (type $none_=>_f64 (func (result f64)))
  (type $i64_i32_=>_i32 (func (param i64 i32) (result i32)))
@@ -426,7 +426,7 @@
     if
      i32.const 0
      i32.const 192
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1811,7 +1811,7 @@
     if
      i32.const 0
      i32.const 192
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2394,7 +2394,7 @@
   if
    i32.const 128
    i32.const 192
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2437,6 +2437,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2453,7 +2469,7 @@
   if
    i32.const 0
    i32.const 192
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2482,10 +2498,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -393,7 +393,7 @@
     if
      i32.const 0
      i32.const 1216
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -410,6 +410,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 31876
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1216
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -434,61 +485,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 31876
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1216
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1216
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -496,7 +499,7 @@
   else
    i32.const 15136
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1344
@@ -506,7 +509,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 15140
@@ -516,11 +519,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -529,17 +532,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1359,7 +1362,7 @@
     if
      i32.const 0
      i32.const 1216
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1732,7 +1735,7 @@
   if
    i32.const 1152
    i32.const 1216
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -12749,7 +12752,7 @@
    i32.gt_s
    select
    local.set $1
-   loop $for-loop|06
+   loop $for-loop|05
     local.get $1
     local.get $9
     i32.lt_s
@@ -12765,7 +12768,7 @@
      i32.const 1
      i32.add
      local.set $1
-     br $for-loop|06
+     br $for-loop|05
     end
    end
    i32.const 5
@@ -12811,7 +12814,7 @@
    i32.gt_s
    select
    local.set $9
-   loop $for-loop|08
+   loop $for-loop|07
     local.get $1
     local.get $9
     i32.lt_s
@@ -12827,7 +12830,7 @@
      i32.const 1
      i32.add
      local.set $1
-     br $for-loop|08
+     br $for-loop|07
     end
    end
    i32.const 5
@@ -12866,7 +12869,7 @@
    i32.gt_s
    select
    local.set $1
-   loop $for-loop|010
+   loop $for-loop|09
     local.get $1
     local.get $9
     i32.lt_s
@@ -12882,7 +12885,7 @@
      i32.const 1
      i32.add
      local.set $1
-     br $for-loop|010
+     br $for-loop|09
     end
    end
    i32.const 5
@@ -12925,7 +12928,7 @@
    i32.gt_s
    select
    local.set $9
-   loop $for-loop|012
+   loop $for-loop|011
     local.get $1
     local.get $9
     i32.lt_s
@@ -12941,7 +12944,7 @@
      i32.const 1
      i32.add
      local.set $1
-     br $for-loop|012
+     br $for-loop|011
     end
    end
    i32.const 5
@@ -15102,7 +15105,7 @@
    local.get $8
    i32.load offset=12
    local.set $0
-   loop $for-loop|013
+   loop $for-loop|012
     local.get $0
     local.get $1
     i32.gt_s
@@ -15129,7 +15132,7 @@
      i32.const 1
      i32.add
      local.set $1
-     br $for-loop|013
+     br $for-loop|012
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -16146,7 +16149,7 @@
     local.get $1
     i32.load offset=4
     local.set $8
-    loop $while-continue|015
+    loop $while-continue|013
      local.get $0
      i32.const 0
      i32.ge_s
@@ -16165,7 +16168,7 @@
       i32.const 1
       i32.sub
       local.set $0
-      br $while-continue|015
+      br $while-continue|013
      end
     end
     i32.const -1
@@ -16186,12 +16189,12 @@
    global.set $~argumentsLength
    i32.const -1
    local.set $3
-   block $__inlined_func$~lib/array/Array<i32>#lastIndexOf20
+   block $__inlined_func$~lib/array/Array<i32>#lastIndexOf18
     local.get $1
     i32.load offset=12
     local.tee $0
     i32.eqz
-    br_if $__inlined_func$~lib/array/Array<i32>#lastIndexOf20
+    br_if $__inlined_func$~lib/array/Array<i32>#lastIndexOf18
     local.get $0
     local.get $0
     i32.add
@@ -16206,7 +16209,7 @@
     local.get $1
     i32.load offset=4
     local.set $8
-    loop $while-continue|021
+    loop $while-continue|019
      local.get $0
      i32.const 0
      i32.ge_s
@@ -16220,12 +16223,12 @@
       i32.load
       i32.const 7
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#lastIndexOf20
+      br_if $__inlined_func$~lib/array/Array<i32>#lastIndexOf18
       local.get $3
       i32.const 1
       i32.sub
       local.set $0
-      br $while-continue|021
+      br $while-continue|019
      end
     end
     i32.const -1
@@ -16244,12 +16247,12 @@
    end
    i32.const -1
    local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#lastIndexOf22
+   block $__inlined_func$~lib/array/Array<i32>#lastIndexOf20
     local.get $1
     i32.load offset=12
     local.tee $3
     i32.eqz
-    br_if $__inlined_func$~lib/array/Array<i32>#lastIndexOf22
+    br_if $__inlined_func$~lib/array/Array<i32>#lastIndexOf20
     local.get $3
     i32.const 1
     i32.sub
@@ -16275,7 +16278,7 @@
       i32.load
       i32.const 2
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#lastIndexOf22
+      br_if $__inlined_func$~lib/array/Array<i32>#lastIndexOf20
       local.get $0
       i32.const 1
       i32.sub
@@ -16456,7 +16459,7 @@
    local.set $1
    i32.const -1
    local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#indexOf23
+   block $__inlined_func$~lib/array/Array<i32>#indexOf21
     local.get $3
     i32.load offset=12
     local.tee $8
@@ -16465,11 +16468,11 @@
     i32.const 1
     local.get $8
     select
-    br_if $__inlined_func$~lib/array/Array<i32>#indexOf23
+    br_if $__inlined_func$~lib/array/Array<i32>#indexOf21
     local.get $3
     i32.load offset=4
     local.set $3
-    loop $while-continue|024
+    loop $while-continue|022
      local.get $1
      local.get $8
      i32.lt_s
@@ -16483,12 +16486,12 @@
       i32.load
       i32.const 44
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf23
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf21
       local.get $0
       i32.const 1
       i32.add
       local.set $1
-      br $while-continue|024
+      br $while-continue|022
      end
     end
     i32.const -1
@@ -16513,7 +16516,7 @@
    local.set $1
    i32.const -1
    local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#indexOf26
+   block $__inlined_func$~lib/array/Array<i32>#indexOf24
     local.get $3
     i32.load offset=12
     local.tee $8
@@ -16522,11 +16525,11 @@
     i32.const 1
     local.get $8
     select
-    br_if $__inlined_func$~lib/array/Array<i32>#indexOf26
+    br_if $__inlined_func$~lib/array/Array<i32>#indexOf24
     local.get $3
     i32.load offset=4
     local.set $3
-    loop $while-continue|027
+    loop $while-continue|025
      local.get $1
      local.get $8
      i32.lt_s
@@ -16540,12 +16543,12 @@
       i32.load
       i32.const 42
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf26
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf24
       local.get $0
       i32.const 1
       i32.add
       local.set $1
-      br $while-continue|027
+      br $while-continue|025
      end
     end
     i32.const -1
@@ -16570,7 +16573,7 @@
    local.set $1
    i32.const -1
    local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#indexOf29
+   block $__inlined_func$~lib/array/Array<i32>#indexOf27
     local.get $3
     i32.load offset=12
     local.tee $8
@@ -16579,11 +16582,11 @@
     i32.const 1
     local.get $8
     select
-    br_if $__inlined_func$~lib/array/Array<i32>#indexOf29
+    br_if $__inlined_func$~lib/array/Array<i32>#indexOf27
     local.get $3
     i32.load offset=4
     local.set $3
-    loop $while-continue|030
+    loop $while-continue|028
      local.get $1
      local.get $8
      i32.lt_s
@@ -16597,12 +16600,12 @@
       i32.load
       i32.const 45
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf29
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf27
       local.get $0
       i32.const 1
       i32.add
       local.set $1
-      br $while-continue|030
+      br $while-continue|028
      end
     end
     i32.const -1
@@ -16627,7 +16630,7 @@
    local.set $1
    i32.const -1
    local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#indexOf32
+   block $__inlined_func$~lib/array/Array<i32>#indexOf30
     local.get $3
     i32.load offset=12
     local.tee $8
@@ -16636,11 +16639,11 @@
     i32.const 1
     local.get $8
     select
-    br_if $__inlined_func$~lib/array/Array<i32>#indexOf32
+    br_if $__inlined_func$~lib/array/Array<i32>#indexOf30
     local.get $3
     i32.load offset=4
     local.set $3
-    loop $while-continue|033
+    loop $while-continue|031
      local.get $1
      local.get $8
      i32.lt_s
@@ -16654,12 +16657,12 @@
       i32.load
       i32.const 43
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf32
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf30
       local.get $0
       i32.const 1
       i32.add
       local.set $1
-      br $while-continue|033
+      br $while-continue|031
      end
     end
     i32.const -1
@@ -16682,7 +16685,7 @@
    i32.store
    i32.const -1
    local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#indexOf35
+   block $__inlined_func$~lib/array/Array<i32>#indexOf33
     local.get $1
     i32.load offset=12
     local.tee $3
@@ -16691,7 +16694,7 @@
     i32.const 1
     local.get $3
     select
-    br_if $__inlined_func$~lib/array/Array<i32>#indexOf35
+    br_if $__inlined_func$~lib/array/Array<i32>#indexOf33
     local.get $3
     i32.const 100
     i32.sub
@@ -16705,7 +16708,7 @@
     local.get $1
     i32.load offset=4
     local.set $1
-    loop $while-continue|036
+    loop $while-continue|034
      local.get $0
      local.get $3
      i32.lt_s
@@ -16718,12 +16721,12 @@
       i32.load
       i32.const 43
       i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf35
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf33
       local.get $0
       i32.const 1
       i32.add
       local.set $0
-      br $while-continue|036
+      br $while-continue|034
      end
     end
     i32.const -1
@@ -16746,7 +16749,7 @@
    i32.store
    i32.const -1
    local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#indexOf39
+   block $__inlined_func$~lib/array/Array<i32>#indexOf36
     local.get $1
     i32.load offset=12
     local.tee $3
@@ -16755,9 +16758,73 @@
     i32.const 1
     local.get $3
     select
-    br_if $__inlined_func$~lib/array/Array<i32>#indexOf39
+    br_if $__inlined_func$~lib/array/Array<i32>#indexOf36
     local.get $3
     i32.const 2
+    i32.sub
+    local.tee $0
+    i32.const 0
+    local.get $0
+    i32.const 0
+    i32.gt_s
+    select
+    local.set $0
+    local.get $1
+    i32.load offset=4
+    local.set $1
+    loop $while-continue|037
+     local.get $0
+     local.get $3
+     i32.lt_s
+     if
+      local.get $0
+      i32.const 2
+      i32.shl
+      local.get $1
+      i32.add
+      i32.load
+      i32.const 43
+      i32.eq
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf36
+      local.get $0
+      i32.const 1
+      i32.add
+      local.set $0
+      br $while-continue|037
+     end
+    end
+    i32.const -1
+    local.set $0
+   end
+   local.get $0
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 0
+    i32.const 1552
+    i32.const 420
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $std/array/arr
+   local.tee $1
+   i32.store
+   i32.const -1
+   local.set $0
+   block $__inlined_func$~lib/array/Array<i32>#indexOf39
+    local.get $1
+    i32.load offset=12
+    local.tee $3
+    i32.const -4
+    i32.le_s
+    i32.const 1
+    local.get $3
+    select
+    br_if $__inlined_func$~lib/array/Array<i32>#indexOf39
+    local.get $3
+    i32.const 4
     i32.sub
     local.tee $0
     i32.const 0
@@ -16799,70 +16866,6 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 420
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $std/array/arr
-   local.tee $1
-   i32.store
-   i32.const -1
-   local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#indexOf43
-    local.get $1
-    i32.load offset=12
-    local.tee $3
-    i32.const -4
-    i32.le_s
-    i32.const 1
-    local.get $3
-    select
-    br_if $__inlined_func$~lib/array/Array<i32>#indexOf43
-    local.get $3
-    i32.const 4
-    i32.sub
-    local.tee $0
-    i32.const 0
-    local.get $0
-    i32.const 0
-    i32.gt_s
-    select
-    local.set $0
-    local.get $1
-    i32.load offset=4
-    local.set $1
-    loop $while-continue|044
-     local.get $0
-     local.get $3
-     i32.lt_s
-     if
-      local.get $0
-      i32.const 2
-      i32.shl
-      local.get $1
-      i32.add
-      i32.load
-      i32.const 43
-      i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf43
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
-      br $while-continue|044
-     end
-    end
-    i32.const -1
-    local.set $0
-   end
-   local.get $0
-   i32.const 0
-   i32.lt_s
-   if
-    i32.const 0
-    i32.const 1552
     i32.const 423
     i32.const 3
     call $~lib/builtins/abort
@@ -16876,11 +16879,68 @@
    local.set $1
    i32.const -1
    local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#indexOf46
+   block $__inlined_func$~lib/array/Array<i32>#indexOf43
     local.get $3
     i32.load offset=12
     local.tee $8
     i32.const 0
+    i32.le_s
+    i32.const 1
+    local.get $8
+    select
+    br_if $__inlined_func$~lib/array/Array<i32>#indexOf43
+    local.get $3
+    i32.load offset=4
+    local.set $3
+    loop $while-continue|044
+     local.get $1
+     local.get $8
+     i32.lt_s
+     if
+      local.get $1
+      local.tee $0
+      i32.const 2
+      i32.shl
+      local.get $3
+      i32.add
+      i32.load
+      i32.const 43
+      i32.eq
+      br_if $__inlined_func$~lib/array/Array<i32>#indexOf43
+      local.get $0
+      i32.const 1
+      i32.add
+      local.set $1
+      br $while-continue|044
+     end
+    end
+    i32.const -1
+    local.set $0
+   end
+   local.get $0
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 0
+    i32.const 1552
+    i32.const 426
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   global.get $std/array/arr
+   local.tee $3
+   i32.store
+   i32.const 1
+   local.set $1
+   i32.const -1
+   local.set $0
+   block $__inlined_func$~lib/array/Array<i32>#indexOf46
+    local.get $3
+    i32.load offset=12
+    local.tee $8
+    i32.const 1
     i32.le_s
     i32.const 1
     local.get $8
@@ -16920,7 +16980,7 @@
    if
     i32.const 0
     i32.const 1552
-    i32.const 426
+    i32.const 429
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -16929,7 +16989,7 @@
    global.get $std/array/arr
    local.tee $3
    i32.store
-   i32.const 1
+   i32.const 2
    local.set $1
    i32.const -1
    local.set $0
@@ -16937,7 +16997,7 @@
     local.get $3
     i32.load offset=12
     local.tee $8
-    i32.const 1
+    i32.const 2
     i32.le_s
     i32.const 1
     local.get $8
@@ -16966,63 +17026,6 @@
       i32.add
       local.set $1
       br $while-continue|050
-     end
-    end
-    i32.const -1
-    local.set $0
-   end
-   local.get $0
-   i32.const 0
-   i32.lt_s
-   if
-    i32.const 0
-    i32.const 1552
-    i32.const 429
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $std/array/arr
-   local.tee $3
-   i32.store
-   i32.const 2
-   local.set $1
-   i32.const -1
-   local.set $0
-   block $__inlined_func$~lib/array/Array<i32>#indexOf52
-    local.get $3
-    i32.load offset=12
-    local.tee $8
-    i32.const 2
-    i32.le_s
-    i32.const 1
-    local.get $8
-    select
-    br_if $__inlined_func$~lib/array/Array<i32>#indexOf52
-    local.get $3
-    i32.load offset=4
-    local.set $3
-    loop $while-continue|053
-     local.get $1
-     local.get $8
-     i32.lt_s
-     if
-      local.get $1
-      local.tee $0
-      i32.const 2
-      i32.shl
-      local.get $3
-      i32.add
-      i32.load
-      i32.const 43
-      i32.eq
-      br_if $__inlined_func$~lib/array/Array<i32>#indexOf52
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $1
-      br $while-continue|053
      end
     end
     i32.const -1
@@ -22304,11 +22307,11 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   block $1of154
-    block $0of155
-     block $outOfRange56
+   block $1of151
+    block $0of152
+     block $outOfRange53
       global.get $~argumentsLength
-      br_table $0of155 $1of154 $outOfRange56
+      br_table $0of152 $1of151 $outOfRange53
      end
      unreachable
     end
@@ -23153,7 +23156,7 @@
    local.get $1
    local.get $4
    i32.store
-   loop $for-loop|03
+   loop $for-loop|055
     local.get $3
     i32.const 512
     i32.lt_s
@@ -23196,7 +23199,7 @@
      i32.const 1
      i32.add
      local.set $3
-     br $for-loop|03
+     br $for-loop|055
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -23242,13 +23245,13 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   block $1of160
-    block $0of161
-     block $outOfRange62
+   block $1of157
+    block $0of158
+     block $outOfRange59
       global.get $~argumentsLength
       i32.const 1
       i32.sub
-      br_table $0of161 $1of160 $outOfRange62
+      br_table $0of158 $1of157 $outOfRange59
      end
      unreachable
     end
@@ -23295,7 +23298,7 @@
     local.get $0
     i32.load offset=12
     local.set $8
-    loop $for-loop|063
+    loop $for-loop|060
      local.get $1
      local.get $8
      i32.lt_s
@@ -23337,7 +23340,7 @@
       i32.const 1
       i32.add
       local.set $1
-      br $for-loop|063
+      br $for-loop|060
      end
     end
     global.get $~lib/memory/__stack_pointer
@@ -23578,7 +23581,7 @@
     i32.store
     i32.const 0
     local.set $0
-    loop $for-loop|164
+    loop $for-loop|161
      local.get $2
      local.get $4
      i32.lt_s
@@ -23630,7 +23633,7 @@
       i32.const 1
       i32.add
       local.set $2
-      br $for-loop|164
+      br $for-loop|161
      end
     end
     local.get $3
@@ -24192,7 +24195,7 @@
     i32.store
     i32.const 0
     local.set $0
-    loop $for-loop|065
+    loop $for-loop|062
      local.get $2
      local.get $4
      i32.lt_s
@@ -24231,7 +24234,7 @@
       i32.const 1
       i32.add
       local.set $2
-      br $for-loop|065
+      br $for-loop|062
      end
     end
     local.get $9
@@ -24383,7 +24386,7 @@
     i32.store
     i32.const 0
     local.set $0
-    loop $for-loop|066
+    loop $for-loop|063
      local.get $2
      local.get $4
      i32.lt_s
@@ -24424,7 +24427,7 @@
       i32.const 1
       i32.add
       local.set $2
-      br $for-loop|066
+      br $for-loop|063
      end
     end
     local.get $9
@@ -24761,7 +24764,7 @@
     i32.const 1
     i32.shr_u
     local.set $4
-    loop $for-loop|067
+    loop $for-loop|064
      local.get $1
      local.get $2
      i32.gt_s
@@ -24803,7 +24806,7 @@
       i32.const 1
       i32.add
       local.set $2
-      br $for-loop|067
+      br $for-loop|064
      end
     end
     global.get $~lib/memory/__stack_pointer
@@ -24975,7 +24978,7 @@
     i32.const 1
     i32.shr_u
     local.set $4
-    loop $for-loop|068
+    loop $for-loop|065
      local.get $1
      local.get $2
      i32.gt_s
@@ -25017,7 +25020,7 @@
       i32.const 1
       i32.add
       local.set $2
-      br $for-loop|068
+      br $for-loop|065
      end
     end
     global.get $~lib/memory/__stack_pointer
@@ -25197,7 +25200,7 @@
     i32.const 1
     i32.shr_u
     local.set $4
-    loop $for-loop|069
+    loop $for-loop|066
      local.get $1
      local.get $2
      i32.gt_s
@@ -25239,7 +25242,7 @@
       i32.const 1
       i32.add
       local.set $2
-      br $for-loop|069
+      br $for-loop|066
      end
     end
     global.get $~lib/memory/__stack_pointer
@@ -27733,7 +27736,7 @@
   if
    i32.const 0
    i32.const 1216
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -27764,7 +27767,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -110,7 +110,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1495,7 +1495,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2078,7 +2078,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2271,6 +2271,22 @@
   i32.const 1
   return
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2287,7 +2303,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2316,10 +2332,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -73,7 +73,7 @@
     if
      i32.const 0
      i32.const 1232
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -90,6 +90,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18228
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1232
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1232
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -114,61 +165,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18228
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1232
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1232
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -176,7 +179,7 @@
   else
    i32.const 1712
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1360
@@ -186,7 +189,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1716
@@ -196,11 +199,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -209,17 +212,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -989,7 +992,7 @@
     if
      i32.const 0
      i32.const 1232
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1216,7 +1219,7 @@
   if
    i32.const 1168
    i32.const 1232
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2257,12 +2260,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1232
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2288,8 +2292,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -117,7 +117,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1502,7 +1502,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2085,7 +2085,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2128,6 +2128,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2144,7 +2160,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2173,10 +2189,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -2,8 +2,8 @@
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
- (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
  (type $i32_i64_i32_=>_none (func (param i32 i64 i32)))
@@ -79,7 +79,7 @@
     if
      i32.const 0
      i32.const 1232
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -96,6 +96,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18172
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1232
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1232
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -120,61 +171,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18172
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1232
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1232
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -182,7 +185,7 @@
   else
    i32.const 1744
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1360
@@ -192,7 +195,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1748
@@ -202,11 +205,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -215,17 +218,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -995,7 +998,7 @@
     if
      i32.const 0
      i32.const 1232
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1222,7 +1225,7 @@
   if
    i32.const 1168
    i32.const 1232
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -4130,12 +4133,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1232
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -4161,8 +4165,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -463,7 +463,7 @@
     if
      i32.const 0
      i32.const 240
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1848,7 +1848,7 @@
     if
      i32.const 0
      i32.const 240
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2431,7 +2431,7 @@
   if
    i32.const 176
    i32.const 240
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -3665,6 +3665,22 @@
   end
   i32.const -1
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3681,7 +3697,7 @@
   if
    i32.const 0
    i32.const 240
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -3710,10 +3726,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -340,7 +340,7 @@
     if
      i32.const 0
      i32.const 1264
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -357,6 +357,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 23948
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1264
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1264
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -381,61 +432,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 23948
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1264
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1264
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -443,7 +446,7 @@
   else
    i32.const 7504
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1392
@@ -453,7 +456,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 7508
@@ -463,11 +466,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -476,17 +479,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1256,7 +1259,7 @@
     if
      i32.const 0
      i32.const 1264
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1483,7 +1486,7 @@
   if
    i32.const 1200
    i32.const 1264
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -8555,7 +8558,7 @@
   if
    i32.const 0
    i32.const 1264
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -8586,7 +8589,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -130,7 +130,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1515,7 +1515,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2098,7 +2098,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2141,6 +2141,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2157,7 +2173,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2186,10 +2202,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -87,7 +87,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -104,6 +104,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18404
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1120
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -128,61 +179,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18404
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -190,7 +193,7 @@
   else
    i32.const 1760
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1248
@@ -200,7 +203,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1764
@@ -210,11 +213,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -223,17 +226,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1003,7 +1006,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1230,7 +1233,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -23422,12 +23425,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1120
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -23453,8 +23457,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -116,7 +116,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1501,7 +1501,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2084,7 +2084,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/new.release.wat
+++ b/tests/compiler/std/new.release.wat
@@ -67,7 +67,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -851,7 +851,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -171,7 +171,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1556,7 +1556,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2139,7 +2139,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -126,7 +126,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -910,7 +910,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -125,7 +125,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1510,7 +1510,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2093,7 +2093,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2136,6 +2136,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2152,7 +2168,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2181,10 +2197,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -80,7 +80,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -97,6 +97,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18220
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1120
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -121,61 +172,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18220
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -183,7 +186,7 @@
   else
    i32.const 1648
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1248
@@ -193,7 +196,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1652
@@ -203,11 +206,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -216,17 +219,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -996,7 +999,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1223,7 +1226,7 @@
   if
    i32.const 1056
    i32.const 1120
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -17129,12 +17132,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1120
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -17160,8 +17164,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -159,7 +159,7 @@
     if
      i32.const 0
      i32.const 672
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1544,7 +1544,7 @@
     if
      i32.const 0
      i32.const 672
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2122,7 +2122,7 @@
   if
    i32.const 608
    i32.const 672
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2210,6 +2210,22 @@
   memory.copy
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2226,7 +2242,7 @@
   if
    i32.const 0
    i32.const 672
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2255,10 +2271,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -118,7 +118,7 @@
     if
      i32.const 0
      i32.const 1696
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -135,6 +135,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 18396
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1696
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1696
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -159,61 +210,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 18396
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1696
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1696
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -221,7 +224,7 @@
   else
    i32.const 1952
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1472
@@ -231,7 +234,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 1956
@@ -241,11 +244,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -254,17 +257,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1034,7 +1037,7 @@
     if
      i32.const 0
      i32.const 1696
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1326,7 +1329,7 @@
     if
      i32.const 1632
      i32.const 1696
-     i32.const 260
+     i32.const 270
      i32.const 31
      call $~lib/builtins/abort
      unreachable
@@ -1647,7 +1650,7 @@
      if
       i32.const 0
       i32.const 1696
-      i32.const 294
+      i32.const 304
       i32.const 14
       call $~lib/builtins/abort
       unreachable
@@ -1673,8 +1676,39 @@
       i32.eqz
       i32.eq
       if
-       local.get $1
-       call $~lib/rt/itcms/Object#makeGray
+       global.get $~lib/rt/itcms/state
+       i32.const 1
+       i32.eq
+       if
+        local.get $1
+        call $~lib/rt/itcms/Object#makeGray
+       else
+        local.get $1
+        call $~lib/rt/itcms/Object#unlink
+        global.get $~lib/rt/itcms/fromSpace
+        local.tee $2
+        i32.load offset=8
+        local.set $4
+        local.get $1
+        global.get $~lib/rt/itcms/white
+        local.get $2
+        i32.or
+        i32.store offset=4
+        local.get $1
+        local.get $4
+        i32.store offset=8
+        local.get $4
+        local.get $4
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        local.get $1
+        i32.or
+        i32.store offset=4
+        local.get $2
+        local.get $1
+        i32.store offset=8
+       end
       else
        global.get $~lib/rt/itcms/state
        i32.const 1

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -4,8 +4,8 @@
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
- (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -239,7 +239,7 @@
     if
      i32.const 0
      i32.const 384
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1624,7 +1624,7 @@
     if
      i32.const 0
      i32.const 384
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2207,7 +2207,7 @@
   if
    i32.const 320
    i32.const 384
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2272,6 +2272,22 @@
   i32.const 288
   call $~lib/rt/__newBuffer
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2288,7 +2304,7 @@
   if
    i32.const 0
    i32.const 384
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2317,10 +2333,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
@@ -189,7 +189,7 @@
     if
      i32.const 0
      i32.const 1408
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -206,6 +206,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 20252
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1408
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1408
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -230,61 +281,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 20252
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1408
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1408
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -292,7 +295,7 @@
   else
    i32.const 3728
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1088
@@ -302,7 +305,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 3732
@@ -312,11 +315,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -325,17 +328,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1155,7 +1158,7 @@
     if
      i32.const 0
      i32.const 1408
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1528,7 +1531,7 @@
   if
    i32.const 1344
    i32.const 1408
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1634,22 +1637,6 @@
   local.get $0
   memory.fill
   local.get $1
- )
- (func $~lib/staticarray/StaticArray<std/staticarray/Ref>#__uset (param $0 i32) (param $1 i32) (param $2 i32)
-  local.get $1
-  i32.const 2
-  i32.shl
-  local.get $0
-  i32.add
-  local.get $2
-  i32.store
-  local.get $2
-  if
-   local.get $0
-   local.get $2
-   i32.const 1
-   call $byn-split-outlined-A$~lib/rt/itcms/__link
-  end
  )
  (func $~lib/array/Array<i32>#__get (param $0 i32) (param $1 i32) (result i32)
   local.get $0
@@ -3186,13 +3173,27 @@
    local.tee $6
    i32.store offset=4
    local.get $6
-   i32.const 0
    call $std/staticarray/Ref#constructor
-   call $~lib/staticarray/StaticArray<std/staticarray/Ref>#__uset
+   local.tee $7
+   i32.store
+   local.get $7
+   if
+    local.get $6
+    local.get $7
+    i32.const 1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
    local.get $6
-   i32.const 1
    call $std/staticarray/Ref#constructor
-   call $~lib/staticarray/StaticArray<std/staticarray/Ref>#__uset
+   local.tee $7
+   i32.store offset=4
+   local.get $7
+   if
+    local.get $6
+    local.get $7
+    i32.const 1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
    local.get $6
    global.set $std/staticarray/arr4
    i32.const 0
@@ -4365,7 +4366,7 @@
     i32.lt_s
     select
     local.set $1
-    loop $while-continue|01
+    loop $while-continue|02
      local.get $1
      i32.const 0
      i32.ge_s
@@ -4383,7 +4384,7 @@
       i32.const 1
       i32.sub
       local.set $1
-      br $while-continue|01
+      br $while-continue|02
      end
     end
     i32.const -1
@@ -4404,7 +4405,7 @@
    global.set $~argumentsLength
    i32.const -1
    local.set $1
-   block $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf6
+   block $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf7
     local.get $2
     i32.const 20
     i32.sub
@@ -4413,7 +4414,7 @@
     i32.shr_u
     local.tee $0
     i32.eqz
-    br_if $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf6
+    br_if $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf7
     local.get $0
     local.get $0
     i32.add
@@ -4425,7 +4426,7 @@
     i32.lt_s
     select
     local.set $1
-    loop $while-continue|07
+    loop $while-continue|08
      local.get $1
      i32.const 0
      i32.ge_s
@@ -4438,12 +4439,12 @@
       i32.load
       i32.const 7
       i32.eq
-      br_if $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf6
+      br_if $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf7
       local.get $1
       i32.const 1
       i32.sub
       local.set $1
-      br $while-continue|07
+      br $while-continue|08
      end
     end
     i32.const -1
@@ -4462,7 +4463,7 @@
    end
    i32.const -1
    local.set $1
-   block $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf8
+   block $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf9
     local.get $2
     i32.const 20
     i32.sub
@@ -4471,7 +4472,7 @@
     i32.shr_u
     local.tee $0
     i32.eqz
-    br_if $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf8
+    br_if $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf9
     local.get $0
     i32.const 1
     i32.sub
@@ -4494,7 +4495,7 @@
       i32.load
       i32.const 2
       i32.eq
-      br_if $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf8
+      br_if $__inlined_func$~lib/staticarray/StaticArray<i32>#lastIndexOf9
       local.get $1
       i32.const 1
       i32.sub
@@ -6108,11 +6109,11 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   block $1of114
-    block $0of115
-     block $outOfRange16
+   block $1of115
+    block $0of116
+     block $outOfRange17
       global.get $~argumentsLength
-      br_table $0of115 $1of114 $outOfRange16
+      br_table $0of116 $1of115 $outOfRange17
      end
      unreachable
     end
@@ -7015,7 +7016,7 @@
   if
    i32.const 0
    i32.const 1408
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -7046,7 +7047,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -292,7 +292,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1677,7 +1677,7 @@
     if
      i32.const 0
      i32.const 128
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2260,7 +2260,7 @@
   if
    i32.const 64
    i32.const 128
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -236,7 +236,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1020,7 +1020,7 @@
     if
      i32.const 0
      i32.const 1152
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1247,7 +1247,7 @@
   if
    i32.const 1088
    i32.const 1152
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -130,7 +130,7 @@
     if
      i32.const 0
      i32.const 192
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1515,7 +1515,7 @@
     if
      i32.const 0
      i32.const 192
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2098,7 +2098,7 @@
   if
    i32.const 128
    i32.const 192
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -102,7 +102,7 @@
     if
      i32.const 0
      i32.const 1216
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -886,7 +886,7 @@
     if
      i32.const 0
      i32.const 1216
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1113,7 +1113,7 @@
   if
    i32.const 1152
    i32.const 1216
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -830,7 +830,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -2215,7 +2215,7 @@
     if
      i32.const 0
      i32.const 416
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2798,7 +2798,7 @@
   if
    i32.const 352
    i32.const 416
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2926,6 +2926,22 @@
   end
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2942,7 +2958,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2971,10 +2987,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -661,7 +661,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -678,6 +678,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 42380
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1440
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1440
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -702,61 +753,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 42380
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1440
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1440
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -764,7 +767,7 @@
   else
    i32.const 25952
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1264
@@ -774,7 +777,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 25956
@@ -784,11 +787,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -797,17 +800,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1577,7 +1580,7 @@
     if
      i32.const 0
      i32.const 1440
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1804,7 +1807,7 @@
   if
    i32.const 1376
    i32.const 1440
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -23544,7 +23547,7 @@
   if
    i32.const 0
    i32.const 1440
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -23575,7 +23578,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -163,7 +163,7 @@
     if
      i32.const 0
      i32.const 176
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1548,7 +1548,7 @@
     if
      i32.const 0
      i32.const 176
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2131,7 +2131,7 @@
   if
    i32.const 112
    i32.const 176
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2174,6 +2174,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2190,7 +2206,7 @@
   if
    i32.const 0
    i32.const 176
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2219,10 +2235,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -1,8 +1,8 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
@@ -164,7 +164,7 @@
     if
      i32.const 0
      i32.const 1200
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -181,6 +181,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 19084
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1200
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1200
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -205,61 +256,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 19084
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1200
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1200
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -267,7 +270,7 @@
   else
    i32.const 2656
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1328
@@ -277,7 +280,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 2660
@@ -287,11 +290,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -300,17 +303,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1080,7 +1083,7 @@
     if
      i32.const 0
      i32.const 1200
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1307,7 +1310,7 @@
   if
    i32.const 1136
    i32.const 1200
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2297,23 +2300,15 @@
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2700
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   global.get $~lib/symbol/stringToId
-   if
+   block $folding-inner0
     global.get $~lib/memory/__stack_pointer
-    global.get $~lib/symbol/stringToId
-    local.tee $0
+    i32.const 2700
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
     i32.store
-    local.get $0
-    i32.const 1056
-    call $~lib/util/hash/HASH<~lib/string/String>
-    call $~lib/map/Map<~lib/string/String,usize>#find
+    global.get $~lib/symbol/stringToId
     if
      global.get $~lib/memory/__stack_pointer
      global.get $~lib/symbol/stringToId
@@ -2323,729 +2318,739 @@
      i32.const 1056
      call $~lib/util/hash/HASH<~lib/string/String>
      call $~lib/map/Map<~lib/string/String,usize>#find
-     local.tee $0
-     i32.eqz
      if
-      i32.const 1648
-      i32.const 1712
-      i32.const 105
-      i32.const 17
-      call $~lib/builtins/abort
-      unreachable
+      global.get $~lib/memory/__stack_pointer
+      global.get $~lib/symbol/stringToId
+      local.tee $0
+      i32.store
+      local.get $0
+      i32.const 1056
+      call $~lib/util/hash/HASH<~lib/string/String>
+      call $~lib/map/Map<~lib/string/String,usize>#find
+      local.tee $0
+      i32.eqz
+      if
+       i32.const 1648
+       i32.const 1712
+       i32.const 105
+       i32.const 17
+       call $~lib/builtins/abort
+       unreachable
+      end
+      local.get $0
+      i32.load offset=4
+      global.get $~lib/memory/__stack_pointer
+      i32.const 4
+      i32.add
+      global.set $~lib/memory/__stack_pointer
+      return
      end
-     local.get $0
-     i32.load offset=4
+    else
      global.get $~lib/memory/__stack_pointer
      i32.const 4
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     return
-    end
-   else
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 2700
-    i32.lt_s
-    br_if $folding-inner1
-    global.get $~lib/memory/__stack_pointer
-    local.tee $0
-    i32.const 0
-    i32.store
-    local.get $0
-    i32.const 24
-    i32.const 3
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-    local.get $0
-    i32.const 16
-    call $~lib/arraybuffer/ArrayBuffer#constructor
-    local.tee $1
-    i32.store
-    local.get $1
-    if
-     local.get $0
-     local.get $1
-     i32.const 0
-     call $byn-split-outlined-A$~lib/rt/itcms/__link
-    end
-    local.get $0
-    i32.const 3
-    i32.store offset=4
-    local.get $0
-    i32.const 48
-    call $~lib/arraybuffer/ArrayBuffer#constructor
-    local.tee $1
-    i32.store offset=8
-    local.get $1
-    if
-     local.get $0
-     local.get $1
-     i32.const 0
-     call $byn-split-outlined-A$~lib/rt/itcms/__link
-    end
-    local.get $0
-    i32.const 4
-    i32.store offset=12
-    local.get $0
-    i32.const 0
-    i32.store offset=16
-    local.get $0
-    i32.const 0
-    i32.store offset=20
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    global.set $~lib/symbol/stringToId
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    global.get $~lib/memory/__stack_pointer
-    i32.const 2700
-    i32.lt_s
-    br_if $folding-inner1
-    global.get $~lib/memory/__stack_pointer
-    local.tee $0
-    i32.const 0
-    i32.store
-    local.get $0
-    i32.const 24
-    i32.const 4
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-    local.get $0
-    i32.const 16
-    call $~lib/arraybuffer/ArrayBuffer#constructor
-    local.tee $1
-    i32.store
-    local.get $1
-    if
-     local.get $0
-     local.get $1
-     i32.const 0
-     call $byn-split-outlined-A$~lib/rt/itcms/__link
-    end
-    local.get $0
-    i32.const 3
-    i32.store offset=4
-    local.get $0
-    i32.const 48
-    call $~lib/arraybuffer/ArrayBuffer#constructor
-    local.tee $1
-    i32.store offset=8
-    local.get $1
-    if
-     local.get $0
-     local.get $1
-     i32.const 0
-     call $byn-split-outlined-A$~lib/rt/itcms/__link
-    end
-    local.get $0
-    i32.const 4
-    i32.store offset=12
-    local.get $0
-    i32.const 0
-    i32.store offset=16
-    local.get $0
-    i32.const 0
-    i32.store offset=20
-    global.get $~lib/memory/__stack_pointer
-    i32.const 4
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-    local.get $0
-    global.set $~lib/symbol/idToString
-   end
-   global.get $~lib/symbol/nextId
-   local.tee $2
-   i32.const 1
-   i32.add
-   global.set $~lib/symbol/nextId
-   local.get $2
-   i32.eqz
-   if
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.tee $0
-   global.get $~lib/symbol/stringToId
-   local.tee $4
-   i32.store
-   local.get $0
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2700
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $4
-   i32.const 1056
-   call $~lib/util/hash/HASH<~lib/string/String>
-   local.tee $5
-   call $~lib/map/Map<~lib/string/String,usize>#find
-   local.tee $0
-   if
-    local.get $0
-    local.get $2
-    i32.store offset=4
-   else
-    local.get $4
-    i32.load offset=16
-    local.get $4
-    i32.load offset=12
-    i32.eq
-    if
-     local.get $4
-     i32.load offset=20
-     local.get $4
-     i32.load offset=12
-     i32.const 3
-     i32.mul
-     i32.const 4
-     i32.div_s
-     i32.lt_s
-     if (result i32)
-      local.get $4
-      i32.load offset=4
-     else
-      local.get $4
-      i32.load offset=4
-      i32.const 1
-      i32.shl
-      i32.const 1
-      i32.or
-     end
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
      i32.const 2700
      i32.lt_s
-     br_if $folding-inner1
+     br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
      local.tee $0
-     i64.const 0
-     i64.store
-     local.get $0
      i32.const 0
-     i32.store offset=8
-     local.get $0
-     local.get $6
-     i32.const 1
-     i32.add
-     local.tee $0
-     i32.const 2
-     i32.shl
-     call $~lib/arraybuffer/ArrayBuffer#constructor
-     local.tee $7
      i32.store
-     global.get $~lib/memory/__stack_pointer
      local.get $0
+     i32.const 24
      i32.const 3
-     i32.shl
-     i32.const 3
-     i32.div_s
-     local.tee $8
-     i32.const 12
-     i32.mul
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store
+     local.get $0
+     i32.const 16
      call $~lib/arraybuffer/ArrayBuffer#constructor
      local.tee $1
-     i32.store offset=4
-     local.get $4
-     i32.load offset=8
-     local.tee $3
-     local.get $4
-     i32.load offset=16
-     i32.const 12
-     i32.mul
-     i32.add
-     local.set $9
-     local.get $1
-     local.set $0
-     loop $while-continue|0
-      local.get $3
-      local.get $9
-      i32.ne
-      if
-       local.get $3
-       i32.load offset=8
-       i32.const 1
-       i32.and
-       i32.eqz
-       if
-        global.get $~lib/memory/__stack_pointer
-        local.get $3
-        i32.load
-        local.tee $10
-        i32.store offset=8
-        local.get $0
-        local.get $10
-        i32.store
-        local.get $0
-        local.get $3
-        i32.load offset=4
-        i32.store offset=4
-        local.get $0
-        local.get $10
-        call $~lib/util/hash/HASH<~lib/string/String>
-        local.get $6
-        i32.and
-        i32.const 2
-        i32.shl
-        local.get $7
-        i32.add
-        local.tee $10
-        i32.load
-        i32.store offset=8
-        local.get $10
-        local.get $0
-        i32.store
-        local.get $0
-        i32.const 12
-        i32.add
-        local.set $0
-       end
-       local.get $3
-       i32.const 12
-       i32.add
-       local.set $3
-       br $while-continue|0
-      end
-     end
-     local.get $4
-     local.get $7
      i32.store
-     local.get $7
-     if
-      local.get $4
-      local.get $7
-      i32.const 0
-      call $byn-split-outlined-A$~lib/rt/itcms/__link
-     end
-     local.get $4
-     local.get $6
-     i32.store offset=4
-     local.get $4
-     local.get $1
-     i32.store offset=8
      local.get $1
      if
-      local.get $4
+      local.get $0
       local.get $1
       i32.const 0
       call $byn-split-outlined-A$~lib/rt/itcms/__link
      end
-     local.get $4
-     local.get $8
+     local.get $0
+     i32.const 3
+     i32.store offset=4
+     local.get $0
+     i32.const 48
+     call $~lib/arraybuffer/ArrayBuffer#constructor
+     local.tee $1
+     i32.store offset=8
+     local.get $1
+     if
+      local.get $0
+      local.get $1
+      i32.const 0
+      call $byn-split-outlined-A$~lib/rt/itcms/__link
+     end
+     local.get $0
+     i32.const 4
      i32.store offset=12
+     local.get $0
+     i32.const 0
+     i32.store offset=16
+     local.get $0
+     i32.const 0
+     i32.store offset=20
+     global.get $~lib/memory/__stack_pointer
+     i32.const 4
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $0
+     global.set $~lib/symbol/stringToId
+     global.get $~lib/memory/__stack_pointer
+     i32.const 4
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 2700
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     local.tee $0
+     i32.const 0
+     i32.store
+     local.get $0
+     i32.const 24
+     i32.const 4
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store
+     local.get $0
+     i32.const 16
+     call $~lib/arraybuffer/ArrayBuffer#constructor
+     local.tee $1
+     i32.store
+     local.get $1
+     if
+      local.get $0
+      local.get $1
+      i32.const 0
+      call $byn-split-outlined-A$~lib/rt/itcms/__link
+     end
+     local.get $0
+     i32.const 3
+     i32.store offset=4
+     local.get $0
+     i32.const 48
+     call $~lib/arraybuffer/ArrayBuffer#constructor
+     local.tee $1
+     i32.store offset=8
+     local.get $1
+     if
+      local.get $0
+      local.get $1
+      i32.const 0
+      call $byn-split-outlined-A$~lib/rt/itcms/__link
+     end
+     local.get $0
+     i32.const 4
+     i32.store offset=12
+     local.get $0
+     i32.const 0
+     i32.store offset=16
+     local.get $0
+     i32.const 0
+     i32.store offset=20
+     global.get $~lib/memory/__stack_pointer
+     i32.const 4
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $0
+     global.set $~lib/symbol/idToString
+    end
+    global.get $~lib/symbol/nextId
+    local.tee $3
+    i32.const 1
+    i32.add
+    global.set $~lib/symbol/nextId
+    local.get $3
+    i32.eqz
+    if
+     unreachable
+    end
+    global.get $~lib/memory/__stack_pointer
+    local.tee $0
+    global.get $~lib/symbol/stringToId
+    local.tee $4
+    i32.store
+    local.get $0
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 2700
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store
+    local.get $4
+    i32.const 1056
+    call $~lib/util/hash/HASH<~lib/string/String>
+    local.tee $5
+    call $~lib/map/Map<~lib/string/String,usize>#find
+    local.tee $0
+    if
+     local.get $0
+     local.get $3
+     i32.store offset=4
+    else
+     local.get $4
+     i32.load offset=16
+     local.get $4
+     i32.load offset=12
+     i32.eq
+     if
+      local.get $4
+      i32.load offset=20
+      local.get $4
+      i32.load offset=12
+      i32.const 3
+      i32.mul
+      i32.const 4
+      i32.div_s
+      i32.lt_s
+      if (result i32)
+       local.get $4
+       i32.load offset=4
+      else
+       local.get $4
+       i32.load offset=4
+       i32.const 1
+       i32.shl
+       i32.const 1
+       i32.or
+      end
+      local.set $6
+      global.get $~lib/memory/__stack_pointer
+      i32.const 12
+      i32.sub
+      global.set $~lib/memory/__stack_pointer
+      global.get $~lib/memory/__stack_pointer
+      i32.const 2700
+      i32.lt_s
+      br_if $folding-inner1
+      global.get $~lib/memory/__stack_pointer
+      local.tee $0
+      i64.const 0
+      i64.store
+      local.get $0
+      i32.const 0
+      i32.store offset=8
+      local.get $0
+      local.get $6
+      i32.const 1
+      i32.add
+      local.tee $0
+      i32.const 2
+      i32.shl
+      call $~lib/arraybuffer/ArrayBuffer#constructor
+      local.tee $7
+      i32.store
+      global.get $~lib/memory/__stack_pointer
+      local.get $0
+      i32.const 3
+      i32.shl
+      i32.const 3
+      i32.div_s
+      local.tee $8
+      i32.const 12
+      i32.mul
+      call $~lib/arraybuffer/ArrayBuffer#constructor
+      local.tee $1
+      i32.store offset=4
+      local.get $4
+      i32.load offset=8
+      local.tee $2
+      local.get $4
+      i32.load offset=16
+      i32.const 12
+      i32.mul
+      i32.add
+      local.set $9
+      local.get $1
+      local.set $0
+      loop $while-continue|0
+       local.get $2
+       local.get $9
+       i32.ne
+       if
+        local.get $2
+        i32.load offset=8
+        i32.const 1
+        i32.and
+        i32.eqz
+        if
+         global.get $~lib/memory/__stack_pointer
+         local.get $2
+         i32.load
+         local.tee $10
+         i32.store offset=8
+         local.get $0
+         local.get $10
+         i32.store
+         local.get $0
+         local.get $2
+         i32.load offset=4
+         i32.store offset=4
+         local.get $0
+         local.get $10
+         call $~lib/util/hash/HASH<~lib/string/String>
+         local.get $6
+         i32.and
+         i32.const 2
+         i32.shl
+         local.get $7
+         i32.add
+         local.tee $10
+         i32.load
+         i32.store offset=8
+         local.get $10
+         local.get $0
+         i32.store
+         local.get $0
+         i32.const 12
+         i32.add
+         local.set $0
+        end
+        local.get $2
+        i32.const 12
+        i32.add
+        local.set $2
+        br $while-continue|0
+       end
+      end
+      local.get $4
+      local.get $7
+      i32.store
+      local.get $7
+      if
+       local.get $4
+       local.get $7
+       i32.const 0
+       call $byn-split-outlined-A$~lib/rt/itcms/__link
+      end
+      local.get $4
+      local.get $6
+      i32.store offset=4
+      local.get $4
+      local.get $1
+      i32.store offset=8
+      local.get $1
+      if
+       local.get $4
+       local.get $1
+       i32.const 0
+       call $byn-split-outlined-A$~lib/rt/itcms/__link
+      end
+      local.get $4
+      local.get $8
+      i32.store offset=12
+      local.get $4
+      local.get $4
+      i32.load offset=20
+      i32.store offset=16
+      global.get $~lib/memory/__stack_pointer
+      i32.const 12
+      i32.add
+      global.set $~lib/memory/__stack_pointer
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $4
+     i32.load offset=8
+     local.tee $0
+     i32.store
+     local.get $4
+     local.get $4
+     i32.load offset=16
+     local.tee $1
+     i32.const 1
+     i32.add
+     i32.store offset=16
+     local.get $1
+     i32.const 12
+     i32.mul
+     local.get $0
+     i32.add
+     local.tee $0
+     i32.const 1056
+     i32.store
+     local.get $4
+     i32.const 1056
+     i32.const 1
+     call $byn-split-outlined-A$~lib/rt/itcms/__link
+     local.get $0
+     local.get $3
+     i32.store offset=4
      local.get $4
      local.get $4
      i32.load offset=20
-     i32.store offset=16
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12
+     i32.const 1
      i32.add
-     global.set $~lib/memory/__stack_pointer
+     i32.store offset=20
+     local.get $0
+     local.get $4
+     i32.load
+     local.get $4
+     i32.load offset=4
+     local.get $5
+     i32.and
+     i32.const 2
+     i32.shl
+     i32.add
+     local.tee $1
+     i32.load
+     i32.store offset=8
+     local.get $1
+     local.get $0
+     i32.store
     end
     global.get $~lib/memory/__stack_pointer
-    local.get $4
-    i32.load offset=8
-    local.tee $0
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    global.get $~lib/symbol/idToString
+    local.tee $4
     i32.store
-    local.get $4
-    local.get $4
-    i32.load offset=16
-    local.tee $1
-    i32.const 1
-    i32.add
-    i32.store offset=16
-    local.get $1
-    i32.const 12
-    i32.mul
-    local.get $0
-    i32.add
-    local.tee $0
-    i32.const 1056
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 2700
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
     i32.store
-    local.get $4
-    i32.const 1056
-    i32.const 1
-    call $byn-split-outlined-A$~lib/rt/itcms/__link
-    local.get $0
-    local.get $2
-    i32.store offset=4
-    local.get $4
-    local.get $4
-    i32.load offset=20
-    i32.const 1
-    i32.add
-    i32.store offset=20
-    local.get $0
     local.get $4
     i32.load
+    local.get $3
+    i32.const -1028477379
+    i32.mul
+    i32.const 374761397
+    i32.add
+    i32.const 17
+    i32.rotl
+    i32.const 668265263
+    i32.mul
+    local.tee $0
+    local.get $0
+    i32.const 15
+    i32.shr_u
+    i32.xor
+    i32.const -2048144777
+    i32.mul
+    local.tee $0
+    local.get $0
+    i32.const 13
+    i32.shr_u
+    i32.xor
+    i32.const -1028477379
+    i32.mul
+    local.tee $0
+    local.get $0
+    i32.const 16
+    i32.shr_u
+    i32.xor
+    local.tee $5
     local.get $4
     i32.load offset=4
-    local.get $5
     i32.and
     i32.const 2
     i32.shl
     i32.add
-    local.tee $1
     i32.load
-    i32.store offset=8
-    local.get $1
-    local.get $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/symbol/idToString
-   local.tee $4
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2700
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $4
-   i32.load
-   local.get $2
-   i32.const -1028477379
-   i32.mul
-   i32.const 374761397
-   i32.add
-   i32.const 17
-   i32.rotl
-   i32.const 668265263
-   i32.mul
-   local.tee $0
-   i32.const 15
-   i32.shr_u
-   local.get $0
-   i32.xor
-   i32.const -2048144777
-   i32.mul
-   local.tee $0
-   i32.const 13
-   i32.shr_u
-   local.get $0
-   i32.xor
-   i32.const -1028477379
-   i32.mul
-   local.tee $0
-   i32.const 16
-   i32.shr_u
-   local.get $0
-   i32.xor
-   local.tee $5
-   local.get $4
-   i32.load offset=4
-   i32.and
-   i32.const 2
-   i32.shl
-   i32.add
-   i32.load
-   local.set $0
-   block $__inlined_func$~lib/map/Map<usize,~lib/string/String>#find
-    loop $while-continue|06
-     local.get $0
-     if
-      local.get $0
-      i32.load offset=8
-      local.tee $1
-      i32.const 1
-      i32.and
-      if (result i32)
-       i32.const 0
-      else
-       local.get $2
-       local.get $0
-       i32.load
-       i32.eq
-      end
-      br_if $__inlined_func$~lib/map/Map<usize,~lib/string/String>#find
-      local.get $1
-      i32.const -2
-      i32.and
-      local.set $0
-      br $while-continue|06
-     end
-    end
-    i32.const 0
     local.set $0
-   end
-   local.get $0
-   if
-    local.get $0
-    i32.const 1056
-    i32.store offset=4
-    local.get $4
-    i32.const 1056
-    i32.const 1
-    call $byn-split-outlined-A$~lib/rt/itcms/__link
-   else
-    local.get $4
-    i32.load offset=16
-    local.get $4
-    i32.load offset=12
-    i32.eq
-    if
-     local.get $4
-     i32.load offset=20
-     local.get $4
-     i32.load offset=12
-     i32.const 3
-     i32.mul
-     i32.const 4
-     i32.div_s
-     i32.lt_s
-     if (result i32)
-      local.get $4
-      i32.load offset=4
-     else
-      local.get $4
-      i32.load offset=4
-      i32.const 1
-      i32.shl
-      i32.const 1
-      i32.or
-     end
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2700
-     i32.lt_s
-     br_if $folding-inner1
-     global.get $~lib/memory/__stack_pointer
-     local.tee $0
-     i64.const 0
-     i64.store
-     local.get $0
-     local.get $6
-     i32.const 1
-     i32.add
-     local.tee $0
-     i32.const 2
-     i32.shl
-     call $~lib/arraybuffer/ArrayBuffer#constructor
-     local.tee $7
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.const 3
-     i32.shl
-     i32.const 3
-     i32.div_s
-     local.tee $8
-     i32.const 12
-     i32.mul
-     call $~lib/arraybuffer/ArrayBuffer#constructor
-     local.tee $1
-     i32.store offset=4
-     local.get $4
-     i32.load offset=8
-     local.tee $3
-     local.get $4
-     i32.load offset=16
-     i32.const 12
-     i32.mul
-     i32.add
-     local.set $9
-     local.get $1
-     local.set $0
+    block $__inlined_func$~lib/map/Map<usize,~lib/string/String>#find
      loop $while-continue|00
-      local.get $3
-      local.get $9
-      i32.ne
+      local.get $0
       if
-       local.get $3
+       local.get $0
        i32.load offset=8
+       local.tee $1
        i32.const 1
        i32.and
-       i32.eqz
-       if
-        local.get $0
+       if (result i32)
+        i32.const 0
+       else
         local.get $3
+        local.get $0
         i32.load
-        local.tee $10
-        i32.store
-        local.get $0
-        local.get $3
-        i32.load offset=4
-        i32.store offset=4
-        local.get $0
-        local.get $10
-        i32.const -1028477379
-        i32.mul
-        i32.const 374761397
-        i32.add
-        i32.const 17
-        i32.rotl
-        i32.const 668265263
-        i32.mul
-        local.tee $10
-        i32.const 15
-        i32.shr_u
-        local.get $10
-        i32.xor
-        i32.const -2048144777
-        i32.mul
-        local.tee $10
-        i32.const 13
-        i32.shr_u
-        local.get $10
-        i32.xor
-        i32.const -1028477379
-        i32.mul
-        local.tee $10
-        i32.const 16
-        i32.shr_u
-        local.get $10
-        i32.xor
-        local.get $6
-        i32.and
-        i32.const 2
-        i32.shl
-        local.get $7
-        i32.add
-        local.tee $10
-        i32.load
-        i32.store offset=8
-        local.get $10
-        local.get $0
-        i32.store
-        local.get $0
-        i32.const 12
-        i32.add
-        local.set $0
+        i32.eq
        end
-       local.get $3
-       i32.const 12
-       i32.add
-       local.set $3
+       br_if $__inlined_func$~lib/map/Map<usize,~lib/string/String>#find
+       local.get $1
+       i32.const -2
+       i32.and
+       local.set $0
        br $while-continue|00
       end
      end
-     local.get $4
-     local.get $7
-     i32.store
-     local.get $7
-     if
-      local.get $4
-      local.get $7
-      i32.const 0
-      call $byn-split-outlined-A$~lib/rt/itcms/__link
-     end
-     local.get $4
-     local.get $6
+     i32.const 0
+     local.set $0
+    end
+    local.get $0
+    if
+     local.get $0
+     i32.const 1056
      i32.store offset=4
      local.get $4
-     local.get $1
-     i32.store offset=8
-     local.get $1
+     i32.const 1056
+     i32.const 1
+     call $byn-split-outlined-A$~lib/rt/itcms/__link
+    else
+     local.get $4
+     i32.load offset=16
+     local.get $4
+     i32.load offset=12
+     i32.eq
      if
       local.get $4
+      i32.load offset=20
+      local.get $4
+      i32.load offset=12
+      i32.const 3
+      i32.mul
+      i32.const 4
+      i32.div_s
+      i32.lt_s
+      if (result i32)
+       local.get $4
+       i32.load offset=4
+      else
+       local.get $4
+       i32.load offset=4
+       i32.const 1
+       i32.shl
+       i32.const 1
+       i32.or
+      end
+      local.set $6
+      global.get $~lib/memory/__stack_pointer
+      i32.const 8
+      i32.sub
+      global.set $~lib/memory/__stack_pointer
+      global.get $~lib/memory/__stack_pointer
+      i32.const 2700
+      i32.lt_s
+      br_if $folding-inner1
+      global.get $~lib/memory/__stack_pointer
+      local.tee $0
+      i64.const 0
+      i64.store
+      local.get $0
+      local.get $6
+      i32.const 1
+      i32.add
+      local.tee $0
+      i32.const 2
+      i32.shl
+      call $~lib/arraybuffer/ArrayBuffer#constructor
+      local.tee $7
+      i32.store
+      global.get $~lib/memory/__stack_pointer
+      local.get $0
+      i32.const 3
+      i32.shl
+      i32.const 3
+      i32.div_s
+      local.tee $8
+      i32.const 12
+      i32.mul
+      call $~lib/arraybuffer/ArrayBuffer#constructor
+      local.tee $1
+      i32.store offset=4
+      local.get $4
+      i32.load offset=8
+      local.tee $2
+      local.get $4
+      i32.load offset=16
+      i32.const 12
+      i32.mul
+      i32.add
+      local.set $9
       local.get $1
-      i32.const 0
-      call $byn-split-outlined-A$~lib/rt/itcms/__link
+      local.set $0
+      loop $while-continue|01
+       local.get $2
+       local.get $9
+       i32.ne
+       if
+        local.get $2
+        i32.load offset=8
+        i32.const 1
+        i32.and
+        i32.eqz
+        if
+         local.get $0
+         local.get $2
+         i32.load
+         local.tee $10
+         i32.store
+         local.get $0
+         local.get $2
+         i32.load offset=4
+         i32.store offset=4
+         local.get $0
+         local.get $10
+         i32.const -1028477379
+         i32.mul
+         i32.const 374761397
+         i32.add
+         i32.const 17
+         i32.rotl
+         i32.const 668265263
+         i32.mul
+         local.tee $10
+         local.get $10
+         i32.const 15
+         i32.shr_u
+         i32.xor
+         i32.const -2048144777
+         i32.mul
+         local.tee $10
+         local.get $10
+         i32.const 13
+         i32.shr_u
+         i32.xor
+         i32.const -1028477379
+         i32.mul
+         local.tee $10
+         local.get $10
+         i32.const 16
+         i32.shr_u
+         i32.xor
+         local.get $6
+         i32.and
+         i32.const 2
+         i32.shl
+         local.get $7
+         i32.add
+         local.tee $10
+         i32.load
+         i32.store offset=8
+         local.get $10
+         local.get $0
+         i32.store
+         local.get $0
+         i32.const 12
+         i32.add
+         local.set $0
+        end
+        local.get $2
+        i32.const 12
+        i32.add
+        local.set $2
+        br $while-continue|01
+       end
+      end
+      local.get $4
+      local.get $7
+      i32.store
+      local.get $7
+      if
+       local.get $4
+       local.get $7
+       i32.const 0
+       call $byn-split-outlined-A$~lib/rt/itcms/__link
+      end
+      local.get $4
+      local.get $6
+      i32.store offset=4
+      local.get $4
+      local.get $1
+      i32.store offset=8
+      local.get $1
+      if
+       local.get $4
+       local.get $1
+       i32.const 0
+       call $byn-split-outlined-A$~lib/rt/itcms/__link
+      end
+      local.get $4
+      local.get $8
+      i32.store offset=12
+      local.get $4
+      local.get $4
+      i32.load offset=20
+      i32.store offset=16
+      global.get $~lib/memory/__stack_pointer
+      i32.const 8
+      i32.add
+      global.set $~lib/memory/__stack_pointer
      end
+     global.get $~lib/memory/__stack_pointer
      local.get $4
-     local.get $8
-     i32.store offset=12
+     i32.load offset=8
+     local.tee $0
+     i32.store
+     local.get $4
+     local.get $4
+     i32.load offset=16
+     local.tee $1
+     i32.const 1
+     i32.add
+     i32.store offset=16
+     local.get $1
+     i32.const 12
+     i32.mul
+     local.get $0
+     i32.add
+     local.tee $0
+     local.get $3
+     i32.store
+     local.get $0
+     i32.const 1056
+     i32.store offset=4
+     local.get $4
+     i32.const 1056
+     i32.const 1
+     call $byn-split-outlined-A$~lib/rt/itcms/__link
      local.get $4
      local.get $4
      i32.load offset=20
-     i32.store offset=16
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
+     i32.const 1
      i32.add
-     global.set $~lib/memory/__stack_pointer
+     i32.store offset=20
+     local.get $0
+     local.get $4
+     i32.load
+     local.get $4
+     i32.load offset=4
+     local.get $5
+     i32.and
+     i32.const 2
+     i32.shl
+     i32.add
+     local.tee $1
+     i32.load
+     i32.store offset=8
+     local.get $1
+     local.get $0
+     i32.store
     end
     global.get $~lib/memory/__stack_pointer
-    local.get $4
-    i32.load offset=8
-    local.tee $0
-    i32.store
-    local.get $4
-    local.get $4
-    i32.load offset=16
-    local.tee $1
-    i32.const 1
+    i32.const 4
     i32.add
-    i32.store offset=16
-    local.get $1
-    i32.const 12
-    i32.mul
-    local.get $0
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
     i32.add
-    local.tee $0
-    local.get $2
-    i32.store
-    local.get $0
-    i32.const 1056
-    i32.store offset=4
-    local.get $4
-    i32.const 1056
-    i32.const 1
-    call $byn-split-outlined-A$~lib/rt/itcms/__link
-    local.get $4
-    local.get $4
-    i32.load offset=20
-    i32.const 1
-    i32.add
-    i32.store offset=20
-    local.get $0
-    local.get $4
-    i32.load
-    local.get $4
-    i32.load offset=4
-    local.get $5
-    i32.and
-    i32.const 2
-    i32.shl
-    i32.add
-    local.tee $1
-    i32.load
-    i32.store offset=8
-    local.get $1
-    local.get $0
-    i32.store
+    global.set $~lib/memory/__stack_pointer
+    local.get $3
+    return
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $2
-   return
   end
   i32.const 19104
   i32.const 19152
@@ -3809,7 +3814,7 @@
   if
    i32.const 0
    i32.const 1200
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -3840,7 +3845,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -474,7 +474,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1859,7 +1859,7 @@
     if
      i32.const 0
      i32.const 208
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2442,7 +2442,7 @@
   if
    i32.const 144
    i32.const 208
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2485,6 +2485,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2501,7 +2517,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2530,10 +2546,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -415,7 +415,7 @@
     if
      i32.const 0
      i32.const 1232
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -432,6 +432,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 33012
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1232
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1232
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -456,61 +507,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 33012
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1232
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1232
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -518,7 +521,7 @@
   else
    i32.const 16000
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1360
@@ -528,7 +531,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 16004
@@ -538,11 +541,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -551,17 +554,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1381,7 +1384,7 @@
     if
      i32.const 0
      i32.const 1232
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1754,7 +1757,7 @@
   if
    i32.const 1168
    i32.const 1232
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -46875,7 +46878,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $1
                                        i32.store offset=4
-                                       loop $for-loop|01
+                                       loop $for-loop|018
                                         local.get $4
                                         local.get $15
                                         i32.gt_s
@@ -46901,7 +46904,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|01
+                                         br $for-loop|018
                                         end
                                        end
                                        local.get $2
@@ -47018,7 +47021,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $1
                                        i32.store offset=4
-                                       loop $for-loop|03
+                                       loop $for-loop|020
                                         local.get $4
                                         local.get $15
                                         i32.gt_s
@@ -47044,7 +47047,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|03
+                                         br $for-loop|020
                                         end
                                        end
                                        local.get $2
@@ -47161,7 +47164,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $1
                                        i32.store offset=4
-                                       loop $for-loop|07
+                                       loop $for-loop|023
                                         local.get $4
                                         local.get $15
                                         i32.gt_s
@@ -47187,7 +47190,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|07
+                                         br $for-loop|023
                                         end
                                        end
                                        local.get $2
@@ -47309,7 +47312,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $2
                                        i32.store offset=4
-                                       loop $for-loop|011
+                                       loop $for-loop|025
                                         local.get $7
                                         local.get $15
                                         i32.gt_s
@@ -47338,7 +47341,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|011
+                                         br $for-loop|025
                                         end
                                        end
                                        local.get $4
@@ -47460,7 +47463,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $2
                                        i32.store offset=4
-                                       loop $for-loop|016
+                                       loop $for-loop|028
                                         local.get $7
                                         local.get $15
                                         i32.gt_s
@@ -47489,7 +47492,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|016
+                                         br $for-loop|028
                                         end
                                        end
                                        local.get $4
@@ -47611,7 +47614,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $2
                                        i32.store offset=4
-                                       loop $for-loop|019
+                                       loop $for-loop|030
                                         local.get $7
                                         local.get $15
                                         i32.gt_s
@@ -47640,7 +47643,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|019
+                                         br $for-loop|030
                                         end
                                        end
                                        local.get $4
@@ -47762,7 +47765,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $2
                                        i32.store offset=4
-                                       loop $for-loop|023
+                                       loop $for-loop|033
                                         local.get $7
                                         local.get $15
                                         i32.gt_s
@@ -47791,7 +47794,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|023
+                                         br $for-loop|033
                                         end
                                        end
                                        local.get $4
@@ -47913,7 +47916,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $1
                                        i32.store offset=4
-                                       loop $for-loop|026
+                                       loop $for-loop|035
                                         local.get $5
                                         local.get $15
                                         i32.gt_s
@@ -47942,7 +47945,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|026
+                                         br $for-loop|035
                                         end
                                        end
                                        local.get $3
@@ -48064,7 +48067,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $1
                                        i32.store offset=4
-                                       loop $for-loop|029
+                                       loop $for-loop|038
                                         local.get $5
                                         local.get $15
                                         i32.gt_s
@@ -48093,7 +48096,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|029
+                                         br $for-loop|038
                                         end
                                        end
                                        local.get $3
@@ -48215,7 +48218,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $1
                                        i32.store offset=4
-                                       loop $for-loop|033
+                                       loop $for-loop|040
                                         local.get $5
                                         local.get $15
                                         i32.gt_s
@@ -48244,7 +48247,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|033
+                                         br $for-loop|040
                                         end
                                        end
                                        local.get $3
@@ -48366,7 +48369,7 @@
                                        call $~lib/rt/itcms/__new
                                        local.tee $1
                                        i32.store offset=4
-                                       loop $for-loop|036
+                                       loop $for-loop|043
                                         local.get $5
                                         local.get $15
                                         i32.gt_s
@@ -48395,7 +48398,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $for-loop|036
+                                         br $for-loop|043
                                         end
                                        end
                                        local.get $3
@@ -48495,7 +48498,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|01638
+                                       loop $for-loop|044
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -48520,7 +48523,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|01638
+                                         br $for-loop|044
                                         end
                                        end
                                        i32.const 0
@@ -48615,7 +48618,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|018
+                                       loop $for-loop|045
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -48640,7 +48643,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|018
+                                         br $for-loop|045
                                         end
                                        end
                                        i32.const 0
@@ -48659,7 +48662,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|0419
+                                       loop $for-loop|0446
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -48684,7 +48687,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0419
+                                         br $for-loop|0446
                                         end
                                        end
                                        i32.const 0
@@ -48723,7 +48726,7 @@
                                       i32.const 2
                                       i32.const 6
                                       call $~lib/typedarray/Uint8ClampedArray#__set
-                                      block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.020 (result i32)
+                                      block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.047 (result i32)
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 4432
                                        i32.store offset=4
@@ -48735,7 +48738,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|021
+                                       loop $for-loop|048
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -48754,20 +48757,20 @@
                                          i32.const 4432
                                          i32.load
                                          call_indirect $0 (type $i32_i32_i32_=>_i32)
-                                         br_if $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.020
+                                         br_if $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.047
                                          drop
                                          local.get $5
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|021
+                                         br $for-loop|048
                                         end
                                        end
                                        i32.const 0
                                       end
                                       i32.eqz
                                       br_if $folding-inner23
-                                      block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0122 (result i32)
+                                      block $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0149 (result i32)
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 4464
                                        i32.store offset=4
@@ -48779,7 +48782,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|0423
+                                       loop $for-loop|0450
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -48798,13 +48801,13 @@
                                          i32.const 4464
                                          i32.load
                                          call_indirect $0 (type $i32_i32_i32_=>_i32)
-                                         br_if $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0122
+                                         br_if $~lib/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0149
                                          drop
                                          local.get $5
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0423
+                                         br $for-loop|0450
                                         end
                                        end
                                        i32.const 0
@@ -48857,7 +48860,7 @@
                                        i32.const 1
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|024
+                                       loop $for-loop|051
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -48884,7 +48887,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|024
+                                         br $for-loop|051
                                         end
                                        end
                                        i32.const 0
@@ -48905,7 +48908,7 @@
                                        i32.const 1
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|0425
+                                       loop $for-loop|0452
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -48932,7 +48935,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0425
+                                         br $for-loop|0452
                                         end
                                        end
                                        i32.const 0
@@ -48985,7 +48988,7 @@
                                        i32.const 1
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|02639
+                                       loop $for-loop|053
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -49012,7 +49015,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|02639
+                                         br $for-loop|053
                                         end
                                        end
                                        i32.const 0
@@ -49033,7 +49036,7 @@
                                        i32.const 1
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|0427
+                                       loop $for-loop|0454
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -49060,7 +49063,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0427
+                                         br $for-loop|0454
                                         end
                                        end
                                        i32.const 0
@@ -49113,7 +49116,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|028
+                                       loop $for-loop|055
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -49140,7 +49143,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|028
+                                         br $for-loop|055
                                         end
                                        end
                                        i32.const 0
@@ -49161,7 +49164,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|0429
+                                       loop $for-loop|0456
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -49188,7 +49191,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0429
+                                         br $for-loop|0456
                                         end
                                        end
                                        i32.const 0
@@ -49241,7 +49244,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|030
+                                       loop $for-loop|057
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -49268,7 +49271,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|030
+                                         br $for-loop|057
                                         end
                                        end
                                        i32.const 0
@@ -49289,7 +49292,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|0431
+                                       loop $for-loop|0458
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -49316,7 +49319,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0431
+                                         br $for-loop|0458
                                         end
                                        end
                                        i32.const 0
@@ -49369,7 +49372,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|03340
+                                       loop $for-loop|060
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -49396,7 +49399,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|03340
+                                         br $for-loop|060
                                         end
                                        end
                                        i32.const 0
@@ -49417,7 +49420,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|0434
+                                       loop $for-loop|0461
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -49444,7 +49447,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0434
+                                         br $for-loop|0461
                                         end
                                        end
                                        i32.const 0
@@ -49497,7 +49500,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|035
+                                       loop $for-loop|062
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -49524,7 +49527,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|035
+                                         br $for-loop|062
                                         end
                                        end
                                        i32.const 0
@@ -49545,7 +49548,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|0436
+                                       loop $for-loop|0463
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -49572,7 +49575,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0436
+                                         br $for-loop|0463
                                         end
                                        end
                                        i32.const 0
@@ -49625,7 +49628,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|038
+                                       loop $for-loop|065
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -49652,7 +49655,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|038
+                                         br $for-loop|065
                                         end
                                        end
                                        i32.const 0
@@ -49673,7 +49676,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|0439
+                                       loop $for-loop|0466
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -49700,7 +49703,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0439
+                                         br $for-loop|0466
                                         end
                                        end
                                        i32.const 0
@@ -49753,7 +49756,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|040
+                                       loop $for-loop|067
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -49780,7 +49783,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|040
+                                         br $for-loop|067
                                         end
                                        end
                                        i32.const 0
@@ -49801,7 +49804,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|0441
+                                       loop $for-loop|0468
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -49828,7 +49831,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0441
+                                         br $for-loop|0468
                                         end
                                        end
                                        i32.const 0
@@ -49879,7 +49882,7 @@
                                       i32.load offset=8
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
-                                       loop $for-loop|043
+                                       loop $for-loop|069
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -49900,7 +49903,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|043
+                                         br $for-loop|069
                                         end
                                        end
                                        i32.const -1
@@ -49922,7 +49925,7 @@
                                       i32.load offset=8
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.01
-                                       loop $for-loop|0444
+                                       loop $for-loop|0470
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -49943,7 +49946,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0444
+                                         br $for-loop|0470
                                         end
                                        end
                                        i32.const -1
@@ -49998,7 +50001,7 @@
                                       i32.load offset=8
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
-                                       loop $for-loop|045
+                                       loop $for-loop|072
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50019,7 +50022,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|045
+                                         br $for-loop|072
                                         end
                                        end
                                        i32.const -1
@@ -50041,7 +50044,7 @@
                                       i32.load offset=8
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.01
-                                       loop $for-loop|0446
+                                       loop $for-loop|0473
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50062,7 +50065,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0446
+                                         br $for-loop|0473
                                         end
                                        end
                                        i32.const -1
@@ -50116,8 +50119,8 @@
                                       local.get $3
                                       i32.load offset=8
                                       local.set $1
-                                      block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.047
-                                       loop $for-loop|048
+                                      block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.074
+                                       loop $for-loop|075
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50133,12 +50136,12 @@
                                          i32.const 5136
                                          i32.load
                                          call_indirect $0 (type $i32_i32_i32_=>_i32)
-                                         br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.047
+                                         br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.074
                                          local.get $5
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|048
+                                         br $for-loop|075
                                         end
                                        end
                                        i32.const -1
@@ -50159,8 +50162,8 @@
                                       local.get $3
                                       i32.load offset=8
                                       local.set $1
-                                      block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0149
-                                       loop $for-loop|0450
+                                      block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0176
+                                       loop $for-loop|0477
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50176,12 +50179,12 @@
                                          i32.const 5168
                                          i32.load
                                          call_indirect $0 (type $i32_i32_i32_=>_i32)
-                                         br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0149
+                                         br_if $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0176
                                          local.get $5
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0450
+                                         br $for-loop|0477
                                         end
                                        end
                                        i32.const -1
@@ -50238,7 +50241,7 @@
                                       i32.shr_u
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
-                                       loop $for-loop|051
+                                       loop $for-loop|078
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50261,7 +50264,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|051
+                                         br $for-loop|078
                                         end
                                        end
                                        i32.const -1
@@ -50285,7 +50288,7 @@
                                       i32.shr_u
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.01
-                                       loop $for-loop|0452
+                                       loop $for-loop|0479
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50308,7 +50311,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0452
+                                         br $for-loop|0479
                                         end
                                        end
                                        i32.const -1
@@ -50365,7 +50368,7 @@
                                       i32.shr_u
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
-                                       loop $for-loop|053
+                                       loop $for-loop|080
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50388,7 +50391,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|053
+                                         br $for-loop|080
                                         end
                                        end
                                        i32.const -1
@@ -50412,7 +50415,7 @@
                                       i32.shr_u
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.01
-                                       loop $for-loop|0454
+                                       loop $for-loop|0481
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50435,7 +50438,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0454
+                                         br $for-loop|0481
                                         end
                                        end
                                        i32.const -1
@@ -50492,7 +50495,7 @@
                                       i32.shr_u
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
-                                       loop $for-loop|055
+                                       loop $for-loop|082
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50515,7 +50518,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|055
+                                         br $for-loop|082
                                         end
                                        end
                                        i32.const -1
@@ -50539,7 +50542,7 @@
                                       i32.shr_u
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.01
-                                       loop $for-loop|0456
+                                       loop $for-loop|0483
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50562,7 +50565,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0456
+                                         br $for-loop|0483
                                         end
                                        end
                                        i32.const -1
@@ -50619,7 +50622,7 @@
                                       i32.shr_u
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint32Array,u32>|inlined.0
-                                       loop $for-loop|057
+                                       loop $for-loop|084
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50642,7 +50645,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|057
+                                         br $for-loop|084
                                         end
                                        end
                                        i32.const -1
@@ -50666,7 +50669,7 @@
                                       i32.shr_u
                                       local.set $1
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint32Array,u32>|inlined.01
-                                       loop $for-loop|0458
+                                       loop $for-loop|0485
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -50689,7 +50692,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0458
+                                         br $for-loop|0485
                                         end
                                        end
                                        i32.const -1
@@ -50746,7 +50749,7 @@
                                       i32.shr_u
                                       local.set $0
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
-                                       loop $for-loop|060
+                                       loop $for-loop|087
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -50769,7 +50772,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|060
+                                         br $for-loop|087
                                         end
                                        end
                                        i32.const -1
@@ -50793,7 +50796,7 @@
                                       i32.shr_u
                                       local.set $0
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.01
-                                       loop $for-loop|0461
+                                       loop $for-loop|0488
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -50816,7 +50819,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0461
+                                         br $for-loop|0488
                                         end
                                        end
                                        i32.const -1
@@ -50873,7 +50876,7 @@
                                       i32.shr_u
                                       local.set $0
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint64Array,u64>|inlined.0
-                                       loop $for-loop|062
+                                       loop $for-loop|089
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -50896,7 +50899,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|062
+                                         br $for-loop|089
                                         end
                                        end
                                        i32.const -1
@@ -50920,7 +50923,7 @@
                                       i32.shr_u
                                       local.set $0
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Uint64Array,u64>|inlined.01
-                                       loop $for-loop|0463
+                                       loop $for-loop|0490
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -50943,7 +50946,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0463
+                                         br $for-loop|0490
                                         end
                                        end
                                        i32.const -1
@@ -51000,7 +51003,7 @@
                                       i32.shr_u
                                       local.set $0
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
-                                       loop $for-loop|065
+                                       loop $for-loop|092
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -51023,7 +51026,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|065
+                                         br $for-loop|092
                                         end
                                        end
                                        i32.const -1
@@ -51047,7 +51050,7 @@
                                       i32.shr_u
                                       local.set $0
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.01
-                                       loop $for-loop|0466
+                                       loop $for-loop|0493
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -51070,7 +51073,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0466
+                                         br $for-loop|0493
                                         end
                                        end
                                        i32.const -1
@@ -51127,7 +51130,7 @@
                                       i32.shr_u
                                       local.set $0
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
-                                       loop $for-loop|067
+                                       loop $for-loop|094
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -51150,7 +51153,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|067
+                                         br $for-loop|094
                                         end
                                        end
                                        i32.const -1
@@ -51174,7 +51177,7 @@
                                       i32.shr_u
                                       local.set $0
                                       block $~lib/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.01
-                                       loop $for-loop|0468
+                                       loop $for-loop|0495
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -51197,7 +51200,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0468
+                                         br $for-loop|0495
                                         end
                                        end
                                        i32.const -1
@@ -51252,7 +51255,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
-                                       loop $for-loop|069
+                                       loop $for-loop|097
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51273,7 +51276,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|069
+                                         br $for-loop|097
                                         end
                                        end
                                        i32.const -1
@@ -51295,7 +51298,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Int8Array,i8>|inlined.01
-                                       loop $for-loop|0470
+                                       loop $for-loop|0498
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51316,7 +51319,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0470
+                                         br $for-loop|0498
                                         end
                                        end
                                        i32.const -1
@@ -51371,7 +51374,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
-                                       loop $for-loop|072
+                                       loop $for-loop|099
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51392,7 +51395,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|072
+                                         br $for-loop|099
                                         end
                                        end
                                        i32.const -1
@@ -51414,7 +51417,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.01
-                                       loop $for-loop|0473
+                                       loop $for-loop|04100
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51435,7 +51438,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0473
+                                         br $for-loop|04100
                                         end
                                        end
                                        i32.const -1
@@ -51489,8 +51492,8 @@
                                       i32.const 1
                                       i32.sub
                                       local.set $5
-                                      block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.074
-                                       loop $for-loop|075
+                                      block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0101
+                                       loop $for-loop|0102
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51506,12 +51509,12 @@
                                          i32.const 5840
                                          i32.load
                                          call_indirect $0 (type $i32_i32_i32_=>_i32)
-                                         br_if $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.074
+                                         br_if $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0101
                                          local.get $5
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|075
+                                         br $for-loop|0102
                                         end
                                        end
                                        i32.const -1
@@ -51532,8 +51535,8 @@
                                       i32.const 1
                                       i32.sub
                                       local.set $5
-                                      block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0176
-                                       loop $for-loop|0477
+                                      block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.01103
+                                       loop $for-loop|04104
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51549,12 +51552,12 @@
                                          i32.const 5872
                                          i32.load
                                          call_indirect $0 (type $i32_i32_i32_=>_i32)
-                                         br_if $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0176
+                                         br_if $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.01103
                                          local.get $5
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0477
+                                         br $for-loop|04104
                                         end
                                        end
                                        i32.const -1
@@ -51611,7 +51614,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
-                                       loop $for-loop|078
+                                       loop $for-loop|0105
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51634,7 +51637,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|078
+                                         br $for-loop|0105
                                         end
                                        end
                                        i32.const -1
@@ -51658,7 +51661,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Int16Array,i16>|inlined.01
-                                       loop $for-loop|0479
+                                       loop $for-loop|04106
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51681,7 +51684,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0479
+                                         br $for-loop|04106
                                         end
                                        end
                                        i32.const -1
@@ -51738,7 +51741,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
-                                       loop $for-loop|080
+                                       loop $for-loop|0107
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51761,7 +51764,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|080
+                                         br $for-loop|0107
                                         end
                                        end
                                        i32.const -1
@@ -51785,7 +51788,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.01
-                                       loop $for-loop|0481
+                                       loop $for-loop|04108
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51808,7 +51811,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0481
+                                         br $for-loop|04108
                                         end
                                        end
                                        i32.const -1
@@ -51865,7 +51868,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
-                                       loop $for-loop|082
+                                       loop $for-loop|0109
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51888,7 +51891,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|082
+                                         br $for-loop|0109
                                         end
                                        end
                                        i32.const -1
@@ -51912,7 +51915,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Int32Array,i32>|inlined.01
-                                       loop $for-loop|0483
+                                       loop $for-loop|04110
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -51935,7 +51938,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0483
+                                         br $for-loop|04110
                                         end
                                        end
                                        i32.const -1
@@ -51992,7 +51995,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint32Array,u32>|inlined.0
-                                       loop $for-loop|084
+                                       loop $for-loop|0112
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52015,7 +52018,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|084
+                                         br $for-loop|0112
                                         end
                                        end
                                        i32.const -1
@@ -52039,7 +52042,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint32Array,u32>|inlined.01
-                                       loop $for-loop|0485
+                                       loop $for-loop|04113
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52062,7 +52065,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0485
+                                         br $for-loop|04113
                                         end
                                        end
                                        i32.const -1
@@ -52119,7 +52122,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
-                                       loop $for-loop|087
+                                       loop $for-loop|0114
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52142,7 +52145,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|087
+                                         br $for-loop|0114
                                         end
                                        end
                                        i32.const -1
@@ -52166,7 +52169,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Int64Array,i64>|inlined.01
-                                       loop $for-loop|0488
+                                       loop $for-loop|04115
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52189,7 +52192,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0488
+                                         br $for-loop|04115
                                         end
                                        end
                                        i32.const -1
@@ -52246,7 +52249,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint64Array,u64>|inlined.0
-                                       loop $for-loop|089
+                                       loop $for-loop|0116
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52269,7 +52272,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|089
+                                         br $for-loop|0116
                                         end
                                        end
                                        i32.const -1
@@ -52293,7 +52296,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Uint64Array,u64>|inlined.01
-                                       loop $for-loop|0490
+                                       loop $for-loop|04117
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52316,7 +52319,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0490
+                                         br $for-loop|04117
                                         end
                                        end
                                        i32.const -1
@@ -52373,7 +52376,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
-                                       loop $for-loop|092
+                                       loop $for-loop|0118
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52396,7 +52399,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|092
+                                         br $for-loop|0118
                                         end
                                        end
                                        i32.const -1
@@ -52420,7 +52423,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Float32Array,f32>|inlined.01
-                                       loop $for-loop|0493
+                                       loop $for-loop|04119
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52443,7 +52446,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0493
+                                         br $for-loop|04119
                                         end
                                        end
                                        i32.const -1
@@ -52500,7 +52503,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
-                                       loop $for-loop|094
+                                       loop $for-loop|0120
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52523,7 +52526,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|094
+                                         br $for-loop|0120
                                         end
                                        end
                                        i32.const -1
@@ -52547,7 +52550,7 @@
                                       i32.sub
                                       local.set $5
                                       block $~lib/typedarray/FIND_LAST_INDEX<~lib/typedarray/Float64Array,f64>|inlined.01
-                                       loop $for-loop|0495
+                                       loop $for-loop|04121
                                         local.get $5
                                         i32.const 0
                                         i32.ge_s
@@ -52570,7 +52573,7 @@
                                          i32.const 1
                                          i32.sub
                                          local.set $5
-                                         br $for-loop|0495
+                                         br $for-loop|04121
                                         end
                                        end
                                        i32.const -1
@@ -52625,7 +52628,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|097
+                                       loop $for-loop|0122
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -52651,7 +52654,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|097
+                                         br $for-loop|0122
                                         end
                                        end
                                        i32.const 1
@@ -52670,7 +52673,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|0498
+                                       loop $for-loop|04123
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -52696,7 +52699,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0498
+                                         br $for-loop|04123
                                         end
                                        end
                                        i32.const 1
@@ -52747,7 +52750,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|099
+                                       loop $for-loop|0124
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -52773,7 +52776,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|099
+                                         br $for-loop|0124
                                         end
                                        end
                                        i32.const 1
@@ -52792,7 +52795,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|04100
+                                       loop $for-loop|04125
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -52818,7 +52821,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04100
+                                         br $for-loop|04125
                                         end
                                        end
                                        i32.const 1
@@ -52857,7 +52860,7 @@
                                       i32.const 2
                                       i32.const 6
                                       call $~lib/typedarray/Uint8ClampedArray#__set
-                                      block $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0101 (result i32)
+                                      block $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0126 (result i32)
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 6544
                                        i32.store offset=4
@@ -52869,7 +52872,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|0102
+                                       loop $for-loop|0127
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -52889,20 +52892,20 @@
                                          i32.load
                                          call_indirect $0 (type $i32_i32_i32_=>_i32)
                                          i32.eqz
-                                         br_if $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0101
+                                         br_if $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0126
                                          drop
                                          local.get $5
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0102
+                                         br $for-loop|0127
                                         end
                                        end
                                        i32.const 1
                                       end
                                       i32.eqz
                                       br_if $folding-inner29
-                                      block $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.01103 (result i32)
+                                      block $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.01128 (result i32)
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 6576
                                        i32.store offset=4
@@ -52914,7 +52917,7 @@
                                        local.get $3
                                        i32.load offset=8
                                        local.set $1
-                                       loop $for-loop|04104
+                                       loop $for-loop|04129
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -52934,13 +52937,13 @@
                                          i32.load
                                          call_indirect $0 (type $i32_i32_i32_=>_i32)
                                          i32.eqz
-                                         br_if $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.01103
+                                         br_if $~lib/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.01128
                                          drop
                                          local.get $5
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04104
+                                         br $for-loop|04129
                                         end
                                        end
                                        i32.const 1
@@ -52993,7 +52996,7 @@
                                        i32.const 1
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|0105
+                                       loop $for-loop|0130
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -53021,7 +53024,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0105
+                                         br $for-loop|0130
                                         end
                                        end
                                        i32.const 1
@@ -53042,7 +53045,7 @@
                                        i32.const 1
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|04106
+                                       loop $for-loop|04131
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -53070,7 +53073,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04106
+                                         br $for-loop|04131
                                         end
                                        end
                                        i32.const 1
@@ -53123,7 +53126,7 @@
                                        i32.const 1
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|0107
+                                       loop $for-loop|0132
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -53151,7 +53154,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0107
+                                         br $for-loop|0132
                                         end
                                        end
                                        i32.const 1
@@ -53172,7 +53175,7 @@
                                        i32.const 1
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|04108
+                                       loop $for-loop|04133
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -53200,7 +53203,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04108
+                                         br $for-loop|04133
                                         end
                                        end
                                        i32.const 1
@@ -53253,7 +53256,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|0109
+                                       loop $for-loop|0134
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -53281,7 +53284,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0109
+                                         br $for-loop|0134
                                         end
                                        end
                                        i32.const 1
@@ -53302,7 +53305,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|04110
+                                       loop $for-loop|04135
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -53330,7 +53333,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04110
+                                         br $for-loop|04135
                                         end
                                        end
                                        i32.const 1
@@ -53383,7 +53386,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|0112
+                                       loop $for-loop|0136
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -53411,7 +53414,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0112
+                                         br $for-loop|0136
                                         end
                                        end
                                        i32.const 1
@@ -53432,7 +53435,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $1
-                                       loop $for-loop|04113
+                                       loop $for-loop|04137
                                         local.get $1
                                         local.get $5
                                         i32.gt_s
@@ -53460,7 +53463,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04113
+                                         br $for-loop|04137
                                         end
                                        end
                                        i32.const 1
@@ -53513,7 +53516,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|0114
+                                       loop $for-loop|0138
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -53541,7 +53544,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0114
+                                         br $for-loop|0138
                                         end
                                        end
                                        i32.const 1
@@ -53562,7 +53565,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|04115
+                                       loop $for-loop|04139
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -53590,7 +53593,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04115
+                                         br $for-loop|04139
                                         end
                                        end
                                        i32.const 1
@@ -53643,7 +53646,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|0116
+                                       loop $for-loop|0140
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -53671,7 +53674,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0116
+                                         br $for-loop|0140
                                         end
                                        end
                                        i32.const 1
@@ -53692,7 +53695,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|04117
+                                       loop $for-loop|04141
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -53720,7 +53723,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04117
+                                         br $for-loop|04141
                                         end
                                        end
                                        i32.const 1
@@ -53773,7 +53776,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|0118
+                                       loop $for-loop|0142
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -53801,7 +53804,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0118
+                                         br $for-loop|0142
                                         end
                                        end
                                        i32.const 1
@@ -53822,7 +53825,7 @@
                                        i32.const 2
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|04119
+                                       loop $for-loop|04143
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -53850,7 +53853,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04119
+                                         br $for-loop|04143
                                         end
                                        end
                                        i32.const 1
@@ -53903,7 +53906,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|0120
+                                       loop $for-loop|0144
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -53931,7 +53934,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|0120
+                                         br $for-loop|0144
                                         end
                                        end
                                        i32.const 1
@@ -53952,7 +53955,7 @@
                                        i32.const 3
                                        i32.shr_u
                                        local.set $0
-                                       loop $for-loop|04121
+                                       loop $for-loop|04145
                                         local.get $0
                                         local.get $5
                                         i32.gt_s
@@ -53980,7 +53983,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $5
-                                         br $for-loop|04121
+                                         br $for-loop|04145
                                         end
                                        end
                                        i32.const 1
@@ -54055,7 +54058,7 @@
                                       local.get $4
                                       i32.load offset=8
                                       local.set $2
-                                      loop $for-loop|0116122
+                                      loop $for-loop|0116146
                                        local.get $1
                                        local.get $2
                                        i32.lt_s
@@ -54075,7 +54078,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $1
-                                        br $for-loop|0116122
+                                        br $for-loop|0116146
                                        end
                                       end
                                       global.get $std/typedarray/forEachCallCount
@@ -54454,7 +54457,7 @@
                                       i32.const 1
                                       i32.shr_u
                                       local.set $2
-                                      loop $for-loop|0138
+                                      loop $for-loop|0138147
                                        local.get $1
                                        local.get $2
                                        i32.lt_s
@@ -54476,7 +54479,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $1
-                                        br $for-loop|0138
+                                        br $for-loop|0138147
                                        end
                                       end
                                       global.get $std/typedarray/forEachCallCount
@@ -55111,7 +55114,7 @@
                                       call $~lib/typedarray/Int8Array#constructor
                                       local.tee $0
                                       i32.store offset=8
-                                      loop $for-loop|0123
+                                      loop $for-loop|0149
                                        local.get $2
                                        local.get $5
                                        i32.gt_s
@@ -55134,7 +55137,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $5
-                                        br $for-loop|0123
+                                        br $for-loop|0149
                                        end
                                       end
                                       local.get $1
@@ -55243,7 +55246,7 @@
                                       call $~lib/typedarray/Uint8Array#constructor
                                       local.tee $0
                                       i32.store offset=8
-                                      loop $for-loop|0124
+                                      loop $for-loop|0150
                                        local.get $2
                                        local.get $5
                                        i32.gt_s
@@ -55268,7 +55271,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $5
-                                        br $for-loop|0124
+                                        br $for-loop|0150
                                        end
                                       end
                                       local.get $1
@@ -55278,7 +55281,7 @@
                                       call $~lib/util/bytes/REVERSE<u8>
                                       i32.const 0
                                       local.set $5
-                                      loop $for-loop|1125
+                                      loop $for-loop|1151
                                        local.get $2
                                        local.get $5
                                        i32.gt_s
@@ -55301,7 +55304,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $5
-                                        br $for-loop|1125
+                                        br $for-loop|1151
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -55377,7 +55380,7 @@
                                       call $~lib/typedarray/Uint8ClampedArray#constructor
                                       local.tee $0
                                       i32.store offset=8
-                                      loop $for-loop|0126
+                                      loop $for-loop|0152
                                        local.get $2
                                        local.get $5
                                        i32.gt_s
@@ -55402,7 +55405,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $5
-                                        br $for-loop|0126
+                                        br $for-loop|0152
                                        end
                                       end
                                       local.get $1
@@ -55412,7 +55415,7 @@
                                       call $~lib/util/bytes/REVERSE<u8>
                                       i32.const 0
                                       local.set $5
-                                      loop $for-loop|1127
+                                      loop $for-loop|1153
                                        local.get $2
                                        local.get $5
                                        i32.gt_s
@@ -55435,7 +55438,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $5
-                                        br $for-loop|1127
+                                        br $for-loop|1153
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -55542,7 +55545,7 @@
                                       drop
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|1128
+                                      loop $for-loop|1154
                                        local.get $2
                                        local.get $15
                                        i32.gt_s
@@ -55564,7 +55567,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|1128
+                                        br $for-loop|1154
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -55637,7 +55640,7 @@
                                       i32.store offset=8
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|021129
+                                      loop $for-loop|021
                                        local.get $2
                                        local.get $15
                                        i32.gt_s
@@ -55662,7 +55665,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|021129
+                                        br $for-loop|021
                                        end
                                       end
                                       local.get $1
@@ -55766,7 +55769,7 @@
                                       i32.store offset=8
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|02941
+                                      loop $for-loop|029
                                        local.get $11
                                        local.get $15
                                        i32.gt_s
@@ -55787,7 +55790,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|02941
+                                        br $for-loop|029
                                        end
                                       end
                                       i32.const 0
@@ -55902,7 +55905,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $3
-                                       loop $while-continue|0131
+                                       loop $while-continue|0156
                                         local.get $1
                                         local.get $4
                                         i32.lt_u
@@ -55933,7 +55936,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $1
-                                         br $while-continue|0131
+                                         br $while-continue|0156
                                         end
                                        end
                                       end
@@ -56042,7 +56045,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $3
-                                       loop $while-continue|0133
+                                       loop $while-continue|0158
                                         local.get $0
                                         local.get $4
                                         i32.lt_u
@@ -56073,7 +56076,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $0
-                                         br $while-continue|0133
+                                         br $while-continue|0158
                                         end
                                        end
                                       end
@@ -56132,7 +56135,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $3
-                                       loop $while-continue|0135
+                                       loop $while-continue|0160
                                         local.get $1
                                         local.get $4
                                         i32.lt_u
@@ -56163,7 +56166,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $1
-                                         br $while-continue|0135
+                                         br $while-continue|0160
                                         end
                                        end
                                       end
@@ -56227,7 +56230,7 @@
                                       i32.store offset=8
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|045136
+                                      loop $for-loop|045161
                                        local.get $9
                                        local.get $15
                                        i32.gt_s
@@ -56250,7 +56253,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|045136
+                                        br $for-loop|045161
                                        end
                                       end
                                       i32.const 0
@@ -56274,7 +56277,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $2
-                                       loop $while-continue|0137
+                                       loop $while-continue|0162
                                         local.get $0
                                         local.get $3
                                         i32.lt_u
@@ -56305,7 +56308,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $0
-                                         br $while-continue|0137
+                                         br $while-continue|0162
                                         end
                                        end
                                       end
@@ -56365,7 +56368,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $2
-                                       loop $while-continue|0139
+                                       loop $while-continue|0164
                                         local.get $1
                                         local.get $3
                                         i32.lt_u
@@ -56396,7 +56399,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $1
-                                         br $while-continue|0139
+                                         br $while-continue|0164
                                         end
                                        end
                                       end
@@ -56460,7 +56463,7 @@
                                       i32.store offset=8
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|053140
+                                      loop $for-loop|053165
                                        local.get $9
                                        local.get $15
                                        i32.gt_s
@@ -56483,7 +56486,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|053140
+                                        br $for-loop|053165
                                        end
                                       end
                                       i32.const 0
@@ -56507,7 +56510,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $2
-                                       loop $while-continue|0142
+                                       loop $while-continue|0167
                                         local.get $0
                                         local.get $3
                                         i32.lt_u
@@ -56538,7 +56541,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $0
-                                         br $while-continue|0142
+                                         br $while-continue|0167
                                         end
                                        end
                                       end
@@ -56598,7 +56601,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $2
-                                       loop $while-continue|0144
+                                       loop $while-continue|0169
                                         local.get $1
                                         local.get $3
                                         i32.lt_u
@@ -56629,7 +56632,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $1
-                                         br $while-continue|0144
+                                         br $while-continue|0169
                                         end
                                        end
                                       end
@@ -56740,7 +56743,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $2
-                                       loop $while-continue|0145
+                                       loop $while-continue|0170
                                         local.get $0
                                         local.get $3
                                         i32.lt_u
@@ -56771,7 +56774,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $0
-                                         br $while-continue|0145
+                                         br $while-continue|0170
                                         end
                                        end
                                       end
@@ -56831,7 +56834,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $2
-                                       loop $while-continue|0147
+                                       loop $while-continue|0172
                                         local.get $1
                                         local.get $3
                                         i32.lt_u
@@ -56862,7 +56865,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $1
-                                         br $while-continue|0147
+                                         br $while-continue|0172
                                         end
                                        end
                                       end
@@ -56926,7 +56929,7 @@
                                       i32.store offset=8
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|069148
+                                      loop $for-loop|069173
                                        local.get $9
                                        local.get $15
                                        i32.gt_s
@@ -56949,7 +56952,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|069148
+                                        br $for-loop|069173
                                        end
                                       end
                                       i32.const 0
@@ -56973,7 +56976,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $2
-                                       loop $while-continue|0149
+                                       loop $while-continue|0174
                                         local.get $0
                                         local.get $3
                                         i32.lt_u
@@ -57004,7 +57007,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $0
-                                         br $while-continue|0149
+                                         br $while-continue|0174
                                         end
                                        end
                                       end
@@ -57065,7 +57068,7 @@
                                        i32.const 1
                                        i32.sub
                                        local.set $2
-                                       loop $while-continue|0151
+                                       loop $while-continue|0176
                                         local.get $1
                                         local.get $3
                                         i32.lt_u
@@ -57096,7 +57099,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $1
-                                         br $while-continue|0151
+                                         br $while-continue|0176
                                         end
                                        end
                                       end
@@ -57168,7 +57171,7 @@
                                        local.get $4
                                        i32.load offset=4
                                        local.set $2
-                                       loop $while-continue|0152
+                                       loop $while-continue|0177
                                         local.get $0
                                         local.get $3
                                         i32.lt_s
@@ -57187,7 +57190,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $0
-                                         br $while-continue|0152
+                                         br $while-continue|0177
                                         end
                                        end
                                        i32.const -1
@@ -57222,7 +57225,7 @@
                                        local.get $4
                                        i32.load offset=4
                                        local.set $0
-                                       loop $while-continue|0153
+                                       loop $while-continue|0178
                                         local.get $1
                                         local.get $15
                                         i32.gt_s
@@ -57247,7 +57250,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $15
-                                         br $while-continue|0153
+                                         br $while-continue|0178
                                         end
                                        end
                                        i32.const 0
@@ -57288,7 +57291,7 @@
                                        local.get $4
                                        i32.load offset=4
                                        local.set $2
-                                       loop $while-continue|0154
+                                       loop $while-continue|0179
                                         local.get $0
                                         local.get $3
                                         i32.lt_s
@@ -57307,7 +57310,7 @@
                                          i32.const 1
                                          i32.add
                                          local.set $0
-                                         br $while-continue|0154
+                                         br $while-continue|0179
                                         end
                                        end
                                        i32.const -1
@@ -58588,7 +58591,7 @@
                                       i32.store offset=4
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|092155
+                                      loop $for-loop|092180
                                        local.get $3
                                        local.get $15
                                        i32.gt_s
@@ -58605,7 +58608,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|092155
+                                        br $for-loop|092180
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -58688,7 +58691,7 @@
                                       i32.store offset=4
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|0102156
+                                      loop $for-loop|0102181
                                        local.get $5
                                        local.get $15
                                        i32.gt_s
@@ -58705,7 +58708,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|0102156
+                                        br $for-loop|0102181
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -58827,7 +58830,7 @@
                                       i32.store offset=4
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|0112158
+                                      loop $for-loop|0112182
                                        local.get $5
                                        local.get $15
                                        i32.gt_s
@@ -58843,7 +58846,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|0112158
+                                        br $for-loop|0112182
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -58967,7 +58970,7 @@
                                       i32.store offset=4
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|0122
+                                      loop $for-loop|0122183
                                        local.get $5
                                        local.get $15
                                        i32.gt_s
@@ -58984,7 +58987,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|0122
+                                        br $for-loop|0122183
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -59059,7 +59062,7 @@
                                       i32.store offset=16
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|1127161
+                                      loop $for-loop|1127
                                        local.get $5
                                        local.get $15
                                        i32.gt_s
@@ -59076,7 +59079,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|1127161
+                                        br $for-loop|1127
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -59108,7 +59111,7 @@
                                       i32.store offset=4
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|0132
+                                      loop $for-loop|0132184
                                        local.get $5
                                        local.get $15
                                        i32.gt_s
@@ -59123,7 +59126,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|0132
+                                        br $for-loop|0132184
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -59247,7 +59250,7 @@
                                       i32.store offset=4
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|0142
+                                      loop $for-loop|0142185
                                        local.get $5
                                        local.get $15
                                        i32.gt_s
@@ -59262,7 +59265,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|0142
+                                        br $for-loop|0142185
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -59386,7 +59389,7 @@
                                       i32.store offset=4
                                       i32.const 0
                                       local.set $15
-                                      loop $for-loop|0152
+                                      loop $for-loop|0152186
                                        local.get $5
                                        local.get $15
                                        i32.gt_s
@@ -59402,7 +59405,7 @@
                                         i32.const 1
                                         i32.add
                                         local.set $15
-                                        br $for-loop|0152
+                                        br $for-loop|0152186
                                        end
                                       end
                                       global.get $~lib/memory/__stack_pointer
@@ -60406,11 +60409,11 @@
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 0
                                        i32.store
-                                       block $1of1170
-                                        block $0of1171
-                                         block $outOfRange172
+                                       block $1of1189
+                                        block $0of1190
+                                         block $outOfRange191
                                           global.get $~argumentsLength
-                                          br_table $0of1171 $1of1170 $outOfRange172
+                                          br_table $0of1190 $1of1189 $outOfRange191
                                          end
                                          unreachable
                                         end
@@ -60532,11 +60535,11 @@
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 0
                                        i32.store
-                                       block $1of1174
-                                        block $0of1175
-                                         block $outOfRange176
+                                       block $1of1193
+                                        block $0of1194
+                                         block $outOfRange195
                                           global.get $~argumentsLength
-                                          br_table $0of1175 $1of1174 $outOfRange176
+                                          br_table $0of1194 $1of1193 $outOfRange195
                                          end
                                          unreachable
                                         end
@@ -60658,11 +60661,11 @@
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 0
                                        i32.store
-                                       block $1of144
-                                        block $0of145
-                                         block $outOfRange46
+                                       block $1of121
+                                        block $0of122
+                                         block $outOfRange23
                                           global.get $~argumentsLength
-                                          br_table $0of145 $1of144 $outOfRange46
+                                          br_table $0of122 $1of121 $outOfRange23
                                          end
                                          unreachable
                                         end
@@ -60788,11 +60791,11 @@
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 0
                                        i32.store
-                                       block $1of148
-                                        block $0of149
-                                         block $outOfRange50
+                                       block $1of126
+                                        block $0of127
+                                         block $outOfRange28
                                           global.get $~argumentsLength
-                                          br_table $0of149 $1of148 $outOfRange50
+                                          br_table $0of127 $1of126 $outOfRange28
                                          end
                                          unreachable
                                         end
@@ -60918,11 +60921,11 @@
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 0
                                        i32.store
-                                       block $1of152
-                                        block $0of153
-                                         block $outOfRange54
+                                       block $1of131
+                                        block $0of132
+                                         block $outOfRange33
                                           global.get $~argumentsLength
-                                          br_table $0of153 $1of152 $outOfRange54
+                                          br_table $0of132 $1of131 $outOfRange33
                                          end
                                          unreachable
                                         end
@@ -61048,11 +61051,11 @@
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 0
                                        i32.store
-                                       block $1of156
-                                        block $0of157
-                                         block $outOfRange58
+                                       block $1of136
+                                        block $0of137
+                                         block $outOfRange38
                                           global.get $~argumentsLength
-                                          br_table $0of157 $1of156 $outOfRange58
+                                          br_table $0of137 $1of136 $outOfRange38
                                          end
                                          unreachable
                                         end
@@ -61178,11 +61181,11 @@
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 0
                                        i32.store
-                                       block $1of160
-                                        block $0of161
-                                         block $outOfRange62
+                                       block $1of141
+                                        block $0of142
+                                         block $outOfRange43
                                           global.get $~argumentsLength
-                                          br_table $0of161 $1of160 $outOfRange62
+                                          br_table $0of142 $1of141 $outOfRange43
                                          end
                                          unreachable
                                         end
@@ -61308,11 +61311,11 @@
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 0
                                        i32.store
-                                       block $1of164
-                                        block $0of165
-                                         block $outOfRange66
+                                       block $1of145
+                                        block $0of146
+                                         block $outOfRange47
                                           global.get $~argumentsLength
-                                          br_table $0of165 $1of164 $outOfRange66
+                                          br_table $0of146 $1of145 $outOfRange47
                                          end
                                          unreachable
                                         end
@@ -61438,11 +61441,11 @@
                                        global.get $~lib/memory/__stack_pointer
                                        i32.const 0
                                        i32.store
-                                       block $1of168
-                                        block $0of169
-                                         block $outOfRange70
+                                       block $1of149
+                                        block $0of150
+                                         block $outOfRange51
                                           global.get $~argumentsLength
-                                          br_table $0of169 $1of168 $outOfRange70
+                                          br_table $0of150 $1of149 $outOfRange51
                                          end
                                          unreachable
                                         end
@@ -64292,12 +64295,13 @@
   end
  )
  (func $byn-split-outlined-A$~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
   local.get $0
   i32.eqz
   if
    i32.const 0
    i32.const 1232
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -64323,8 +64327,39 @@
    i32.eqz
    i32.eq
    if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $1
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $0
+     i32.load offset=8
+     local.set $2
+     local.get $1
+     global.get $~lib/rt/itcms/white
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $1
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -173,7 +173,7 @@
     if
      i32.const 0
      i32.const 224
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1558,7 +1558,7 @@
     if
      i32.const 0
      i32.const 224
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2141,7 +2141,7 @@
   if
    i32.const 160
    i32.const 224
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -115,7 +115,7 @@
     if
      i32.const 0
      i32.const 1248
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -899,7 +899,7 @@
     if
      i32.const 0
      i32.const 1248
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1126,7 +1126,7 @@
   if
    i32.const 1184
    i32.const 1248
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -104,7 +104,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1489,7 +1489,7 @@
     if
      i32.const 0
      i32.const 96
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2072,7 +2072,7 @@
   if
    i32.const 32
    i32.const 96
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -74,7 +74,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -858,7 +858,7 @@
     if
      i32.const 0
      i32.const 1120
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -322,7 +322,7 @@
     if
      i32.const 0
      i32.const 256
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1707,7 +1707,7 @@
     if
      i32.const 0
      i32.const 256
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2290,7 +2290,7 @@
   if
    i32.const 192
    i32.const 256
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -2333,6 +2333,22 @@
   memory.fill
   local.get $3
  )
+ (func $~lib/rt/itcms/Object#needScan (param $0 i32)
+  global.get $~lib/rt/itcms/state
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   call $~lib/rt/itcms/Object#makeGray
+  else
+   local.get $0
+   call $~lib/rt/itcms/Object#unlink
+   local.get $0
+   global.get $~lib/rt/itcms/fromSpace
+   global.get $~lib/rt/itcms/white
+   call $~lib/rt/itcms/Object#linkTo
+  end
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2349,7 +2365,7 @@
   if
    i32.const 0
    i32.const 256
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -2378,10 +2394,10 @@
     local.get $2
     if
      local.get $4
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     else
      local.get $3
-     call $~lib/rt/itcms/Object#makeGray
+     call $~lib/rt/itcms/Object#needScan
     end
    else
     local.get $5

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -2,8 +2,8 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $f64_=>_i32 (func (param f64) (result i32)))
  (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
@@ -243,7 +243,7 @@
     if
      i32.const 0
      i32.const 1280
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -260,6 +260,57 @@
     br $while-continue|0
    end
   end
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.tee $1
+  i32.eqz
+  if
+   i32.const 0
+   local.get $0
+   i32.const 22116
+   i32.lt_u
+   local.get $0
+   i32.load offset=8
+   select
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1280
+    i32.const 127
+    i32.const 18
+    call $~lib/builtins/abort
+    unreachable
+   end
+   return
+  end
+  local.get $0
+  i32.load offset=8
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1280
+   i32.const 131
+   i32.const 16
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  local.get $1
+  i32.or
+  i32.store offset=4
  )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
@@ -284,61 +335,13 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink
-   local.get $0
-   i32.load offset=4
-   i32.const -4
-   i32.and
-   local.tee $1
-   i32.eqz
-   if
-    i32.const 0
-    local.get $0
-    i32.const 22116
-    i32.lt_u
-    local.get $0
-    i32.load offset=8
-    select
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1280
-     i32.const 127
-     i32.const 18
-     call $~lib/builtins/abort
-     unreachable
-    end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink
-   end
-   local.get $0
-   i32.load offset=8
-   local.tee $2
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1280
-    i32.const 131
-    i32.const 16
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $1
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   local.get $2
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.get $1
-   i32.or
-   i32.store offset=4
-  end
+  local.get $0
+  call $~lib/rt/itcms/Object#unlink
   global.get $~lib/rt/itcms/toSpace
-  local.set $2
+  local.set $1
   local.get $0
   i32.load offset=12
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.le_u
   if (result i32)
@@ -346,7 +349,7 @@
   else
    i32.const 5680
    i32.load
-   local.get $1
+   local.get $2
    i32.lt_u
    if
     i32.const 1408
@@ -356,7 +359,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   local.get $1
+   local.get $2
    i32.const 3
    i32.shl
    i32.const 5684
@@ -366,11 +369,11 @@
    i32.and
   end
   local.set $3
-  local.get $2
+  local.get $1
   i32.load offset=8
-  local.set $1
+  local.set $2
   local.get $0
-  local.get $2
+  local.get $1
   global.get $~lib/rt/itcms/white
   i32.eqz
   i32.const 2
@@ -379,17 +382,17 @@
   i32.or
   i32.store offset=4
   local.get $0
-  local.get $1
+  local.get $2
   i32.store offset=8
-  local.get $1
-  local.get $1
+  local.get $2
+  local.get $2
   i32.load offset=4
   i32.const 3
   i32.and
   local.get $0
   i32.or
   i32.store offset=4
-  local.get $2
+  local.get $1
   local.get $0
   i32.store offset=8
  )
@@ -1159,7 +1162,7 @@
     if
      i32.const 0
      i32.const 1280
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -1386,7 +1389,7 @@
   if
    i32.const 1216
    i32.const 1280
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable
@@ -1679,22 +1682,6 @@
   local.get $0
   memory.fill
   local.get $1
- )
- (func $~lib/staticarray/StaticArray<~lib/string/String>#__uset (param $0 i32) (param $1 i32) (param $2 i32)
-  local.get $1
-  i32.const 2
-  i32.shl
-  local.get $0
-  i32.add
-  local.get $2
-  i32.store
-  local.get $2
-  if
-   local.get $0
-   local.get $2
-   i32.const 1
-   call $byn-split-outlined-A$~lib/rt/itcms/__link
-  end
  )
  (func $~lib/staticarray/StaticArray<~lib/string/String>#join (param $0 i32) (result i32)
   (local $1 i32)
@@ -3349,17 +3336,23 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1744
    i32.store offset=16
-   i32.const 1744
-   i32.const 1
+   i32.const 1748
    i32.const 1056
-   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+   i32.store
+   i32.const 1744
+   i32.const 1056
+   i32.const 1
+   call $byn-split-outlined-A$~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 1744
    i32.store offset=16
-   i32.const 1744
-   i32.const 3
+   i32.const 1756
    i32.const 1088
-   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+   i32.store
+   i32.const 1744
+   i32.const 1088
+   i32.const 1
+   call $byn-split-outlined-A$~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 1744
    i32.store offset=16
@@ -3471,21 +3464,34 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 3680
    i32.store offset=8
-   i32.const 3680
-   i32.const 1
+   i32.const 3684
    local.get $0
-   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+   i32.store
+   local.get $0
+   if
+    i32.const 3680
+    local.get $0
+    i32.const 1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
    global.get $~lib/memory/__stack_pointer
    i32.const 3680
    i32.store offset=8
-   i32.const 3680
-   i32.const 3
+   i32.const 3692
    local.get $1
-   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+   i32.store
+   local.get $1
+   if
+    i32.const 3680
+    local.get $1
+    i32.const 1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
    global.get $~lib/memory/__stack_pointer
+   local.tee $0
    i32.const 3680
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
+   local.get $0
    i32.const 1184
    i32.store offset=12
    i32.const 3680
@@ -3593,21 +3599,34 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 4976
    i32.store offset=8
-   i32.const 4976
-   i32.const 1
+   i32.const 4980
    local.get $0
-   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+   i32.store
+   local.get $0
+   if
+    i32.const 4976
+    local.get $0
+    i32.const 1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
    global.get $~lib/memory/__stack_pointer
    i32.const 4976
    i32.store offset=8
-   i32.const 4976
-   i32.const 3
+   i32.const 4988
    local.get $1
-   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+   i32.store
+   local.get $1
+   if
+    i32.const 4976
+    local.get $1
+    i32.const 1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
    global.get $~lib/memory/__stack_pointer
+   local.tee $0
    i32.const 4976
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
+   local.get $0
    i32.const 1184
    i32.store offset=12
    i32.const 4976
@@ -3727,21 +3746,34 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 5440
    i32.store offset=16
-   i32.const 5440
-   i32.const 1
+   i32.const 5444
    local.get $1
-   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+   i32.store
+   local.get $1
+   if
+    i32.const 5440
+    local.get $1
+    i32.const 1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
    global.get $~lib/memory/__stack_pointer
    i32.const 5440
    i32.store offset=16
-   i32.const 5440
-   i32.const 3
+   i32.const 5452
    local.get $0
-   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+   i32.store
+   local.get $0
+   if
+    i32.const 5440
+    local.get $0
+    i32.const 1
+    call $byn-split-outlined-A$~lib/rt/itcms/__link
+   end
    global.get $~lib/memory/__stack_pointer
+   local.tee $0
    i32.const 5440
    i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
+   local.get $0
    i32.const 1184
    i32.store offset=20
    i32.const 5440
@@ -4229,21 +4261,34 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 5616
   i32.store offset=12
-  i32.const 5616
-  i32.const 1
+  i32.const 5620
   local.get $0
-  call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+  i32.store
+  local.get $0
+  if
+   i32.const 5616
+   local.get $0
+   i32.const 1
+   call $byn-split-outlined-A$~lib/rt/itcms/__link
+  end
   global.get $~lib/memory/__stack_pointer
   i32.const 5616
   i32.store offset=12
-  i32.const 5616
-  i32.const 3
+  i32.const 5628
   local.get $1
-  call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
+  i32.store
+  local.get $1
+  if
+   i32.const 5616
+   local.get $1
+   i32.const 1
+   call $byn-split-outlined-A$~lib/rt/itcms/__link
+  end
   global.get $~lib/memory/__stack_pointer
+  local.tee $0
   i32.const 5616
   i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
+  local.get $0
   i32.const 1184
   i32.store offset=16
   i32.const 5616
@@ -4441,7 +4486,7 @@
   if
    i32.const 0
    i32.const 1280
-   i32.const 294
+   i32.const 304
    i32.const 14
    call $~lib/builtins/abort
    unreachable
@@ -4472,7 +4517,40 @@
     local.get $1
     local.get $2
     select
-    call $~lib/rt/itcms/Object#makeGray
+    local.set $0
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $0
+     call $~lib/rt/itcms/Object#unlink
+     global.get $~lib/rt/itcms/fromSpace
+     local.tee $1
+     i32.load offset=8
+     local.set $2
+     local.get $0
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.or
+     i32.store offset=4
+     local.get $0
+     local.get $2
+     i32.store offset=8
+     local.get $2
+     local.get $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.get $0
+     i32.or
+     i32.store offset=4
+     local.get $1
+     local.get $0
+     i32.store offset=8
+    end
    else
     global.get $~lib/rt/itcms/state
     i32.const 1

--- a/tests/compiler/throw.debug.wat
+++ b/tests/compiler/throw.debug.wat
@@ -220,7 +220,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1605,7 +1605,7 @@
     if
      i32.const 0
      i32.const 368
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/throw.release.wat
+++ b/tests/compiler/throw.release.wat
@@ -70,7 +70,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -661,7 +661,7 @@
     if
      i32.const 0
      i32.const 1392
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -281,7 +281,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1666,7 +1666,7 @@
     if
      i32.const 0
      i32.const 400
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2249,7 +2249,7 @@
   if
    i32.const 336
    i32.const 400
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -206,7 +206,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -990,7 +990,7 @@
     if
      i32.const 0
      i32.const 1424
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -558,7 +558,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -1943,7 +1943,7 @@
     if
      i32.const 0
      i32.const 144
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable
@@ -2526,7 +2526,7 @@
   if
    i32.const 80
    i32.const 144
-   i32.const 260
+   i32.const 270
    i32.const 31
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -62,7 +62,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 159
+     i32.const 169
      i32.const 16
      call $~lib/builtins/abort
      unreachable
@@ -846,7 +846,7 @@
     if
      i32.const 0
      i32.const 1168
-     i32.const 228
+     i32.const 238
      i32.const 20
      call $~lib/builtins/abort
      unreachable


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->

⯈Fixed Template literals cause GC crash #2178
⯈This bug is caused by the misuse of `makeGray`. `makeGray` can only be used in `STATE_MARK` because it will add the object into `toSpace`, in the sweep state, `toSpace` is used to store the object which need to free.
⯈Add a `needScan` function to handle this situation, in the mark state it will call `makeGray` and in the other state will link the object into `fromSpace` (just like __unpin did)

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
